### PR TITLE
refactor(net): remove unnecessary unsafe from NAT translate functions

### DIFF
--- a/services/arcbox-net/src/darwin/nat.rs
+++ b/services/arcbox-net/src/darwin/nat.rs
@@ -190,18 +190,13 @@ impl DarwinNatNetwork {
 
     /// Processes a packet from a guest (TX direction).
     ///
-    /// # Safety
-    ///
-    /// The packet data must be valid.
-    ///
     /// # Errors
     ///
     /// Returns an error if translation fails.
-    pub unsafe fn process_tx_packet(&mut self, packet: &mut [u8]) -> Result<NatResult> {
+    pub fn process_tx_packet(&mut self, packet: &mut [u8]) -> Result<NatResult> {
         self.stats.record_tx(1, packet.len() as u64);
 
-        // Safety: packet data is valid per function contract
-        match unsafe { self.nat_engine.translate(packet, NatDirection::Outbound) } {
+        match self.nat_engine.translate(packet, NatDirection::Outbound) {
             Ok(result) => {
                 if result == NatResult::Translated {
                     self.stats.record_nat_translation(true);
@@ -217,18 +212,13 @@ impl DarwinNatNetwork {
 
     /// Processes a packet to a guest (RX direction).
     ///
-    /// # Safety
-    ///
-    /// The packet data must be valid.
-    ///
     /// # Errors
     ///
     /// Returns an error if translation fails.
-    pub unsafe fn process_rx_packet(&mut self, packet: &mut [u8]) -> Result<NatResult> {
+    pub fn process_rx_packet(&mut self, packet: &mut [u8]) -> Result<NatResult> {
         self.stats.record_rx(1, packet.len() as u64);
 
-        // Safety: packet data is valid per function contract
-        match unsafe { self.nat_engine.translate(packet, NatDirection::Inbound) } {
+        match self.nat_engine.translate(packet, NatDirection::Inbound) {
             Ok(result) => {
                 if result == NatResult::Translated {
                     self.stats.record_nat_translation(false);

--- a/services/arcbox-net/src/nat_backend.rs
+++ b/services/arcbox-net/src/nat_backend.rs
@@ -131,11 +131,9 @@ impl NatNetBackend {
 
             let mut packet_data = self.rx_scratch[..n].to_vec();
 
-            // Safety: packet_data is a valid Ethernet frame received from host.
-            let result = unsafe {
-                self.nat_engine
-                    .translate(&mut packet_data, NatDirection::Inbound)
-            };
+            let result = self
+                .nat_engine
+                .translate(&mut packet_data, NatDirection::Inbound);
 
             match result {
                 Ok(NatResult::Translated | NatResult::PassThrough) => {
@@ -169,11 +167,9 @@ impl NetBackend for NatNetBackend {
         // packet.data is the Ethernet frame from the guest.
         let mut frame = packet.data.clone();
 
-        // Safety: frame is a valid Ethernet frame from the guest VM.
-        let result = unsafe {
-            self.nat_engine
-                .translate(&mut frame, NatDirection::Outbound)
-        };
+        let result = self
+            .nat_engine
+            .translate(&mut frame, NatDirection::Outbound);
 
         match result {
             Ok(NatResult::Translated | NatResult::PassThrough) => self.host_io.send_packet(&frame),

--- a/services/arcbox-net/src/nat_engine/translate.rs
+++ b/services/arcbox-net/src/nat_engine/translate.rs
@@ -109,12 +109,7 @@ impl NatEngine {
     }
 
     /// Translates a packet.
-    ///
-    /// # Safety
-    ///
-    /// The packet buffer must be valid and large enough for the IP header
-    /// and transport header to be modified in place.
-    pub unsafe fn translate(
+    pub fn translate(
         &mut self,
         packet: &mut [u8],
         direction: NatDirection,
@@ -172,24 +167,19 @@ impl NatEngine {
         let src_port = u16::from_be_bytes([packet[l4_offset], packet[l4_offset + 1]]);
         let dst_port = u16::from_be_bytes([packet[l4_offset + 2], packet[l4_offset + 3]]);
 
-        // Safety: packet bounds have been validated above
         match direction {
-            NatDirection::Outbound => unsafe {
-                self.translate_outbound(
-                    packet, ip_offset, l4_offset, src_ip, dst_ip, src_port, dst_port, protocol,
-                )
-            },
-            NatDirection::Inbound => unsafe {
-                self.translate_inbound(
-                    packet, ip_offset, l4_offset, src_ip, dst_ip, src_port, dst_port, protocol,
-                )
-            },
+            NatDirection::Outbound => self.translate_outbound(
+                packet, ip_offset, l4_offset, src_ip, dst_ip, src_port, dst_port, protocol,
+            ),
+            NatDirection::Inbound => self.translate_inbound(
+                packet, ip_offset, l4_offset, src_ip, dst_ip, src_port, dst_port, protocol,
+            ),
         }
     }
 
     /// Translates an outbound packet (SNAT).
     #[allow(clippy::too_many_arguments)]
-    unsafe fn translate_outbound(
+    fn translate_outbound(
         &mut self,
         packet: &mut [u8],
         ip_offset: usize,
@@ -260,7 +250,7 @@ impl NatEngine {
 
     /// Translates an inbound packet (reverse NAT).
     #[allow(clippy::too_many_arguments)]
-    unsafe fn translate_inbound(
+    fn translate_inbound(
         &mut self,
         packet: &mut [u8],
         ip_offset: usize,
@@ -411,7 +401,7 @@ mod tests {
             6, // TCP
         );
 
-        let result = unsafe { engine.translate(&mut packet, NatDirection::Outbound) };
+        let result = engine.translate(&mut packet, NatDirection::Outbound);
         assert_eq!(result.unwrap(), NatResult::Translated);
 
         // Check source IP was changed to external IP
@@ -429,7 +419,7 @@ mod tests {
         // Source is not in internal network
         let mut packet = create_test_packet([8, 8, 4, 4], [8, 8, 8, 8], 12345, 80, 6);
 
-        let result = unsafe { engine.translate(&mut packet, NatDirection::Outbound) };
+        let result = engine.translate(&mut packet, NatDirection::Outbound);
         assert_eq!(result.unwrap(), NatResult::PassThrough);
 
         // Source IP should be unchanged
@@ -443,11 +433,9 @@ mod tests {
 
         // First create outbound connection
         let mut outbound = create_test_packet([192, 168, 64, 100], [8, 8, 8, 8], 12345, 80, 6);
-        unsafe {
-            engine
-                .translate(&mut outbound, NatDirection::Outbound)
-                .unwrap()
-        };
+        engine
+            .translate(&mut outbound, NatDirection::Outbound)
+            .unwrap();
 
         // Get the NAT port
         let nat_port = u16::from_be_bytes([outbound[34], outbound[35]]);
@@ -455,7 +443,7 @@ mod tests {
         // Create inbound response
         let mut inbound = create_test_packet([8, 8, 8, 8], [10, 0, 0, 1], 80, nat_port, 6);
 
-        let result = unsafe { engine.translate(&mut inbound, NatDirection::Inbound) };
+        let result = engine.translate(&mut inbound, NatDirection::Inbound);
         assert_eq!(result.unwrap(), NatResult::Translated);
 
         // Destination should be restored to original
@@ -469,7 +457,7 @@ mod tests {
         // Inbound packet without existing connection
         let mut packet = create_test_packet([8, 8, 8, 8], [10, 0, 0, 1], 80, 54321, 6);
 
-        let result = unsafe { engine.translate(&mut packet, NatDirection::Inbound) };
+        let result = engine.translate(&mut packet, NatDirection::Inbound);
         assert_eq!(result.unwrap(), NatResult::Dropped);
     }
 

--- a/services/arcbox-net/tests/integration_test.rs
+++ b/services/arcbox-net/tests/integration_test.rs
@@ -240,7 +240,7 @@ mod nat_engine {
         // Outbound packet
         let mut outbound = create_tcp_packet(guest_ip, server_ip, guest_port, server_port);
 
-        let result = unsafe { engine.translate(&mut outbound, NatDirection::Outbound) };
+        let result = engine.translate(&mut outbound, NatDirection::Outbound);
         assert_eq!(result.unwrap(), NatResult::Translated);
 
         // Verify SNAT: source IP changed to external
@@ -253,7 +253,7 @@ mod nat_engine {
         // Server responds
         let mut inbound = create_tcp_packet(server_ip, [203, 0, 113, 1], server_port, nat_port);
 
-        let result = unsafe { engine.translate(&mut inbound, NatDirection::Inbound) };
+        let result = engine.translate(&mut inbound, NatDirection::Inbound);
         assert_eq!(result.unwrap(), NatResult::Translated);
 
         // Verify reverse NAT: destination restored to guest
@@ -283,7 +283,7 @@ mod nat_engine {
             let src_port = (40000 + i) as u16;
 
             let mut packet = create_tcp_packet(src_ip, *dst_ip, src_port, *dst_port);
-            let result = unsafe { engine.translate(&mut packet, NatDirection::Outbound) };
+            let result = engine.translate(&mut packet, NatDirection::Outbound);
             assert_eq!(result.unwrap(), NatResult::Translated);
 
             let nat_port = u16::from_be_bytes([packet[34], packet[35]]);
@@ -308,11 +308,9 @@ mod nat_engine {
 
         // Create a connection
         let mut packet = create_tcp_packet([10, 10, 1, 1], [8, 8, 8, 8], 12345, 53);
-        unsafe {
-            engine
-                .translate(&mut packet, NatDirection::Outbound)
-                .unwrap()
-        };
+        engine
+            .translate(&mut packet, NatDirection::Outbound)
+            .unwrap();
 
         assert_eq!(engine.connection_count(), 1);
 
@@ -376,7 +374,7 @@ mod nat_engine {
         packet[34..36].copy_from_slice(&54321u16.to_be_bytes()); // src port
         packet[36..38].copy_from_slice(&53u16.to_be_bytes()); // dst port (DNS)
 
-        let result = unsafe { engine.translate(&mut packet, NatDirection::Outbound) };
+        let result = engine.translate(&mut packet, NatDirection::Outbound);
         assert_eq!(result.unwrap(), NatResult::Translated);
 
         // Source should be NATed
@@ -397,7 +395,7 @@ mod nat_engine {
             80,
         );
 
-        let result = unsafe { engine.translate(&mut packet, NatDirection::Outbound) };
+        let result = engine.translate(&mut packet, NatDirection::Outbound);
         assert_eq!(result.unwrap(), NatResult::PassThrough);
 
         // Source should be unchanged
@@ -419,7 +417,7 @@ mod nat_engine {
         packet[26..30].copy_from_slice(&[192, 168, 0, 10]);
         packet[30..34].copy_from_slice(&[8, 8, 8, 8]);
 
-        let result = unsafe { engine.translate(&mut packet, NatDirection::Outbound) };
+        let result = engine.translate(&mut packet, NatDirection::Outbound);
         assert_eq!(result.unwrap(), NatResult::PassThrough);
     }
 }
@@ -605,7 +603,7 @@ mod error_handling {
         // Packet way too short
         let mut short_packet = vec![0u8; 10];
 
-        let result = unsafe { engine.translate(&mut short_packet, NatDirection::Outbound) };
+        let result = engine.translate(&mut short_packet, NatDirection::Outbound);
 
         assert!(matches!(result, Err(TranslateError::PacketTooShort)));
     }
@@ -620,7 +618,7 @@ mod error_handling {
         packet[13] = 0x00;
         packet[14] = 0x65; // IPv6 version in IPv4 packet (invalid)
 
-        let result = unsafe { engine.translate(&mut packet, NatDirection::Outbound) };
+        let result = engine.translate(&mut packet, NatDirection::Outbound);
 
         assert!(matches!(result, Err(TranslateError::InvalidIpHeader)));
     }
@@ -635,7 +633,7 @@ mod error_handling {
         packet[13] = 0x00;
         packet[14] = 0x41; // IHL = 1 (invalid, must be >= 5)
 
-        let result = unsafe { engine.translate(&mut packet, NatDirection::Outbound) };
+        let result = engine.translate(&mut packet, NatDirection::Outbound);
 
         assert!(matches!(result, Err(TranslateError::InvalidIpHeader)));
     }
@@ -650,7 +648,7 @@ mod error_handling {
         packet[12] = 0x08;
         packet[13] = 0x06; // EtherType: ARP
 
-        let result = unsafe { engine.translate(&mut packet, NatDirection::Outbound) };
+        let result = engine.translate(&mut packet, NatDirection::Outbound);
 
         assert!(result.is_ok());
     }


### PR DESCRIPTION
## Summary

Remove unnecessary `unsafe` markers from NAT packet translation functions. All operations inside are safe slice indexing with bounds validated before access.

## Changes

- Remove `unsafe` from `translate()`, `translate_outbound()`, `translate_inbound()` in `nat_engine/translate.rs`
- Remove `unsafe` from `process_tx_packet()`, `process_rx_packet()` in `darwin/nat.rs`
- Remove all corresponding `unsafe {}` wrappers and `// Safety:` comments at 19 call sites
- Remove now-unnecessary `# Safety` doc sections

## Rationale

These functions only perform:
1. Length checks (`packet.len() < 42`)
2. Safe slice indexing (`packet[offset..offset+N]`)
3. `copy_from_slice` for in-place modification

No raw pointer dereference, no `transmute`, no FFI — the `unsafe` markers were historical artifacts with no actual soundness requirement.

## Verification

- `cargo clippy -p arcbox-net` — zero warnings
- `cargo test -p arcbox-net` — 199 tests pass (175 unit + 24 integration)