### PR TITLE
fix(daemon): add ExitTimeOut to launchd plists to prevent SIGKILL during shutdown

### DIFF
--- a/app/arcbox-cli/src/commands/install.rs
+++ b/app/arcbox-cli/src/commands/install.rs
@@ -229,6 +229,13 @@ fn register_daemon_service() -> Result<()> {
     <true/>
     <key>KeepAlive</key>
     <true/>
+    <!--
+      ExitTimeOut: seconds launchd waits after SIGTERM before sending SIGKILL.
+      Default is 20s, but daemon shutdown needs ~35s (5s service drain + 30s VM
+      graceful stop). Set to 45s to avoid SIGKILL mid-shutdown.
+    -->
+    <key>ExitTimeOut</key>
+    <integer>45</integer>
 </dict>
 </plist>
 "#

--- a/bundle/com.arcboxlabs.desktop.helper.plist
+++ b/bundle/com.arcboxlabs.desktop.helper.plist
@@ -19,5 +19,7 @@
             <integer>438</integer>
         </dict>
     </dict>
+    <key>ExitTimeOut</key>
+    <integer>45</integer>
 </dict>
 </plist>

--- a/bundle/com.arcboxlabs.desktop.helper.plist
+++ b/bundle/com.arcboxlabs.desktop.helper.plist
@@ -19,6 +19,8 @@
             <integer>438</integer>
         </dict>
     </dict>
+    <!-- Keep a generous launchd SIGTERM-to-SIGKILL window for helper cleanup;
+         the daemon needs the full 45s for VM shutdown, while helper normally exits faster. -->
     <key>ExitTimeOut</key>
     <integer>45</integer>
 </dict>

--- a/scripts/dev.arcbox.daemon.plist
+++ b/scripts/dev.arcbox.daemon.plist
@@ -69,5 +69,13 @@
     <!-- Minimum interval between restarts (seconds) to avoid rapid restart loops -->
     <key>ThrottleInterval</key>
     <integer>5</integer>
+
+    <!--
+      ExitTimeOut: seconds launchd waits after SIGTERM before sending SIGKILL.
+      Default is 20s, but daemon shutdown needs ~35s (5s gRPC drain + 30s VM
+      graceful stop). Set to 45s to avoid SIGKILL mid-shutdown.
+    -->
+    <key>ExitTimeOut</key>
+    <integer>45</integer>
 </dict>
 </plist>


### PR DESCRIPTION
## Summary
- Add `ExitTimeOut` of 45 seconds to both launchd plist files
- Prevents launchd from SIGKILL-ing the daemon during graceful shutdown (default 20s timeout is too short for 5s gRPC drain + 30s VM stop)

## Test plan
- [ ] Verify `arcbox daemon stop` completes gracefully without SIGKILL
- [ ] Verify macOS system restart doesn't leave stale sockets

Closes ABX-237