### PR TITLE
fix(helper): move expression-level #[allow] to function level

### DIFF
--- a/app/arcbox-helper/src/server/peer_auth.rs
+++ b/app/arcbox-helper/src/server/peer_auth.rs
@@ -143,6 +143,7 @@ mod security {
     }
 
     /// Creates a CFString from a Rust &str. Caller must CFRelease.
+    #[allow(clippy::cast_possible_wrap)]
     unsafe fn cf_string(s: &str) -> CFStringRef {
         #[link(name = "CoreFoundation", kind = "framework")]
         unsafe extern "C" {
@@ -161,7 +162,6 @@ mod security {
             CFStringCreateWithBytes(
                 K_CF_ALLOCATOR_DEFAULT,
                 s.as_ptr(),
-                #[allow(clippy::cast_possible_wrap)]
                 s.len() as isize,
                 K_CF_STRING_ENCODING_UTF8,
                 0,


### PR DESCRIPTION
## Summary
- `#[allow(clippy::cast_possible_wrap)]` on a function argument is an unstable expression attribute (`stmt_expr_attributes`), fails on stable Rust
- Move the allow to the enclosing function
- Fixes release build failure for v0.3.0

## Test plan
- [x] `cargo build -p arcbox-helper --release` passes