### PR TITLE
fix(net): enable sandbox TCP by seeding smoltcp neighbor cache (ABX-278)

### DIFF
--- a/virt/arcbox-net/src/darwin/datapath_loop.rs
+++ b/virt/arcbox-net/src/darwin/datapath_loop.rs
@@ -171,8 +171,9 @@ impl NetworkDatapath {
         // which is required for the TCP listen pool.
         iface.set_any_ip(true);
 
-        // Add a default route so smoltcp can send TCP replies (SYN-ACK, etc.)
-        // to the guest for connections to arbitrary external IPs.
+        // Default route via gateway_ip (self).  smoltcp's any_ip acceptance
+        // check requires `has_ip_addr(next_hop)` to be true, so the route
+        // MUST point to an interface-owned address.
         iface
             .routes_mut()
             .add_default_ipv4_route(gateway_ip)
@@ -259,11 +260,19 @@ impl NetworkDatapath {
                 // Guest → Host: read frames, classify, and dispatch.
                 readable = guest_async.readable() => {
                     let mut guard = readable?;
+                    let prev_mac = guest_mac;
                     // Drain all available frames from the FD, classifying each.
                     device.drain_guest_fd(&mut guest_mac);
                     // We drained until WouldBlock; clear readiness to avoid
                     // spinning on the biased readable arm.
                     guard.clear_ready();
+
+                    // Seed smoltcp neighbor cache as soon as guest MAC is learned.
+                    if prev_mac.is_none() {
+                        if let Some(gmac) = guest_mac {
+                            device.seed_gateway_neighbor(gateway_ip, gateway_mac, gmac);
+                        }
+                    }
 
                     // Process intercepted frames (DHCP, DNS, UDP, ICMP).
                     let intercepted = device.take_intercepted();
@@ -351,6 +360,11 @@ impl NetworkDatapath {
 
                 _ = maintenance.tick() => {
                     socket_proxy.maintenance();
+                    // Refresh the gateway → guest_mac neighbor cache entry
+                    // before it expires (ENTRY_LIFETIME = 60s, tick = 30s).
+                    if let Some(gmac) = guest_mac {
+                        device.seed_gateway_neighbor(gateway_ip, gateway_mac, gmac);
+                    }
                 }
             }
 

--- a/virt/arcbox-net/src/darwin/smoltcp_device.rs
+++ b/virt/arcbox-net/src/darwin/smoltcp_device.rs
@@ -137,6 +137,44 @@ impl SmoltcpDevice {
         self.rx_queue.push_back(frame);
     }
 
+    /// Seeds smoltcp's neighbor cache with a `gateway_ip → guest_mac` mapping.
+    ///
+    /// smoltcp's default route points to `gateway_ip` (its own interface IP) to
+    /// satisfy the `any_ip` acceptance check.  When sending TCP replies to
+    /// sandbox IPs (outside the /24 subnet), smoltcp resolves the next-hop via
+    /// ARP — but nobody answers ARP for its own IP, so replies are never sent.
+    ///
+    /// This method injects a synthetic ARP reply that teaches smoltcp
+    /// "gateway_ip lives at guest_mac", so reply frames carry the guest VM's
+    /// MAC as the Ethernet destination.  The guest kernel then forwards them
+    /// to the correct sandbox via the TAP interface.
+    ///
+    /// See [ABX-278] for the full problem description.
+    pub fn seed_gateway_neighbor(
+        &mut self,
+        gateway_ip: Ipv4Addr,
+        gateway_mac: [u8; 6],
+        guest_mac: [u8; 6],
+    ) {
+        let gw = gateway_ip.octets();
+        let mut frame = Vec::with_capacity(42);
+        // Ethernet: dst=gateway (smoltcp), src=guest
+        frame.extend_from_slice(&gateway_mac);
+        frame.extend_from_slice(&guest_mac);
+        frame.extend_from_slice(&[0x08, 0x06]); // EtherType: ARP
+        // ARP payload
+        frame.extend_from_slice(&[0x00, 0x01]); // Hardware type: Ethernet
+        frame.extend_from_slice(&[0x08, 0x00]); // Protocol type: IPv4
+        frame.push(6); // Hardware address length
+        frame.push(4); // Protocol address length
+        frame.extend_from_slice(&[0x00, 0x02]); // Operation: Reply
+        frame.extend_from_slice(&guest_mac); // Sender hardware address
+        frame.extend_from_slice(&gw); // Sender protocol address
+        frame.extend_from_slice(&gateway_mac); // Target hardware address
+        frame.extend_from_slice(&gw); // Target protocol address
+        self.rx_queue.push_back(frame);
+    }
+
     /// Takes all intercepted frames, leaving the internal buffer empty.
     pub fn take_intercepted(&mut self) -> Vec<InterceptedFrame> {
         std::mem::take(&mut self.intercepted)
@@ -651,5 +689,43 @@ mod tests {
             "Non-SYN TCP should go to rx_queue"
         );
         assert!(device.gated_syns.is_empty());
+    }
+
+    #[test]
+    fn seed_gateway_neighbor_injects_arp_reply() {
+        let gateway_ip = Ipv4Addr::new(10, 0, 2, 1);
+        let gateway_mac = [0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0x01];
+        let guest_mac = [0x02, 0x11, 0x22, 0x33, 0x44, 0x55];
+
+        let mut device = SmoltcpDevice::new(0, gateway_ip);
+        assert!(device.rx_queue.is_empty());
+
+        device.seed_gateway_neighbor(gateway_ip, gateway_mac, guest_mac);
+
+        assert_eq!(device.rx_queue.len(), 1);
+        let frame = &device.rx_queue[0];
+        assert_eq!(frame.len(), 42, "ARP frame should be 42 bytes");
+        // Ethernet header
+        assert_eq!(&frame[0..6], &gateway_mac, "Ethernet dst should be gateway");
+        assert_eq!(&frame[6..12], &guest_mac, "Ethernet src should be guest");
+        assert_eq!(&frame[12..14], &[0x08, 0x06], "EtherType should be ARP");
+        // ARP payload
+        assert_eq!(&frame[20..22], &[0x00, 0x02], "ARP opcode should be Reply");
+        assert_eq!(&frame[22..28], &guest_mac, "ARP sender MAC should be guest");
+        assert_eq!(
+            &frame[28..32],
+            &[10, 0, 2, 1],
+            "ARP sender IP should be gateway"
+        );
+        assert_eq!(
+            &frame[32..38],
+            &gateway_mac,
+            "ARP target MAC should be gateway"
+        );
+        assert_eq!(
+            &frame[38..42],
+            &[10, 0, 2, 1],
+            "ARP target IP should be gateway"
+        );
     }
 }


### PR DESCRIPTION
## Summary

Sandbox microVMs can ping external IPs but TCP connections always time out. Root cause: smoltcp's split-TCP architecture (TcpBridge) has an asymmetric path — outbound works by reading raw frame bytes and creating host sockets directly, but inbound requires smoltcp to construct reply frames and route them to `172.20.0.x` (sandbox subnet). smoltcp's default route points to `gateway_ip` (its own IP) to satisfy the `any_ip` acceptance check, so ARP resolution for the next-hop fails silently (nobody answers ARP for smoltcp's own IP).

- **`SmoltcpDevice::seed_gateway_neighbor()`**: injects a synthetic ARP reply (`gateway_ip → guest_mac`) into smoltcp's rx_queue, teaching the neighbor cache that the default next-hop resolves to the guest VM's MAC
- **First-time seeding**: triggered immediately when guest MAC is learned from the first frame
- **Periodic refresh**: every 30s via the existing maintenance tick (< 60s `ENTRY_LIFETIME`)
- Unit test verifying the 42-byte ARP reply frame format

Docker containers are unaffected (iptables MASQUERADE rewrites src to `10.0.2.2`, staying within the /24 subnet). ICMP was already working via a separate proxy that manually constructs reply frames.

Closes ABX-278

## Test plan
- [x] `curl -v http://example.com` succeeds from sandbox (TCP handshake + HTTP response)
- [x] `ping` to external IPs still works (ICMP unaffected)
- [x] Docker container networking unaffected
- [x] `cargo test -p arcbox-net` — 227 tests pass (including new `seed_gateway_neighbor_injects_arp_reply`)
- [ ] Verify sandbox `network: none` mode still boots correctly