### PR TITLE
feat(virt): integrate Rosetta x86_64 translation for Apple Silicon VMs

### DIFF
--- a/app/arcbox-core/src/vm.rs
+++ b/app/arcbox-core/src/vm.rs
@@ -165,7 +165,7 @@ impl Default for VmConfig {
             vsock: true,
             guest_cid: None,
             balloon: true, // Enable balloon by default
-            rosetta: cfg!(target_arch = "aarch64"),
+            rosetta: cfg!(all(target_os = "macos", target_arch = "aarch64")),
         }
     }
 }

--- a/guest/arcbox-agent/src/init.rs
+++ b/guest/arcbox-agent/src/init.rs
@@ -202,17 +202,19 @@ mod platform {
         const ROSETTA_TAG: &str = "rosetta";
         const ROSETTA_BINARY: &str = "/media/rosetta/rosetta";
 
-        // Mount the Rosetta VirtioFS share.
-        mkdir_p(ROSETTA_MOUNT);
-        if let Err(e) = mount(
-            Some(ROSETTA_TAG),
-            ROSETTA_MOUNT,
-            Some("virtiofs"),
-            MsFlags::MS_RDONLY,
-            None::<&str>,
-        ) {
-            tracing::debug!(error = %e, "Rosetta VirtioFS share not available — x86_64 translation disabled");
-            return;
+        // Mount the Rosetta VirtioFS share (skip if already mounted).
+        if !crate::mount::is_mounted(ROSETTA_MOUNT) {
+            mkdir_p(ROSETTA_MOUNT);
+            if let Err(e) = mount(
+                Some(ROSETTA_TAG),
+                ROSETTA_MOUNT,
+                Some("virtiofs"),
+                MsFlags::MS_RDONLY,
+                None::<&str>,
+            ) {
+                tracing::debug!(error = %e, "Rosetta VirtioFS share not available — x86_64 translation disabled");
+                return;
+            }
         }
 
         // Verify the Rosetta binary exists in the share.
@@ -234,6 +236,12 @@ mod platform {
                 tracing::warn!(error = %e, "failed to mount binfmt_misc — Rosetta registration skipped");
                 return;
             }
+        }
+
+        // Skip if already registered (idempotent re-entry).
+        if Path::new("/proc/sys/fs/binfmt_misc/rosetta").exists() {
+            tracing::debug!("Rosetta binfmt_misc handler already registered");
+            return;
         }
 
         // Register Rosetta as the x86_64 ELF interpreter.

--- a/virt/arcbox-hypervisor/src/darwin/vm.rs
+++ b/virt/arcbox-hypervisor/src/darwin/vm.rs
@@ -833,12 +833,21 @@ impl DarwinVm {
                 actual: "config already consumed".to_string(),
             })?;
 
-        let rosetta_share = LinuxRosettaDirectoryShare::new().map_err(|e| {
-            HypervisorError::DeviceError(format!("failed to create Rosetta directory share: {e}"))
-        })?;
+        let rosetta_share = match LinuxRosettaDirectoryShare::new() {
+            Ok(share) => share,
+            Err(e) => {
+                tracing::warn!("Failed to create Rosetta directory share: {e}");
+                return Ok(());
+            }
+        };
 
-        let mut fs_device = VirtioFileSystemDeviceConfiguration::new("rosetta")
-            .map_err(|e| HypervisorError::DeviceError(e.to_string()))?;
+        let mut fs_device = match VirtioFileSystemDeviceConfiguration::new("rosetta") {
+            Ok(device) => device,
+            Err(e) => {
+                tracing::warn!("Failed to create Rosetta VirtioFS device: {e}");
+                return Ok(());
+            }
+        };
         fs_device.set_share(rosetta_share);
         vz_config.add_directory_share(fs_device);
 

--- a/virt/arcbox-vmm/src/vmm/darwin.rs
+++ b/virt/arcbox-vmm/src/vmm/darwin.rs
@@ -42,9 +42,13 @@ impl Vmm {
             );
         }
 
-        // Add Rosetta x86_64 translation share if enabled.
+        // Add Rosetta x86_64 translation share if enabled (best-effort).
         if self.config.enable_rosetta {
-            vm.add_rosetta_share()?;
+            if let Err(e) = vm.add_rosetta_share() {
+                tracing::warn!(
+                    "Rosetta share setup failed, continuing without x86_64 translation: {e}"
+                );
+            }
         }
 
         // Add block devices


### PR DESCRIPTION
## Summary

- Wire the existing `LinuxRosettaDirectoryShare` ObjC bindings through the full VMM stack so x86_64 Docker images and builds run at near-native speed on Apple Silicon
- Add `rosetta: bool` to `VmConfig` (default `true` on aarch64), propagate through `VmmConfig` → hypervisor `VmConfig` builder
- Add `DarwinVm::add_rosetta_share()` which checks Rosetta availability, creates the directory share, and attaches it as a VirtioFS device (tag: `rosetta`)
- Guest agent mounts the Rosetta share at `/media/rosetta` (read-only), mounts `binfmt_misc`, and registers Rosetta as the x86_64 ELF interpreter with `CF` flags

## Design decisions

- **Best-effort semantics**: every step (host availability check, guest VirtioFS mount, binfmt_misc mount, registration) fails gracefully with a log message — Intel Macs, missing Rosetta installs, and disabled config all result in a silent no-op
- **`F` flag (fix-binary)**: the kernel opens an fd to the Rosetta binary at registration time, so containers inherit x86_64 translation without needing to mount `/media/rosetta` themselves
- **`C` flag (credentials)**: setuid/setgid permissions are calculated from the target binary, not the Rosetta interpreter
- **Read-only mount**: the Rosetta share is mounted `MS_RDONLY` since nothing in the guest needs to write to it

## Test plan

- [x] On Apple Silicon: verify `docker run --platform linux/amd64 alpine uname -m` returns `x86_64`
- [x] On Apple Silicon: verify `docker build --platform linux/amd64 -f Dockerfile .` completes successfully with a simple multi-stage Dockerfile
- [x] On Intel Mac: verify daemon starts normally without Rosetta-related errors (graceful skip)
- [x] Verify `/proc/sys/fs/binfmt_misc/rosetta` exists in guest after boot
- [ ] Verify Rosetta binary is accessible at `/media/rosetta/rosetta` in guest