### PR TITLE
fix(agent): disable jailer and update sandbox paths

### DIFF
--- a/guest/arcbox-agent/src/config.rs
+++ b/guest/arcbox-agent/src/config.rs
@@ -9,6 +9,9 @@
 
 use arcbox_vm::VmmConfig;
 use arcbox_vm::config::{DefaultVmConfig, FirecrackerConfig, GrpcConfig, NetworkConfig};
+// JailerConfig will be needed once jailer is re-enabled.
+#[allow(unused_imports)]
+use arcbox_vm::config::JailerConfig;
 
 /// Guest-specific VMM configuration defaults.
 ///
@@ -16,9 +19,21 @@ use arcbox_vm::config::{DefaultVmConfig, FirecrackerConfig, GrpcConfig, NetworkC
 fn guest_defaults() -> VmmConfig {
     VmmConfig {
         firecracker: FirecrackerConfig {
-            binary: "/usr/local/bin/firecracker".into(),
+            binary: "/arcbox/bin/firecracker".into(),
+            // TODO: re-enable jailer once /srv/jailer exists in EROFS rootfs.
+            // jailer: Some(JailerConfig {
+            //     binary: "/arcbox/bin/jailer".into(),
+            //     uid: 0,
+            //     gid: 0,
+            //     chroot_base_dir: None,
+            //     netns: None,
+            //     new_pid_ns: false,
+            //     cgroup_version: None,
+            //     parent_cgroup: None,
+            //     resource_limits: vec![],
+            // }),
             jailer: None,
-            data_dir: "/var/lib/arcbox/sandboxes".into(),
+            data_dir: "/var/lib/arcbox".into(),
             log_level: None,
             no_seccomp: false,
             seccomp_filter: None,
@@ -39,9 +54,9 @@ fn guest_defaults() -> VmmConfig {
         defaults: DefaultVmConfig {
             vcpus: 1,
             memory_mib: 512,
-            kernel: "/var/lib/arcbox/kernel/vmlinux".into(),
-            rootfs: "/var/lib/arcbox/images/sandbox.ext4".into(),
-            boot_args: "console=ttyS0 reboot=k panic=1 pci=off".into(),
+            kernel: "/arcbox/bin/vmlinux".into(),
+            rootfs: "/arcbox/bin/sandbox.ext4".into(),
+            boot_args: "console=ttyS0 reboot=k panic=1 pci=off init=/sbin/vm-agent".into(),
         },
     }
 }


### PR DESCRIPTION
## Summary
- Disable jailer config in guest agent defaults (requires `/srv/jailer` in EROFS rootfs which doesn't exist yet)
- Update binary paths to `/arcbox/bin/` (virtiofs mount from host)
- Fix `data_dir` to `/var/lib/arcbox` to avoid double "sandboxes" in path

## Related
- Linear: ABX-194

## Test plan
- [ ] Verify guest agent starts without jailer
- [ ] Confirm sandbox paths resolve correctly under virtiofs mount