### PR TITLE
chore(ci): add release-plz for automated releases

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -1,0 +1,77 @@
+name: Release-plz
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  # Publish unpublished packages to crates.io and create GitHub release.
+  # Uses GitHub App token so that the created tag triggers release.yml.
+  release-plz-release:
+    name: Release
+    runs-on: ubuntu-latest
+    if: ${{ github.repository_owner == 'arcboxlabs' }}
+    permissions:
+      contents: write
+      pull-requests: read
+    steps:
+      - name: Generate GitHub App token
+        uses: actions/create-github-app-token@v2
+        id: app-token
+        with:
+          app-id: ${{ secrets.BOT_APP_ID }}
+          private-key: ${{ secrets.BOT_APP_PRIVATE_KEY }}
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+      - name: Run release-plz release
+        uses: release-plz/action@v0.5
+        with:
+          command: release
+        env:
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+
+  # Create/update a release PR with version bumps and changelog.
+  # Skipped when the push is a release commit (merged release PR).
+  release-plz-pr:
+    name: Release PR
+    runs-on: ubuntu-latest
+    if: |-
+      ${{
+        github.repository_owner == 'arcboxlabs'
+        && !startsWith(github.event.head_commit.message, 'chore: release')
+        && !contains(github.event.head_commit.message, 'release-plz/')
+      }}
+    permissions:
+      contents: write
+      pull-requests: write
+    concurrency:
+      group: release-plz-${{ github.ref }}
+      cancel-in-progress: false
+    steps:
+      - name: Generate GitHub App token
+        uses: actions/create-github-app-token@v2
+        id: app-token
+        with:
+          app-id: ${{ secrets.BOT_APP_ID }}
+          private-key: ${{ secrets.BOT_APP_PRIVATE_KEY }}
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+      - name: Run release-plz release-pr
+        uses: release-plz/action@v0.5
+        with:
+          command: release-pr
+        env:
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Release
+name: Release Build
 
 on:
   push:
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: 'Tag to build (e.g. v0.0.1-alpha.3)'
+        description: 'Tag to build (e.g. v0.1.5)'
         required: true
         type: string
 
@@ -25,7 +25,6 @@ jobs:
     timeout-minutes: 30
     outputs:
       version: ${{ steps.version.outputs.version }}
-      prerelease: ${{ steps.version.outputs.prerelease }}
       tarball: ${{ steps.tarball.outputs.tarball }}
 
     steps:
@@ -41,14 +40,6 @@ jobs:
             VERSION="${GITHUB_REF#refs/tags/}"
           fi
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-
-          # Detect pre-release (alpha, beta, rc)
-          if echo "$VERSION" | grep -qE '(alpha|beta|rc)'; then
-            echo "prerelease=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "prerelease=false" >> "$GITHUB_OUTPUT"
-          fi
-
           echo "Building version: $VERSION"
 
       - name: Setup Rust
@@ -58,8 +49,7 @@ jobs:
 
       - name: Install Protobuf compiler
         timeout-minutes: 5
-        run: |
-          brew install protobuf
+        run: brew install protobuf
 
       - name: Cache cargo
         uses: actions/cache@v4
@@ -77,8 +67,7 @@ jobs:
 
       - name: Build arcbox binaries (release)
         timeout-minutes: 15
-        run: |
-          cargo build --release --locked -p arcbox-cli -p arcbox-daemon
+        run: cargo build --release --locked -p arcbox-cli -p arcbox-daemon
 
       - name: Codesign arcbox-daemon with virtualization entitlement
         run: |
@@ -101,12 +90,8 @@ jobs:
           STAGING="arcbox-darwin-arm64-${VERSION}"
 
           mkdir -p "$STAGING"
-
-          # CLI + daemon binaries
           cp target/release/abctl "$STAGING/"
           cp target/release/arcbox-daemon "$STAGING/"
-
-          # Entitlements (needed for codesigning after install)
           cp tests/resources/entitlements.plist "$STAGING/"
 
           tar czf "$TARBALL_NAME" "$STAGING"
@@ -117,12 +102,10 @@ jobs:
           ls -lh "$TARBALL_NAME"
 
       - name: Generate SHA256 checksum
-        id: checksum
         run: |
           TARBALL="${{ steps.tarball.outputs.tarball }}"
           shasum -a 256 "$TARBALL" > "${TARBALL}.sha256"
           cat "${TARBALL}.sha256"
-          echo "checksum_file=${TARBALL}.sha256" >> "$GITHUB_OUTPUT"
 
       - name: Upload tarball artifact
         uses: actions/upload-artifact@v4
@@ -134,10 +117,10 @@ jobs:
           retention-days: 30
 
   # ==========================================================================
-  # Create GitHub Release
+  # Attach binaries to the existing GitHub Release (created by release-plz)
   # ==========================================================================
-  create-release:
-    name: Create Release
+  upload-release-assets:
+    name: Upload Release Assets
     needs: [build-macos-arm64]
     runs-on: ubuntu-latest
     permissions:
@@ -149,72 +132,21 @@ jobs:
         with:
           path: artifacts/
 
-      - name: List artifacts
-        run: |
-          echo "=== Downloaded artifacts ==="
-          find artifacts/ -type f -ls
-
       - name: Collect release assets
         run: |
           mkdir -p release-assets
           find artifacts/ -type f \( -name '*.tar.gz' -o -name '*.sha256' \) \
             -exec cp {} release-assets/ \;
-          echo "=== Release assets ==="
-          ls -lh release-assets/
-
-      - name: Generate combined checksums
-        run: |
           cd release-assets
           cat *.sha256 > checksums.txt
-          echo "=== checksums.txt ==="
-          cat checksums.txt
+          echo "=== Release assets ==="
+          ls -lh .
 
-      - name: Create GitHub Release
+      - name: Upload assets to GitHub Release
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ needs.build-macos-arm64.outputs.version }}
-          name: ArcBox ${{ needs.build-macos-arm64.outputs.version }}
-          prerelease: ${{ needs.build-macos-arm64.outputs.prerelease == 'true' }}
-          generate_release_notes: true
           files: |
             release-assets/*.tar.gz
             release-assets/*.sha256
             release-assets/checksums.txt
-          body: |
-            ## Installation
-
-            ### Recommended (install script)
-
-            ```bash
-            curl -fsSL https://get.arcbox.dev | bash
-            ```
-
-            ### Homebrew
-
-            ```bash
-            brew install --formula https://raw.githubusercontent.com/${{ github.repository }}/${{ needs.build-macos-arm64.outputs.version }}/Formula/arcbox.rb
-            ```
-
-            ### Manual tarball install (macOS Apple Silicon)
-
-            ```bash
-            curl -LO https://github.com/${{ github.repository }}/releases/download/${{ needs.build-macos-arm64.outputs.version }}/${{ needs.build-macos-arm64.outputs.tarball }}
-            tar xzf ${{ needs.build-macos-arm64.outputs.tarball }}
-            cd arcbox-darwin-arm64-${{ needs.build-macos-arm64.outputs.version }}
-
-            # Re-sign daemon with virtualization entitlement
-            codesign --entitlements entitlements.plist --force -s - arcbox-daemon
-
-            # Install binaries
-            sudo cp abctl /usr/local/bin/
-            sudo cp arcbox-daemon /usr/local/bin/
-
-            # Download runtime boot assets
-            abctl boot prefetch
-            ```
-
-            ### Verify checksums
-
-            ```bash
-            shasum -a 256 -c checksums.txt
-            ```

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,0 +1,50 @@
+[workspace]
+# macOS-only codebase; CI publishes from ubuntu — skip build verification.
+publish_no_verify = true
+# Pre-1.0: no semver checking.
+semver_check = false
+# Per-crate tags and GitHub releases are noisy for a 20-crate workspace.
+# Only the facade crate (arcbox) creates a tag and release.
+git_release_enable = false
+git_tag_enable = false
+changelog_update = true
+pr_name = "chore: release v{{ version }}"
+release_commits = "^(feat|fix|perf|refactor|docs|chore)"
+pr_branch_prefix = "release-plz/"
+
+[changelog]
+body = """
+{% for group, commits in commits | group_by(attribute="group") -%}
+### {{ group | upper_first }}
+{%- for commit in commits %}
+- {{ commit.message | upper_first }} ({%- if commit.remote.pr_number -%}[#{{ commit.remote.pr_number }}](https://github.com/arcboxlabs/arcbox/pull/{{ commit.remote.pr_number }}){%- else -%}{{ commit.id | truncate(length=7, end="") }}{%- endif -%})
+{%- endfor %}
+
+{%- endfor %}
+"""
+commit_parsers = [
+    { message = "^feat", group = "Features" },
+    { message = "^fix", group = "Bug Fixes" },
+    { message = "^perf", group = "Performance" },
+    { message = "^refactor", group = "Refactor" },
+    { message = "^docs", group = "Documentation" },
+    { message = "^chore\\(release\\)", skip = true },
+    { message = "^chore: release", skip = true },
+    { message = "^chore", group = "Miscellaneous" },
+]
+
+# ── Facade crate: single tag + GitHub release ────────────────────────
+[[package]]
+name = "arcbox"
+git_tag_enable = true
+git_tag_name = "v{{ version }}"
+git_release_enable = true
+git_release_name = "v{{ version }}"
+changelog_path = "CHANGELOG.md"
+
+# ── Guest agent: Linux cross-compile target, not published ───────────
+[[package]]
+name = "arcbox-agent"
+publish = false
+release = false
+changelog_update = false


### PR DESCRIPTION
## Summary

- Add `release-plz.toml` workspace configuration
- Add `release-plz.yml` GitHub Actions workflow (release + release-pr)
- Simplify `release.yml` to attach binaries to existing GitHub Release

## How it works

1. Push to `master` → `release-plz-pr` job creates/updates a Release PR (version bump + CHANGELOG)
2. Merge Release PR → `release-plz-release` job publishes to crates.io, creates git tag (`v{{ version }}`), creates GitHub Release
3. Tag push → `release.yml` builds macOS binaries and attaches to the GitHub Release

## Anti-loop

- `release-plz-pr` job is skipped when the commit message starts with `chore: release` (the release PR merge commit)
- `GITHUB_TOKEN` cannot trigger other workflows, so release-plz's tag/commit won't re-trigger CI

## Configuration

| Setting | Value |
|---------|-------|
| `publish_no_verify` | `true` (macOS codebase, CI on ubuntu) |
| `semver_check` | `false` (pre-1.0) |
| Git tag/release | Only `arcbox` facade crate (`v{{ version }}`) |
| `arcbox-agent` | `publish = false` (Linux cross-compile target) |

## Required secrets

- `CARGO_REGISTRY_TOKEN` — crates.io API token (needs to be added to repo secrets)