### PR TITLE
feat(sandbox): support creating sandboxes from Dockerfiles

### DIFF
--- a/app/arcbox-cli/src/commands/sandbox.rs
+++ b/app/arcbox-cli/src/commands/sandbox.rs
@@ -86,9 +86,15 @@ pub struct CreateArgs {
     /// Kernel image path (empty = daemon default)
     #[arg(long)]
     pub kernel: Option<String>,
-    /// Root filesystem image path (empty = daemon default)
-    #[arg(long)]
+    /// Root filesystem ext4 image path (empty = daemon default)
+    #[arg(long, conflicts_with_all = ["from_dockerfile", "from_image"])]
     pub rootfs: Option<String>,
+    /// Build sandbox rootfs from a Dockerfile
+    #[arg(long, conflicts_with_all = ["rootfs", "from_image"])]
+    pub from_dockerfile: Option<String>,
+    /// Build sandbox rootfs from an existing Docker image
+    #[arg(long, conflicts_with_all = ["rootfs", "from_dockerfile"])]
+    pub from_image: Option<String>,
     /// Number of vCPUs (0 = daemon default)
     #[arg(long, default_value = "0")]
     pub cpus: u32,
@@ -249,26 +255,17 @@ async fn execute_create(args: CreateArgs) -> Result<()> {
 
     let labels = parse_labels(&args.label)?;
 
-    // Resolve rootfs: detect ext4 (use directly), Dockerfile (build+convert),
-    // or reject unrecognised formats.
-    let (rootfs, rootfs_type) = match &args.rootfs {
-        Some(path) if !path.is_empty() => {
-            let p = std::path::Path::new(path);
-            if arcbox_cli::rootfs_builder::has_ext4_magic(p) {
-                (path.clone(), String::new())
-            } else if arcbox_cli::rootfs_builder::looks_like_dockerfile(p) {
-                let (guest_path, rtype) = arcbox_cli::rootfs_builder::build_and_export(path)
-                    .await
-                    .context("Failed to build Docker image from Dockerfile")?;
-                (guest_path, rtype)
-            } else {
-                anyhow::bail!(
-                    "unrecognised rootfs format: {path}\n\
-                     Expected an ext4 image or a Dockerfile (starting with FROM)"
-                );
-            }
-        }
-        _ => (String::new(), String::new()),
+    // Resolve rootfs from whichever flag was provided.
+    let rootfs = if let Some(path) = &args.from_dockerfile {
+        arcbox_cli::rootfs_builder::resolve_from_dockerfile(path)
+            .await
+            .context("Failed to build Docker image from Dockerfile")?
+    } else if let Some(image_ref) = &args.from_image {
+        arcbox_cli::rootfs_builder::resolve_from_image(image_ref)
+            .await
+            .context("Failed to resolve Docker image")?
+    } else {
+        args.rootfs.clone().unwrap_or_default()
     };
 
     let req = CreateSandboxRequest {
@@ -276,7 +273,6 @@ async fn execute_create(args: CreateArgs) -> Result<()> {
         labels,
         kernel: args.kernel.unwrap_or_default(),
         rootfs,
-        rootfs_type,
         limits: Some(ResourceLimits {
             vcpus: args.cpus,
             memory_mib: args.memory,

--- a/app/arcbox-cli/src/rootfs_builder.rs
+++ b/app/arcbox-cli/src/rootfs_builder.rs
@@ -1,11 +1,14 @@
-//! Build a Docker image from a Dockerfile and export it as a tarball.
+//! Resolve Docker images to guest-visible overlay2 layer paths.
 //!
-//! Runs `docker build` and `docker save` on the host via the ArcBox Docker
-//! context. The tarball is written to `~/.arcbox/bin/` so it is visible to
-//! the guest VM at `/arcbox/bin/` via VirtioFS. The guest agent then handles
-//! the ext4 conversion and vm-agent injection.
+//! For `--from-dockerfile`, runs `docker build` via the ArcBox Docker context
+//! (proxied to guest dockerd), then inspects the image to get the overlay2
+//! layer directory. For `--from-image`, inspects an existing image directly.
+//!
+//! The returned path is a guest-internal filesystem path (under Docker's
+//! overlay2 storage) that the guest agent passes to `oci2rootfs` for ext4
+//! conversion.
 
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 use anyhow::{Context, Result, bail};
 use sha2::{Digest, Sha256};
@@ -13,14 +16,6 @@ use tokio::process::Command;
 
 /// Docker context name used for ArcBox Docker API.
 const DOCKER_CONTEXT: &str = "arcbox";
-
-/// Host-side output directory (VirtioFS-shared with guest as /arcbox/bin/).
-fn output_dir() -> Result<PathBuf> {
-    let dir = dirs::home_dir()
-        .context("cannot determine home directory")?
-        .join(".arcbox/bin");
-    Ok(dir)
-}
 
 /// Check if a file has a valid ext4 superblock magic.
 pub fn has_ext4_magic(path: &Path) -> bool {
@@ -48,12 +43,9 @@ pub fn looks_like_dockerfile(path: &Path) -> bool {
         .is_some_and(|line| line.trim().to_ascii_uppercase().starts_with("FROM "))
 }
 
-/// Build a Docker image from a Dockerfile and export it via `docker save`.
-///
-/// Returns `(guest_path, rootfs_type)`:
-/// - Cache hit:  `("/arcbox/bin/rootfs-<hash>.ext4", "")` — ready to boot.
-/// - Cache miss: `("/arcbox/bin/arcbox-save-<hash>.tar", "dockerfile")` — agent converts.
-pub async fn build_and_export(dockerfile_path: &str) -> Result<(String, String)> {
+/// Build a Docker image from a Dockerfile and return its guest-visible
+/// overlay2 layer directory path.
+pub async fn resolve_from_dockerfile(dockerfile_path: &str) -> Result<String> {
     let dockerfile = Path::new(dockerfile_path);
     if !dockerfile.exists() {
         bail!("Dockerfile not found: {dockerfile_path}");
@@ -69,22 +61,7 @@ pub async fn build_and_export(dockerfile_path: &str) -> Result<(String, String)>
         .await
         .context("failed to read Dockerfile")?;
     let hash = cache_key(&content);
-
-    let out = output_dir()?;
-    tokio::fs::create_dir_all(&out).await?;
-
-    // Check if the ext4 is already cached (skip build+save+convert).
-    // Validate the cached file has ext4 magic to avoid using corrupt artifacts.
-    let cached_ext4 = out.join(format!("rootfs-{hash}.ext4"));
-    if cached_ext4.exists() && has_ext4_magic(&cached_ext4) {
-        eprintln!("Using cached rootfs");
-        return Ok((format!("/arcbox/bin/rootfs-{hash}.ext4"), String::new()));
-    }
-
     let tag = format!("arcbox-sandbox:{hash}");
-    let tar_filename = format!("arcbox-save-{hash}.tar");
-    let tar_host_path = out.join(&tar_filename);
-    let tar_guest_path = format!("/arcbox/bin/{tar_filename}");
 
     let context_dir = dockerfile
         .parent()
@@ -113,27 +90,53 @@ pub async fn build_and_export(dockerfile_path: &str) -> Result<(String, String)>
         bail!("docker build failed:\n{stderr}");
     }
 
-    // docker save
-    eprintln!("Exporting image...");
+    inspect_layer_path(&tag).await
+}
+
+/// Get the guest-visible overlay2 layer directory for an existing Docker image.
+pub async fn resolve_from_image(image_ref: &str) -> Result<String> {
+    inspect_layer_path(image_ref).await
+}
+
+/// Query the overlay2 layer directory for an image via `docker inspect`.
+///
+/// Returns the chain-id directory (parent of UpperDir) so that `oci2rootfs`
+/// can resolve the full layer chain.
+async fn inspect_layer_path(image_ref: &str) -> Result<String> {
     let output = Command::new("docker")
         .args([
             "--context",
             DOCKER_CONTEXT,
-            "save",
-            &tag,
-            "-o",
-            &tar_host_path.to_string_lossy(),
+            "inspect",
+            "--format",
+            "{{.GraphDriver.Data.UpperDir}}",
+            image_ref,
         ])
         .output()
         .await
-        .context("failed to spawn docker save")?;
+        .context("failed to spawn docker inspect")?;
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
-        bail!("docker save failed:\n{stderr}");
+        bail!("docker inspect failed (is the image present?):\n{stderr}");
     }
 
-    eprintln!("Image exported to {}", tar_host_path.display());
-    Ok((tar_guest_path, "dockerfile".to_string()))
+    let upper_dir = String::from_utf8(output.stdout)
+        .context("docker inspect returned non-UTF-8 output")?
+        .trim()
+        .to_string();
+
+    if upper_dir.is_empty() {
+        bail!("docker inspect returned empty UpperDir for {image_ref}");
+    }
+
+    // oci2rootfs expects the chain-id directory (contains diff/, link, lower),
+    // not the diff/ subdirectory itself.
+    let layer_dir = upper_dir
+        .strip_suffix("/diff")
+        .unwrap_or(&upper_dir)
+        .to_string();
+
+    Ok(layer_dir)
 }
 
 /// Full SHA-256 hex digest of content.

--- a/app/arcbox-docker/src/api.rs
+++ b/app/arcbox-docker/src/api.rs
@@ -131,8 +131,6 @@ fn api_routes() -> Router<AppState> {
         .route("/images/{id}/json", get(handlers::inspect_image))
         .route("/images/{id}", delete(handlers::remove_image))
         .route("/images/{id}/tag", post(handlers::tag_image))
-        .route("/images/{id}/get", get(handlers::get_image))
-        .route("/images/get", get(handlers::get_images))
         .route("/networks", get(handlers::list_networks))
         .route("/networks/create", post(handlers::create_network))
         .route("/networks/{id}", get(handlers::inspect_network))

--- a/app/arcbox-docker/src/handlers/image.rs
+++ b/app/arcbox-docker/src/handlers/image.rs
@@ -12,5 +12,3 @@ crate::handlers::proxy_handler!(pull_image);
 crate::handlers::proxy_handler!(inspect_image);
 crate::handlers::proxy_handler!(remove_image);
 crate::handlers::proxy_handler!(tag_image);
-crate::handlers::proxy_handler!(get_image);
-crate::handlers::proxy_handler!(get_images);

--- a/app/arcbox-docker/src/handlers/mod.rs
+++ b/app/arcbox-docker/src/handlers/mod.rs
@@ -84,10 +84,7 @@ pub use container::{
 };
 pub use events::events;
 pub use exec::{exec_create, exec_inspect, exec_resize, exec_start};
-pub use image::{
-    get_image, get_images, inspect_image, list_images, load_image, pull_image, remove_image,
-    tag_image,
-};
+pub use image::{inspect_image, list_images, load_image, pull_image, remove_image, tag_image};
 pub use network::{create_network, inspect_network, list_networks, remove_network};
 pub use system::{get_info, get_version, ping};
 pub use volume::{create_volume, inspect_volume, list_volumes, prune_volumes, remove_volume};

--- a/guest/arcbox-agent/src/rootfs_builder.rs
+++ b/guest/arcbox-agent/src/rootfs_builder.rs
@@ -1,14 +1,8 @@
-//! Convert a `docker save` tarball to a bootable ext4 rootfs.
+//! Convert a Docker overlay2 layer directory to a bootable ext4 rootfs.
 //!
-//! Runs entirely inside the guest VM. The tarball is visible via VirtioFS
-//! at `/arcbox/bin/`. Steps:
-//!
-//! 1. Validate the tarball path is under the expected directory.
-//! 2. Extract the tar to a temp directory.
-//! 3. Run `oci2rootfs` to produce an ext4 image.
-//! 4. Inject `/sbin/vm-agent` into the ext4 via loop mount.
-//! 5. Atomically rename into the cache path.
-//! 6. Clean up and return the ext4 path.
+//! Runs `oci2rootfs` on the overlay2 layer path, then injects `/sbin/vm-agent`
+//! into the resulting ext4 via loop mount. Cached ext4 images are reused to
+//! avoid redundant conversions.
 
 use std::path::Path;
 
@@ -16,161 +10,82 @@ use anyhow::{Context, Result, bail};
 use tokio::process::Command;
 use uuid::Uuid;
 
-/// Path to the `oci2rootfs` binary (Linux aarch64, on VirtioFS).
+/// Path to the `oci2rootfs` binary (on VirtioFS).
 const OCI2ROOTFS_BIN: &str = "/arcbox/bin/oci2rootfs";
 
-/// Path to the `vm-agent` binary (trusted, inside guest).
+/// Path to the `vm-agent` binary (on VirtioFS).
 const VM_AGENT_BIN: &str = "/arcbox/bin/vm-agent";
 
 /// Directory for cached rootfs images.
 const ROOTFS_CACHE_DIR: &str = "/arcbox/bin";
 
-/// Expected prefix for tarball filenames.
-const TAR_PREFIX: &str = "arcbox-save-";
+/// Check if a file has a valid ext4 superblock magic (0x53EF at offset 0x438).
+pub fn has_ext4_magic(path: &Path) -> bool {
+    use std::io::{Read, Seek, SeekFrom};
+    let Ok(mut file) = std::fs::File::open(path) else {
+        return false;
+    };
+    let mut magic = [0u8; 2];
+    file.seek(SeekFrom::Start(0x438)).is_ok()
+        && file.read_exact(&mut magic).is_ok()
+        && magic == [0x53, 0xEF]
+}
 
-/// Convert a `docker save` tarball to a bootable ext4 rootfs.
+/// Convert an overlay2 layer directory to a bootable ext4 rootfs.
 ///
-/// `tar_path` is a guest-visible path (e.g. `/arcbox/bin/arcbox-save-<hash>.tar`).
-/// Returns the path to the generated ext4 image.
-pub async fn convert_tar_to_rootfs(tar_path: &str) -> Result<String> {
-    // Validate path is under the expected directory.
-    validate_tar_path(tar_path)?;
-
-    if !Path::new(tar_path).exists() {
-        bail!("docker save tarball not found: {tar_path}");
+/// `layer_path` is a guest-visible overlay2 chain-id directory
+/// (e.g. `/var/lib/docker/overlay2/<chain-id>`).
+/// Returns the path to the generated (or cached) ext4 image.
+pub async fn convert_layer_to_rootfs(layer_path: &str) -> Result<String> {
+    if !Path::new(layer_path).exists() {
+        bail!("layer path not found: {layer_path}");
     }
 
-    // Extract hash from filename. Reject unexpected names.
-    let hash = extract_hash(tar_path)?;
+    // Cache key derived from the layer path (overlay2 chain-id directories
+    // are content-addressed, so the path is a stable identifier).
+    let hash = path_hash(layer_path);
     let ext4_path = format!("{ROOTFS_CACHE_DIR}/rootfs-{hash}.ext4");
 
-    // Use a unique request ID for temp paths to avoid concurrent collisions.
+    // Check cache.
+    if Path::new(&ext4_path).exists() && has_ext4_magic(Path::new(&ext4_path)) {
+        tracing::info!(path = %ext4_path, "using cached rootfs");
+        return Ok(ext4_path);
+    }
+
     let req_id = Uuid::new_v4().to_string();
-
-    // Extract tar to a unique temp directory (cleaned up via scope guard).
-    let oci_dir = format!("/tmp/arcbox-rootfs-{req_id}-oci");
-    let _oci_guard = TempDirGuard(&oci_dir);
-    extract_tar(tar_path, &oci_dir).await?;
-
-    // Determine ext4 size from extracted content.
-    let content_size = dir_size_recursive(&oci_dir).await;
-    let ext4_size = (content_size * 3 / 2).max(256 * 1024 * 1024); // 1.5x, min 256MB
-
-    // Convert to ext4 — write to temp file first, rename atomically on success.
     let ext4_tmp = format!("{ROOTFS_CACHE_DIR}/.rootfs-{req_id}.ext4.tmp");
-    tracing::info!(ext4 = %ext4_path, size = ext4_size, "converting tar to ext4");
-    oci_to_ext4(&oci_dir, &ext4_tmp, ext4_size).await?;
+
+    // Run oci2rootfs.
+    tracing::info!(layer = %layer_path, ext4 = %ext4_path, "converting overlay2 layer to ext4");
+    run_oci2rootfs(layer_path, &ext4_tmp).await?;
 
     // Inject vm-agent.
     tracing::info!("injecting vm-agent into rootfs");
     inject_vm_agent(&ext4_tmp, &req_id).await?;
 
-    // Atomic rename into cache path.
+    // Atomic rename into cache.
     tokio::fs::rename(&ext4_tmp, &ext4_path)
         .await
         .context("failed to rename ext4 into cache")?;
-
-    // Cleanup tarball.
-    let _ = tokio::fs::remove_file(tar_path).await;
 
     tracing::info!(path = %ext4_path, "rootfs ready");
     Ok(ext4_path)
 }
 
-/// Validate that the tar path is under the expected shared directory.
-fn validate_tar_path(tar_path: &str) -> Result<()> {
-    let path = Path::new(tar_path);
-
-    // Must be under /arcbox/bin/.
-    if !tar_path.starts_with(ROOTFS_CACHE_DIR) {
-        bail!("tarball path must be under {ROOTFS_CACHE_DIR}, got: {tar_path}");
-    }
-
-    // Reject path traversal.
-    if path
-        .components()
-        .any(|c| matches!(c, std::path::Component::ParentDir))
-    {
-        bail!("tarball path contains path traversal: {tar_path}");
-    }
-
-    Ok(())
-}
-
-/// Extract the hash from a tarball filename like `arcbox-save-<hash>.tar`.
-fn extract_hash(tar_path: &str) -> Result<String> {
-    Path::new(tar_path)
-        .file_stem()
-        .and_then(|s| s.to_str())
-        .and_then(|s| s.strip_prefix(TAR_PREFIX))
-        .map(String::from)
-        .ok_or_else(|| {
-            anyhow::anyhow!(
-                "unexpected tarball name: {tar_path} \
-                 (expected pattern: {TAR_PREFIX}<hash>.tar)"
-            )
-        })
-}
-
-async fn extract_tar(tar_path: &str, dest: &str) -> Result<()> {
-    tokio::fs::create_dir_all(dest).await?;
-    let output = Command::new("/bin/busybox")
-        .args(["tar", "-xf", tar_path, "-C", dest])
-        .output()
-        .await
-        .context("failed to extract tar")?;
-
-    if !output.status.success() {
-        bail!(
-            "tar extract failed: {}",
-            String::from_utf8_lossy(&output.stderr)
-        );
-    }
-    Ok(())
-}
-
-/// Recursively compute total file size of a directory tree.
-async fn dir_size_recursive(path: &str) -> u64 {
-    async fn walk(path: &Path) -> u64 {
-        let Ok(meta) = tokio::fs::symlink_metadata(path).await else {
-            return 0;
-        };
-
-        if meta.is_file() {
-            return meta.len();
-        }
-
-        if meta.is_dir() {
-            let Ok(mut dir) = tokio::fs::read_dir(path).await else {
-                return 0;
-            };
-            let mut total = 0u64;
-            while let Ok(Some(entry)) = dir.next_entry().await {
-                total += Box::pin(walk(&entry.path())).await;
-            }
-            return total;
-        }
-
-        0
-    }
-
-    let size = walk(Path::new(path)).await;
-    if size > 0 { size } else { 512 * 1024 * 1024 }
-}
-
-async fn oci_to_ext4(oci_dir: &str, ext4_path: &str, size: u64) -> Result<()> {
+/// Run `oci2rootfs` on an overlay2 layer directory.
+async fn run_oci2rootfs(layer_path: &str, output: &str) -> Result<()> {
     if !Path::new(OCI2ROOTFS_BIN).exists() {
         bail!("oci2rootfs not found at {OCI2ROOTFS_BIN}");
     }
 
-    let output = Command::new(OCI2ROOTFS_BIN)
-        .args([oci_dir, "--output", ext4_path, "--size", &size.to_string()])
+    let result = Command::new(OCI2ROOTFS_BIN)
+        .args([layer_path, "--output", output])
         .output()
         .await
         .context("failed to spawn oci2rootfs")?;
 
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
+    if !result.status.success() {
+        let stderr = String::from_utf8_lossy(&result.stderr);
         bail!("oci2rootfs failed: {stderr}");
     }
     Ok(())
@@ -223,13 +138,12 @@ async fn inject_vm_agent(ext4_path: &str, req_id: &str) -> Result<()> {
     Ok(())
 }
 
-/// Scope guard that removes a temporary directory on drop.
-struct TempDirGuard<'a>(&'a str);
-
-impl Drop for TempDirGuard<'_> {
-    fn drop(&mut self) {
-        let _ = std::fs::remove_dir_all(self.0);
-    }
+/// Derive a stable cache key from the layer path.
+fn path_hash(path: &str) -> String {
+    use std::hash::{Hash, Hasher};
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    path.hash(&mut hasher);
+    format!("{:016x}", hasher.finish())
 }
 
 #[cfg(test)]
@@ -237,37 +151,22 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_extract_hash_valid() {
-        let hash = extract_hash("/arcbox/bin/arcbox-save-abc123.tar").unwrap();
-        assert_eq!(hash, "abc123");
+    fn test_has_ext4_magic_nonexistent() {
+        assert!(!has_ext4_magic(Path::new("/nonexistent")));
     }
 
     #[test]
-    fn test_extract_hash_full_sha256() {
-        let h = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
-        let path = format!("/arcbox/bin/arcbox-save-{h}.tar");
-        let hash = extract_hash(&path).unwrap();
-        assert_eq!(hash, h);
+    fn test_path_hash_deterministic() {
+        let a = path_hash("/var/lib/docker/overlay2/abc123");
+        let b = path_hash("/var/lib/docker/overlay2/abc123");
+        assert_eq!(a, b);
+        assert_eq!(a.len(), 16);
     }
 
     #[test]
-    fn test_extract_hash_rejects_bad_name() {
-        assert!(extract_hash("/arcbox/bin/random.tar").is_err());
-        assert!(extract_hash("/arcbox/bin/arcbox-save-.tar").is_err());
-    }
-
-    #[test]
-    fn test_validate_tar_path_ok() {
-        assert!(validate_tar_path("/arcbox/bin/arcbox-save-abc.tar").is_ok());
-    }
-
-    #[test]
-    fn test_validate_tar_path_rejects_outside() {
-        assert!(validate_tar_path("/tmp/arcbox-save-abc.tar").is_err());
-    }
-
-    #[test]
-    fn test_validate_tar_path_rejects_traversal() {
-        assert!(validate_tar_path("/arcbox/bin/../etc/passwd").is_err());
+    fn test_path_hash_different() {
+        let a = path_hash("/var/lib/docker/overlay2/abc123");
+        let b = path_hash("/var/lib/docker/overlay2/def456");
+        assert_ne!(a, b);
     }
 }

--- a/guest/arcbox-agent/src/sandbox.rs
+++ b/guest/arcbox-agent/src/sandbox.rs
@@ -66,9 +66,9 @@ impl SandboxService {
 
     /// Create a sandbox.
     ///
-    /// When `rootfs_type` is `"dockerfile"`, `rootfs` is a path to a `docker save`
-    /// tarball. The agent converts it to ext4 via `oci2rootfs` and injects
-    /// `vm-agent` before booting.
+    /// When the rootfs path points to a directory (overlay2 layer), the agent
+    /// converts it to ext4 via `oci2rootfs` and injects `vm-agent` before
+    /// booting. Ext4 images are used directly.
     pub async fn create(
         &self,
         payload: &[u8],
@@ -77,12 +77,12 @@ impl SandboxService {
             .map_err(|e| SandboxError::Decode(e.to_string()))?;
         let mut spec = proto_to_spec(req);
 
-        if spec.rootfs_type == "dockerfile" {
-            let ext4_path = crate::rootfs_builder::convert_tar_to_rootfs(&spec.rootfs)
+        // Auto-detect: directory → overlay2 layer needing conversion.
+        if !spec.rootfs.is_empty() && std::path::Path::new(&spec.rootfs).is_dir() {
+            let ext4_path = crate::rootfs_builder::convert_layer_to_rootfs(&spec.rootfs)
                 .await
                 .map_err(|e| SandboxError::Internal(format!("rootfs build failed: {e}")))?;
             spec.rootfs = ext4_path;
-            spec.rootfs_type.clear();
         }
 
         let (id, ip_address) = self
@@ -636,7 +636,6 @@ fn proto_to_spec(req: sandbox_v1::CreateSandboxRequest) -> SandboxSpec {
         network: SandboxNetworkSpec { mode: network.mode },
         ttl_seconds: req.ttl_seconds,
         ssh_public_key: req.ssh_public_key,
-        rootfs_type: req.rootfs_type,
     }
 }
 

--- a/guest/arcbox-agent/tests/sandbox_service_manager.rs
+++ b/guest/arcbox-agent/tests/sandbox_service_manager.rs
@@ -86,7 +86,6 @@ async fn sandbox_service_calls_sandbox_manager() {
         }),
         ttl_seconds: 0,
         ssh_public_key: None,
-        rootfs_type: String::new(),
     };
     let create_payload = create_req.encode_to_vec();
     let created = service

--- a/rpc/arcbox-protocol/proto/sandbox.proto
+++ b/rpc/arcbox-protocol/proto/sandbox.proto
@@ -180,13 +180,7 @@ message CreateSandboxRequest {
     // SSH public key injected via MMDS (empty = no SSH).
     optional string ssh_public_key = 15;
 
-    // --- Rootfs type ---
-    // How to interpret the rootfs field:
-    //   ""/"ext4" (default) — rootfs is a path to an ext4 image, use directly.
-    //   "dockerfile"        — rootfs is a guest-visible path to a docker save
-    //                         tarball; the agent converts it to ext4, injects
-    //                         vm-agent, and boots.
-    string rootfs_type = 16;
+    reserved 16;
 }
 
 // Response to CreateSandbox.

--- a/rpc/arcbox-protocol/src/generated/sandbox.v1.rs
+++ b/rpc/arcbox-protocol/src/generated/sandbox.v1.rs
@@ -115,14 +115,6 @@ pub struct CreateSandboxRequest {
     /// SSH public key injected via MMDS (empty = no SSH).
     #[prost(string, optional, tag = "15")]
     pub ssh_public_key: ::core::option::Option<::prost::alloc::string::String>,
-    /// --- Rootfs type ---
-    /// How to interpret the rootfs field:
-    ///    ""/"ext4" (default) — rootfs is a path to an ext4 image, use directly.
-    ///    "dockerfile"        — rootfs is a guest-visible path to a docker save
-    ///                          tarball; the agent converts it to ext4, injects
-    ///                          vm-agent, and boots.
-    #[prost(string, tag = "16")]
-    pub rootfs_type: ::prost::alloc::string::String,
 }
 /// Response to CreateSandbox.
 /// Returned immediately; the sandbox may still be booting (state "starting").

--- a/virt/arcbox-vm/src/sandbox.rs
+++ b/virt/arcbox-vm/src/sandbox.rs
@@ -126,8 +126,6 @@ pub struct SandboxSpec {
     pub ttl_seconds: u32,
     /// SSH public key injected via MMDS (None = no SSH setup).
     pub ssh_public_key: Option<String>,
-    /// Rootfs type: `""` / `"ext4"` (use directly) or `"dockerfile"` (tar to convert).
-    pub rootfs_type: String,
 }
 
 /// Parameters to restore a sandbox from a checkpoint.


### PR DESCRIPTION
## Summary

Adds `--from-dockerfile` and `--from-image` CLI flags for creating sandboxes from Docker images, using direct overlay2 layer path resolution instead of tarball round-trips.

### Flow

```
Host CLI: --from-dockerfile → docker build → docker inspect → overlay2 layer path
Host CLI: --from-image → docker inspect → overlay2 layer path
  ↓ gRPC (rootfs = guest-internal overlay2 chain-id directory)
Guest Agent: auto-detect directory → oci2rootfs <layer-path> → ext4 → inject vm-agent → boot
```

- `--from-dockerfile` runs `docker build` (proxied to guest dockerd via ArcBox Docker context), then `docker inspect` to get the overlay2 `UpperDir` → chain-id directory
- `--from-image` directly inspects an existing image for its layer path
- `--rootfs` continues to work for direct ext4 image paths (no change)
- Guest agent auto-detects: if rootfs is a directory → convert via `oci2rootfs`; if file → use as ext4 directly
- Cached ext4 images (keyed by layer path hash) skip conversion on subsequent creates

### What changed vs previous iteration

Addressed [PeronGH's design review](https://github.com/arcboxlabs/arcbox/pull/158#pullrequestreview-2803458893):

- **No `docker save` / tarball round-trip** — `oci2rootfs` now reads overlay2 directories directly ([arcboxlabs/oci2rootfs#1](https://github.com/arcboxlabs/oci2rootfs/pull/1))
- **Removed `rootfs_type` proto field** — guest agent auto-detects via `Path::is_dir()`
- **Three explicit CLI flags** instead of auto-detecting file format on `--rootfs`
- **Removed `/images/{id}/get` and `/images/get`** Docker compat proxy routes (no longer needed)
- **No `~/.arcbox/bin/` staging** — layer path is passed directly from `docker inspect`
- **Net -127 lines** — simpler architecture, less code

### Usage

```bash
# From Dockerfile
arcbox sandbox create --from-dockerfile /path/to/Dockerfile --memory 1024

# From existing Docker image
arcbox sandbox create --from-image ubuntu:22.04 --memory 1024

# Direct ext4 (unchanged)
arcbox sandbox create --rootfs /path/to/rootfs.ext4 --memory 1024
```

## Test plan

- [x] `cargo clippy` + `cargo fmt` — zero new warnings
- [x] `cargo test` — all tests pass
- [x] `arcbox sandbox create --rootfs <ext4>` still works (no regression)
- [x] `arcbox sandbox create --from-dockerfile <Dockerfile>` builds, converts, and boots
- [x] `arcbox sandbox create --from-image <ref>` resolves, converts, and boots
- [x] Second create with same Dockerfile/image hits cache and skips conversion