### PR TITLE
chore(vz): add SAFETY comments to all unsafe blocks in arcbox-vz

### DIFF
--- a/hypervisor/arcbox-vz/examples/virtiofs.rs
+++ b/hypervisor/arcbox-vz/examples/virtiofs.rs
@@ -156,6 +156,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     if let Some(fd) = read_fd {
         // Set non-blocking
+        // SAFETY: fd is a valid file descriptor from SerialPortConfiguration. fcntl F_GETFL/F_SETFL are safe on valid fds.
         unsafe {
             let flags = libc::fcntl(fd, libc::F_GETFL);
             libc::fcntl(fd, libc::F_SETFL, flags | libc::O_NONBLOCK);
@@ -165,6 +166,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
         while start.elapsed() < Duration::from_secs(10) {
             let mut buf = [0u8; 1024];
+            // SAFETY: fd is a valid non-blocking file descriptor. buf is a valid write target.
             let n = unsafe { libc::read(fd, buf.as_mut_ptr() as *mut libc::c_void, buf.len()) };
             if n > 0 {
                 let s = String::from_utf8_lossy(&buf[..n as usize]);

--- a/hypervisor/arcbox-vz/examples/vsock_echo.rs
+++ b/hypervisor/arcbox-vz/examples/vsock_echo.rs
@@ -105,6 +105,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Read serial output while waiting
     if let Some(fd) = read_fd {
         // Set non-blocking
+        // SAFETY: fd is a valid file descriptor from SerialPortConfiguration. fcntl F_GETFL/F_SETFL are safe on valid fds.
         unsafe {
             let flags = libc::fcntl(fd, libc::F_GETFL);
             libc::fcntl(fd, libc::F_SETFL, flags | libc::O_NONBLOCK);
@@ -115,6 +116,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
         while start.elapsed() < Duration::from_secs(5) {
             let mut buf = [0u8; 1024];
+            // SAFETY: fd is a valid non-blocking file descriptor. buf is a valid write target.
             let n = unsafe { libc::read(fd, buf.as_mut_ptr() as *mut libc::c_void, buf.len()) };
             if n > 0 {
                 let s = String::from_utf8_lossy(&buf[..n as usize]);

--- a/hypervisor/arcbox-vz/examples/vsock_listen.rs
+++ b/hypervisor/arcbox-vz/examples/vsock_listen.rs
@@ -106,6 +106,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Read serial output while waiting
     if let Some(fd) = read_fd {
         // Set non-blocking
+        // SAFETY: fd is a valid file descriptor from SerialPortConfiguration. fcntl F_GETFL/F_SETFL are safe on valid fds.
         unsafe {
             let flags = libc::fcntl(fd, libc::F_GETFL);
             libc::fcntl(fd, libc::F_SETFL, flags | libc::O_NONBLOCK);
@@ -115,6 +116,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
         while start.elapsed() < Duration::from_secs(5) {
             let mut buf = [0u8; 1024];
+            // SAFETY: fd is a valid non-blocking file descriptor. buf is a valid write target.
             let n = unsafe { libc::read(fd, buf.as_mut_ptr() as *mut libc::c_void, buf.len()) };
             if n > 0 {
                 let s = String::from_utf8_lossy(&buf[..n as usize]);

--- a/hypervisor/arcbox-vz/src/configuration/boot_loader.rs
+++ b/hypervisor/arcbox-vz/src/configuration/boot_loader.rs
@@ -28,6 +28,7 @@ pub struct LinuxBootLoader {
     inner: *mut AnyObject,
 }
 
+// SAFETY: Inner ObjC pointer is only used via msg_send! which dispatches to the ObjC runtime. Not shared across threads without external synchronization.
 unsafe impl Send for LinuxBootLoader {}
 
 impl LinuxBootLoader {
@@ -49,6 +50,7 @@ impl LinuxBootLoader {
 
         let path_str = path.to_string_lossy();
 
+        // SAFETY: ObjC alloc/init pattern on valid VZLinuxBootLoader class. Result is checked non-null.
         unsafe {
             let cls = get_class("VZLinuxBootLoader").ok_or_else(|| VZError::Internal {
                 code: -1,
@@ -77,6 +79,7 @@ impl LinuxBootLoader {
         let path = path.as_ref();
         if path.exists() {
             let path_str = path.to_string_lossy();
+            // SAFETY: self.inner is a valid VZLinuxBootLoader. NSURL is created from a validated path.
             unsafe {
                 let url = nsurl_file_path(&path_str);
                 msg_send_void!(self.inner, setInitialRamdiskURL: url);
@@ -91,6 +94,7 @@ impl LinuxBootLoader {
     ///
     /// * `cmdline` - Kernel command line string (e.g., "console=hvc0 root=/dev/vda")
     pub fn set_command_line(&mut self, cmdline: &str) -> &mut Self {
+        // SAFETY: self.inner is a valid VZLinuxBootLoader. NSString is created from a valid Rust str.
         unsafe {
             let s = crate::ffi::nsstring(cmdline);
             msg_send_void!(self.inner, setCommandLine: s);

--- a/hypervisor/arcbox-vz/src/configuration/platform.rs
+++ b/hypervisor/arcbox-vz/src/configuration/platform.rs
@@ -26,11 +26,13 @@ pub struct GenericPlatform {
     inner: *mut AnyObject,
 }
 
+// SAFETY: Inner ObjC pointer is only used via msg_send! which dispatches to the ObjC runtime.
 unsafe impl Send for GenericPlatform {}
 
 impl GenericPlatform {
     /// Creates a new generic platform configuration.
     pub fn new() -> VZResult<Self> {
+        // SAFETY: ObjC alloc/init pattern on valid VZGenericPlatformConfiguration class. Result is checked non-null. retain prevents autorelease.
         unsafe {
             let cls =
                 get_class("VZGenericPlatformConfiguration").ok_or_else(|| VZError::Internal {
@@ -68,6 +70,7 @@ impl GenericPlatform {
         if cls.class_method(sel).is_none() {
             return false;
         }
+        // SAFETY: Selector existence is checked above via class_method. Sending to a valid class pointer.
         unsafe { msg_send_bool!(cls, isNestedVirtualizationSupported).as_bool() }
     }
 
@@ -77,12 +80,14 @@ impl GenericPlatform {
     pub fn set_nested_virt_enabled(&self, enabled: bool) {
         // Guard: the setter selector only exists on macOS 15+.
         let sel = objc2::sel!(setNestedVirtualizationEnabled:);
+        // SAFETY: self.inner is a valid ObjC object pointer; casting to &AnyObject to query its class.
         if !unsafe { &*(self.inner as *const AnyObject) }
             .class()
             .responds_to(sel)
         {
             return;
         }
+        // SAFETY: Selector existence is checked above via responds_to. self.inner is a valid VZGenericPlatformConfiguration.
         unsafe {
             msg_send_void_bool!(self.inner, setNestedVirtualizationEnabled: Bool::new(enabled));
         }

--- a/hypervisor/arcbox-vz/src/configuration/vm_config.rs
+++ b/hypervisor/arcbox-vz/src/configuration/vm_config.rs
@@ -33,11 +33,13 @@ pub struct VirtualMachineConfiguration {
     memory_balloon_devices: Vec<*mut AnyObject>,
 }
 
+// SAFETY: Inner ObjC pointer is only used via msg_send! which dispatches to the ObjC runtime.
 unsafe impl Send for VirtualMachineConfiguration {}
 
 impl VirtualMachineConfiguration {
     /// Creates a new VM configuration with default settings.
     pub fn new() -> VZResult<Self> {
+        // SAFETY: ObjC alloc/init pattern on valid VZVirtualMachineConfiguration class. Result is checked non-null.
         unsafe {
             let cls =
                 get_class("VZVirtualMachineConfiguration").ok_or_else(|| VZError::Internal {
@@ -75,6 +77,7 @@ impl VirtualMachineConfiguration {
     /// Use `arcbox_vz::min_cpu_count()` and `arcbox_vz::max_cpu_count()`
     /// to get the valid range.
     pub fn set_cpu_count(&mut self, count: usize) -> &mut Self {
+        // SAFETY: self.inner is a valid VZVirtualMachineConfiguration. The selector matches the expected argument type.
         unsafe {
             msg_send_void_u64!(self.inner, setCPUCount: count as u64);
         }
@@ -83,6 +86,7 @@ impl VirtualMachineConfiguration {
 
     /// Gets the configured CPU count.
     pub fn cpu_count(&self) -> u64 {
+        // SAFETY: self.inner is a valid VZVirtualMachineConfiguration. The selector matches the expected argument type.
         unsafe { msg_send_u64!(self.inner, CPUCount) }
     }
 
@@ -94,6 +98,7 @@ impl VirtualMachineConfiguration {
     /// Use `arcbox_vz::min_memory_size()` and `arcbox_vz::max_memory_size()`
     /// to get the valid range.
     pub fn set_memory_size(&mut self, bytes: u64) -> &mut Self {
+        // SAFETY: self.inner is a valid VZVirtualMachineConfiguration. The selector matches the expected argument type.
         unsafe {
             msg_send_void_u64!(self.inner, setMemorySize: bytes);
         }
@@ -102,11 +107,13 @@ impl VirtualMachineConfiguration {
 
     /// Gets the configured memory size in bytes.
     pub fn memory_size(&self) -> u64 {
+        // SAFETY: self.inner is a valid VZVirtualMachineConfiguration. The selector matches the expected argument type.
         unsafe { msg_send_u64!(self.inner, memorySize) }
     }
 
     /// Sets the boot loader for the VM.
     pub fn set_boot_loader(&mut self, boot_loader: impl BootLoader) -> &mut Self {
+        // SAFETY: self.inner is a valid VZVirtualMachineConfiguration. The selector matches the expected argument type.
         unsafe {
             msg_send_void!(self.inner, setBootLoader: boot_loader.as_ptr());
         }
@@ -115,6 +122,7 @@ impl VirtualMachineConfiguration {
 
     /// Sets the platform configuration.
     pub fn set_platform(&mut self, platform: impl Platform) -> &mut Self {
+        // SAFETY: self.inner is a valid VZVirtualMachineConfiguration. The selector matches the expected argument type.
         unsafe {
             msg_send_void!(self.inner, setPlatform: platform.as_ptr());
         }
@@ -182,6 +190,7 @@ impl VirtualMachineConfiguration {
     /// This is called automatically by `build()`, but can be called
     /// manually to check for configuration errors early.
     pub fn validate(&self) -> VZResult<()> {
+        // SAFETY: self.inner is a valid VZVirtualMachineConfiguration. validateWithError: writes to the error out-parameter only on failure.
         unsafe {
             let mut error: *mut AnyObject = ptr::null_mut();
             let valid = msg_send_bool!(self.inner, validateWithError: &mut error);
@@ -208,6 +217,7 @@ impl VirtualMachineConfiguration {
         let queue = DispatchQueue::new("com.arcbox.vz.vm");
 
         // Create VM with queue
+        // SAFETY: ObjC alloc/init pattern on VZVirtualMachine with a validated configuration and a valid dispatch queue.
         let vm_ptr = unsafe {
             let cls = get_class("VZVirtualMachine").ok_or_else(|| VZError::Internal {
                 code: -1,
@@ -230,6 +240,7 @@ impl VirtualMachineConfiguration {
 
     /// Applies all device configurations to the VZ configuration.
     fn apply_devices(&mut self) {
+        // SAFETY: self.inner is a valid VZVirtualMachineConfiguration. Each device pointer was obtained from a valid VZ configuration object's into_ptr().
         unsafe {
             if !self.storage_devices.is_empty() {
                 let array = nsarray(&self.storage_devices);

--- a/hypervisor/arcbox-vz/src/delegate.rs
+++ b/hypervisor/arcbox-vz/src/delegate.rs
@@ -35,6 +35,7 @@ pub enum DelegateError {
 // FFI Declarations
 // ============================================================================
 
+// SAFETY: ObjC runtime FFI declarations — these are well-known C functions with stable ABI.
 unsafe extern "C" {
     fn class_addMethod(
         cls: *const AnyClass,
@@ -134,10 +135,11 @@ fn send_connection(handle: ListenerHandle, conn: IncomingConnection) -> bool {
 /// Wrapper for optional class pointer that implements Send + Sync.
 struct ClassResult(Result<*const AnyClass, DelegateError>);
 
-// Safety: The class is registered once and never modified.
+// SAFETY: The class is registered once and never modified.
 // Objective-C classes are thread-safe for reading.
 // The error variant contains no pointers.
 unsafe impl Send for ClassResult {}
+// SAFETY: See above — the class pointer is immutable after registration.
 unsafe impl Sync for ClassResult {}
 
 /// Class pointer for our delegate implementation.
@@ -152,6 +154,7 @@ const HANDLE_IVAR: &[u8] = b"_listenerHandle\0";
 ///
 /// Returns an error if the delegate class cannot be created.
 pub fn get_delegate_class() -> Result<*const AnyClass, DelegateError> {
+    // SAFETY: Class creation is done once via OnceLock; `create_delegate_class` is unsafe fn.
     let result = DELEGATE_CLASS.get_or_init(|| ClassResult(unsafe { create_delegate_class() }));
     // Clone the result since we can't move out of OnceLock
     match &result.0 {
@@ -167,6 +170,9 @@ pub fn get_delegate_class() -> Result<*const AnyClass, DelegateError> {
 
 /// Creates the `VZSocketListenerDelegate` Objective-C class dynamically.
 unsafe fn create_delegate_class() -> Result<*const AnyClass, DelegateError> {
+    // SAFETY: All ObjC runtime calls (objc_getClass, objc_allocateClassPair, class_addIvar,
+    // class_addMethod, objc_registerClassPair) use valid class/selector names and are called
+    // in the correct sequence. The resulting class is registered once and stored globally.
     unsafe {
         // Get NSObject as superclass
         let nsobj_name = CString::new("NSObject").unwrap();
@@ -241,6 +247,9 @@ unsafe extern "C" fn should_accept_connection(
     connection: *mut AnyObject,
     _device: *mut AnyObject,
 ) -> Bool {
+    // SAFETY: ObjC delegate callback invoked by Virtualization.framework. `this` is a valid
+    // delegate instance created by `create_delegate_instance`. `connection` is validated
+    // non-null before use. `libc::dup` is safe to call on a valid fd.
     unsafe {
         tracing::debug!("should_accept_connection called");
 
@@ -318,6 +327,9 @@ unsafe extern "C" fn should_accept_connection(
 /// Returns an error if the delegate class cannot be created or if
 /// instance allocation fails.
 pub fn create_delegate_instance(handle: ListenerHandle) -> Result<*mut AnyObject, DelegateError> {
+    // SAFETY: `cls` is a valid registered ObjC class from `get_delegate_class`. alloc/init
+    // follow standard ObjC two-phase initialization. `object_setInstanceVariable` stores a
+    // u64 handle value in the ivar added during class creation.
     unsafe {
         let cls = get_delegate_class()?;
 

--- a/hypervisor/arcbox-vz/src/device/balloon.rs
+++ b/hypervisor/arcbox-vz/src/device/balloon.rs
@@ -22,11 +22,13 @@ pub struct MemoryBalloonDeviceConfiguration {
     inner: *mut AnyObject,
 }
 
+// SAFETY: Inner ObjC pointer is only used via msg_send! which dispatches to the ObjC runtime.
 unsafe impl Send for MemoryBalloonDeviceConfiguration {}
 
 impl MemoryBalloonDeviceConfiguration {
     /// Creates a new memory balloon device configuration.
     pub fn new() -> VZResult<Self> {
+        // SAFETY: ObjC new on valid VZVirtioTraditionalMemoryBalloonDeviceConfiguration class. retain prevents autorelease.
         unsafe {
             let cls = get_class("VZVirtioTraditionalMemoryBalloonDeviceConfiguration").ok_or_else(
                 || VZError::Internal {
@@ -85,7 +87,9 @@ pub struct MemoryBalloonDevice {
     inner: *mut AnyObject,
 }
 
+// SAFETY: The inner pointer refers to a VZ framework-managed object. Access is synchronized by the framework's internal dispatch queue.
 unsafe impl Send for MemoryBalloonDevice {}
+// SAFETY: See above — access is synchronized by the framework's dispatch queue.
 unsafe impl Sync for MemoryBalloonDevice {}
 
 impl MemoryBalloonDevice {
@@ -112,6 +116,7 @@ impl MemoryBalloonDevice {
             tracing::warn!("set_target_memory_size called on null device");
             return;
         }
+        // SAFETY: self.inner is checked non-null above. Sending setTargetVirtualMachineMemorySize: with a u64 value.
         unsafe {
             msg_send_void_u64!(self.inner, setTargetVirtualMachineMemorySize: bytes);
         }
@@ -130,6 +135,7 @@ impl MemoryBalloonDevice {
             tracing::warn!("target_memory_size called on null device");
             return 0;
         }
+        // SAFETY: self.inner is checked non-null above. Sending targetVirtualMachineMemorySize to a valid balloon device.
         unsafe { msg_send_u64!(self.inner, targetVirtualMachineMemorySize) }
     }
 
@@ -158,6 +164,7 @@ pub fn vm_memory_balloon_devices(vm_ptr: *mut AnyObject) -> Vec<MemoryBalloonDev
         return Vec::new();
     }
 
+    // SAFETY: vm_ptr is checked non-null above. Sending memoryBalloonDevices returns a valid NSArray. Elements are valid balloon device pointers.
     unsafe {
         let devices: *mut AnyObject = msg_send!(vm_ptr, memoryBalloonDevices);
         if devices.is_null() {

--- a/hypervisor/arcbox-vz/src/device/entropy.rs
+++ b/hypervisor/arcbox-vz/src/device/entropy.rs
@@ -12,11 +12,13 @@ pub struct EntropyDeviceConfiguration {
     inner: *mut AnyObject,
 }
 
+// SAFETY: Inner ObjC pointer is only used via msg_send! which dispatches to the ObjC runtime.
 unsafe impl Send for EntropyDeviceConfiguration {}
 
 impl EntropyDeviceConfiguration {
     /// Creates a new entropy device configuration.
     pub fn new() -> VZResult<Self> {
+        // SAFETY: ObjC new on valid VZVirtioEntropyDeviceConfiguration class. Result is checked non-null. retain prevents autorelease.
         unsafe {
             let cls = get_class("VZVirtioEntropyDeviceConfiguration").ok_or_else(|| {
                 VZError::Internal {

--- a/hypervisor/arcbox-vz/src/device/filesystem.rs
+++ b/hypervisor/arcbox-vz/src/device/filesystem.rs
@@ -62,6 +62,7 @@ pub struct SharedDirectory {
     inner: *mut AnyObject,
 }
 
+// SAFETY: Inner ObjC pointer is only used via msg_send! which dispatches to the ObjC runtime.
 unsafe impl Send for SharedDirectory {}
 
 impl SharedDirectory {
@@ -94,6 +95,7 @@ impl SharedDirectory {
             )));
         }
 
+        // SAFETY: ObjC alloc/init on valid VZSharedDirectory class. NSURL from validated path. readOnly is a Bool value.
         unsafe {
             let cls = get_class("VZSharedDirectory").ok_or_else(|| VZError::Internal {
                 code: -1,
@@ -209,6 +211,7 @@ pub struct SingleDirectoryShare {
     inner: *mut AnyObject,
 }
 
+// SAFETY: Inner ObjC pointer is only used via msg_send! which dispatches to the ObjC runtime.
 unsafe impl Send for SingleDirectoryShare {}
 
 impl SingleDirectoryShare {
@@ -218,6 +221,7 @@ impl SingleDirectoryShare {
     ///
     /// * `directory` - The shared directory to expose
     pub fn new(directory: SharedDirectory) -> VZResult<Self> {
+        // SAFETY: ObjC alloc/init on valid VZSingleDirectoryShare class with a valid SharedDirectory pointer.
         unsafe {
             let cls = get_class("VZSingleDirectoryShare").ok_or_else(|| VZError::Internal {
                 code: -1,
@@ -309,11 +313,13 @@ pub struct MultipleDirectoryShare {
     directories: HashMap<String, *mut AnyObject>,
 }
 
+// SAFETY: Inner ObjC pointer is only used via msg_send! which dispatches to the ObjC runtime.
 unsafe impl Send for MultipleDirectoryShare {}
 
 impl MultipleDirectoryShare {
     /// Creates a new multiple directory share.
     pub fn new() -> VZResult<Self> {
+        // SAFETY: ObjC new on valid VZMultipleDirectoryShare class. retain prevents autorelease.
         unsafe {
             let cls = get_class("VZMultipleDirectoryShare").ok_or_else(|| VZError::Internal {
                 code: -1,
@@ -347,6 +353,7 @@ impl MultipleDirectoryShare {
     /// * `name` - The name the directory will appear as in the guest
     /// * `directory` - The shared directory to add
     pub fn add(&mut self, name: &str, directory: SharedDirectory) -> &mut Self {
+        // SAFETY: self.inner is a valid VZMultipleDirectoryShare. Sending setObject:forKey: to its directories NSMutableDictionary.
         unsafe {
             // Get the directories dictionary
             let dirs: *mut AnyObject = msg_send!(self.inner, directories);
@@ -443,6 +450,7 @@ pub struct VirtioFileSystemDeviceConfiguration {
     tag: String,
 }
 
+// SAFETY: Inner ObjC pointer is only used via msg_send! which dispatches to the ObjC runtime.
 unsafe impl Send for VirtioFileSystemDeviceConfiguration {}
 
 impl VirtioFileSystemDeviceConfiguration {
@@ -465,6 +473,7 @@ impl VirtioFileSystemDeviceConfiguration {
             ));
         }
 
+        // SAFETY: ObjC alloc/init on valid VZVirtioFileSystemDeviceConfiguration class. Tag is validated via validateTag:error: before use.
         unsafe {
             let cls = get_class("VZVirtioFileSystemDeviceConfiguration").ok_or_else(|| {
                 VZError::Internal {
@@ -546,6 +555,7 @@ impl VirtioFileSystemDeviceConfiguration {
     ///
     /// * `share` - The directory share configuration
     pub fn set_share<S: DirectoryShare>(&mut self, share: S) -> &mut Self {
+        // SAFETY: self.inner is a valid VZVirtioFileSystemDeviceConfiguration. share.into_ptr() provides a valid directory share object.
         unsafe {
             let set_sel = objc2::sel!(setShare:);
             let set_fn: unsafe extern "C" fn(*mut AnyObject, objc2::runtime::Sel, *mut AnyObject) =
@@ -629,11 +639,13 @@ pub struct LinuxRosettaDirectoryShare {
     inner: *mut AnyObject,
 }
 
+// SAFETY: Inner ObjC pointer is only used via msg_send! which dispatches to the ObjC runtime.
 unsafe impl Send for LinuxRosettaDirectoryShare {}
 
 impl LinuxRosettaDirectoryShare {
     /// Checks the availability of Rosetta on this system.
     pub fn availability() -> RosettaAvailability {
+        // SAFETY: cls is a valid VZLinuxRosettaDirectoryShare class pointer from get_class. Sending availability to it.
         unsafe {
             let cls = match get_class("VZLinuxRosettaDirectoryShare") {
                 Some(c) => c,
@@ -672,6 +684,7 @@ impl LinuxRosettaDirectoryShare {
             )));
         }
 
+        // SAFETY: ObjC new on valid VZLinuxRosettaDirectoryShare class. Availability is checked above. retain prevents autorelease.
         unsafe {
             let cls =
                 get_class("VZLinuxRosettaDirectoryShare").ok_or_else(|| VZError::Internal {

--- a/hypervisor/arcbox-vz/src/device/network.rs
+++ b/hypervisor/arcbox-vz/src/device/network.rs
@@ -11,6 +11,7 @@ pub struct NetworkDeviceConfiguration {
     inner: *mut AnyObject,
 }
 
+// SAFETY: Inner ObjC pointer is only used via msg_send! which dispatches to the ObjC runtime.
 unsafe impl Send for NetworkDeviceConfiguration {}
 
 impl NetworkDeviceConfiguration {
@@ -43,6 +44,7 @@ impl NetworkDeviceConfiguration {
 
     /// Creates a network device with the given attachment.
     fn with_attachment(attachment: *mut AnyObject) -> VZResult<Self> {
+        // SAFETY: ObjC new on valid VZVirtioNetworkDeviceConfiguration class. Result is checked non-null.
         unsafe {
             let cls = get_class("VZVirtioNetworkDeviceConfiguration").ok_or_else(|| {
                 VZError::Internal {
@@ -92,6 +94,7 @@ impl Drop for NetworkDeviceConfiguration {
 // ============================================================================
 
 fn create_file_handle_attachment(file_handle: *mut AnyObject) -> VZResult<*mut AnyObject> {
+    // SAFETY: ObjC alloc/init on valid VZFileHandleNetworkDeviceAttachment. ObjC exceptions are caught to prevent abort.
     unsafe {
         let cls =
             get_class("VZFileHandleNetworkDeviceAttachment").ok_or_else(|| VZError::Internal {
@@ -144,6 +147,7 @@ fn create_file_handle_attachment(file_handle: *mut AnyObject) -> VZResult<*mut A
 }
 
 fn create_nat_attachment() -> VZResult<*mut AnyObject> {
+    // SAFETY: ObjC new on valid VZNATNetworkDeviceAttachment class. Result is checked non-null.
     unsafe {
         let cls = get_class("VZNATNetworkDeviceAttachment").ok_or_else(|| VZError::Internal {
             code: -1,
@@ -163,6 +167,7 @@ fn create_nat_attachment() -> VZResult<*mut AnyObject> {
 }
 
 fn create_random_mac() -> VZResult<*mut AnyObject> {
+    // SAFETY: Sending randomLocallyAdministeredAddress to valid VZMACAddress class.
     unsafe {
         let cls = get_class("VZMACAddress").ok_or_else(|| VZError::Internal {
             code: -1,

--- a/hypervisor/arcbox-vz/src/device/serial.rs
+++ b/hypervisor/arcbox-vz/src/device/serial.rs
@@ -13,6 +13,7 @@ pub struct SerialPortConfiguration {
     fds: Option<(RawFd, RawFd)>,
 }
 
+// SAFETY: Inner ObjC pointer is only used via msg_send! which dispatches to the ObjC runtime.
 unsafe impl Send for SerialPortConfiguration {}
 
 impl SerialPortConfiguration {
@@ -25,6 +26,7 @@ impl SerialPortConfiguration {
         let mut input_pipe: [libc::c_int; 2] = [0, 0];
         let mut output_pipe: [libc::c_int; 2] = [0, 0];
 
+        // SAFETY: libc::pipe creates valid fd pairs. File handles are created from valid fds. ObjC objects follow alloc/init pattern with null checks.
         unsafe {
             if libc::pipe(input_pipe.as_mut_ptr()) != 0 {
                 return Err(VZError::OperationFailed(
@@ -132,6 +134,7 @@ fn create_serial_port_attachment(
     read_handle: *mut AnyObject,
     write_handle: *mut AnyObject,
 ) -> VZResult<*mut AnyObject> {
+    // SAFETY: ObjC alloc/init on valid VZFileHandleSerialPortAttachment class with valid NSFileHandle objects.
     unsafe {
         let cls =
             get_class("VZFileHandleSerialPortAttachment").ok_or_else(|| VZError::Internal {

--- a/hypervisor/arcbox-vz/src/device/socket.rs
+++ b/hypervisor/arcbox-vz/src/device/socket.rs
@@ -12,11 +12,13 @@ pub struct SocketDeviceConfiguration {
     inner: *mut AnyObject,
 }
 
+// SAFETY: Inner ObjC pointer is only used via msg_send! which dispatches to the ObjC runtime.
 unsafe impl Send for SocketDeviceConfiguration {}
 
 impl SocketDeviceConfiguration {
     /// Creates a new socket device configuration.
     pub fn new() -> VZResult<Self> {
+        // SAFETY: ObjC new on valid VZVirtioSocketDeviceConfiguration class. Result is checked non-null.
         unsafe {
             let cls = get_class("VZVirtioSocketDeviceConfiguration").ok_or_else(|| {
                 VZError::Internal {

--- a/hypervisor/arcbox-vz/src/device/storage.rs
+++ b/hypervisor/arcbox-vz/src/device/storage.rs
@@ -13,6 +13,7 @@ pub struct StorageDeviceConfiguration {
     inner: *mut AnyObject,
 }
 
+// SAFETY: Inner ObjC pointer is only used via msg_send! which dispatches to the ObjC runtime.
 unsafe impl Send for StorageDeviceConfiguration {}
 
 impl StorageDeviceConfiguration {
@@ -34,6 +35,7 @@ impl StorageDeviceConfiguration {
 
     /// Creates a storage device with the given attachment.
     fn with_attachment(attachment: *mut AnyObject) -> VZResult<Self> {
+        // SAFETY: ObjC alloc/init on valid VZVirtioBlockDeviceConfiguration class with a valid attachment pointer.
         unsafe {
             let cls =
                 get_class("VZVirtioBlockDeviceConfiguration").ok_or_else(|| VZError::Internal {
@@ -76,6 +78,7 @@ impl Drop for StorageDeviceConfiguration {
 // ============================================================================
 
 fn create_disk_attachment(path: &str, read_only: bool) -> VZResult<*mut AnyObject> {
+    // SAFETY: ObjC alloc/init on valid VZDiskImageStorageDeviceAttachment class. NSURL from validated path. Error out-parameter is checked.
     unsafe {
         let cls =
             get_class("VZDiskImageStorageDeviceAttachment").ok_or_else(|| VZError::Internal {

--- a/hypervisor/arcbox-vz/src/ffi/block.rs
+++ b/hypervisor/arcbox-vz/src/ffi/block.rs
@@ -164,6 +164,7 @@ unsafe extern "C" fn vsock_block_copy(_dst: *mut c_void, _src: *const c_void) {
 /// When a block is released, this function is called.
 /// We need to drop the sender if it hasn't been used.
 unsafe extern "C" fn vsock_block_dispose(block: *mut c_void) {
+    // SAFETY: block is a valid VsockContextBlock pointer provided by the block runtime. sender_ptr is either null (already consumed) or a valid Box pointer from create_vsock_context_block.
     unsafe {
         let block = block as *mut VsockContextBlock;
         let sender_ptr = (*block).sender_ptr;
@@ -182,6 +183,7 @@ unsafe extern "C" fn vsock_block_invoke(
     connection: *mut AnyObject,
     error: *mut AnyObject,
 ) {
+    // SAFETY: block is a valid VsockContextBlock pointer invoked by Virtualization.framework. sender_ptr was set by create_vsock_context_block. We take ownership via Box::from_raw and null out the pointer to prevent double-free in dispose.
     unsafe {
         let sender_ptr = (*block).sender_ptr;
         if sender_ptr.is_null() {
@@ -270,6 +272,7 @@ pub fn create_vsock_context_block(sender: oneshot::Sender<VsockResult>) -> *cons
     let sender_box = Box::new(sender);
     let sender_ptr = Box::into_raw(sender_box) as *mut c_void;
 
+    // SAFETY: Constructing a stack block with the correct ABI layout (isa, flags, invoke, descriptor). _NSConcreteStackBlock is the correct ISA for stack-allocated blocks. _Block_copy copies it to the heap, making the returned pointer valid for the block's lifetime.
     unsafe {
         // Create block on stack
         let stack_block = VsockContextBlock {
@@ -290,6 +293,7 @@ pub fn create_vsock_context_block(sender: oneshot::Sender<VsockResult>) -> *cons
 // Block Runtime FFI
 // ============================================================================
 
+// SAFETY: These are well-known block runtime symbols provided by the system.
 unsafe extern "C" {
     /// Global block ISA for stack blocks.
     pub static _NSConcreteStackBlock: *const c_void;
@@ -308,7 +312,9 @@ unsafe extern "C" {
 /// Wrapper for block pointers that are Send + Sync.
 pub struct BlockPtr(pub *const c_void);
 
+// SAFETY: BlockPtr wraps a heap-copied block pointer that is only used as an opaque handle passed to ObjC APIs. The block is created once and never mutated.
 unsafe impl Send for BlockPtr {}
+// SAFETY: See above — the block pointer is immutable after creation.
 unsafe impl Sync for BlockPtr {}
 
 /// Standard block descriptor for simple blocks.
@@ -326,6 +332,7 @@ pub static SIMPLE_BLOCK_DESCRIPTOR: BlockDescriptor = BlockDescriptor {
 pub unsafe fn create_completion_block(
     invoke: unsafe extern "C" fn(*const c_void, *mut AnyObject),
 ) -> *const c_void {
+    // SAFETY: Constructing a stack block with correct ABI layout. _Block_copy copies to heap. Caller ensures the returned pointer is eventually released.
     unsafe {
         let stack_block = CompletionBlock {
             isa: _NSConcreteStackBlock,
@@ -348,6 +355,7 @@ pub unsafe fn create_completion_block(
 pub unsafe fn create_vsock_completion_block(
     invoke: unsafe extern "C" fn(*const c_void, *mut AnyObject, *mut AnyObject),
 ) -> *const c_void {
+    // SAFETY: Same as create_completion_block — stack block with correct ABI layout, copied to heap via _Block_copy.
     unsafe {
         let stack_block = VsockCompletionBlock {
             isa: _NSConcreteStackBlock,

--- a/hypervisor/arcbox-vz/src/ffi/dispatch.rs
+++ b/hypervisor/arcbox-vz/src/ffi/dispatch.rs
@@ -10,6 +10,7 @@ use std::ffi::c_void;
 // Dispatch FFI
 // ============================================================================
 
+// SAFETY: These are GCD (Grand Central Dispatch) FFI declarations from libdispatch, a system library always available on macOS.
 unsafe extern "C" {
     fn dispatch_queue_create(label: *const i8, attr: *const c_void) -> *mut AnyObject;
     fn dispatch_sync_f(
@@ -38,7 +39,9 @@ pub struct DispatchQueue {
     owned: bool,
 }
 
+// SAFETY: GCD dispatch queues are thread-safe by design. The inner pointer is only used to submit work via dispatch_sync_f/dispatch_async_f, which are themselves thread-safe.
 unsafe impl Send for DispatchQueue {}
+// SAFETY: See above — GCD queues are designed for concurrent use from multiple threads.
 unsafe impl Sync for DispatchQueue {}
 
 impl DispatchQueue {
@@ -46,6 +49,7 @@ impl DispatchQueue {
     #[must_use]
     pub fn new(label: &str) -> Self {
         let label_cstr = std::ffi::CString::new(label).unwrap();
+        // SAFETY: dispatch_queue_create with a valid C string label and null attr (DISPATCH_QUEUE_SERIAL) always returns a valid queue.
         let queue = unsafe {
             dispatch_queue_create(
                 label_cstr.as_ptr(),
@@ -64,6 +68,7 @@ impl DispatchQueue {
     #[must_use]
     pub fn main() -> Self {
         Self {
+            // SAFETY: _dispatch_main_q is a global symbol always available on macOS.
             inner: unsafe { _dispatch_main_q },
             owned: false,
         }
@@ -113,6 +118,7 @@ impl DispatchQueue {
         where
             F: FnOnce() -> R,
         {
+            // SAFETY: context is a valid pointer to Context<F, R> created in sync(). The closure is taken exactly once.
             unsafe {
                 let ctx = &mut *(context as *mut Context<'_, F, R>);
                 if let Some(f) = ctx.closure.take() {
@@ -126,6 +132,7 @@ impl DispatchQueue {
             result: &mut result,
         };
 
+        // SAFETY: Context lives on the caller's stack and dispatch_sync_f blocks until trampoline completes, so the reference remains valid.
         unsafe {
             dispatch_sync_f(
                 self.inner,
@@ -159,12 +166,14 @@ impl DispatchQueue {
         where
             F: FnOnce() + Send + 'static,
         {
+            // SAFETY: context is a valid pointer to a Box<F> leaked via Box::into_raw. We reclaim ownership here.
             unsafe {
                 let f = Box::from_raw(context as *mut F);
                 f();
             }
         }
 
+        // SAFETY: context is a leaked Box pointer that will be reclaimed inside the trampoline. The trampoline has the correct type for F.
         unsafe {
             dispatch_async_f(self.inner, context as *mut c_void, trampoline::<F>);
         }
@@ -174,6 +183,7 @@ impl DispatchQueue {
 impl Drop for DispatchQueue {
     fn drop(&mut self) {
         if self.owned && !self.inner.is_null() {
+            // SAFETY: We only release queues we created (owned=true). The queue pointer was returned by dispatch_queue_create.
             unsafe {
                 dispatch_release(self.inner);
             }

--- a/hypervisor/arcbox-vz/src/ffi/foundation.rs
+++ b/hypervisor/arcbox-vz/src/ffi/foundation.rs
@@ -12,6 +12,7 @@ use crate::msg_send;
 
 /// Creates an `NSString` from a Rust string.
 pub fn nsstring(s: &str) -> *mut AnyObject {
+    // SAFETY: NSString class is always available in the ObjC runtime. initWithBytes:length:encoding: is called with valid UTF-8 pointer/length from the Rust str, and encoding 4 (NSUTF8StringEncoding).
     unsafe {
         let cls = get_class("NSString").expect("NSString class not found");
         let alloc = msg_send!(cls, alloc);
@@ -33,6 +34,7 @@ pub fn nsstring_to_string(obj: *mut AnyObject) -> String {
     if obj.is_null() {
         return String::new();
     }
+    // SAFETY: obj is checked non-null above. UTF8String returns a null-terminated C string valid for the lifetime of the NSString.
     unsafe {
         let sel_utf8 = objc2::sel!(UTF8String);
         let func: unsafe extern "C" fn(*const AnyObject, objc2::runtime::Sel) -> *const i8 =
@@ -65,6 +67,7 @@ pub fn nsurl_file_path(path: &str) -> *mut AnyObject {
             .unwrap_or_else(|_| path.to_string())
     };
 
+    // SAFETY: NSURL and NSString classes are always available. fileURLWithPath: receives a valid NSString. retain prevents premature autorelease.
     unsafe {
         let cls = get_class("NSURL").expect("NSURL class not found");
         let path_str = nsstring(&abs_path);
@@ -81,6 +84,7 @@ pub fn nsurl_file_path(path: &str) -> *mut AnyObject {
 
 /// Creates an `NSArray` from raw pointers.
 pub fn nsarray(objects: &[*mut AnyObject]) -> *mut AnyObject {
+    // SAFETY: NSArray class is always available. arrayWithObjects:count: receives a valid pointer to the objects slice and its length.
     unsafe {
         let cls = get_class("NSArray").expect("NSArray class not found");
         let sel = objc2::sel!(arrayWithObjects:count:);
@@ -99,6 +103,7 @@ pub fn nsarray_count(array: *mut AnyObject) -> usize {
     if array.is_null() {
         return 0;
     }
+    // SAFETY: array is checked non-null above. Sending count to a valid NSArray object.
     unsafe {
         let sel = objc2::sel!(count);
         let func: unsafe extern "C" fn(*const AnyObject, objc2::runtime::Sel) -> usize =
@@ -112,6 +117,7 @@ pub fn nsarray_object_at_index(array: *mut AnyObject, index: usize) -> *mut AnyO
     if array.is_null() {
         return std::ptr::null_mut();
     }
+    // SAFETY: array is checked non-null above. Caller must ensure index is within bounds.
     unsafe {
         let sel = objc2::sel!(objectAtIndex:);
         let func: unsafe extern "C" fn(
@@ -132,6 +138,7 @@ pub fn nsarray_object_at_index(array: *mut AnyObject, index: usize) -> *mut AnyO
 /// Uses `initWithFileDescriptor:closeOnDealloc:NO` to prevent `NSFileHandle`
 /// from closing the fd when deallocated.
 pub fn file_handle_for_fd(fd: i32) -> *mut AnyObject {
+    // SAFETY: NSFileHandle class is always available. initWithFileDescriptor:closeOnDealloc: is called with a caller-provided fd; closeOnDealloc:false prevents NSFileHandle from closing the fd.
     unsafe {
         let cls = get_class("NSFileHandle").expect("NSFileHandle class not found");
         let obj = msg_send!(cls, alloc);
@@ -156,12 +163,14 @@ pub fn retain(obj: *mut AnyObject) -> *mut AnyObject {
     if obj.is_null() {
         return obj;
     }
+    // SAFETY: obj is checked non-null above. Sending retain to a valid ObjC object.
     unsafe { msg_send!(obj, retain) }
 }
 
 /// Releases an Objective-C object.
 pub fn release(obj: *mut AnyObject) {
     if !obj.is_null() {
+        // SAFETY: obj is checked non-null above. Sending release to a valid ObjC object.
         unsafe {
             let _: *mut AnyObject = msg_send!(obj, release);
         }

--- a/hypervisor/arcbox-vz/src/ffi/memory.rs
+++ b/hypervisor/arcbox-vz/src/ffi/memory.rs
@@ -21,6 +21,7 @@ use std::ptr;
 ///
 /// Returns an error if mmap fails.
 pub fn allocate_memory(size: u64) -> VZResult<*mut u8> {
+    // SAFETY: mmap with MAP_PRIVATE | MAP_ANONYMOUS allocates a new anonymous mapping. Arguments are valid: null addr lets the kernel choose, size is caller-provided, fd=-1 is correct for anonymous mappings. The returned pointer is checked against MAP_FAILED.
     unsafe {
         let ptr = libc::mmap(
             ptr::null_mut(),
@@ -60,6 +61,7 @@ pub fn allocate_memory(size: u64) -> VZResult<*mut u8> {
 /// and `size` must match the size used during allocation.
 pub fn free_memory(ptr: *mut u8, size: u64) {
     if !ptr.is_null() {
+        // SAFETY: Caller guarantees ptr was returned by allocate_memory (i.e., mmap) and size matches the original allocation.
         unsafe {
             libc::munmap(ptr.cast(), size as usize);
         }
@@ -82,6 +84,7 @@ mod tests {
         assert!(!ptr.is_null());
 
         // Test we can write to it
+        // SAFETY: ptr is a valid allocation from allocate_memory, writing a single byte is within the 16MB allocation.
         unsafe {
             *ptr = 42;
             assert_eq!(*ptr, 42);
@@ -96,6 +99,7 @@ mod tests {
         let ptr = allocate_memory(size).expect("allocation failed");
 
         // Verify memory is zeroed
+        // SAFETY: ptr is a valid allocation from allocate_memory, reads are within the 4096-byte allocation.
         unsafe {
             for i in 0..size as usize {
                 assert_eq!(*ptr.add(i), 0);

--- a/hypervisor/arcbox-vz/src/ffi/mod.rs
+++ b/hypervisor/arcbox-vz/src/ffi/mod.rs
@@ -29,6 +29,7 @@ static FRAMEWORK_INIT: Once = Once::new();
 
 /// Ensures Virtualization.framework is loaded.
 fn ensure_framework_loaded() {
+    // SAFETY: dlopen loads the system Virtualization.framework. Called once via Once. dlerror is checked only when handle is null.
     FRAMEWORK_INIT.call_once(|| unsafe {
         let path = std::ffi::CString::new(
             "/System/Library/Frameworks/Virtualization.framework/Virtualization",
@@ -54,6 +55,7 @@ fn ensure_framework_loaded() {
 /// Checks if virtualization is supported on this system.
 pub fn is_supported() -> bool {
     ensure_framework_loaded();
+    // SAFETY: Sending isSupported to a valid VZVirtualMachine class pointer obtained from get_class.
     unsafe {
         let cls = match get_class("VZVirtualMachine") {
             Some(c) => c,
@@ -66,6 +68,7 @@ pub fn is_supported() -> bool {
 /// Gets the maximum supported CPU count.
 pub fn max_cpu_count() -> u64 {
     ensure_framework_loaded();
+    // SAFETY: Sending maximumAllowedCPUCount to a valid VZVirtualMachineConfiguration class pointer.
     unsafe {
         let cls = get_class("VZVirtualMachineConfiguration").unwrap();
         msg_send_u64!(cls, maximumAllowedCPUCount)
@@ -75,6 +78,7 @@ pub fn max_cpu_count() -> u64 {
 /// Gets the minimum supported CPU count.
 pub fn min_cpu_count() -> u64 {
     ensure_framework_loaded();
+    // SAFETY: Sending minimumAllowedCPUCount to a valid VZVirtualMachineConfiguration class pointer.
     unsafe {
         let cls = get_class("VZVirtualMachineConfiguration").unwrap();
         msg_send_u64!(cls, minimumAllowedCPUCount)
@@ -84,6 +88,7 @@ pub fn min_cpu_count() -> u64 {
 /// Gets the maximum supported memory size.
 pub fn max_memory_size() -> u64 {
     ensure_framework_loaded();
+    // SAFETY: Sending maximumAllowedMemorySize to a valid VZVirtualMachineConfiguration class pointer.
     unsafe {
         let cls = get_class("VZVirtualMachineConfiguration").unwrap();
         msg_send_u64!(cls, maximumAllowedMemorySize)
@@ -93,6 +98,7 @@ pub fn max_memory_size() -> u64 {
 /// Gets the minimum supported memory size.
 pub fn min_memory_size() -> u64 {
     ensure_framework_loaded();
+    // SAFETY: Sending minimumAllowedMemorySize to a valid VZVirtualMachineConfiguration class pointer.
     unsafe {
         let cls = get_class("VZVirtualMachineConfiguration").unwrap();
         msg_send_u64!(cls, minimumAllowedMemorySize)
@@ -111,6 +117,7 @@ pub fn extract_nserror(error: *mut AnyObject) -> VZError {
             message: "Unknown error".to_string(),
         };
     }
+    // SAFETY: error is checked non-null above. Sending localizedDescription and code to a valid NSError object.
     unsafe {
         let desc = msg_send!(error, localizedDescription);
         let code: i64 = msg_send_i64!(error, code);

--- a/hypervisor/arcbox-vz/src/ffi/runloop.rs
+++ b/hypervisor/arcbox-vz/src/ffi/runloop.rs
@@ -43,6 +43,7 @@ impl From<i32> for CFRunLoopRunResult {
 // FFI Declarations
 // ============================================================================
 
+// SAFETY: Core Foundation run loop FFI declarations. These functions and the kCFRunLoopDefaultMode constant are always available on macOS.
 unsafe extern "C" {
     fn CFRunLoopGetMain() -> CFRunLoopRef;
     fn CFRunLoopGetCurrent() -> CFRunLoopRef;
@@ -64,6 +65,7 @@ unsafe extern "C" {
 /// The main run loop is the run loop of the main thread.
 #[must_use]
 pub fn cf_run_loop_get_main() -> CFRunLoopRef {
+    // SAFETY: CFRunLoopGetMain always returns the valid main run loop reference.
     unsafe { CFRunLoopGetMain() }
 }
 
@@ -72,6 +74,7 @@ pub fn cf_run_loop_get_main() -> CFRunLoopRef {
 /// Each thread has its own run loop.
 #[must_use]
 pub fn cf_run_loop_get_current() -> CFRunLoopRef {
+    // SAFETY: CFRunLoopGetCurrent always returns a valid run loop for the current thread.
     unsafe { CFRunLoopGetCurrent() }
 }
 
@@ -81,6 +84,7 @@ pub fn cf_run_loop_get_current() -> CFRunLoopRef {
 /// It should not normally be used directly; prefer `run_loop_until` for
 /// most use cases.
 pub fn cf_run_loop_run() {
+    // SAFETY: CFRunLoopRun runs the current thread's run loop, no preconditions.
     unsafe { CFRunLoopRun() }
 }
 
@@ -96,6 +100,7 @@ pub fn cf_run_loop_run() {
 ///
 /// The caller must ensure `rl` is a valid `CFRunLoopRef`.
 pub unsafe fn cf_run_loop_stop(rl: CFRunLoopRef) {
+    // SAFETY: Caller guarantees rl is a valid CFRunLoopRef.
     unsafe { CFRunLoopStop(rl) }
 }
 
@@ -114,6 +119,7 @@ pub fn cf_run_loop_run_in_mode(
     seconds: f64,
     return_after_source_handled: bool,
 ) -> CFRunLoopRunResult {
+    // SAFETY: kCFRunLoopDefaultMode is a valid global CFStringRef constant. seconds and returnAfterSourceHandled are plain values.
     unsafe {
         let result =
             CFRunLoopRunInMode(kCFRunLoopDefaultMode, seconds, return_after_source_handled);

--- a/hypervisor/arcbox-vz/src/ffi/runtime.rs
+++ b/hypervisor/arcbox-vz/src/ffi/runtime.rs
@@ -14,6 +14,7 @@ use super::ensure_framework_loaded;
 pub fn get_class(name: &str) -> Option<&'static AnyClass> {
     ensure_framework_loaded();
     let name_cstr = std::ffi::CString::new(name).ok()?;
+    // SAFETY: objc_getClass returns null for unknown classes (checked below) or a valid class pointer that lives for the program's lifetime.
     unsafe {
         let cls = objc_getClass(name_cstr.as_ptr());
         if cls.is_null() {
@@ -31,6 +32,7 @@ pub fn get_class(name: &str) -> Option<&'static AnyClass> {
 // FFI function pointer for objc_msgSend.
 #[allow(improper_ctypes)]
 #[allow(missing_docs)]
+// SAFETY: objc_msgSend is the ObjC message dispatch function, always available in the ObjC runtime.
 unsafe extern "C" {
     pub fn objc_msgSend();
 }

--- a/hypervisor/arcbox-vz/src/socket.rs
+++ b/hypervisor/arcbox-vz/src/socket.rs
@@ -39,6 +39,7 @@ use tokio::sync::{mpsc, oneshot};
 // FFI Declarations
 // ============================================================================
 
+// SAFETY: dispatch_async_f is a GCD function from libdispatch, always available on macOS.
 unsafe extern "C" {
     fn dispatch_async_f(
         queue: *mut AnyObject,
@@ -61,11 +62,13 @@ struct ConnectContext {
     block: *const c_void,
 }
 
-// Safety: The pointers are only used on the VM's dispatch queue
+// SAFETY: The pointers are only used on the VM's dispatch queue
 unsafe impl Send for ConnectContext {}
 
 /// Work function executed on VM's dispatch queue.
 unsafe extern "C" fn connect_work(ctx: *mut c_void) {
+    // SAFETY: ctx is a valid pointer to a Box<ConnectContext> leaked via Box::into_raw in connect().
+    // We reclaim ownership here. objc_msgSend is called with a valid device pointer and selector.
     unsafe {
         let context = Box::from_raw(ctx as *mut ConnectContext);
 
@@ -113,7 +116,10 @@ pub struct VirtioSocketDevice {
     queue: *mut AnyObject,
 }
 
+// SAFETY: The inner ObjC pointer is only accessed via Virtualization.framework's dispatch queue.
+// queue is a thread-safe GCD queue pointer.
 unsafe impl Send for VirtioSocketDevice {}
+// SAFETY: See above — all access goes through the VM's dispatch queue.
 unsafe impl Sync for VirtioSocketDevice {}
 
 impl VirtioSocketDevice {
@@ -178,6 +184,8 @@ impl VirtioSocketDevice {
         // Dispatch connection to VM queue
         // CRITICAL: Must use dispatch_async, not dispatch_sync
         // The completion handler will be called on the same queue
+        // SAFETY: context_ptr is a leaked Box. self.queue is a valid dispatch queue.
+        // connect_work will reclaim the Box.
         unsafe {
             tracing::debug!("Dispatching connect to VM queue {:?}", self.queue);
             dispatch_async_f(self.queue, context_ptr as *mut c_void, connect_work);
@@ -189,6 +197,7 @@ impl VirtioSocketDevice {
         match tokio::time::timeout(timeout, rx).await {
             Ok(Ok(result)) => {
                 // Release the block now that we're done
+                // SAFETY: block was heap-allocated by create_vsock_context_block via _Block_copy.
                 unsafe {
                     _Block_release(block);
                 }
@@ -227,6 +236,7 @@ impl VirtioSocketDevice {
             }
             Ok(Err(_)) => {
                 // Channel was closed without sending (shouldn't happen)
+                // SAFETY: block was heap-allocated by create_vsock_context_block via _Block_copy.
                 unsafe {
                     _Block_release(block);
                 }
@@ -277,6 +287,9 @@ impl VirtioSocketDevice {
     pub fn listen(&self, port: u32) -> VZResult<VirtioSocketListener> {
         tracing::debug!("VirtioSocketDevice::listen(port={})", port);
 
+        // SAFETY: All ObjC objects are obtained from valid classes via get_class. ObjC messages
+        // use correct selectors and argument types. dispatch_sync_f blocks until completion, so
+        // stack references remain valid.
         unsafe {
             // Create VZVirtioSocketListener object
             let listener_cls =
@@ -339,9 +352,12 @@ impl VirtioSocketDevice {
                 listener: *mut AnyObject,
                 port: u32,
             }
+            // SAFETY: The ObjC pointers are only used inside set_listener_work on the VM's dispatch queue.
             unsafe impl Send for SetListenerContext {}
 
             unsafe extern "C" fn set_listener_work(ctx: *mut c_void) {
+                // SAFETY: ctx is a valid Box<SetListenerContext> pointer.
+                // Sending setSocketListener:forPort: to a valid VZVirtioSocketDevice.
                 unsafe {
                     let context = Box::from_raw(ctx as *mut SetListenerContext);
                     tracing::debug!(
@@ -375,7 +391,7 @@ impl VirtioSocketDevice {
             });
             let context_ptr = Box::into_raw(context);
 
-            // Use dispatch_sync_f to wait for completion
+            // SAFETY: dispatch_sync_f is a GCD function from libdispatch.
             unsafe extern "C" {
                 fn dispatch_sync_f(
                     queue: *mut AnyObject,
@@ -407,8 +423,8 @@ impl VirtioSocketDevice {
     pub fn remove_listener(&self, port: u32) {
         tracing::debug!("VirtioSocketDevice::remove_listener(port={})", port);
 
+        // SAFETY: Sending setSocketListener:forPort: to a valid VZVirtioSocketDevice with nil listener.
         unsafe {
-            // [device setSocketListener:nil forPort:port]
             let set_listener_sel = objc2::sel!(setSocketListener:forPort:);
             let set_listener_fn: unsafe extern "C" fn(
                 *mut AnyObject,
@@ -499,6 +515,7 @@ impl VirtioSocketConnection {
     ///
     /// The number of bytes read, or an error.
     pub fn read(&self, buf: &mut [u8]) -> std::io::Result<usize> {
+        // SAFETY: self.fd is a valid file descriptor. buf.as_mut_ptr() and buf.len() provide a valid write target.
         let n = unsafe { libc::read(self.fd, buf.as_mut_ptr() as *mut c_void, buf.len()) };
         if n < 0 {
             Err(std::io::Error::last_os_error())
@@ -519,6 +536,7 @@ impl VirtioSocketConnection {
     ///
     /// The number of bytes written, or an error.
     pub fn write(&self, buf: &[u8]) -> std::io::Result<usize> {
+        // SAFETY: self.fd is a valid file descriptor. buf.as_ptr() and buf.len() provide valid read source.
         let n = unsafe { libc::write(self.fd, buf.as_ptr() as *const c_void, buf.len()) };
         if n < 0 {
             Err(std::io::Error::last_os_error())
@@ -541,6 +559,7 @@ impl VirtioSocketConnection {
 impl Drop for VirtioSocketConnection {
     fn drop(&mut self) {
         if self.fd >= 0 {
+            // SAFETY: self.fd is a valid file descriptor obtained via dup() during connection setup.
             unsafe {
                 libc::close(self.fd);
             }
@@ -590,7 +609,7 @@ pub struct VirtioSocketListener {
     delegate: *mut AnyObject,
 }
 
-// Safety: The Objective-C objects are only accessed from the main thread
+// SAFETY: The Objective-C objects are only accessed from the main thread
 // through Virtualization.framework's internal dispatch queue.
 unsafe impl Send for VirtioSocketListener {}
 

--- a/hypervisor/arcbox-vz/src/vm.rs
+++ b/hypervisor/arcbox-vz/src/vm.rs
@@ -75,8 +75,9 @@ pub struct VirtualMachine {
     queue: DispatchQueue,
 }
 
-// Safety: The VZ handles are properly synchronized through the dispatch queue
+// SAFETY: The VZ handles are properly synchronized through the dispatch queue.
 unsafe impl Send for VirtualMachine {}
+// SAFETY: See above — all VZ operations are dispatched to the VM's serial queue.
 unsafe impl Sync for VirtualMachine {}
 
 impl VirtualMachine {
@@ -89,6 +90,7 @@ impl VirtualMachine {
 
     /// Returns the current state of the VM.
     pub fn state(&self) -> VirtualMachineState {
+        // SAFETY: self.inner is a valid VZVirtualMachine pointer. Sending state returns an i64 enum value.
         unsafe {
             let state = msg_send_i64!(self.inner, state);
             VirtualMachineState::from(state)
@@ -97,21 +99,25 @@ impl VirtualMachine {
 
     /// Returns whether the VM can be started.
     pub fn can_start(&self) -> bool {
+        // SAFETY: Sending canStart to a valid VZVirtualMachine.
         unsafe { msg_send_bool!(self.inner, canStart).as_bool() }
     }
 
     /// Returns whether the VM can be stopped.
     pub fn can_stop(&self) -> bool {
+        // SAFETY: Sending canStop to a valid VZVirtualMachine.
         unsafe { msg_send_bool!(self.inner, canStop).as_bool() }
     }
 
     /// Returns whether the VM can be paused.
     pub fn can_pause(&self) -> bool {
+        // SAFETY: Sending canPause to a valid VZVirtualMachine.
         unsafe { msg_send_bool!(self.inner, canPause).as_bool() }
     }
 
     /// Returns whether the VM can be resumed.
     pub fn can_resume(&self) -> bool {
+        // SAFETY: Sending canResume to a valid VZVirtualMachine.
         unsafe { msg_send_bool!(self.inner, canResume).as_bool() }
     }
 
@@ -119,6 +125,7 @@ impl VirtualMachine {
     #[must_use]
     pub fn can_request_stop(&self) -> bool {
         self.queue
+            // SAFETY: Sending canRequestStop to a valid VZVirtualMachine on its dispatch queue.
             .sync(|| unsafe { msg_send_bool!(self.inner, canRequestStop).as_bool() })
     }
 
@@ -142,6 +149,8 @@ impl VirtualMachine {
         // Create completion block
         static START_BLOCK: OnceLock<BlockPtr> = OnceLock::new();
 
+        // SAFETY: Constructing a stack completion block with correct ABI layout, copied to heap
+        // via _Block_copy. The block is created once and stored in OnceLock.
         let block_ptr = START_BLOCK.get_or_init(|| unsafe {
             #[repr(C)]
             struct CompletionBlock {
@@ -182,6 +191,7 @@ impl VirtualMachine {
 
         // Dispatch start to VM queue
         let inner = self.inner;
+        // SAFETY: Sending startWithCompletionHandler: to a valid VZVirtualMachine on its dispatch queue.
         self.queue.sync(|| unsafe {
             let sel = objc2::sel!(startWithCompletionHandler:);
             let func: unsafe extern "C" fn(*const AnyObject, objc2::runtime::Sel, *const c_void) =
@@ -211,6 +221,8 @@ impl VirtualMachine {
 
         // For simplicity, use polling instead of completion handler
         let inner = self.inner;
+        // SAFETY: Calling stopWithCompletionHandler: on a valid VZVirtualMachine on its dispatch
+        // queue. ObjC exceptions are caught.
         let stop_dispatch: VZResult<()> = self.queue.sync(|| unsafe {
             // Create a simple completion block
             static STOP_BLOCK: OnceLock<BlockPtr> = OnceLock::new();
@@ -226,6 +238,7 @@ impl VirtualMachine {
                 }
 
                 unsafe extern "C" fn stop_handler(_block: *const c_void, error: *mut AnyObject) {
+                    // SAFETY: error is checked non-null. Sending localizedDescription to a valid NSError.
                     unsafe {
                         if !error.is_null() {
                             let desc = msg_send!(error, localizedDescription);
@@ -300,6 +313,7 @@ impl VirtualMachine {
         }
 
         let inner = self.inner;
+        // SAFETY: Calling pauseWithCompletionHandler: on a valid VZVirtualMachine on its dispatch queue.
         self.queue.sync(|| unsafe {
             static PAUSE_BLOCK: OnceLock<BlockPtr> = OnceLock::new();
 
@@ -314,6 +328,7 @@ impl VirtualMachine {
                 }
 
                 unsafe extern "C" fn pause_handler(_block: *const c_void, error: *mut AnyObject) {
+                    // SAFETY: error is checked non-null. Sending localizedDescription to a valid NSError.
                     unsafe {
                         if !error.is_null() {
                             let desc = msg_send!(error, localizedDescription);
@@ -368,6 +383,7 @@ impl VirtualMachine {
         }
 
         let inner = self.inner;
+        // SAFETY: Calling resumeWithCompletionHandler: on a valid VZVirtualMachine on its dispatch queue.
         self.queue.sync(|| unsafe {
             static RESUME_BLOCK: OnceLock<BlockPtr> = OnceLock::new();
 
@@ -382,6 +398,7 @@ impl VirtualMachine {
                 }
 
                 unsafe extern "C" fn resume_handler(_block: *const c_void, error: *mut AnyObject) {
+                    // SAFETY: error is checked non-null. Sending localizedDescription to a valid NSError.
                     unsafe {
                         if !error.is_null() {
                             let desc = msg_send!(error, localizedDescription);
@@ -435,6 +452,7 @@ impl VirtualMachine {
             });
         }
 
+        // SAFETY: Sending requestStopWithError: to a valid VZVirtualMachine on its dispatch queue.
         self.queue.sync(|| unsafe {
             let mut error: *mut AnyObject = std::ptr::null_mut();
             let result = msg_send_bool!(self.inner, requestStopWithError: &mut error);
@@ -450,6 +468,8 @@ impl VirtualMachine {
     ///
     /// These can be used for vsock communication with the guest.
     pub fn socket_devices(&self) -> Vec<VirtioSocketDevice> {
+        // SAFETY: Sending socketDevices to a valid VZVirtualMachine. NSArray elements are valid
+        // VZVirtioSocketDevice pointers retained by the framework.
         unsafe {
             let devices: *mut AnyObject = msg_send!(self.inner, socketDevices);
             if devices.is_null() {


### PR DESCRIPTION
Add `// SAFETY:` comments to all 107 `unsafe {}` blocks and 29 `unsafe impl` declarations in `arcbox-vz/`, as required by AGENTS.md.

**Changes**: 20 files, +152 lines (comments only, no logic changes).

**Categories covered**:
- `unsafe impl Send/Sync` for ObjC pointer wrapper types
- ObjC message dispatch via `msg_send!` / `objc_msgSend`
- ObjC runtime class creation (`delegate.rs`)
- Block ABI construction and manual memory management (`block.rs`)
- Raw pointer ownership transfer (`Box::into_raw` / `Box::from_raw`)
- System calls (`mmap`, `munmap`, `pipe`, `read`, `write`, `close`, `dup`)
- GCD dispatch and Core Foundation run loop FFI
- Framework loading via `dlopen`

`cargo clippy` passes clean (6 pre-existing warnings unrelated to this change).