### PR TITLE
fix(net): add Copy bound to MpmcRing to prevent soundness hole

### DIFF
--- a/virt/arcbox-net/src/datapath/ring.rs
+++ b/virt/arcbox-net/src/datapath/ring.rs
@@ -228,18 +228,6 @@ impl<T> LockFreeRing<T> {
         count
     }
 
-    /// Tries to enqueue an item, returning immediately if full.
-    #[inline]
-    pub fn try_enqueue(&self, item: T) -> Result<(), T> {
-        self.enqueue(item)
-    }
-
-    /// Tries to dequeue an item, returning immediately if empty.
-    #[inline]
-    pub fn try_dequeue(&self) -> Option<T> {
-        self.dequeue()
-    }
-
     /// Peeks at the next item to be dequeued without removing it.
     ///
     /// # Safety
@@ -308,7 +296,7 @@ pub struct MpmcRing<T> {
 unsafe impl<T: Send> Send for MpmcRing<T> {}
 unsafe impl<T: Send> Sync for MpmcRing<T> {}
 
-impl<T> MpmcRing<T> {
+impl<T: Copy> MpmcRing<T> {
     /// Creates a new MPMC ring buffer.
     #[must_use]
     pub fn new(capacity: usize) -> Self {
@@ -415,11 +403,8 @@ impl<T> MpmcRing<T> {
     }
 }
 
-impl<T> Drop for MpmcRing<T> {
-    fn drop(&mut self) {
-        while self.dequeue().is_some() {}
-    }
-}
+// No Drop impl needed: T: Copy guarantees no destructors, and
+// Box<[UnsafeCell<MaybeUninit<T>>]> frees the buffer memory.
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
## Summary

Fixes a soundness hole in `MpmcRing::dequeue()` where `assume_init_read()` is called **before** the CAS that claims slot ownership. On CAS failure, the read value is silently dropped — for non-`Copy` types this is UB (double-drop).

```rust
// BEFORE (unsound for non-Copy T):
let item = unsafe { (*self.buffer[idx].get()).assume_init_read() };  // read
match self.tail.0.compare_exchange_weak(...) {
    Ok(_) => return Some(item),     // OK: we own it
    Err(t) => {
        tail = t;                   // BUG: `item` dropped here, but slot
        std::hint::spin_loop();     //   still "owns" the value → double-drop
    }
}
```

**Fix**: Add `T: Copy` bound to `MpmcRing<T>` impl. Copy types have no destructors, so the discard on CAS failure is safe. All current callers already use `u32`/`u64`.

Also:
- Remove `Drop` impl (no-op for Copy types — `MaybeUninit` doesn't drop contents, `Box` frees memory)
- Remove `try_enqueue`/`try_dequeue` (trivial aliases with zero callers)

Cherry-picked from the soundness fix in #66 (which targeted the now-closed #65 base branch). Supersedes #66.

## Test plan
- [x] `cargo clippy -p arcbox-net --tests` — zero errors
- [x] `cargo test -p arcbox-net -- ring` — 3 passed