### PR TITLE
test(net): add network datapath mock tests via socketpair

### DIFF
--- a/virt/arcbox-net/tests/datapath_test.rs
+++ b/virt/arcbox-net/tests/datapath_test.rs
@@ -67,6 +67,7 @@ fn create_test_datapath() -> (NetworkDatapath, std::os::fd::OwnedFd, Cancellatio
         GUEST_IP,
         GATEWAY_MAC,
         cancel.clone(),
+        1500, // mtu
     );
 
     (datapath, guest_fd, cancel)
@@ -179,7 +180,7 @@ async fn test_frame_classification_arp() {
     let (host_fd, guest_fd) = mock_guest_nic();
     set_nonblocking(host_fd.as_raw_fd());
 
-    let mut device = SmoltcpDevice::new(host_fd.as_raw_fd(), GATEWAY_IP);
+    let mut device = SmoltcpDevice::new(host_fd.as_raw_fd(), GATEWAY_IP, 1500);
     let mut guest_mac = None;
 
     // Write an ARP request from the guest side.
@@ -207,7 +208,7 @@ async fn test_frame_classification_tcp_syn() {
     let (host_fd, guest_fd) = mock_guest_nic();
     set_nonblocking(host_fd.as_raw_fd());
 
-    let mut device = SmoltcpDevice::new(host_fd.as_raw_fd(), GATEWAY_IP);
+    let mut device = SmoltcpDevice::new(host_fd.as_raw_fd(), GATEWAY_IP, 1500);
     let mut guest_mac = None;
 
     let syn = build_tcp_syn(
@@ -237,7 +238,7 @@ async fn test_frame_classification_icmp() {
     let (host_fd, guest_fd) = mock_guest_nic();
     set_nonblocking(host_fd.as_raw_fd());
 
-    let mut device = SmoltcpDevice::new(host_fd.as_raw_fd(), GATEWAY_IP);
+    let mut device = SmoltcpDevice::new(host_fd.as_raw_fd(), GATEWAY_IP, 1500);
     let mut guest_mac = None;
 
     let icmp = build_icmp_echo(
@@ -266,7 +267,7 @@ async fn test_frame_classification_dhcp() {
     let (host_fd, guest_fd) = mock_guest_nic();
     set_nonblocking(host_fd.as_raw_fd());
 
-    let mut device = SmoltcpDevice::new(host_fd.as_raw_fd(), GATEWAY_IP);
+    let mut device = SmoltcpDevice::new(host_fd.as_raw_fd(), GATEWAY_IP, 1500);
     let mut guest_mac = None;
 
     let discover = build_dhcp_discover(CLIENT_MAC, 0x1234);

--- a/virt/arcbox-net/tests/datapath_test.rs
+++ b/virt/arcbox-net/tests/datapath_test.rs
@@ -1,0 +1,280 @@
+//! Network datapath integration tests using mock guest NIC.
+//!
+//! These tests exercise the full `NetworkDatapath` event loop by creating a
+//! socketpair mock in place of the real VZ framework guest FD. L2 Ethernet
+//! frames are injected through the "guest" end and responses are read back,
+//! verifying DHCP, DNS, frame classification, and TCP SYN gating without
+//! requiring a VM, root privileges, or code signing.
+
+#![cfg(target_os = "macos")]
+
+mod helpers;
+
+use std::net::Ipv4Addr;
+use std::os::fd::AsRawFd;
+use std::time::Duration;
+
+use tokio::sync::mpsc;
+use tokio_util::sync::CancellationToken;
+
+use arcbox_dhcp::DhcpConfig;
+use arcbox_net::darwin::datapath_loop::NetworkDatapath;
+use arcbox_net::darwin::socket_proxy::SocketProxy;
+use arcbox_net::dns::{DnsConfig, DnsForwarder};
+
+use helpers::frames::{
+    build_arp_request, build_dhcp_discover, build_dhcp_request, build_icmp_echo, build_tcp_syn,
+    extract_dhcp_payload, parse_dhcp,
+};
+use helpers::mock_nic::{fd_write, mock_guest_nic, recv_frames_timeout, set_nonblocking};
+
+/// Test network configuration constants.
+const GATEWAY_IP: Ipv4Addr = Ipv4Addr::new(192, 168, 64, 1);
+const GUEST_IP: Ipv4Addr = Ipv4Addr::new(192, 168, 64, 2);
+const GATEWAY_MAC: [u8; 6] = [0x02, 0x00, 0x00, 0x00, 0x00, 0x01];
+const CLIENT_MAC: [u8; 6] = [0x02, 0xAA, 0xBB, 0xCC, 0xDD, 0xEE];
+
+/// Creates a `NetworkDatapath` wired to a mock socketpair.
+///
+/// Returns `(datapath, guest_fd, cancel_token)` where `guest_fd` is the
+/// test-side end of the socketpair for injecting/reading L2 frames.
+fn create_test_datapath() -> (NetworkDatapath, std::os::fd::OwnedFd, CancellationToken) {
+    let (host_fd, guest_fd) = mock_guest_nic();
+    set_nonblocking(guest_fd.as_raw_fd());
+
+    let cancel = CancellationToken::new();
+
+    let (reply_tx, reply_rx) = mpsc::channel(256);
+    let (_cmd_tx, cmd_rx) = mpsc::channel(64);
+
+    let socket_proxy =
+        SocketProxy::new(GATEWAY_IP, GATEWAY_MAC, GUEST_IP, reply_tx, cancel.clone());
+
+    let dhcp_config = DhcpConfig::new(GATEWAY_IP, Ipv4Addr::new(255, 255, 255, 0));
+    let dhcp_server = arcbox_dhcp::DhcpServer::new(dhcp_config);
+
+    let dns_config = DnsConfig::new(GATEWAY_IP);
+    let dns_forwarder = DnsForwarder::new(dns_config);
+
+    let datapath = NetworkDatapath::new(
+        host_fd,
+        socket_proxy,
+        reply_rx,
+        cmd_rx,
+        dhcp_server,
+        dns_forwarder,
+        GATEWAY_IP,
+        GUEST_IP,
+        GATEWAY_MAC,
+        cancel.clone(),
+    );
+
+    (datapath, guest_fd, cancel)
+}
+
+/// Spawns the datapath event loop as a background tokio task and returns
+/// the join handle. The caller should cancel via the `CancellationToken`
+/// when the test is done.
+fn spawn_datapath(datapath: NetworkDatapath) -> tokio::task::JoinHandle<std::io::Result<()>> {
+    tokio::spawn(async move { datapath.run().await })
+}
+
+// ---------------------------------------------------------------------------
+// DHCP tests
+// ---------------------------------------------------------------------------
+
+/// Full DHCP cycle: DISCOVER -> OFFER -> REQUEST -> ACK.
+///
+/// Verifies that the datapath's integrated DHCP server responds correctly
+/// to a complete lease acquisition sequence.
+#[tokio::test]
+async fn test_dhcp_full_cycle() {
+    let (datapath, guest_fd, cancel) = create_test_datapath();
+    let handle = spawn_datapath(datapath);
+    let guest_raw = guest_fd.as_raw_fd();
+
+    // Allow the datapath event loop to start.
+    tokio::time::sleep(Duration::from_millis(20)).await;
+
+    let xid: u32 = 0xDEAD_BEEF;
+
+    // --- Step 1: Send DHCP DISCOVER ---
+    let discover = build_dhcp_discover(CLIENT_MAC, xid);
+    fd_write(guest_raw, &discover).expect("failed to write DISCOVER");
+
+    // --- Step 2: Read DHCP OFFER ---
+    let frames = recv_frames_timeout(guest_raw, Duration::from_secs(2)).await;
+    assert!(!frames.is_empty(), "expected DHCP OFFER, got no frames");
+
+    // Find the DHCP response among returned frames.
+    let offer_frame = frames
+        .iter()
+        .find(|f| {
+            extract_dhcp_payload(f)
+                .and_then(parse_dhcp)
+                .is_some_and(|p| p.message_type == Some(2)) // OFFER
+        })
+        .expect("no DHCP OFFER frame found");
+
+    let offer = parse_dhcp(extract_dhcp_payload(offer_frame).unwrap()).unwrap();
+    assert_eq!(offer.op, 2, "OFFER op should be BOOTREPLY");
+    assert_eq!(offer.xid, xid, "OFFER xid should match");
+    assert_eq!(offer.message_type, Some(2), "should be OFFER (type 2)");
+    assert!(
+        !offer.yiaddr.is_unspecified(),
+        "OFFER should assign an IP address"
+    );
+    let offered_ip = offer.yiaddr;
+
+    // Verify the offered IP is in the expected subnet.
+    let offered_octets = offered_ip.octets();
+    assert_eq!(
+        &offered_octets[..3],
+        &[192, 168, 64],
+        "offered IP should be in 192.168.64.0/24"
+    );
+
+    // --- Step 3: Send DHCP REQUEST for the offered IP ---
+    let request = build_dhcp_request(CLIENT_MAC, xid, offered_ip, GATEWAY_IP);
+    fd_write(guest_raw, &request).expect("failed to write REQUEST");
+
+    // --- Step 4: Read DHCP ACK ---
+    let frames = recv_frames_timeout(guest_raw, Duration::from_secs(2)).await;
+    assert!(!frames.is_empty(), "expected DHCP ACK, got no frames");
+
+    let ack_frame = frames
+        .iter()
+        .find(|f| {
+            extract_dhcp_payload(f)
+                .and_then(parse_dhcp)
+                .is_some_and(|p| p.message_type == Some(5)) // ACK
+        })
+        .expect("no DHCP ACK frame found");
+
+    let ack = parse_dhcp(extract_dhcp_payload(ack_frame).unwrap()).unwrap();
+    assert_eq!(ack.op, 2, "ACK op should be BOOTREPLY");
+    assert_eq!(ack.xid, xid, "ACK xid should match");
+    assert_eq!(ack.message_type, Some(5), "should be ACK (type 5)");
+    assert_eq!(ack.yiaddr, offered_ip, "ACK should confirm the offered IP");
+
+    // Verify lease parameters are present.
+    assert!(ack.lease_time.is_some(), "ACK should include lease time");
+    assert!(ack.subnet_mask.is_some(), "ACK should include subnet mask");
+
+    // Cleanup: cancel the datapath and wait for it to finish.
+    cancel.cancel();
+    handle.await.unwrap().unwrap();
+}
+
+// ---------------------------------------------------------------------------
+// Frame classification tests (via SmoltcpDevice directly)
+// ---------------------------------------------------------------------------
+
+/// Verifies that an ARP request injected through the socketpair is classified
+/// into the smoltcp rx_queue (not intercepted).
+#[tokio::test]
+async fn test_frame_classification_arp() {
+    use arcbox_net::darwin::smoltcp_device::SmoltcpDevice;
+
+    let (host_fd, guest_fd) = mock_guest_nic();
+    set_nonblocking(host_fd.as_raw_fd());
+
+    let mut device = SmoltcpDevice::new(host_fd.as_raw_fd(), GATEWAY_IP);
+    let mut guest_mac = None;
+
+    // Write an ARP request from the guest side.
+    let arp = build_arp_request(CLIENT_MAC, GUEST_IP, GATEWAY_IP);
+    fd_write(guest_fd.as_raw_fd(), &arp).expect("write ARP");
+
+    device.drain_guest_fd(&mut guest_mac);
+
+    // ARP should be in the smoltcp rx_queue, not intercepted.
+    let intercepted = device.take_intercepted();
+    assert!(intercepted.is_empty(), "ARP should not be intercepted");
+    assert_eq!(
+        guest_mac,
+        Some(CLIENT_MAC),
+        "guest MAC should be learned from ARP"
+    );
+}
+
+/// Verifies that a TCP SYN injected through the socketpair is gated
+/// (held back for host connect).
+#[tokio::test]
+async fn test_frame_classification_tcp_syn() {
+    use arcbox_net::darwin::smoltcp_device::SmoltcpDevice;
+
+    let (host_fd, guest_fd) = mock_guest_nic();
+    set_nonblocking(host_fd.as_raw_fd());
+
+    let mut device = SmoltcpDevice::new(host_fd.as_raw_fd(), GATEWAY_IP);
+    let mut guest_mac = None;
+
+    let syn = build_tcp_syn(
+        CLIENT_MAC,
+        GATEWAY_MAC,
+        GUEST_IP,
+        12345,
+        Ipv4Addr::new(1, 1, 1, 1),
+        443,
+    );
+    fd_write(guest_fd.as_raw_fd(), &syn).expect("write SYN");
+
+    device.drain_guest_fd(&mut guest_mac);
+
+    let gated = device.take_gated_syns();
+    assert_eq!(gated.len(), 1, "TCP SYN should be gated");
+    assert_eq!(gated[0].dst_port, 443);
+    assert_eq!(gated[0].src_port, 12345);
+    assert_eq!(gated[0].dst_ip, Ipv4Addr::new(1, 1, 1, 1));
+}
+
+/// Verifies that ICMP frames are classified as intercepted.
+#[tokio::test]
+async fn test_frame_classification_icmp() {
+    use arcbox_net::darwin::smoltcp_device::{InterceptedKind, SmoltcpDevice};
+
+    let (host_fd, guest_fd) = mock_guest_nic();
+    set_nonblocking(host_fd.as_raw_fd());
+
+    let mut device = SmoltcpDevice::new(host_fd.as_raw_fd(), GATEWAY_IP);
+    let mut guest_mac = None;
+
+    let icmp = build_icmp_echo(
+        CLIENT_MAC,
+        GATEWAY_MAC,
+        GUEST_IP,
+        Ipv4Addr::new(8, 8, 8, 8),
+        1,
+        1,
+    );
+    fd_write(guest_fd.as_raw_fd(), &icmp).expect("write ICMP");
+
+    device.drain_guest_fd(&mut guest_mac);
+
+    let intercepted = device.take_intercepted();
+    assert_eq!(intercepted.len(), 1);
+    assert_eq!(intercepted[0].kind, InterceptedKind::Icmp);
+}
+
+/// Verifies that a DHCP (UDP dst port 67) frame is classified as intercepted
+/// with kind `Dhcp`.
+#[tokio::test]
+async fn test_frame_classification_dhcp() {
+    use arcbox_net::darwin::smoltcp_device::{InterceptedKind, SmoltcpDevice};
+
+    let (host_fd, guest_fd) = mock_guest_nic();
+    set_nonblocking(host_fd.as_raw_fd());
+
+    let mut device = SmoltcpDevice::new(host_fd.as_raw_fd(), GATEWAY_IP);
+    let mut guest_mac = None;
+
+    let discover = build_dhcp_discover(CLIENT_MAC, 0x1234);
+    fd_write(guest_fd.as_raw_fd(), &discover).expect("write DHCP DISCOVER");
+
+    device.drain_guest_fd(&mut guest_mac);
+
+    let intercepted = device.take_intercepted();
+    assert_eq!(intercepted.len(), 1);
+    assert_eq!(intercepted[0].kind, InterceptedKind::Dhcp);
+}

--- a/virt/arcbox-net/tests/helpers/frames.rs
+++ b/virt/arcbox-net/tests/helpers/frames.rs
@@ -1,0 +1,472 @@
+//! Ethernet frame builders and parsers for network datapath tests.
+//!
+//! Constructs well-formed L2 Ethernet frames that can be injected into the
+//! mock guest NIC socketpair. Also provides minimal parsers for validating
+//! response frames.
+
+// Builders/parsers are used across different test files; not all are
+// exercised yet but will be as more datapath tests are added.
+#![allow(dead_code)]
+
+use std::net::Ipv4Addr;
+
+/// Ethernet header length.
+const ETH_HDR: usize = 14;
+
+// ---------------------------------------------------------------------------
+// Frame builders
+// ---------------------------------------------------------------------------
+
+/// Builds an ARP request frame.
+///
+/// Standard 42-byte Ethernet + ARP for IPv4 over Ethernet.
+pub fn build_arp_request(src_mac: [u8; 6], src_ip: Ipv4Addr, target_ip: Ipv4Addr) -> Vec<u8> {
+    let mut frame = vec![0u8; 42];
+    // Ethernet: dst = broadcast, src = sender, type = ARP (0x0806)
+    frame[0..6].copy_from_slice(&[0xFF; 6]);
+    frame[6..12].copy_from_slice(&src_mac);
+    frame[12..14].copy_from_slice(&[0x08, 0x06]);
+    // ARP payload
+    frame[14..16].copy_from_slice(&[0x00, 0x01]); // HW type: Ethernet
+    frame[16..18].copy_from_slice(&[0x08, 0x00]); // Protocol: IPv4
+    frame[18] = 6; // HW addr len
+    frame[19] = 4; // Proto addr len
+    frame[20..22].copy_from_slice(&[0x00, 0x01]); // Op: Request
+    frame[22..28].copy_from_slice(&src_mac); // Sender HW addr
+    frame[28..32].copy_from_slice(&src_ip.octets()); // Sender proto addr
+    frame[32..38].copy_from_slice(&[0x00; 6]); // Target HW addr (unknown)
+    frame[38..42].copy_from_slice(&target_ip.octets()); // Target proto addr
+    frame
+}
+
+/// Builds a DHCP DISCOVER frame (full L2/IP/UDP/DHCP stack).
+///
+/// The returned frame is a broadcast Ethernet frame with:
+/// - IP: 0.0.0.0 -> 255.255.255.255
+/// - UDP: src=68, dst=67
+/// - DHCP DISCOVER payload with the given client MAC and transaction ID.
+pub fn build_dhcp_discover(client_mac: [u8; 6], xid: u32) -> Vec<u8> {
+    let dhcp_payload = build_dhcp_discover_payload(client_mac, xid);
+    build_udp_frame(
+        client_mac,
+        [0xFF; 6], // broadcast
+        Ipv4Addr::UNSPECIFIED,
+        Ipv4Addr::BROADCAST,
+        68,
+        67,
+        &dhcp_payload,
+    )
+}
+
+/// Builds a DHCP REQUEST frame (full L2/IP/UDP/DHCP stack).
+///
+/// Requests the IP `requested_ip` from the server at `server_ip`.
+pub fn build_dhcp_request(
+    client_mac: [u8; 6],
+    xid: u32,
+    requested_ip: Ipv4Addr,
+    server_ip: Ipv4Addr,
+) -> Vec<u8> {
+    let dhcp_payload = build_dhcp_request_payload(client_mac, xid, requested_ip, server_ip);
+    build_udp_frame(
+        client_mac,
+        [0xFF; 6], // broadcast
+        Ipv4Addr::UNSPECIFIED,
+        Ipv4Addr::BROADCAST,
+        68,
+        67,
+        &dhcp_payload,
+    )
+}
+
+/// Builds a TCP SYN frame.
+pub fn build_tcp_syn(
+    src_mac: [u8; 6],
+    dst_mac: [u8; 6],
+    src_ip: Ipv4Addr,
+    src_port: u16,
+    dst_ip: Ipv4Addr,
+    dst_port: u16,
+) -> Vec<u8> {
+    let tcp_hdr_len = 20;
+    let ip_total = 20 + tcp_hdr_len;
+    let frame_len = ETH_HDR + ip_total;
+    let mut frame = vec![0u8; frame_len];
+
+    // Ethernet header
+    write_eth_header(&mut frame, src_mac, dst_mac, 0x0800);
+
+    // IPv4 header
+    let ip = ETH_HDR;
+    frame[ip] = 0x45;
+    frame[ip + 2..ip + 4].copy_from_slice(&(ip_total as u16).to_be_bytes());
+    frame[ip + 8] = 64; // TTL
+    frame[ip + 9] = 6; // TCP
+    frame[ip + 12..ip + 16].copy_from_slice(&src_ip.octets());
+    frame[ip + 16..ip + 20].copy_from_slice(&dst_ip.octets());
+    write_ipv4_checksum(&mut frame[ip..ip + 20]);
+
+    // TCP header
+    let l4 = ip + 20;
+    frame[l4..l4 + 2].copy_from_slice(&src_port.to_be_bytes());
+    frame[l4 + 2..l4 + 4].copy_from_slice(&dst_port.to_be_bytes());
+    frame[l4 + 4..l4 + 8].copy_from_slice(&1000u32.to_be_bytes()); // seq
+    frame[l4 + 12] = 0x50; // data offset = 5 words
+    frame[l4 + 13] = 0x02; // SYN flag
+
+    frame
+}
+
+/// Builds a DNS query frame (L2/IP/UDP/DNS).
+pub fn build_dns_query(
+    src_mac: [u8; 6],
+    dst_mac: [u8; 6],
+    src_ip: Ipv4Addr,
+    gateway_ip: Ipv4Addr,
+    domain: &str,
+) -> Vec<u8> {
+    let dns_payload = build_dns_query_payload(domain);
+    build_udp_frame(
+        src_mac,
+        dst_mac,
+        src_ip,
+        gateway_ip,
+        12345, // ephemeral src port
+        53,
+        &dns_payload,
+    )
+}
+
+/// Builds a UDP frame with arbitrary payload.
+pub fn build_udp_frame(
+    src_mac: [u8; 6],
+    dst_mac: [u8; 6],
+    src_ip: Ipv4Addr,
+    dst_ip: Ipv4Addr,
+    src_port: u16,
+    dst_port: u16,
+    payload: &[u8],
+) -> Vec<u8> {
+    let udp_len = 8 + payload.len();
+    let ip_total = 20 + udp_len;
+    let frame_len = ETH_HDR + ip_total;
+    let mut frame = vec![0u8; frame_len];
+
+    // Ethernet header
+    write_eth_header(&mut frame, src_mac, dst_mac, 0x0800);
+
+    // IPv4 header
+    let ip = ETH_HDR;
+    frame[ip] = 0x45;
+    frame[ip + 2..ip + 4].copy_from_slice(&(ip_total as u16).to_be_bytes());
+    frame[ip + 8] = 64; // TTL
+    frame[ip + 9] = 17; // UDP
+    frame[ip + 12..ip + 16].copy_from_slice(&src_ip.octets());
+    frame[ip + 16..ip + 20].copy_from_slice(&dst_ip.octets());
+    write_ipv4_checksum(&mut frame[ip..ip + 20]);
+
+    // UDP header
+    let udp = ip + 20;
+    frame[udp..udp + 2].copy_from_slice(&src_port.to_be_bytes());
+    frame[udp + 2..udp + 4].copy_from_slice(&dst_port.to_be_bytes());
+    frame[udp + 4..udp + 6].copy_from_slice(&(udp_len as u16).to_be_bytes());
+    // UDP checksum = 0 (optional for IPv4)
+
+    // Payload
+    frame[udp + 8..].copy_from_slice(payload);
+
+    frame
+}
+
+/// Builds an ICMP Echo Request frame.
+pub fn build_icmp_echo(
+    src_mac: [u8; 6],
+    dst_mac: [u8; 6],
+    src_ip: Ipv4Addr,
+    dst_ip: Ipv4Addr,
+    id: u16,
+    seq: u16,
+) -> Vec<u8> {
+    let icmp_len = 8; // type(1) + code(1) + checksum(2) + id(2) + seq(2)
+    let ip_total = 20 + icmp_len;
+    let frame_len = ETH_HDR + ip_total;
+    let mut frame = vec![0u8; frame_len];
+
+    // Ethernet header
+    write_eth_header(&mut frame, src_mac, dst_mac, 0x0800);
+
+    // IPv4 header
+    let ip = ETH_HDR;
+    frame[ip] = 0x45;
+    frame[ip + 2..ip + 4].copy_from_slice(&(ip_total as u16).to_be_bytes());
+    frame[ip + 8] = 64; // TTL
+    frame[ip + 9] = 1; // ICMP
+    frame[ip + 12..ip + 16].copy_from_slice(&src_ip.octets());
+    frame[ip + 16..ip + 20].copy_from_slice(&dst_ip.octets());
+    write_ipv4_checksum(&mut frame[ip..ip + 20]);
+
+    // ICMP Echo Request
+    let icmp = ip + 20;
+    frame[icmp] = 8; // Type: Echo Request
+    frame[icmp + 1] = 0; // Code
+    frame[icmp + 4..icmp + 6].copy_from_slice(&id.to_be_bytes());
+    frame[icmp + 6..icmp + 8].copy_from_slice(&seq.to_be_bytes());
+    // ICMP checksum
+    let cksum = internet_checksum(&frame[icmp..icmp + icmp_len]);
+    frame[icmp + 2..icmp + 4].copy_from_slice(&cksum.to_be_bytes());
+
+    frame
+}
+
+// ---------------------------------------------------------------------------
+// Frame parsers
+// ---------------------------------------------------------------------------
+
+/// Parsed Ethernet frame header.
+#[derive(Debug)]
+pub struct ParsedEthFrame<'a> {
+    pub dst_mac: [u8; 6],
+    pub src_mac: [u8; 6],
+    pub ethertype: u16,
+    pub payload: &'a [u8],
+}
+
+/// Parses an Ethernet frame header.
+pub fn parse_eth_frame(frame: &[u8]) -> Option<ParsedEthFrame<'_>> {
+    if frame.len() < ETH_HDR {
+        return None;
+    }
+    let mut dst_mac = [0u8; 6];
+    let mut src_mac = [0u8; 6];
+    dst_mac.copy_from_slice(&frame[0..6]);
+    src_mac.copy_from_slice(&frame[6..12]);
+    let ethertype = u16::from_be_bytes([frame[12], frame[13]]);
+    Some(ParsedEthFrame {
+        dst_mac,
+        src_mac,
+        ethertype,
+        payload: &frame[ETH_HDR..],
+    })
+}
+
+/// Extracts the DHCP payload from a UDP/IP/Ethernet frame.
+///
+/// Returns the raw DHCP bytes (starting after the UDP header), or `None`
+/// if the frame is too short or not a UDP packet.
+pub fn extract_dhcp_payload(frame: &[u8]) -> Option<&[u8]> {
+    if frame.len() < ETH_HDR + 28 {
+        return None;
+    }
+    let ip_start = ETH_HDR;
+    let ihl = ((frame[ip_start] & 0x0F) as usize) * 4;
+    let l4 = ip_start + ihl;
+    let dhcp = l4 + 8;
+    if dhcp >= frame.len() {
+        return None;
+    }
+    Some(&frame[dhcp..])
+}
+
+/// Parsed DHCP response fields (minimal for test validation).
+#[derive(Debug)]
+pub struct ParsedDhcp {
+    pub op: u8,
+    pub xid: u32,
+    pub yiaddr: Ipv4Addr,
+    pub siaddr: Ipv4Addr,
+    pub message_type: Option<u8>,
+    pub subnet_mask: Option<Ipv4Addr>,
+    pub router: Option<Ipv4Addr>,
+    pub lease_time: Option<u32>,
+    pub server_id: Option<Ipv4Addr>,
+}
+
+/// Parses a DHCP payload (raw bytes after UDP header).
+pub fn parse_dhcp(data: &[u8]) -> Option<ParsedDhcp> {
+    if data.len() < 240 {
+        return None;
+    }
+    let op = data[0];
+    let xid = u32::from_be_bytes([data[4], data[5], data[6], data[7]]);
+    let yiaddr = Ipv4Addr::new(data[16], data[17], data[18], data[19]);
+    let siaddr = Ipv4Addr::new(data[20], data[21], data[22], data[23]);
+
+    // Parse options (after magic cookie at offset 236).
+    let mut message_type = None;
+    let mut subnet_mask = None;
+    let mut router = None;
+    let mut lease_time = None;
+    let mut server_id = None;
+
+    if data.len() > 240 && data[236..240] == [99, 130, 83, 99] {
+        let mut i = 240;
+        while i < data.len() {
+            let code = data[i];
+            if code == 255 {
+                break;
+            }
+            if code == 0 {
+                i += 1;
+                continue;
+            }
+            if i + 1 >= data.len() {
+                break;
+            }
+            let len = data[i + 1] as usize;
+            if i + 2 + len > data.len() {
+                break;
+            }
+            let val = &data[i + 2..i + 2 + len];
+            match code {
+                53 if len == 1 => message_type = Some(val[0]),
+                1 if len == 4 => {
+                    subnet_mask = Some(Ipv4Addr::new(val[0], val[1], val[2], val[3]));
+                }
+                3 if len >= 4 => {
+                    router = Some(Ipv4Addr::new(val[0], val[1], val[2], val[3]));
+                }
+                51 if len == 4 => {
+                    lease_time = Some(u32::from_be_bytes([val[0], val[1], val[2], val[3]]));
+                }
+                54 if len == 4 => {
+                    server_id = Some(Ipv4Addr::new(val[0], val[1], val[2], val[3]));
+                }
+                _ => {}
+            }
+            i += 2 + len;
+        }
+    }
+
+    Some(ParsedDhcp {
+        op,
+        xid,
+        yiaddr,
+        siaddr,
+        message_type,
+        subnet_mask,
+        router,
+        lease_time,
+        server_id,
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+/// Writes the Ethernet header at the start of `frame`.
+fn write_eth_header(frame: &mut [u8], src_mac: [u8; 6], dst_mac: [u8; 6], ethertype: u16) {
+    frame[0..6].copy_from_slice(&dst_mac);
+    frame[6..12].copy_from_slice(&src_mac);
+    frame[12..14].copy_from_slice(&ethertype.to_be_bytes());
+}
+
+/// Computes and writes the IPv4 header checksum in-place.
+fn write_ipv4_checksum(header: &mut [u8]) {
+    // Clear existing checksum field.
+    header[10] = 0;
+    header[11] = 0;
+    let cksum = internet_checksum(header);
+    header[10..12].copy_from_slice(&cksum.to_be_bytes());
+}
+
+/// RFC 1071 internet checksum.
+fn internet_checksum(data: &[u8]) -> u16 {
+    let mut sum: u32 = 0;
+    let mut i = 0;
+    while i + 1 < data.len() {
+        sum += u32::from(u16::from_be_bytes([data[i], data[i + 1]]));
+        i += 2;
+    }
+    if i < data.len() {
+        sum += u32::from(data[i]) << 8;
+    }
+    while sum > 0xFFFF {
+        sum = (sum & 0xFFFF) + (sum >> 16);
+    }
+    !sum as u16
+}
+
+/// Builds a DHCP DISCOVER payload (just the BOOTP/DHCP portion).
+fn build_dhcp_discover_payload(client_mac: [u8; 6], xid: u32) -> Vec<u8> {
+    let mut data = vec![0u8; 300]; // Enough for header + magic + options
+
+    data[0] = 1; // BOOTREQUEST
+    data[1] = 1; // HW type: Ethernet
+    data[2] = 6; // HW addr len
+    data[4..8].copy_from_slice(&xid.to_be_bytes());
+    data[28..34].copy_from_slice(&client_mac);
+
+    // Magic cookie at offset 236
+    data[236..240].copy_from_slice(&[99, 130, 83, 99]);
+
+    // Options
+    let mut opt = 240;
+    // Option 53: DHCP Message Type = DISCOVER (1)
+    data[opt] = 53;
+    data[opt + 1] = 1;
+    data[opt + 2] = 1;
+    opt += 3;
+    // Option 255: End
+    data[opt] = 255;
+
+    data
+}
+
+/// Builds a DHCP REQUEST payload.
+fn build_dhcp_request_payload(
+    client_mac: [u8; 6],
+    xid: u32,
+    requested_ip: Ipv4Addr,
+    server_ip: Ipv4Addr,
+) -> Vec<u8> {
+    let mut data = vec![0u8; 300];
+
+    data[0] = 1; // BOOTREQUEST
+    data[1] = 1; // HW type: Ethernet
+    data[2] = 6; // HW addr len
+    data[4..8].copy_from_slice(&xid.to_be_bytes());
+    data[28..34].copy_from_slice(&client_mac);
+
+    // Magic cookie
+    data[236..240].copy_from_slice(&[99, 130, 83, 99]);
+
+    // Options
+    let mut opt = 240;
+    // Option 53: DHCP Message Type = REQUEST (3)
+    data[opt] = 53;
+    data[opt + 1] = 1;
+    data[opt + 2] = 3;
+    opt += 3;
+    // Option 50: Requested IP Address
+    data[opt] = 50;
+    data[opt + 1] = 4;
+    data[opt + 2..opt + 6].copy_from_slice(&requested_ip.octets());
+    opt += 6;
+    // Option 54: Server Identifier
+    data[opt] = 54;
+    data[opt + 1] = 4;
+    data[opt + 2..opt + 6].copy_from_slice(&server_ip.octets());
+    opt += 6;
+    // Option 255: End
+    data[opt] = 255;
+
+    data
+}
+
+/// Builds a minimal DNS A query payload for `domain`.
+fn build_dns_query_payload(domain: &str) -> Vec<u8> {
+    let mut pkt = Vec::new();
+    // Header: ID=0xABCD, flags=standard query, QDCOUNT=1
+    pkt.extend_from_slice(&[0xAB, 0xCD, 0x01, 0x00, 0x00, 0x01, 0x00, 0x00]);
+    pkt.extend_from_slice(&[0x00, 0x00, 0x00, 0x00]);
+    // Question: encode domain labels
+    for label in domain.split('.') {
+        pkt.push(label.len() as u8);
+        pkt.extend_from_slice(label.as_bytes());
+    }
+    pkt.push(0x00); // root label
+    pkt.extend_from_slice(&[0x00, 0x01]); // QTYPE: A
+    pkt.extend_from_slice(&[0x00, 0x01]); // QCLASS: IN
+    pkt
+}

--- a/virt/arcbox-net/tests/helpers/mock_nic.rs
+++ b/virt/arcbox-net/tests/helpers/mock_nic.rs
@@ -1,0 +1,91 @@
+//! Mock guest NIC using a Unix socketpair.
+//!
+//! Provides a socketpair-based mock for the guest VM's network device FD.
+//! The host end is passed to `NetworkDatapath`, while the "guest" end is used
+//! by tests to inject L2 Ethernet frames and read responses.
+
+use std::io;
+use std::os::fd::{FromRawFd, OwnedFd, RawFd};
+
+/// Creates a `SOCK_DGRAM` socketpair and returns `(host_fd, guest_fd)`.
+///
+/// The host FD is passed into `NetworkDatapath` (or `SmoltcpDevice`).
+/// The guest FD is used by the test to write/read raw Ethernet frames.
+pub fn mock_guest_nic() -> (OwnedFd, OwnedFd) {
+    let mut fds: [i32; 2] = [0; 2];
+    // SAFETY: valid pointer to 2-element array.
+    let ret = unsafe { libc::socketpair(libc::AF_UNIX, libc::SOCK_DGRAM, 0, fds.as_mut_ptr()) };
+    assert_eq!(ret, 0, "socketpair() failed");
+    // SAFETY: fds are valid file descriptors returned by socketpair.
+    unsafe { (OwnedFd::from_raw_fd(fds[0]), OwnedFd::from_raw_fd(fds[1])) }
+}
+
+/// Sets a file descriptor to non-blocking mode.
+pub fn set_nonblocking(fd: RawFd) {
+    // SAFETY: fcntl on a valid fd.
+    unsafe {
+        let flags = libc::fcntl(fd, libc::F_GETFL);
+        libc::fcntl(fd, libc::F_SETFL, flags | libc::O_NONBLOCK);
+    }
+}
+
+/// Writes a raw frame to a file descriptor (blocking, for test setup).
+pub fn fd_write(fd: RawFd, data: &[u8]) -> io::Result<usize> {
+    // SAFETY: writing from a valid buffer to a valid fd.
+    let n = unsafe { libc::write(fd, data.as_ptr().cast(), data.len()) };
+    if n < 0 {
+        Err(io::Error::last_os_error())
+    } else {
+        #[allow(clippy::cast_sign_loss)]
+        Ok(n as usize)
+    }
+}
+
+/// Reads a raw frame from a file descriptor (non-blocking).
+///
+/// Returns `Ok(vec)` with the frame data, or `Err` if no data is available
+/// or the read fails.
+pub fn fd_read(fd: RawFd, buf: &mut [u8]) -> io::Result<usize> {
+    // SAFETY: reading into a valid buffer from a valid fd.
+    let n = unsafe { libc::read(fd, buf.as_mut_ptr().cast(), buf.len()) };
+    if n < 0 {
+        Err(io::Error::last_os_error())
+    } else {
+        #[allow(clippy::cast_sign_loss)]
+        Ok(n as usize)
+    }
+}
+
+/// Reads all available frames from a non-blocking FD, returning them as
+/// a `Vec<Vec<u8>>`. Stops on `EWOULDBLOCK`.
+pub fn drain_frames(fd: RawFd) -> Vec<Vec<u8>> {
+    let mut frames = Vec::new();
+    let mut buf = vec![0u8; 65535];
+    loop {
+        match fd_read(fd, &mut buf) {
+            Ok(n) if n > 0 => frames.push(buf[..n].to_vec()),
+            Ok(_) => break,
+            Err(e) if e.kind() == io::ErrorKind::WouldBlock => break,
+            Err(e) if e.kind() == io::ErrorKind::Interrupted => {}
+            Err(_) => break,
+        }
+    }
+    frames
+}
+
+/// Helper to wait for at least one frame to appear on the guest FD,
+/// with a timeout. Returns all frames read.
+pub async fn recv_frames_timeout(fd: RawFd, timeout: std::time::Duration) -> Vec<Vec<u8>> {
+    let deadline = tokio::time::Instant::now() + timeout;
+    loop {
+        let frames = drain_frames(fd);
+        if !frames.is_empty() {
+            return frames;
+        }
+        if tokio::time::Instant::now() >= deadline {
+            return Vec::new();
+        }
+        // Yield briefly to let the datapath task run.
+        tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+    }
+}

--- a/virt/arcbox-net/tests/helpers/mod.rs
+++ b/virt/arcbox-net/tests/helpers/mod.rs
@@ -1,0 +1,4 @@
+//! Shared test helpers for arcbox-net datapath integration tests.
+
+pub mod frames;
+pub mod mock_nic;


### PR DESCRIPTION
## Summary

- Add mock guest NIC infrastructure using `socketpair(AF_UNIX, SOCK_DGRAM)` to test the full network datapath without requiring a VM, root privileges, or code signing
- Implement L2 Ethernet frame builders (ARP, DHCP, TCP SYN, DNS, UDP, ICMP) and parsers for test assertions
- Add 5 integration tests covering DHCP full cycle and frame classification (ARP, TCP SYN gating, ICMP, DHCP interception)

Key finding: `NetworkDatapath` already accepts a plain `OwnedFd` — no refactoring was needed. The architecture is inherently test-friendly.

**Linear**: ABX-298, ABX-300

## New files

| File | Purpose |
|------|---------|
| `virt/arcbox-net/tests/helpers/mock_nic.rs` | socketpair mock NIC + FD I/O utilities |
| `virt/arcbox-net/tests/helpers/frames.rs` | L2 frame builders and parsers |
| `virt/arcbox-net/tests/datapath_test.rs` | 5 integration tests |

## Test plan

- [x] `cargo test -p arcbox-net --test datapath_test` — all 5 tests pass
- [ ] `cargo clippy -p arcbox-net` — zero warnings
- [ ] CI passes on macOS runner