### PR TITLE
fix(cli): remove sfltool resetbtm, fix plist leak, rename app to ArcBox

### DIFF
--- a/.agents/skills/local-dev.md
+++ b/.agents/skills/local-dev.md
@@ -96,7 +96,7 @@ Only `arcbox-daemon` needs Developer ID signing. The other binaries:
 
 ### DNS port 5553 already in use
 
-ArcBox Desktop's daemon binds 5553. Dev daemon fails silently.
+ArcBox's daemon binds 5553. Dev daemon fails silently.
 
 ```bash
 lsof -i :5553

--- a/app/arcbox-cli/src/commands/doctor.rs
+++ b/app/arcbox-cli/src/commands/doctor.rs
@@ -223,7 +223,7 @@ fn check_helper() -> CheckResult {
     }
 
     // Check binary exists in expected location.
-    let helper_path = "/Applications/ArcBox Desktop.app/Contents/Library/HelperTools/ArcBoxHelper";
+    let helper_path = "/Applications/ArcBox.app/Contents/Library/HelperTools/ArcBoxHelper";
     if std::path::Path::new(helper_path).exists() {
         CheckResult::Pass("running".into())
     } else {

--- a/app/arcbox-cli/src/commands/uninstall.rs
+++ b/app/arcbox-cli/src/commands/uninstall.rs
@@ -38,8 +38,7 @@ pub async fn execute(args: UninstallArgs) -> Result<()> {
     } else {
         println!("  • Remove ALL app data (~/.arcbox) including containers");
     }
-    println!("  • Remove app (/Applications/ArcBox Desktop.app)");
-    println!("  • Reset login item approvals (System Settings)   [sudo]");
+    println!("  • Remove app (/Applications/ArcBox.app)");
     println!();
 
     if !args.yes {
@@ -61,7 +60,7 @@ pub async fn execute(args: UninstallArgs) -> Result<()> {
     }
 
     let mut step = 0u32;
-    let total = 10u32;
+    let total = 9u32;
 
     macro_rules! step {
         ($label:expr, $body:expr) => {
@@ -79,10 +78,11 @@ pub async fn execute(args: UninstallArgs) -> Result<()> {
         };
     }
 
-    // 1. Quit the app.
-    step!("Quitting ArcBox Desktop...", {
+    // 1. Quit the app (triggers SMAppService.unregister() via the app's
+    //    termination handler, clearing the BTM / Login Items entry).
+    step!("Quitting ArcBox...", {
         let _ = Command::new("osascript")
-            .args(["-e", r#"quit app "ArcBox Desktop""#])
+            .args(["-e", r#"quit app "ArcBox""#])
             .output();
         // Wait for app to quit and daemon to stop.
         std::thread::sleep(std::time::Duration::from_secs(3));
@@ -105,6 +105,9 @@ pub async fn execute(args: UninstallArgs) -> Result<()> {
         let _ = Command::new("pkill")
             .args(["-f", "com.apple.Virtualization.VirtualMachine"])
             .output();
+        // Remove the daemon launchd plist.
+        let plist = home.join("Library/LaunchAgents/com.arcboxlabs.desktop.daemon.plist");
+        let _ = std::fs::remove_file(plist);
     });
 
     // 3. Stop and remove helper.
@@ -207,15 +210,7 @@ pub async fn execute(args: UninstallArgs) -> Result<()> {
 
     // 9. Remove app bundle.
     step!("Removing app...", {
-        let _ = std::fs::remove_dir_all("/Applications/ArcBox Desktop.app");
-    });
-
-    // 10. Reset login item approvals (SMAppService / BTM database).
-    //     This clears the "Allow in the Background" toggles in System
-    //     Settings → General → Login Items for both the daemon and helper,
-    //     so a reinstall starts with a clean approval state.
-    step!("Resetting login item approvals...   [sudo]", {
-        let _ = Command::new("sudo").args(["sfltool", "resetbtm"]).output();
+        let _ = std::fs::remove_dir_all("/Applications/ArcBox.app");
     });
 
     println!("\nArcBox has been uninstalled.");

--- a/app/arcbox-daemon/src/startup/assets.rs
+++ b/app/arcbox-daemon/src/startup/assets.rs
@@ -10,8 +10,8 @@ use tracing::info;
 
 /// Returns the `Contents/` directory if the daemon is running inside an app bundle.
 ///
-/// Layout: `ArcBox Desktop.app/Contents/Helpers/com.arcboxlabs.desktop.daemon`
-/// → returns `ArcBox Desktop.app/Contents/`
+/// Layout: `ArcBox.app/Contents/Helpers/com.arcboxlabs.desktop.daemon`
+/// → returns `ArcBox.app/Contents/`
 pub fn find_bundle_contents() -> Option<PathBuf> {
     let exe = std::env::current_exe().ok()?;
     // exe = .../Contents/Helpers/com.arcboxlabs.desktop.daemon

--- a/app/arcbox-helper/src/validate/mod.rs
+++ b/app/arcbox-helper/src/validate/mod.rs
@@ -236,7 +236,7 @@ mod tests {
     #[test]
     fn valid_cli_targets() {
         assert!(
-            "/Applications/ArcBox Desktop.app/Contents/MacOS/xbin/docker"
+            "/Applications/ArcBox.app/Contents/MacOS/xbin/docker"
                 .parse::<CliTarget>()
                 .is_ok()
         );

--- a/docs/data-directories.md
+++ b/docs/data-directories.md
@@ -5,7 +5,7 @@ manages at runtime. Paths are grouped by location and annotated with the
 component responsible for creating them.
 
 **Components**: daemon (`arcbox-daemon`), cli (`abctl`), helper (`arcbox-helper`),
-desktop (`ArcBox Desktop.app`), agent (`arcbox-agent`, runs inside the guest VM),
+desktop (`ArcBox.app`), agent (`arcbox-agent`, runs inside the guest VM),
 launchd (macOS system).
 
 ---
@@ -202,7 +202,7 @@ assets to `~/.arcbox/`. Detection logic: `app/arcbox-daemon/src/startup.rs`
 (`find_bundle_contents`).
 
 ```
-ArcBox Desktop.app/Contents/
+ArcBox.app/Contents/
 ├── Helpers/
 │   └── com.arcboxlabs.desktop.daemon     # Daemon binary
 ├── MacOS/


### PR DESCRIPTION
## Summary

- **Remove `sfltool resetbtm`** from `_uninstall` — it reset the entire macOS BTM database, wiping login item permissions for every app on the system. The desktop app's termination handler already calls `SMAppService.unregister()` when step 1 sends `osascript quit`, and macOS purges stale entries overnight once the bundle is deleted.
- **Fix daemon plist leak** — `~/Library/LaunchAgents/com.arcboxlabs.desktop.daemon.plist` was never deleted during uninstall. Now removed in step 2.
- **Rename "ArcBox Desktop" → "ArcBox"** across all code paths, tests, and docs to match the current app bundle name.

## Test plan

- [x] `cargo clippy -p arcbox-cli -p arcbox-helper -p arcbox-daemon` — zero warnings
- [x] `cargo fmt --check` — clean
- [x] `cargo test -p arcbox-helper` — all 35 tests pass (including `valid_cli_targets` with renamed path)
- [x] Manual: run `abctl _uninstall --yes` and verify no `sfltool resetbtm` is called, daemon plist is deleted, and app bundle path is `/Applications/ArcBox.app`