### PR TITLE
fix(cli): link and unlink docker CLI tools in brew hooks

### DIFF
--- a/app/arcbox-cli/src/commands/docker.rs
+++ b/app/arcbox-cli/src/commands/docker.rs
@@ -3,7 +3,7 @@
 //! Manages the integration between Docker CLI and ArcBox by controlling
 //! Docker contexts and installing bundled Docker CLI tools.
 
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use std::sync::Arc;
 
 use anyhow::{Context, Result};
@@ -122,7 +122,7 @@ async fn execute_setup(format: OutputFormat) -> Result<()> {
     let arch = arcbox_asset::current_arch().to_string();
     let mut manager = HostToolManager::new(tools, &arch, runtime_bin.clone());
 
-    if let Some(xbin) = detect_bundle_xbin() {
+    if let Some(xbin) = super::symlink::detect_bundle_xbin() {
         if matches!(format, OutputFormat::Table | OutputFormat::Quiet) {
             println!("Using Docker tools from app bundle: {}", xbin.display());
         }
@@ -363,19 +363,6 @@ async fn create_or_update_symlink(target: &Path, link: &Path) -> Result<()> {
     })?;
 
     Ok(())
-}
-
-/// Detect the `xbin/` directory inside an app bundle.
-///
-/// When `abctl` is running from `Contents/MacOS/bin/abctl`, the xbin directory
-/// is at `Contents/MacOS/xbin/`. Returns `Some(path)` if the directory exists.
-fn detect_bundle_xbin() -> Option<PathBuf> {
-    let exe = std::env::current_exe().ok()?;
-    // exe = …/Contents/MacOS/bin/abctl
-    // parent = …/Contents/MacOS/bin/
-    // parent.parent = …/Contents/MacOS/
-    let xbin = exe.parent()?.parent()?.join("xbin");
-    xbin.is_dir().then_some(xbin)
 }
 
 // =============================================================================

--- a/app/arcbox-cli/src/commands/internal.rs
+++ b/app/arcbox-cli/src/commands/internal.rs
@@ -8,6 +8,8 @@
 //! app's first-launch setup, so the result is identical regardless of
 //! whether the user opens the app first or installs via `brew`.
 
+use std::path::Path;
+
 use anyhow::{Context, Result};
 use arcbox_constants::paths::{HostLayout, labels};
 use clap::Subcommand;
@@ -71,6 +73,11 @@ async fn brew_postflight() -> Result<()> {
         eprintln!("Note: Docker context setup skipped ({e})");
     }
 
+    // 4. Docker CLI tool symlinks — link each bundled tool into /usr/local/bin/
+    //    so `docker`, `docker-compose`, etc. are available immediately after
+    //    `brew install`, without requiring the user to open the app first.
+    link_docker_tools(Path::new("/usr/local/bin"));
+
     Ok(())
 }
 
@@ -112,7 +119,12 @@ async fn brew_uninstall() -> Result<()> {
     // 3. Remove shell integration — same code path as `abctl setup uninstall`.
     super::setup::execute(super::setup::SetupCommands::Uninstall, OutputFormat::Quiet).await?;
 
-    // 4. Remove run directory contents (sockets, pid, lock) so stale files
+    // 4. Remove Docker CLI tool symlinks created by brew-postflight.
+    //    Only removes links that point into an ArcBox app bundle — never
+    //    touches symlinks owned by Docker Desktop or other tools.
+    unlink_docker_tools(Path::new("/usr/local/bin"));
+
+    // 5. Remove run directory contents (sockets, pid, lock) so stale files
     //    don't confuse a future reinstall.
     let _ = tokio::fs::remove_dir_all(&layout.run_dir).await;
 
@@ -124,6 +136,44 @@ async fn brew_uninstall() -> Result<()> {
 fn setup_docker_context() -> Result<()> {
     let manager = super::docker::context_manager()?;
     manager.enable().map_err(Into::into)
+}
+
+// =============================================================================
+// Docker CLI tool symlinks (path 3)
+// =============================================================================
+
+/// Creates `{bin_dir}/{name}` → `{xbin}/{name}` symlinks for each tool in
+/// `DOCKER_CLI_TOOLS`. Non-fatal: logs a note and continues on any error.
+///
+/// This is **path 3** of the Docker CLI discovery mechanisms (see module docs).
+///
+/// `bin_dir` is injectable so tests can use a tempdir instead of `/usr/local/bin`.
+///
+/// Safety rules (mirrors helper's `cli::link`):
+/// - Skips tools whose binary is absent from the bundle.
+/// - Skips if the existing link already points to the correct target (idempotent).
+/// - Only replaces existing symlinks that point into an ArcBox bundle
+///   (`.app/Contents/MacOS/xbin/`). Never touches non-ArcBox-owned links.
+/// - Skips without error if the path exists but is not a symlink (e.g. regular file).
+fn link_docker_tools(bin_dir: &Path) {
+    let Some(xbin) = super::symlink::detect_bundle_xbin() else {
+        eprintln!("Note: Docker CLI tools not linked (xbin directory not found in app bundle)");
+        return;
+    };
+    if let Err(e) = std::fs::create_dir_all(bin_dir) {
+        eprintln!("Note: Could not create {}: {e}", bin_dir.display());
+        return;
+    }
+    super::symlink::link_all_docker_tools(&xbin, bin_dir);
+}
+
+/// Removes `{bin_dir}/{name}` for each tool in `DOCKER_CLI_TOOLS`, but only
+/// if the symlink points into an ArcBox app bundle.
+///
+/// `bin_dir` is injectable so tests can use a tempdir instead of `/usr/local/bin`.
+/// Idempotent: no-op when links are absent or owned by another tool.
+fn unlink_docker_tools(bin_dir: &Path) {
+    super::symlink::unlink_all_docker_tools(bin_dir);
 }
 
 #[cfg(test)]

--- a/app/arcbox-cli/src/commands/mod.rs
+++ b/app/arcbox-cli/src/commands/mod.rs
@@ -58,6 +58,7 @@ pub mod machine;
 pub mod migrate;
 pub mod sandbox;
 pub mod setup;
+pub mod symlink;
 #[cfg(target_os = "macos")]
 pub mod uninstall;
 pub mod version;

--- a/app/arcbox-cli/src/commands/setup.rs
+++ b/app/arcbox-cli/src/commands/setup.rs
@@ -141,7 +141,7 @@ async fn install(format: OutputFormat) -> Result<()> {
 
     // 2b. Symlink Docker CLI tools → ~/.arcbox/bin/ if available.
     //     Tools may be in the app bundle (xbin/) or ~/.arcbox/runtime/bin/.
-    let docker_tools_linked = link_docker_tools(&exe, &bin).await;
+    let docker_tools_linked = link_docker_tools_to_user_bin(&exe, &bin).await;
 
     // 3. Write shell init scripts.
     write_shell_init_scripts(&shell).await?;
@@ -536,45 +536,24 @@ async fn remove_profile_injection(shell: ShellKind) -> Result<Option<PathBuf>> {
     Ok(Some(path))
 }
 
-// =============================================================================
-// Docker tool symlinks
-// =============================================================================
-
-use arcbox_constants::paths::DOCKER_CLI_TOOLS;
-
-/// Symlink Docker CLI tools into `~/.arcbox/bin/` so they are on PATH.
+/// Links Docker tools into `~/.arcbox/bin/` (path 2, user-space, no root).
 ///
-/// This is **path 2** of two independent Docker CLI discovery mechanisms:
+/// Unlike the system-wide paths 1 & 3 which use `safe_link` with ownership
+/// checks, this writes to `~/.arcbox/bin/` which is ArcBox-owned, so
+/// `create_or_update_symlink` (unconditional replace) is safe.
 ///
-///   1. `/usr/local/bin/docker` → `.app/Contents/MacOS/xbin/docker`
-///      Created by the daemon via the privileged helper (requires root).
-///      See `arcbox-daemon/src/self_setup/cli_tools.rs`.
-///
-///   2. `~/.arcbox/bin/docker` → `xbin/docker` or `~/.arcbox/runtime/bin/docker`
-///      Created here by `abctl setup install` (no root required).
-///      Works via `~/.arcbox/bin` being on PATH (injected into shell profile).
-///
-/// Both paths are idempotent and can coexist. Path 1 takes precedence
-/// because `/usr/local/bin` is typically earlier in PATH than `~/.arcbox/bin`.
-///
-/// Searches two source locations in priority order:
-///   1. App bundle `Contents/MacOS/xbin/` (signed, matches the app version)
-///   2. `~/.arcbox/runtime/bin/` (downloaded by the daemon on first start)
-///
-/// Returns the number of tools successfully linked.
-async fn link_docker_tools(abctl_exe: &Path, user_bin: &Path) -> usize {
-    let mut linked = 0;
-
-    // Candidate source directories for Docker CLI tools.
+/// Searches xbin (app bundle) first, then `~/.arcbox/runtime/bin/` (daemon).
+async fn link_docker_tools_to_user_bin(abctl_exe: &Path, user_bin: &Path) -> usize {
     let mut candidates: Vec<PathBuf> = Vec::new();
 
-    // 1. App bundle xbin: abctl lives at Contents/MacOS/bin/abctl,
-    //    xbin is at Contents/MacOS/xbin/.
-    if let Some(bin_dir) = abctl_exe.parent() {
-        let xbin = bin_dir.parent().map(|p| p.join("xbin"));
-        if let Some(ref xbin) = xbin {
+    // 1. App bundle xbin (reuses shared detection logic).
+    if let Some(xbin) = super::symlink::detect_bundle_xbin() {
+        candidates.push(xbin);
+    } else if let Some(bin_dir) = abctl_exe.parent() {
+        // Fallback: derive from exe path (e.g. Homebrew layout).
+        if let Some(xbin) = bin_dir.parent().map(|p| p.join("xbin")) {
             if xbin.is_dir() {
-                candidates.push(xbin.clone());
+                candidates.push(xbin);
             }
         }
     }
@@ -587,7 +566,8 @@ async fn link_docker_tools(abctl_exe: &Path, user_bin: &Path) -> usize {
         }
     }
 
-    for tool_name in DOCKER_CLI_TOOLS {
+    let mut linked = 0usize;
+    for tool_name in arcbox_constants::paths::DOCKER_CLI_TOOLS {
         let link = user_bin.join(tool_name);
 
         // Skip if already a valid symlink pointing to an existing target.
@@ -602,7 +582,6 @@ async fn link_docker_tools(abctl_exe: &Path, user_bin: &Path) -> usize {
             }
         }
 
-        // Find the first candidate that has this tool.
         for src_dir in &candidates {
             let src = src_dir.join(tool_name);
             if src.is_file() {

--- a/app/arcbox-cli/src/commands/symlink.rs
+++ b/app/arcbox-cli/src/commands/symlink.rs
@@ -1,0 +1,276 @@
+//! Shared symlink helpers for Docker CLI tool management.
+//!
+//! Provides the core link/unlink logic used by multiple Docker CLI discovery
+//! paths (see `self_setup/cli_tools.rs` module docs for the full list).
+
+use std::path::{Path, PathBuf};
+use std::{fs, io, os::unix::fs as unix_fs};
+
+use arcbox_constants::paths::{DOCKER_CLI_TOOLS, is_arcbox_owned};
+
+/// Detects the `xbin/` directory inside the current app bundle.
+///
+/// When `abctl` runs from `Contents/MacOS/bin/abctl`, xbin is at
+/// `Contents/MacOS/xbin/`. Returns `None` outside an app bundle.
+pub fn detect_bundle_xbin() -> Option<PathBuf> {
+    let exe = std::env::current_exe().ok()?;
+    // exe = …/Contents/MacOS/bin/abctl
+    let xbin = exe.parent()?.parent()?.join("xbin");
+    xbin.is_dir().then_some(xbin)
+}
+
+/// Outcome of inspecting an existing path before creating a symlink.
+pub enum LinkAction {
+    /// No file exists — safe to create.
+    Create,
+    /// An ArcBox-owned symlink exists but points elsewhere — remove and recreate.
+    Replace,
+    /// Already points to the desired target — nothing to do.
+    AlreadyCurrent,
+    /// Owned by another tool or is a regular file — do not touch.
+    Skip(String),
+}
+
+/// Decides what to do with an existing path at `link` before symlinking to `target`.
+pub fn decide_link(link: &Path, target: &Path) -> LinkAction {
+    match fs::symlink_metadata(link) {
+        Ok(meta) if meta.file_type().is_symlink() => match fs::read_link(link) {
+            Ok(existing) if existing == target => LinkAction::AlreadyCurrent,
+            Ok(existing) if is_arcbox_owned(&existing) => LinkAction::Replace,
+            Ok(existing) => {
+                LinkAction::Skip(format!("owned by another tool ({})", existing.display()))
+            }
+            Err(e) => LinkAction::Skip(format!("could not read symlink: {e}")),
+        },
+        Ok(_) => LinkAction::Skip("exists and is not a symlink".into()),
+        Err(e) if e.kind() == io::ErrorKind::NotFound => LinkAction::Create,
+        Err(e) => LinkAction::Skip(format!("stat failed: {e}")),
+    }
+}
+
+/// Creates a symlink `link` → `target`, handling existing paths safely.
+///
+/// Returns `Ok(true)` if a symlink was created/replaced, `Ok(false)` if skipped
+/// (already current or owned by another tool), `Err` on I/O failure.
+#[allow(dead_code)] // Public API for future consumers (e.g. helper refactor).
+pub fn safe_link(link: &Path, target: &Path) -> Result<bool, String> {
+    match decide_link(link, target) {
+        LinkAction::AlreadyCurrent => Ok(false),
+        LinkAction::Skip(_) => Ok(false),
+        LinkAction::Replace => {
+            fs::remove_file(link)
+                .map_err(|e| format!("failed to remove {}: {e}", link.display()))?;
+            unix_fs::symlink(target, link).map_err(|e| format!("failed to create symlink: {e}"))?;
+            Ok(true)
+        }
+        LinkAction::Create => {
+            unix_fs::symlink(target, link).map_err(|e| format!("failed to create symlink: {e}"))?;
+            Ok(true)
+        }
+    }
+}
+
+/// Removes `link` if it is a symlink pointing into an ArcBox app bundle.
+///
+/// Idempotent: no-op when absent or not ArcBox-owned.
+pub fn safe_unlink(link: &Path) -> bool {
+    if let Ok(meta) = fs::symlink_metadata(link) {
+        if meta.file_type().is_symlink() {
+            if let Ok(target) = fs::read_link(link) {
+                if is_arcbox_owned(&target) {
+                    let _ = fs::remove_file(link);
+                    return true;
+                }
+            }
+        }
+    }
+    false
+}
+
+/// Links all Docker CLI tools from `xbin_dir` into `bin_dir`.
+///
+/// Returns the number of tools successfully linked.
+pub fn link_all_docker_tools(xbin_dir: &Path, bin_dir: &Path) -> usize {
+    let mut linked = 0;
+    for name in DOCKER_CLI_TOOLS {
+        let target = xbin_dir.join(name);
+        if !target.exists() {
+            continue;
+        }
+        let link = bin_dir.join(name);
+        match decide_link(&link, &target) {
+            LinkAction::AlreadyCurrent => {
+                linked += 1;
+            }
+            LinkAction::Skip(reason) => {
+                eprintln!("Note: {}/{name}: {reason}, skipping", bin_dir.display());
+            }
+            action @ (LinkAction::Create | LinkAction::Replace) => {
+                if matches!(action, LinkAction::Replace) {
+                    if let Err(e) = fs::remove_file(&link) {
+                        eprintln!("Note: could not remove {}/{name}: {e}", bin_dir.display());
+                        continue;
+                    }
+                }
+                match unix_fs::symlink(&target, &link) {
+                    Ok(()) => linked += 1,
+                    Err(e) => eprintln!("Note: could not create {}/{name}: {e}", bin_dir.display()),
+                }
+            }
+        }
+    }
+    linked
+}
+
+/// Unlinks all ArcBox-owned Docker CLI tools from `bin_dir`.
+pub fn unlink_all_docker_tools(bin_dir: &Path) {
+    for name in DOCKER_CLI_TOOLS {
+        safe_unlink(&bin_dir.join(name));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    fn make_fake_xbin(base: &Path) -> PathBuf {
+        let xbin = base.join("ArcBox.app/Contents/MacOS/xbin");
+        fs::create_dir_all(&xbin).unwrap();
+        for name in DOCKER_CLI_TOOLS {
+            fs::write(xbin.join(name), b"stub").unwrap();
+        }
+        xbin
+    }
+
+    #[test]
+    fn link_all_creates_symlinks() {
+        let tmp = tempdir().unwrap();
+        let xbin = make_fake_xbin(tmp.path());
+        let bin_dir = tmp.path().join("bin");
+        fs::create_dir_all(&bin_dir).unwrap();
+
+        let linked = link_all_docker_tools(&xbin, &bin_dir);
+        assert_eq!(linked, DOCKER_CLI_TOOLS.len());
+        for name in DOCKER_CLI_TOOLS {
+            assert!(
+                bin_dir
+                    .join(name)
+                    .symlink_metadata()
+                    .unwrap()
+                    .file_type()
+                    .is_symlink()
+            );
+            assert_eq!(fs::read_link(bin_dir.join(name)).unwrap(), xbin.join(name));
+        }
+    }
+
+    #[test]
+    fn link_all_is_idempotent() {
+        let tmp = tempdir().unwrap();
+        let xbin = make_fake_xbin(tmp.path());
+        let bin_dir = tmp.path().join("bin");
+        fs::create_dir_all(&bin_dir).unwrap();
+
+        link_all_docker_tools(&xbin, &bin_dir);
+        let linked = link_all_docker_tools(&xbin, &bin_dir);
+        assert_eq!(linked, DOCKER_CLI_TOOLS.len());
+    }
+
+    #[test]
+    fn link_all_skips_non_arcbox_symlink() {
+        let tmp = tempdir().unwrap();
+        let xbin = make_fake_xbin(tmp.path());
+        let bin_dir = tmp.path().join("bin");
+        fs::create_dir_all(&bin_dir).unwrap();
+
+        // Place a foreign symlink at docker
+        let foreign = tmp.path().join("other/docker");
+        fs::create_dir_all(foreign.parent().unwrap()).unwrap();
+        fs::write(&foreign, b"other").unwrap();
+        unix_fs::symlink(&foreign, bin_dir.join("docker")).unwrap();
+
+        let linked = link_all_docker_tools(&xbin, &bin_dir);
+        // docker skipped, rest linked
+        assert_eq!(linked, DOCKER_CLI_TOOLS.len() - 1);
+        // foreign symlink untouched
+        assert_eq!(fs::read_link(bin_dir.join("docker")).unwrap(), foreign);
+    }
+
+    #[test]
+    fn link_all_skips_regular_file() {
+        let tmp = tempdir().unwrap();
+        let xbin = make_fake_xbin(tmp.path());
+        let bin_dir = tmp.path().join("bin");
+        fs::create_dir_all(&bin_dir).unwrap();
+
+        fs::write(bin_dir.join("docker"), b"regular file").unwrap();
+
+        let linked = link_all_docker_tools(&xbin, &bin_dir);
+        assert_eq!(linked, DOCKER_CLI_TOOLS.len() - 1);
+        assert!(
+            fs::symlink_metadata(bin_dir.join("docker"))
+                .unwrap()
+                .file_type()
+                .is_file()
+        );
+    }
+
+    #[test]
+    fn link_all_replaces_stale_arcbox_symlink() {
+        let tmp = tempdir().unwrap();
+        let xbin = make_fake_xbin(tmp.path());
+        let bin_dir = tmp.path().join("bin");
+        fs::create_dir_all(&bin_dir).unwrap();
+
+        let old_xbin = tmp.path().join("Old.app/Contents/MacOS/xbin");
+        fs::create_dir_all(&old_xbin).unwrap();
+        fs::write(old_xbin.join("docker"), b"old").unwrap();
+        unix_fs::symlink(old_xbin.join("docker"), bin_dir.join("docker")).unwrap();
+
+        let linked = link_all_docker_tools(&xbin, &bin_dir);
+        assert_eq!(linked, DOCKER_CLI_TOOLS.len());
+        assert_eq!(
+            fs::read_link(bin_dir.join("docker")).unwrap(),
+            xbin.join("docker")
+        );
+    }
+
+    #[test]
+    fn unlink_all_removes_arcbox_owned() {
+        let tmp = tempdir().unwrap();
+        let xbin = make_fake_xbin(tmp.path());
+        let bin_dir = tmp.path().join("bin");
+        fs::create_dir_all(&bin_dir).unwrap();
+
+        link_all_docker_tools(&xbin, &bin_dir);
+        unlink_all_docker_tools(&bin_dir);
+
+        for name in DOCKER_CLI_TOOLS {
+            assert!(!bin_dir.join(name).exists());
+        }
+    }
+
+    #[test]
+    fn unlink_all_leaves_non_arcbox() {
+        let tmp = tempdir().unwrap();
+        let bin_dir = tmp.path().join("bin");
+        fs::create_dir_all(&bin_dir).unwrap();
+
+        let foreign = tmp.path().join("other/docker");
+        fs::create_dir_all(foreign.parent().unwrap()).unwrap();
+        fs::write(&foreign, b"other").unwrap();
+        unix_fs::symlink(&foreign, bin_dir.join("docker")).unwrap();
+
+        unlink_all_docker_tools(&bin_dir);
+        assert!(bin_dir.join("docker").exists());
+    }
+
+    #[test]
+    fn unlink_all_is_idempotent() {
+        let tmp = tempdir().unwrap();
+        let bin_dir = tmp.path().join("bin");
+        fs::create_dir_all(&bin_dir).unwrap();
+        unlink_all_docker_tools(&bin_dir); // no panic
+    }
+}

--- a/app/arcbox-helper/src/server/mutations/cli.rs
+++ b/app/arcbox-helper/src/server/mutations/cli.rs
@@ -7,14 +7,8 @@ use std::fs;
 use std::os::unix::fs as unix_fs;
 use std::path::Path;
 
+use arcbox_constants::paths::is_arcbox_owned;
 use arcbox_helper::validate::{CliName, CliTarget};
-
-/// Returns true if a symlink target looks like an ArcBox bundle path.
-fn is_arcbox_owned(target: &Path) -> bool {
-    target
-        .to_string_lossy()
-        .contains(".app/Contents/MacOS/xbin/")
-}
 
 /// Creates `/usr/local/bin/{name}` → `target`.
 ///

--- a/common/arcbox-constants/src/paths.rs
+++ b/common/arcbox-constants/src/paths.rs
@@ -64,6 +64,16 @@ pub const DOCKER_CLI_TOOLS: &[&str] = &[
     "docker-credential-osxkeychain",
 ];
 
+/// Returns true if a symlink target looks like it belongs to an ArcBox app bundle.
+///
+/// Used by multiple subsystems (privileged helper, brew hooks, setup install)
+/// to decide whether an existing `/usr/local/bin/` symlink can be safely replaced.
+pub fn is_arcbox_owned(target: &std::path::Path) -> bool {
+    target
+        .to_string_lossy()
+        .contains(".app/Contents/MacOS/xbin/")
+}
+
 /// Host-side subdirectory names within `~/.arcbox/`.
 pub mod host {
     /// Runtime state (sockets, PID files, ephemeral markers).


### PR DESCRIPTION
Brew-postflight now creates /usr/local/bin symlinks for docker, docker-buildx, docker-compose, and docker-credential-osxkeychain pointing to the bundled xbin/ directory. brew-uninstall removes them, but only if they are ArcBox-owned — symlinks belonging to Docker Desktop or other tools are left untouched.