### PR TITLE
fix(test): use absolute /usr/sbin/ip path in integration tests

### DIFF
--- a/virt/arcbox-vm/tests/common/mod.rs
+++ b/virt/arcbox-vm/tests/common/mod.rs
@@ -26,7 +26,7 @@ pub fn iface_exists(iface: &str) -> bool {
 /// Returns true if the kernel routing table has a route for `ip` via `dev`.
 #[cfg(target_os = "linux")]
 pub fn has_route(ip: &str, dev: &str) -> bool {
-    std::process::Command::new("ip")
+    std::process::Command::new("/usr/sbin/ip")
         .args(["route", "show", ip])
         .output()
         .map(|o| {
@@ -39,7 +39,7 @@ pub fn has_route(ip: &str, dev: &str) -> bool {
 /// Returns the point-to-point peer address configured on `iface`, if any.
 #[cfg(target_os = "linux")]
 pub fn get_peer_addr(iface: &str) -> Option<String> {
-    let output = std::process::Command::new("ip")
+    let output = std::process::Command::new("/usr/sbin/ip")
         .args(["addr", "show", "dev", iface])
         .output()
         .ok()?;

--- a/virt/arcbox-vm/tests/integration.rs
+++ b/virt/arcbox-vm/tests/integration.rs
@@ -216,7 +216,7 @@ fn multiple_taps_are_isolated() {
     );
 
     // Neither TAP is attached to a bridge (no "master" in ip link output).
-    let out1 = std::process::Command::new("ip")
+    let out1 = std::process::Command::new("/usr/sbin/ip")
         .args(["link", "show", &a1.tap_name])
         .output()
         .unwrap();


### PR DESCRIPTION
## Summary

Follow-up from PR #90 review comments. Test helpers used bare `ip` which fails in CI/root environments where PATH doesn't include `/usr/sbin`.

Changed 3 call sites in `virt/arcbox-vm/tests/` to use `/usr/sbin/ip`, consistent with the production `destroy_tap()` code.

## Test plan

- [x] `cargo clippy` + `cargo fmt`
- [ ] CI integration tests pass with absolute path