### PR TITLE
fix(docker): harden restart networking and canonical resolution

### DIFF
--- a/app/arcbox-docker/src/handlers/container.rs
+++ b/app/arcbox-docker/src/handlers/container.rs
@@ -131,17 +131,14 @@ pub async fn restart_container(
 ) -> Result<Response> {
     let response = proxy(&state, &uri, req).await?;
 
-    // Docker restart returns 204 on success.
-    // Resolve canonical ID after proxy — restart doesn't have --rm auto-remove,
-    // and resolving after ensures the VM is ready (proxy calls ensure_vm_ready).
+    // Docker restart returns 204 on success. Refresh DNS (container may get
+    // a new IP) with a single inspect call for both canonical ID and DNS info.
+    // Port forwarding targets the guest VM and survives container restarts.
     if response.status().as_u16() == 204 {
-        if let Some(canonical) = resolve_canonical_from_uri(&state, &uri).await {
-            // Port forwarding targets the guest VM (not the container IP) and
-            // `docker restart` never changes port bindings, so forwarding
-            // rules survive a restart and do not need to be rebuilt.
-            //
-            // Only refresh DNS — the container may get a new IP after restart.
-            if let Some(body_bytes) = inspect_container_body(&state, &canonical).await {
+        if let Some(id) = extract_container_id(&uri) {
+            let _ = state.runtime.ensure_vm_ready().await;
+            if let Some(body_bytes) = inspect_container_body(&state, &id).await {
+                let canonical = canonical_id_or_fallback(&id, &body_bytes);
                 if let Some((name, ip)) = extract_container_dns_info(&body_bytes) {
                     state.runtime.register_dns(&canonical, &name, ip).await;
                 }


### PR DESCRIPTION
## Summary

Follow-up to #50. Addresses two findings from review:

- **restart_container**: previously tore down old port forwarding + DNS *before* re-inspecting, so a transient inspect failure would leave the container permanently unreachable. Now inspects first; only stops old port forwarding after a successful inspect. DNS uses `register_dns` (which overwrites) so no explicit deregister is needed. If inspect fails, old networking stays intact.

- **resolve_canonical_from_uri**: moved `ensure_vm_ready()` into this shared function so all pre-proxy canonical resolution callers (`stop_container`, `kill_container`, `remove_container`, `rename_container`) are covered. Previously only `kill_container` had the guard, while the others could silently skip networking teardown on a cold VM.

## Test plan

- [ ] `cargo check -p arcbox-docker`
- [ ] `docker restart` with transient guest unavailability preserves old networking
- [ ] `docker stop/kill/rm` on cold VM still cleans up networking