### PR TITLE
perf(net): TCP fast path — bypass smoltcp for established connections

### DIFF
--- a/virt/arcbox-net/src/darwin/datapath_loop.rs
+++ b/virt/arcbox-net/src/darwin/datapath_loop.rs
@@ -275,7 +275,18 @@ impl NetworkDatapath {
                     if prev_mac.is_none() {
                         if let Some(gmac) = guest_mac {
                             device.seed_gateway_neighbor(gateway_ip, gateway_mac, gmac);
+                            tcp_bridge.set_fast_path_macs(gateway_mac, gmac);
                         }
+                    }
+
+                    // Fast-path intercept: extract TCP data frames for established
+                    // fast-path connections BEFORE smoltcp sees them. This avoids
+                    // smoltcp's per-segment TCP state machine overhead.
+                    let fast_acks = device.drain_fast_path(|frame_data| {
+                        tcp_bridge.try_fast_path_intercept(frame_data)
+                    });
+                    for ack in fast_acks {
+                        enqueue_or_write(&guest_async, FrameBuf::from(ack), &mut write_queue);
                     }
 
                     // Process intercepted frames (DHCP, DNS, UDP, ICMP).
@@ -409,7 +420,13 @@ impl NetworkDatapath {
             let ts = smoltcp::time::Instant::now();
             iface.poll(ts, &mut device, &mut sockets);
 
-            // 5. Flush TX frames to guest.
+            // 5. Poll fast-path host streams for inbound data and inject
+            //    constructed frames directly to guest (bypasses smoltcp).
+            for frame in tcp_bridge.poll_fast_path() {
+                enqueue_or_write(&guest_async, FrameBuf::from(frame), &mut write_queue);
+            }
+
+            // 6. Flush TX frames to guest (from smoltcp).
             for frame in device.take_tx_pending() {
                 enqueue_or_write(&guest_async, frame, &mut write_queue);
             }

--- a/virt/arcbox-net/src/darwin/smoltcp_device.rs
+++ b/virt/arcbox-net/src/darwin/smoltcp_device.rs
@@ -233,17 +233,22 @@ impl SmoltcpDevice {
         mut try_intercept: impl FnMut(&[u8]) -> Option<Vec<u8>>,
     ) -> Vec<Vec<u8>> {
         let mut ack_frames = Vec::new();
-        let mut kept = std::collections::VecDeque::new();
 
-        while let Some(frame) = self.rx_queue.pop_front() {
-            if let Some(ack) = try_intercept(&frame) {
-                ack_frames.push(ack);
+        // Filter in-place: swap-remove intercepted frames to avoid rebuilding
+        // the VecDeque. We iterate backwards so removal doesn't shift indices.
+        let mut i = 0;
+        while i < self.rx_queue.len() {
+            if let Some(ack) = try_intercept(&self.rx_queue[i]) {
+                if !ack.is_empty() {
+                    ack_frames.push(ack);
+                }
+                self.rx_queue.remove(i);
+                // Don't increment i — next element shifted into current slot.
             } else {
-                kept.push_back(frame);
+                i += 1;
             }
         }
 
-        self.rx_queue = kept;
         ack_frames
     }
 

--- a/virt/arcbox-net/src/darwin/smoltcp_device.rs
+++ b/virt/arcbox-net/src/darwin/smoltcp_device.rs
@@ -234,8 +234,9 @@ impl SmoltcpDevice {
     ) -> Vec<Vec<u8>> {
         let mut ack_frames = Vec::new();
 
-        // Filter in-place: swap-remove intercepted frames to avoid rebuilding
-        // the VecDeque. We iterate backwards so removal doesn't shift indices.
+        // Filter in-place: remove intercepted frames via forward iteration.
+        // VecDeque::remove(i) is O(n) but fast-path connections are few and
+        // most frames pass through unintercepted, so removals are rare.
         let mut i = 0;
         while i < self.rx_queue.len() {
             if let Some(ack) = try_intercept(&self.rx_queue[i]) {

--- a/virt/arcbox-net/src/darwin/smoltcp_device.rs
+++ b/virt/arcbox-net/src/darwin/smoltcp_device.rs
@@ -220,6 +220,33 @@ impl SmoltcpDevice {
         std::mem::take(&mut self.gated_syns)
     }
 
+    /// Filters fast-path TCP data frames from `rx_queue` before smoltcp sees them.
+    ///
+    /// For each frame in `rx_queue`, calls `try_intercept` with a reference to
+    /// the frame data. If the callback returns `Some(ack_frame)`, the frame is
+    /// removed from the queue and the ACK is collected for injection to the guest.
+    ///
+    /// Frames that are not intercepted (callback returns `None`) remain in the
+    /// queue for smoltcp to process normally.
+    pub fn drain_fast_path(
+        &mut self,
+        mut try_intercept: impl FnMut(&[u8]) -> Option<Vec<u8>>,
+    ) -> Vec<Vec<u8>> {
+        let mut ack_frames = Vec::new();
+        let mut kept = std::collections::VecDeque::new();
+
+        while let Some(frame) = self.rx_queue.pop_front() {
+            if let Some(ack) = try_intercept(&frame) {
+                ack_frames.push(ack);
+            } else {
+                kept.push_back(frame);
+            }
+        }
+
+        self.rx_queue = kept;
+        ack_frames
+    }
+
     /// Classifies a frame and routes it to the appropriate queue.
     fn classify_frame(&mut self, frame: FrameBuf, guest_mac: &mut Option<[u8; 6]>) {
         if frame.len() < ETH_HEADER_LEN {

--- a/virt/arcbox-net/src/darwin/smoltcp_device.rs
+++ b/virt/arcbox-net/src/darwin/smoltcp_device.rs
@@ -23,8 +23,8 @@ use std::sync::Arc;
 use smoltcp::phy::{Device, DeviceCapabilities, Medium, RxToken, TxToken};
 use smoltcp::time::Instant;
 
-use crate::datapath::FrameBuf;
 use crate::datapath::pool::PacketPool;
+use crate::datapath::FrameBuf;
 use crate::ethernet::ETH_HEADER_LEN;
 
 /// Default Ethernet MTU (excludes Ethernet header).
@@ -192,7 +192,7 @@ impl SmoltcpDevice {
         frame.extend_from_slice(&gateway_mac);
         frame.extend_from_slice(&guest_mac);
         frame.extend_from_slice(&[0x08, 0x06]); // EtherType: ARP
-        // ARP payload
+                                                // ARP payload
         frame.extend_from_slice(&[0x00, 0x01]); // Hardware type: Ethernet
         frame.extend_from_slice(&[0x08, 0x00]); // Protocol type: IPv4
         frame.push(6); // Hardware address length
@@ -486,7 +486,7 @@ mod tests {
         frame[0..6].copy_from_slice(&[0x02, 0x00, 0x00, 0x00, 0x00, 0x01]);
         frame[6..12].copy_from_slice(&guest_mac);
         frame[12..14].copy_from_slice(&[0x08, 0x00]); // IPv4
-        // IPv4 header
+                                                      // IPv4 header
         let ip = ETH_HEADER_LEN;
         frame[ip] = 0x45;
         frame[ip + 2..ip + 4].copy_from_slice(&40u16.to_be_bytes());
@@ -697,7 +697,7 @@ mod tests {
         let ip = ETH_HEADER_LEN;
         let l4 = ip + 20;
         frame[l4 + 13] = 0x02; // SYN flag
-        // Set src port = 12345, dst port = 443
+                               // Set src port = 12345, dst port = 443
         frame[l4..l4 + 2].copy_from_slice(&12345u16.to_be_bytes());
         frame[l4 + 2..l4 + 4].copy_from_slice(&443u16.to_be_bytes());
         // Set seq = 1000

--- a/virt/arcbox-net/src/darwin/smoltcp_device.rs
+++ b/virt/arcbox-net/src/darwin/smoltcp_device.rs
@@ -23,8 +23,8 @@ use std::sync::Arc;
 use smoltcp::phy::{Device, DeviceCapabilities, Medium, RxToken, TxToken};
 use smoltcp::time::Instant;
 
-use crate::datapath::pool::PacketPool;
 use crate::datapath::FrameBuf;
+use crate::datapath::pool::PacketPool;
 use crate::ethernet::ETH_HEADER_LEN;
 
 /// Default Ethernet MTU (excludes Ethernet header).
@@ -192,7 +192,7 @@ impl SmoltcpDevice {
         frame.extend_from_slice(&gateway_mac);
         frame.extend_from_slice(&guest_mac);
         frame.extend_from_slice(&[0x08, 0x06]); // EtherType: ARP
-                                                // ARP payload
+        // ARP payload
         frame.extend_from_slice(&[0x00, 0x01]); // Hardware type: Ethernet
         frame.extend_from_slice(&[0x08, 0x00]); // Protocol type: IPv4
         frame.push(6); // Hardware address length
@@ -518,7 +518,7 @@ mod tests {
         frame[0..6].copy_from_slice(&[0x02, 0x00, 0x00, 0x00, 0x00, 0x01]);
         frame[6..12].copy_from_slice(&guest_mac);
         frame[12..14].copy_from_slice(&[0x08, 0x00]); // IPv4
-                                                      // IPv4 header
+        // IPv4 header
         let ip = ETH_HEADER_LEN;
         frame[ip] = 0x45;
         frame[ip + 2..ip + 4].copy_from_slice(&40u16.to_be_bytes());
@@ -729,7 +729,7 @@ mod tests {
         let ip = ETH_HEADER_LEN;
         let l4 = ip + 20;
         frame[l4 + 13] = 0x02; // SYN flag
-                               // Set src port = 12345, dst port = 443
+        // Set src port = 12345, dst port = 443
         frame[l4..l4 + 2].copy_from_slice(&12345u16.to_be_bytes());
         frame[l4 + 2..l4 + 4].copy_from_slice(&443u16.to_be_bytes());
         // Set seq = 1000

--- a/virt/arcbox-net/src/darwin/tcp_bridge.rs
+++ b/virt/arcbox-net/src/darwin/tcp_bridge.rs
@@ -133,6 +133,12 @@ struct BridgedConn {
     host_disconnected: bool,
     /// Leftover bytes from a partial `send_slice` that need to be retried.
     pending_send: Option<Vec<u8>>,
+    /// Host stream held for fast-path promotion. When set, the relay task
+    /// has NOT been spawned — the stream is waiting for the socket to reach
+    /// ESTABLISHED before being promoted to `FastPathConn`.
+    held_stream: Option<tokio::net::TcpStream>,
+    /// Four-tuple key for fast-path lookup (set when held_stream is present).
+    flow_key: Option<SynFlowKey>,
 }
 
 /// Manages TCP connections bridged between the smoltcp socket pool and host
@@ -263,6 +269,32 @@ impl TcpBridge {
         };
 
         let conn = self.fast_path_conns.get_mut(&key)?;
+
+        // Sync SEQ/ACK from the first frame if we initialized with zeros
+        // (smoltcp doesn't expose its ISN publicly).
+        let guest_seq = u32::from_be_bytes([
+            frame[l4_start + 4],
+            frame[l4_start + 5],
+            frame[l4_start + 6],
+            frame[l4_start + 7],
+        ]);
+        let guest_ack = u32::from_be_bytes([
+            frame[l4_start + 8],
+            frame[l4_start + 9],
+            frame[l4_start + 10],
+            frame[l4_start + 11],
+        ]);
+        if conn.our_seq == 0 && conn.last_ack == 0 {
+            // First frame after promotion: guest_ack tells us what SEQ
+            // it expects from us, and guest_seq is its next byte.
+            conn.our_seq = guest_ack;
+            conn.last_ack = guest_seq;
+            tracing::debug!(
+                "Fast path: synced SEQ/ACK for {src_ip}:{src_port}→{dst_ip}:{dst_port}: our_seq={}, last_ack={}",
+                conn.our_seq,
+                conn.last_ack
+            );
+        }
 
         // FIN or RST → teardown, let smoltcp handle it.
         if flags & 0x01 != 0 || flags & 0x04 != 0 {
@@ -878,6 +910,8 @@ impl TcpBridge {
                 host_eof: false,
                 host_disconnected: false,
                 pending_send: None,
+                held_stream: None,
+                flow_key: None,
             },
         );
 
@@ -960,35 +994,52 @@ impl TcpBridge {
                     dst_port: local_ep.port,
                 };
 
-                // Create channels for host↔guest data bridging.
-                let (h2g_tx, h2g_rx) = mpsc::channel::<Vec<u8>>(HOST_TO_GUEST_CHANNEL);
-                let (g2h_tx, g2h_rx) = mpsc::channel::<Vec<u8>>(GUEST_TO_HOST_CHANNEL);
-
                 // Try to use a pre-connected stream from the SYN gate.
+                // If available, hold it for fast-path promotion once ESTABLISHED.
+                // Otherwise, fall back to the normal channel-based relay.
                 if let Some(pre) = self.pre_connected.remove(&flow_key) {
                     tracing::debug!(
-                        "TCP bridge: using pre-connected stream for guest:{remote_addr} → {dest_addr}"
+                        "TCP bridge: holding pre-connected stream for fast-path: guest:{remote_addr} → {dest_addr}"
                     );
-                    tokio::spawn(inbound_host_relay(pre.stream, h2g_tx, g2h_rx));
+                    // Create dummy channels (unused — fast path will take over).
+                    let (_h2g_tx, h2g_rx) = mpsc::channel::<Vec<u8>>(1);
+                    let (g2h_tx, _g2h_rx) = mpsc::channel::<Vec<u8>>(1);
+                    self.connections.insert(
+                        handle,
+                        BridgedConn {
+                            handle,
+                            remote: dest_addr,
+                            host_to_guest_rx: h2g_rx,
+                            guest_to_host_tx: Some(g2h_tx),
+                            host_eof: false,
+                            host_disconnected: false,
+                            pending_send: None,
+                            held_stream: Some(pre.stream),
+                            flow_key: Some(flow_key),
+                        },
+                    );
                 } else {
                     tracing::debug!(
                         "TCP bridge: no pre-connected stream, spawning connect for guest:{remote_addr} → {dest_addr}"
                     );
+                    let (h2g_tx, h2g_rx) = mpsc::channel::<Vec<u8>>(HOST_TO_GUEST_CHANNEL);
+                    let (g2h_tx, g2h_rx) = mpsc::channel::<Vec<u8>>(GUEST_TO_HOST_CHANNEL);
                     tokio::spawn(host_conn_task(dest_addr, h2g_tx, g2h_rx));
-                }
-
-                self.connections.insert(
-                    handle,
-                    BridgedConn {
+                    self.connections.insert(
                         handle,
-                        remote: dest_addr,
-                        host_to_guest_rx: h2g_rx,
-                        guest_to_host_tx: Some(g2h_tx),
-                        host_eof: false,
-                        host_disconnected: false,
-                        pending_send: None,
-                    },
-                );
+                        BridgedConn {
+                            handle,
+                            remote: dest_addr,
+                            host_to_guest_rx: h2g_rx,
+                            guest_to_host_tx: Some(g2h_tx),
+                            host_eof: false,
+                            host_disconnected: false,
+                            pending_send: None,
+                            held_stream: None,
+                            flow_key: None,
+                        },
+                    );
+                }
 
                 // This port's listen socket is now occupied. Remove from
                 // listening_ports and schedule a replacement.
@@ -1028,8 +1079,44 @@ impl TcpBridge {
     }
 
     /// Relays data between smoltcp sockets and host TcpStreams for all active
-    /// connections.
+    /// connections. Promotes held-stream connections to fast path when ESTABLISHED.
     fn relay_all(&mut self, sockets: &mut SocketSet<'_>) {
+        // Check for connections ready to promote to fast path.
+        let mut to_promote = Vec::new();
+        for (handle, conn) in &self.connections {
+            if conn.held_stream.is_some() {
+                let sock = sockets.get::<tcp::Socket>(*handle);
+                if sock.state() == tcp::State::Established {
+                    to_promote.push(*handle);
+                }
+            }
+        }
+        for handle in to_promote {
+            if let Some(mut conn) = self.connections.remove(&handle) {
+                if let (Some(stream), Some(flow_key)) = (conn.held_stream.take(), conn.flow_key) {
+                    // smoltcp doesn't expose SEQ/ACK publicly. We initialize
+                    // with zeros — the first guest data frame's SEQ and ACK
+                    // fields will tell us the correct values, and
+                    // try_fast_path_intercept() will sync on first use.
+                    let our_seq = 0u32;
+                    let last_ack = 0u32;
+
+                    // Close the smoltcp socket — fast path takes over.
+                    sockets.get_mut::<tcp::Socket>(handle).abort();
+                    sockets.remove(handle);
+
+                    // Convert tokio stream to std for non-blocking sync I/O.
+                    let std_stream = stream.into_std().unwrap_or_else(|_| {
+                        // Fallback: this shouldn't happen.
+                        tracing::error!("Fast path: failed to convert tokio TcpStream to std");
+                        std::net::TcpStream::connect("127.0.0.1:1").unwrap()
+                    });
+
+                    self.promote_to_fast_path(flow_key, std_stream, our_seq, last_ack);
+                }
+            }
+        }
+
         for conn in self.connections.values_mut() {
             let sock = sockets.get_mut::<tcp::Socket>(conn.handle);
 
@@ -1758,6 +1845,8 @@ mod tests {
                 host_eof: false,
                 host_disconnected: false,
                 pending_send: Some(vec![0xAA; 32]),
+                held_stream: None,
+                flow_key: None,
             },
         );
 
@@ -1800,6 +1889,8 @@ mod tests {
                 host_eof: true,
                 host_disconnected: false,
                 pending_send: Some(vec![0xBB; 10]),
+                held_stream: None,
+                flow_key: None,
             },
         );
 
@@ -1851,6 +1942,8 @@ mod tests {
                 host_eof: false,
                 host_disconnected: false,
                 pending_send: None,
+                held_stream: None,
+                flow_key: None,
             },
         );
 
@@ -1889,6 +1982,8 @@ mod tests {
                 host_eof: false,
                 host_disconnected: false,
                 pending_send: None,
+                held_stream: None,
+                flow_key: None,
             },
         );
 

--- a/virt/arcbox-net/src/darwin/tcp_bridge.rs
+++ b/virt/arcbox-net/src/darwin/tcp_bridge.rs
@@ -79,9 +79,9 @@ const SYN_GATE_CONNECT_TIMEOUT_SECS: u64 = 5;
 /// window, the stream is dropped.
 const PRE_CONNECTED_TTL_SECS: u64 = 10;
 
-/// Full four-tuple key for deduplicating SYN gate entries.
+/// Full four-tuple key for deduplicating SYN gate entries and fast-path lookup.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-struct SynFlowKey {
+pub struct SynFlowKey {
     src_ip: Ipv4Addr,
     src_port: u16,
     dst_ip: Ipv4Addr,
@@ -160,6 +160,37 @@ pub struct TcpBridge {
     /// translated to `127.0.0.1` so they reach the host's loopback
     /// (enables `host.docker.internal` support).
     gateway_ip: Ipv4Addr,
+    /// Fast-path connections that bypass smoltcp for data transfer.
+    /// Keyed by (guest_src_ip, guest_src_port, dest_ip, dest_port).
+    fast_path_conns: HashMap<SynFlowKey, FastPathConn>,
+    /// Gateway MAC for constructing fast-path frames to the guest.
+    fast_path_gateway_mac: [u8; 6],
+    /// Guest MAC for constructing fast-path frames to the guest.
+    fast_path_guest_mac: Option<[u8; 6]>,
+}
+
+/// A TCP connection promoted to the fast path — bypasses smoltcp entirely
+/// for data transfer. smoltcp handled the initial 3-way handshake; data
+/// frames are now intercepted at `classify_ipv4` and relayed directly.
+struct FastPathConn {
+    /// Host-side TCP stream (std blocking — used from the sync datapath loop).
+    stream: std::net::TcpStream,
+    /// Our SEQ number for frames sent TO guest.
+    our_seq: u32,
+    /// Last ACK we sent to guest (= next SEQ we expect FROM guest).
+    last_ack: u32,
+    /// Remote IP as seen by the guest.
+    remote_ip: Ipv4Addr,
+    /// Guest IP.
+    guest_ip: Ipv4Addr,
+    /// Remote port as seen by the guest.
+    remote_port: u16,
+    /// Guest port.
+    guest_port: u16,
+    /// Read buffer for host → guest data (reused across polls).
+    read_buf: Vec<u8>,
+    /// True if host stream has reached EOF.
+    host_eof: bool,
 }
 
 impl TcpBridge {
@@ -174,7 +205,241 @@ impl TcpBridge {
             dns_log: None,
             proxy_env: None,
             gateway_ip,
+            fast_path_conns: HashMap::new(),
+            fast_path_gateway_mac: [0; 6],
+            fast_path_guest_mac: None,
         }
+    }
+
+    /// Updates the MAC addresses used for fast-path frame construction.
+    pub fn set_fast_path_macs(&mut self, gateway_mac: [u8; 6], guest_mac: [u8; 6]) {
+        self.fast_path_gateway_mac = gateway_mac;
+        self.fast_path_guest_mac = Some(guest_mac);
+    }
+
+    /// Checks if a TCP frame matches a fast-path connection.
+    ///
+    /// Called from `classify_ipv4` before the frame reaches smoltcp.
+    /// Returns `Some(ack_frame)` if the frame was handled (payload written
+    /// to host stream, ACK generated), or `None` if not a fast-path match.
+    pub fn try_fast_path_intercept(&mut self, frame: &[u8]) -> Option<Vec<u8>> {
+        if frame.len() < ETH_HEADER_LEN + 40 {
+            return None; // Too short for ETH + IP + TCP minimum
+        }
+
+        let ip_start = ETH_HEADER_LEN;
+        let protocol = frame[ip_start + 9];
+        if protocol != 6 {
+            return None; // Not TCP
+        }
+
+        let ihl = ((frame[ip_start] & 0x0F) as usize) * 4;
+        let l4_start = ip_start + ihl;
+        if frame.len() < l4_start + 20 {
+            return None;
+        }
+
+        let src_ip = Ipv4Addr::new(
+            frame[ip_start + 12],
+            frame[ip_start + 13],
+            frame[ip_start + 14],
+            frame[ip_start + 15],
+        );
+        let dst_ip = Ipv4Addr::new(
+            frame[ip_start + 16],
+            frame[ip_start + 17],
+            frame[ip_start + 18],
+            frame[ip_start + 19],
+        );
+        let src_port = u16::from_be_bytes([frame[l4_start], frame[l4_start + 1]]);
+        let dst_port = u16::from_be_bytes([frame[l4_start + 2], frame[l4_start + 3]]);
+        let flags = frame[l4_start + 13];
+
+        let key = SynFlowKey {
+            src_ip,
+            src_port,
+            dst_ip,
+            dst_port,
+        };
+
+        let conn = self.fast_path_conns.get_mut(&key)?;
+
+        // FIN or RST → teardown, let smoltcp handle it.
+        if flags & 0x01 != 0 || flags & 0x04 != 0 {
+            tracing::debug!(
+                "Fast path: FIN/RST on {src_ip}:{src_port} → {dst_ip}:{dst_port}, removing"
+            );
+            self.fast_path_conns.remove(&key);
+            return None; // Fall through to smoltcp for teardown.
+        }
+
+        // Extract payload.
+        let tcp_data_offset = ((frame[l4_start + 12] >> 4) as usize) * 4;
+        let payload_start = l4_start + tcp_data_offset;
+        let payload_len = if payload_start < frame.len() {
+            frame.len() - payload_start
+        } else {
+            0
+        };
+
+        // Write payload to host stream (if any).
+        if payload_len > 0 {
+            use std::io::Write;
+            let payload = &frame[payload_start..];
+            match conn.stream.write(payload) {
+                Ok(n) => {
+                    conn.last_ack = conn.last_ack.wrapping_add(n as u32);
+                    tracing::trace!(
+                        "Fast path TX: {src_ip}:{src_port}→{dst_ip}:{dst_port} {n} bytes"
+                    );
+                }
+                Err(e) => {
+                    tracing::warn!("Fast path TX write error: {e}");
+                    self.fast_path_conns.remove(&key);
+                    return None;
+                }
+            }
+        }
+
+        // Generate ACK frame back to guest.
+        let guest_mac = self.fast_path_guest_mac.unwrap_or([0xFF; 6]);
+        let ack = crate::ethernet::build_tcp_ack_frame(&crate::ethernet::TcpFrameParams {
+            src_ip: conn.remote_ip,
+            dst_ip: conn.guest_ip,
+            src_port: conn.remote_port,
+            dst_port: conn.guest_port,
+            seq: conn.our_seq,
+            ack: conn.last_ack,
+            window: 65535,
+            src_mac: self.fast_path_gateway_mac,
+            dst_mac: guest_mac,
+        });
+
+        Some(ack)
+    }
+
+    /// Polls fast-path host streams for readable data and generates frames
+    /// to inject into the guest.
+    ///
+    /// Returns frames to be written to the guest FD via `enqueue_or_write`.
+    pub fn poll_fast_path(&mut self) -> Vec<Vec<u8>> {
+        let mut frames = Vec::new();
+        let mut to_remove = Vec::new();
+        let guest_mac = self.fast_path_guest_mac.unwrap_or([0xFF; 6]);
+        let gw_mac = self.fast_path_gateway_mac;
+
+        for (key, conn) in &mut self.fast_path_conns {
+            if conn.host_eof {
+                continue;
+            }
+
+            use std::io::Read;
+            match conn.stream.read(&mut conn.read_buf) {
+                Ok(0) => {
+                    // Host EOF — send FIN to guest.
+                    conn.host_eof = true;
+                    let fin =
+                        crate::ethernet::build_tcp_fin_frame(&crate::ethernet::TcpFrameParams {
+                            src_ip: conn.remote_ip,
+                            dst_ip: conn.guest_ip,
+                            src_port: conn.remote_port,
+                            dst_port: conn.guest_port,
+                            seq: conn.our_seq,
+                            ack: conn.last_ack,
+                            window: 65535,
+                            src_mac: gw_mac,
+                            dst_mac: guest_mac,
+                        });
+                    conn.our_seq = conn.our_seq.wrapping_add(1); // FIN consumes 1 SEQ
+                    frames.push(fin);
+                    to_remove.push(*key);
+                }
+                Ok(n) => {
+                    // Build data frame.
+                    let data_frame = crate::ethernet::build_tcp_data_frame(
+                        &crate::ethernet::TcpFrameParams {
+                            src_ip: conn.remote_ip,
+                            dst_ip: conn.guest_ip,
+                            src_port: conn.remote_port,
+                            dst_port: conn.guest_port,
+                            seq: conn.our_seq,
+                            ack: conn.last_ack,
+                            window: 65535,
+                            src_mac: gw_mac,
+                            dst_mac: guest_mac,
+                        },
+                        &conn.read_buf[..n],
+                    );
+                    conn.our_seq = conn.our_seq.wrapping_add(n as u32);
+                    frames.push(data_frame);
+                }
+                Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => {
+                    // No data available — expected for non-blocking.
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        "Fast path RX error {}:{} → {}:{}: {e}",
+                        conn.remote_ip,
+                        conn.remote_port,
+                        conn.guest_ip,
+                        conn.guest_port
+                    );
+                    to_remove.push(*key);
+                }
+            }
+        }
+
+        for key in to_remove {
+            self.fast_path_conns.remove(&key);
+        }
+
+        frames
+    }
+
+    /// Promotes a connection to the fast path.
+    ///
+    /// Called when a smoltcp connection reaches ESTABLISHED and has a
+    /// pre-connected host stream. The connection is removed from smoltcp
+    /// and data transfer bypasses the TCP state machine entirely.
+    pub fn promote_to_fast_path(
+        &mut self,
+        key: SynFlowKey,
+        stream: std::net::TcpStream,
+        our_seq: u32,
+        last_ack: u32,
+    ) {
+        // Set non-blocking for polling in the event loop.
+        stream.set_nonblocking(true).ok();
+        stream.set_nodelay(true).ok();
+
+        tracing::info!(
+            "Fast path: promoted {}:{} → {}:{} (seq={our_seq}, ack={last_ack})",
+            key.src_ip,
+            key.src_port,
+            key.dst_ip,
+            key.dst_port,
+        );
+
+        self.fast_path_conns.insert(
+            key,
+            FastPathConn {
+                stream,
+                our_seq,
+                last_ack,
+                remote_ip: key.dst_ip,
+                guest_ip: key.src_ip,
+                remote_port: key.dst_port,
+                guest_port: key.src_port,
+                read_buf: vec![0u8; 32768],
+                host_eof: false,
+            },
+        );
+    }
+
+    /// Returns the number of active fast-path connections.
+    #[must_use]
+    pub fn fast_path_count(&self) -> usize {
+        self.fast_path_conns.len()
     }
 
     /// Determines whether to connect via a proxy tunnel for the given destination.

--- a/virt/arcbox-net/src/darwin/tcp_bridge.rs
+++ b/virt/arcbox-net/src/darwin/tcp_bridge.rs
@@ -296,13 +296,33 @@ impl TcpBridge {
             );
         }
 
-        // FIN or RST → teardown, let smoltcp handle it.
-        if flags & 0x01 != 0 || flags & 0x04 != 0 {
-            tracing::debug!(
-                "Fast path: FIN/RST on {src_ip}:{src_port} → {dst_ip}:{dst_port}, removing"
-            );
+        // FIN or RST → handle teardown ourselves (smoltcp socket was removed
+        // on promotion, so falling through would leave the frame unhandled).
+        if flags & 0x04 != 0 {
+            // RST: close host stream immediately, no response needed.
+            tracing::debug!("Fast path: RST from guest {src_ip}:{src_port}→{dst_ip}:{dst_port}");
             self.fast_path_conns.remove(&key);
-            return None; // Fall through to smoltcp for teardown.
+            return Some(Vec::new()); // Intercepted, no reply frame.
+        }
+        if flags & 0x01 != 0 {
+            // FIN: close host stream and send FIN+ACK back to guest.
+            tracing::debug!("Fast path: FIN from guest {src_ip}:{src_port}→{dst_ip}:{dst_port}");
+            // FIN consumes 1 sequence number.
+            conn.last_ack = conn.last_ack.wrapping_add(1);
+            let guest_mac = self.fast_path_guest_mac.unwrap_or([0xFF; 6]);
+            let fin_ack = crate::ethernet::build_tcp_fin_frame(&crate::ethernet::TcpFrameParams {
+                src_ip: conn.remote_ip,
+                dst_ip: conn.guest_ip,
+                src_port: conn.remote_port,
+                dst_port: conn.guest_port,
+                seq: conn.our_seq,
+                ack: conn.last_ack,
+                window: 65535,
+                src_mac: self.fast_path_gateway_mac,
+                dst_mac: guest_mac,
+            });
+            self.fast_path_conns.remove(&key);
+            return Some(fin_ack);
         }
 
         // Extract payload using IPv4 total_length to exclude Ethernet padding.
@@ -389,7 +409,9 @@ impl TcpBridge {
                         });
                     conn.our_seq = conn.our_seq.wrapping_add(1); // FIN consumes 1 SEQ
                     frames.push(fin);
-                    to_remove.push(*key);
+                    // Don't remove yet — keep the entry so the guest's FIN-ACK
+                    // response is handled by try_fast_path_intercept (which will
+                    // see the FIN flag and clean up).
                 }
                 Ok(n) => {
                     // Segment into MSS-sized chunks to stay within MTU.
@@ -1128,10 +1150,10 @@ impl TcpBridge {
                         Err(e) => {
                             tracing::error!(
                                 "Fast path: failed to convert tokio TcpStream to std: {e}. \
-                                 Connection will fall back to smoltcp relay."
+                                 Connection lost (smoltcp socket already removed)."
                             );
-                            // Don't promote — connection was already removed from
-                            // self.connections above, so it will be cleaned up.
+                            // Both smoltcp socket and BridgedConn are gone. The host
+                            // stream will be dropped here. Guest will see a timeout.
                         }
                     }
                 }

--- a/virt/arcbox-net/src/darwin/tcp_bridge.rs
+++ b/virt/arcbox-net/src/darwin/tcp_bridge.rs
@@ -305,25 +305,30 @@ impl TcpBridge {
             return None; // Fall through to smoltcp for teardown.
         }
 
-        // Extract payload.
+        // Extract payload using IPv4 total_length to exclude Ethernet padding.
+        let ip_total_len = u16::from_be_bytes([frame[ip_start + 2], frame[ip_start + 3]]) as usize;
+        let ip_end = ip_start + ip_total_len;
         let tcp_data_offset = ((frame[l4_start + 12] >> 4) as usize) * 4;
         let payload_start = l4_start + tcp_data_offset;
-        let payload_len = if payload_start < frame.len() {
-            frame.len() - payload_start
-        } else {
-            0
-        };
+        let payload_end = ip_end.min(frame.len());
+        let payload_len = payload_end.saturating_sub(payload_start);
 
         // Write payload to host stream (if any).
         if payload_len > 0 {
             use std::io::Write;
-            let payload = &frame[payload_start..];
+            let payload = &frame[payload_start..payload_start + payload_len];
             match conn.stream.write(payload) {
                 Ok(n) => {
                     conn.last_ack = conn.last_ack.wrapping_add(n as u32);
                     tracing::trace!(
                         "Fast path TX: {src_ip}:{src_port}→{dst_ip}:{dst_port} {n} bytes"
                     );
+                }
+                Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => {
+                    // Non-blocking stream not ready. Don't ACK — guest will
+                    // retransmit. Don't remove the connection.
+                    tracing::trace!("Fast path TX: WouldBlock, guest will retransmit");
+                    return Some(Vec::new()); // Signal interception but no ACK frame.
                 }
                 Err(e) => {
                     tracing::warn!("Fast path TX write error: {e}");
@@ -387,23 +392,33 @@ impl TcpBridge {
                     to_remove.push(*key);
                 }
                 Ok(n) => {
-                    // Build data frame.
-                    let data_frame = crate::ethernet::build_tcp_data_frame(
-                        &crate::ethernet::TcpFrameParams {
-                            src_ip: conn.remote_ip,
-                            dst_ip: conn.guest_ip,
-                            src_port: conn.remote_port,
-                            dst_port: conn.guest_port,
-                            seq: conn.our_seq,
-                            ack: conn.last_ack,
-                            window: 65535,
-                            src_mac: gw_mac,
-                            dst_mac: guest_mac,
-                        },
-                        &conn.read_buf[..n],
-                    );
-                    conn.our_seq = conn.our_seq.wrapping_add(n as u32);
-                    frames.push(data_frame);
+                    // Segment into MSS-sized chunks to stay within MTU.
+                    // MSS = MTU - IP(20) - TCP(20). Use 3960 for MTU 4000,
+                    // 1460 for MTU 1500. Conservative default: 3960.
+                    const MSS: usize = 3960;
+                    let data = &conn.read_buf[..n];
+                    let mut offset = 0;
+                    while offset < data.len() {
+                        let chunk_end = (offset + MSS).min(data.len());
+                        let chunk = &data[offset..chunk_end];
+                        let data_frame = crate::ethernet::build_tcp_data_frame(
+                            &crate::ethernet::TcpFrameParams {
+                                src_ip: conn.remote_ip,
+                                dst_ip: conn.guest_ip,
+                                src_port: conn.remote_port,
+                                dst_port: conn.guest_port,
+                                seq: conn.our_seq,
+                                ack: conn.last_ack,
+                                window: 65535,
+                                src_mac: gw_mac,
+                                dst_mac: guest_mac,
+                            },
+                            chunk,
+                        );
+                        conn.our_seq = conn.our_seq.wrapping_add(chunk.len() as u32);
+                        frames.push(data_frame);
+                        offset = chunk_end;
+                    }
                 }
                 Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => {
                     // No data available — expected for non-blocking.

--- a/virt/arcbox-net/src/darwin/tcp_bridge.rs
+++ b/virt/arcbox-net/src/darwin/tcp_bridge.rs
@@ -1121,13 +1121,19 @@ impl TcpBridge {
                     sockets.remove(handle);
 
                     // Convert tokio stream to std for non-blocking sync I/O.
-                    let std_stream = stream.into_std().unwrap_or_else(|_| {
-                        // Fallback: this shouldn't happen.
-                        tracing::error!("Fast path: failed to convert tokio TcpStream to std");
-                        std::net::TcpStream::connect("127.0.0.1:1").unwrap()
-                    });
-
-                    self.promote_to_fast_path(flow_key, std_stream, our_seq, last_ack);
+                    match stream.into_std() {
+                        Ok(std_stream) => {
+                            self.promote_to_fast_path(flow_key, std_stream, our_seq, last_ack);
+                        }
+                        Err(e) => {
+                            tracing::error!(
+                                "Fast path: failed to convert tokio TcpStream to std: {e}. \
+                                 Connection will fall back to smoltcp relay."
+                            );
+                            // Don't promote — connection was already removed from
+                            // self.connections above, so it will be cleaned up.
+                        }
+                    }
                 }
             }
         }

--- a/virt/arcbox-net/src/datapath/frame_buf.rs
+++ b/virt/arcbox-net/src/datapath/frame_buf.rs
@@ -131,12 +131,13 @@ impl std::fmt::Debug for FrameBuf {
     }
 }
 
-// FrameBuf is Send because:
-// - Pooled: Arc<PacketPool> is Send, and pool.get()/free_by_index() are thread-safe.
-// - Heap: Vec<u8> is Send.
-// SAFETY: PacketPool is Send + Sync, and we hold exclusive ownership of the
-// buffer slot (guaranteed by the alloc/free protocol).
-unsafe impl Send for FrameBuf {}
+// Compile-time assertion: FrameBuf must be Send (passed through channels).
+// Arc<PacketPool> is Send (PacketPool is Send+Sync), Vec<u8> is Send,
+// so FrameBuf derives Send automatically — no unsafe impl needed.
+const _: () = {
+    const fn assert_send<T: Send>() {}
+    assert_send::<FrameBuf>();
+};
 
 #[cfg(test)]
 mod tests {

--- a/virt/arcbox-net/src/ethernet.rs
+++ b/virt/arcbox-net/src/ethernet.rs
@@ -290,6 +290,199 @@ fn udp_checksum(src_ip: Ipv4Addr, dst_ip: Ipv4Addr, udp_segment: &[u8]) -> u16 {
     if result == 0 { 0xFFFF } else { result }
 }
 
+/// Computes the TCP checksum over the pseudo-header + TCP segment.
+pub fn tcp_checksum(src_ip: Ipv4Addr, dst_ip: Ipv4Addr, tcp_segment: &[u8]) -> u16 {
+    let mut sum: u32 = 0;
+
+    // Pseudo-header: src_ip(4) + dst_ip(4) + zero(1) + proto(1) + tcp_len(2)
+    let src = src_ip.octets();
+    let dst = dst_ip.octets();
+    sum += u32::from(u16::from_be_bytes([src[0], src[1]]));
+    sum += u32::from(u16::from_be_bytes([src[2], src[3]]));
+    sum += u32::from(u16::from_be_bytes([dst[0], dst[1]]));
+    sum += u32::from(u16::from_be_bytes([dst[2], dst[3]]));
+    sum += 6u32; // Protocol: TCP
+    sum += tcp_segment.len() as u32;
+
+    // TCP segment, treating checksum field (offset 16-17) as 0.
+    let mut i = 0;
+    while i + 1 < tcp_segment.len() {
+        if i != 16 {
+            sum += u32::from(u16::from_be_bytes([tcp_segment[i], tcp_segment[i + 1]]));
+        }
+        i += 2;
+    }
+    if i < tcp_segment.len() {
+        sum += u32::from(tcp_segment[i]) << 8;
+    }
+
+    while sum > 0xFFFF {
+        sum = (sum & 0xFFFF) + (sum >> 16);
+    }
+    !sum as u16
+}
+
+/// Parameters for constructing TCP frames on the fast path.
+#[derive(Debug, Clone, Copy)]
+pub struct TcpFrameParams {
+    pub src_ip: Ipv4Addr,
+    pub dst_ip: Ipv4Addr,
+    pub src_port: u16,
+    pub dst_port: u16,
+    pub seq: u32,
+    pub ack: u32,
+    pub window: u16,
+    pub src_mac: [u8; 6],
+    pub dst_mac: [u8; 6],
+}
+
+/// Builds a TCP ACK frame (no payload) to acknowledge data from the guest.
+///
+/// Used by the TCP fast path to ACK guest data segments without going
+/// through smoltcp's TCP state machine.
+#[must_use]
+pub fn build_tcp_ack_frame(p: &TcpFrameParams) -> Vec<u8> {
+    let TcpFrameParams {
+        src_ip,
+        dst_ip,
+        src_port,
+        dst_port,
+        seq,
+        ack,
+        window,
+        src_mac,
+        dst_mac,
+    } = *p;
+    // ACK frame: ETH(14) + IP(20) + TCP(20) = 54 bytes, no payload.
+    let tcp_hdr_len = 20;
+    let ip_total_len = 20 + tcp_hdr_len;
+    let frame_len = ETH_HEADER_LEN + ip_total_len;
+    let mut frame = vec![0u8; frame_len];
+
+    // -- Ethernet header --
+    frame[0..6].copy_from_slice(&dst_mac);
+    frame[6..12].copy_from_slice(&src_mac);
+    frame[12..14].copy_from_slice(&0x0800u16.to_be_bytes());
+
+    // -- IPv4 header --
+    let ip = ETH_HEADER_LEN;
+    frame[ip] = 0x45; // Version 4, IHL 5
+    frame[ip + 2..ip + 4].copy_from_slice(&(ip_total_len as u16).to_be_bytes());
+    frame[ip + 6..ip + 8].copy_from_slice(&0x4000u16.to_be_bytes()); // Don't Fragment
+    frame[ip + 8] = 64; // TTL
+    frame[ip + 9] = 6; // Protocol: TCP
+    frame[ip + 12..ip + 16].copy_from_slice(&src_ip.octets());
+    frame[ip + 16..ip + 20].copy_from_slice(&dst_ip.octets());
+    let ip_cksum = ipv4_header_checksum(&frame[ip..ip + 20]);
+    frame[ip + 10..ip + 12].copy_from_slice(&ip_cksum.to_be_bytes());
+
+    // -- TCP header (20 bytes, no options) --
+    let tcp = ip + 20;
+    frame[tcp..tcp + 2].copy_from_slice(&src_port.to_be_bytes());
+    frame[tcp + 2..tcp + 4].copy_from_slice(&dst_port.to_be_bytes());
+    frame[tcp + 4..tcp + 8].copy_from_slice(&seq.to_be_bytes());
+    frame[tcp + 8..tcp + 12].copy_from_slice(&ack.to_be_bytes());
+    frame[tcp + 12] = 0x50; // Data offset: 5 (20 bytes), no options
+    frame[tcp + 13] = 0x10; // Flags: ACK
+    frame[tcp + 14..tcp + 16].copy_from_slice(&window.to_be_bytes());
+    let tcp_cksum = tcp_checksum(src_ip, dst_ip, &frame[tcp..]);
+    frame[tcp + 16..tcp + 18].copy_from_slice(&tcp_cksum.to_be_bytes());
+
+    frame
+}
+
+/// Builds a TCP data frame carrying payload from the host to the guest.
+///
+/// Used by the TCP fast path to inject host TcpStream data into the guest
+/// without going through smoltcp's TCP state machine.
+#[must_use]
+pub fn build_tcp_data_frame(p: &TcpFrameParams, payload: &[u8]) -> Vec<u8> {
+    let TcpFrameParams {
+        src_ip,
+        dst_ip,
+        src_port,
+        dst_port,
+        seq,
+        ack,
+        window,
+        src_mac,
+        dst_mac,
+    } = *p;
+
+    let tcp_hdr_len = 20;
+    let tcp_total_len = tcp_hdr_len + payload.len();
+    let ip_total_len = 20 + tcp_total_len;
+    let frame_len = ETH_HEADER_LEN + ip_total_len;
+    let mut frame = vec![0u8; frame_len];
+
+    // -- Ethernet header --
+    frame[0..6].copy_from_slice(&dst_mac);
+    frame[6..12].copy_from_slice(&src_mac);
+    frame[12..14].copy_from_slice(&0x0800u16.to_be_bytes());
+
+    // -- IPv4 header --
+    let ip = ETH_HEADER_LEN;
+    frame[ip] = 0x45;
+    frame[ip + 2..ip + 4].copy_from_slice(&(ip_total_len as u16).to_be_bytes());
+    frame[ip + 6..ip + 8].copy_from_slice(&0x4000u16.to_be_bytes()); // DF
+    frame[ip + 8] = 64; // TTL
+    frame[ip + 9] = 6; // TCP
+    frame[ip + 12..ip + 16].copy_from_slice(&src_ip.octets());
+    frame[ip + 16..ip + 20].copy_from_slice(&dst_ip.octets());
+    let ip_cksum = ipv4_header_checksum(&frame[ip..ip + 20]);
+    frame[ip + 10..ip + 12].copy_from_slice(&ip_cksum.to_be_bytes());
+
+    // -- TCP header --
+    let tcp = ip + 20;
+    frame[tcp..tcp + 2].copy_from_slice(&src_port.to_be_bytes());
+    frame[tcp + 2..tcp + 4].copy_from_slice(&dst_port.to_be_bytes());
+    frame[tcp + 4..tcp + 8].copy_from_slice(&seq.to_be_bytes());
+    frame[tcp + 8..tcp + 12].copy_from_slice(&ack.to_be_bytes());
+    frame[tcp + 12] = 0x50; // Data offset: 5
+    frame[tcp + 13] = 0x18; // Flags: ACK | PSH
+    frame[tcp + 14..tcp + 16].copy_from_slice(&window.to_be_bytes());
+
+    // -- Payload --
+    frame[tcp + 20..].copy_from_slice(payload);
+
+    // TCP checksum over header + payload.
+    let tcp_cksum = tcp_checksum(src_ip, dst_ip, &frame[tcp..]);
+    frame[tcp + 16..tcp + 18].copy_from_slice(&tcp_cksum.to_be_bytes());
+
+    frame
+}
+
+/// Builds a TCP FIN+ACK frame for connection teardown.
+#[must_use]
+pub fn build_tcp_fin_frame(p: &TcpFrameParams) -> Vec<u8> {
+    let mut ack_params = *p;
+    ack_params.window = 65535;
+    let mut frame = build_tcp_ack_frame(&ack_params);
+    // Change flags from ACK to FIN|ACK.
+    let tcp = ETH_HEADER_LEN + 20;
+    frame[tcp + 13] = 0x11; // FIN | ACK
+    // Recompute TCP checksum.
+    frame[tcp + 16..tcp + 18].copy_from_slice(&[0, 0]);
+    let tcp_cksum = tcp_checksum(p.src_ip, p.dst_ip, &frame[tcp..]);
+    frame[tcp + 16..tcp + 18].copy_from_slice(&tcp_cksum.to_be_bytes());
+    frame
+}
+
+/// Builds a TCP RST frame for connection abort.
+#[must_use]
+pub fn build_tcp_rst_frame(p: &TcpFrameParams) -> Vec<u8> {
+    let mut rst_params = *p;
+    rst_params.window = 0;
+    let mut frame = build_tcp_ack_frame(&rst_params);
+    // Change flags from ACK to RST|ACK.
+    let tcp = ETH_HEADER_LEN + 20;
+    frame[tcp + 13] = 0x14; // RST | ACK
+    frame[tcp + 16..tcp + 18].copy_from_slice(&[0, 0]);
+    let tcp_cksum = tcp_checksum(p.src_ip, p.dst_ip, &frame[tcp..]);
+    frame[tcp + 16..tcp + 18].copy_from_slice(&tcp_cksum.to_be_bytes());
+    frame
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -453,5 +646,91 @@ mod tests {
         // Verify UDP checksum is non-zero
         let udp_cksum = u16::from_be_bytes([udp[6], udp[7]]);
         assert_ne!(udp_cksum, 0);
+    }
+
+    fn make_tcp_params(
+        src_ip: [u8; 4],
+        dst_ip: [u8; 4],
+        src_port: u16,
+        dst_port: u16,
+        seq: u32,
+        ack: u32,
+    ) -> TcpFrameParams {
+        TcpFrameParams {
+            src_ip: Ipv4Addr::from(src_ip),
+            dst_ip: Ipv4Addr::from(dst_ip),
+            src_port,
+            dst_port,
+            seq,
+            ack,
+            window: 65535,
+            src_mac: [0x02, 0xAB, 0xCD, 0x00, 0x00, 0x01],
+            dst_mac: [0x52, 0x54, 0x00, 0x12, 0x34, 0x56],
+        }
+    }
+
+    /// Verify checksum: zero the field, recompute, compare to stored.
+    fn verify_tcp_checksum(frame: &[u8], src_ip: Ipv4Addr, dst_ip: Ipv4Addr) {
+        let tcp = 34;
+        let stored = u16::from_be_bytes([frame[tcp + 16], frame[tcp + 17]]);
+        assert_ne!(stored, 0);
+        let mut v = frame.to_vec();
+        v[tcp + 16] = 0;
+        v[tcp + 17] = 0;
+        assert_eq!(tcp_checksum(src_ip, dst_ip, &v[tcp..]), stored);
+    }
+
+    #[test]
+    fn test_tcp_ack_frame_structure() {
+        let p = make_tcp_params([1, 1, 1, 1], [10, 0, 2, 2], 443, 12345, 1000, 2000);
+        let frame = build_tcp_ack_frame(&p);
+
+        assert_eq!(frame.len(), 54);
+        assert_eq!(&frame[0..6], &p.dst_mac);
+        assert_eq!(&frame[6..12], &p.src_mac);
+        assert_eq!(frame[14 + 9], 6); // TCP protocol
+
+        let tcp = 34;
+        assert_eq!(u16::from_be_bytes([frame[tcp], frame[tcp + 1]]), 443);
+        assert_eq!(u16::from_be_bytes([frame[tcp + 2], frame[tcp + 3]]), 12345);
+        assert_eq!(frame[tcp + 13], 0x10); // ACK flag
+        verify_tcp_checksum(&frame, p.src_ip, p.dst_ip);
+    }
+
+    #[test]
+    fn test_tcp_data_frame_payload() {
+        let p = make_tcp_params([1, 1, 1, 1], [10, 0, 2, 2], 80, 54321, 5000, 6000);
+        let payload = b"Hello, world!";
+        let frame = build_tcp_data_frame(&p, payload);
+
+        assert_eq!(frame.len(), 54 + payload.len());
+        assert_eq!(&frame[54..], payload.as_slice());
+        assert_eq!(frame[34 + 13], 0x18); // ACK|PSH
+        verify_tcp_checksum(&frame, p.src_ip, p.dst_ip);
+    }
+
+    #[test]
+    fn test_tcp_fin_frame_flags() {
+        let p = make_tcp_params([10, 0, 2, 1], [10, 0, 2, 2], 80, 1234, 100, 200);
+        let frame = build_tcp_fin_frame(&p);
+        assert_eq!(frame.len(), 54);
+        assert_eq!(frame[34 + 13], 0x11); // FIN | ACK
+        verify_tcp_checksum(&frame, p.src_ip, p.dst_ip);
+    }
+
+    #[test]
+    fn test_tcp_rst_frame_flags() {
+        let p = make_tcp_params([10, 0, 2, 1], [10, 0, 2, 2], 80, 1234, 100, 200);
+        let frame = build_tcp_rst_frame(&p);
+        assert_eq!(frame.len(), 54);
+        assert_eq!(frame[34 + 13], 0x14); // RST | ACK
+        verify_tcp_checksum(&frame, p.src_ip, p.dst_ip);
+    }
+
+    #[test]
+    fn test_tcp_checksum_standalone() {
+        let p = make_tcp_params([192, 168, 1, 1], [192, 168, 1, 2], 80, 443, 0, 0);
+        let frame = build_tcp_ack_frame(&p);
+        verify_tcp_checksum(&frame, p.src_ip, p.dst_ip);
     }
 }

--- a/virt/arcbox-vmm/src/vmm/darwin.rs
+++ b/virt/arcbox-vmm/src/vmm/darwin.rs
@@ -337,10 +337,15 @@ impl Vmm {
 
         // 5. Build the datapath and spawn it on the tokio runtime.
 
-        // Use the enhanced MTU (4000) that we configured on the VZ device.
-        // On macOS < 14 where the setter is unavailable, the VZ device stays
-        // at 1500 and smoltcp will also use 1500 (the VZ side logs which case
-        // applied). Since we target macOS 14+ as P0, this is the common path.
+        // NOTE(MTU): Hardcoded to 4000 intentionally — our platform target is
+        // macOS 14+ Apple Silicon (P0) where VZ's setMaximumTransmissionUnit:
+        // always succeeds. On macOS <14 the VZ setter is skipped via
+        // respondsToSelector: (see arcbox-vz/device/network.rs), and the VZ
+        // device stays at 1500 while smoltcp gets 4000. This mismatch would
+        // cause frames >1500 to be dropped — acceptable since macOS <14 is not
+        // a supported target. If macOS <13 support is ever needed, plumb the
+        // actual MTU from NetworkDeviceConfiguration::mtu() through the
+        // hypervisor abstraction layer.
         let net_mtu = arcbox_net::darwin::smoltcp_device::ENHANCED_ETHERNET_MTU;
 
         let datapath = NetworkDatapath::new(

--- a/virt/arcbox-vmm/src/vmm/darwin.rs
+++ b/virt/arcbox-vmm/src/vmm/darwin.rs
@@ -343,7 +343,7 @@ impl Vmm {
         // respondsToSelector: (see arcbox-vz/device/network.rs), and the VZ
         // device stays at 1500 while smoltcp gets 4000. This mismatch would
         // cause frames >1500 to be dropped — acceptable since macOS <14 is not
-        // a supported target. If macOS <13 support is ever needed, plumb the
+        // a supported target. If macOS <14 support is ever needed, plumb the
         // actual MTU from NetworkDeviceConfiguration::mtu() through the
         // hypervisor abstraction layer.
         let net_mtu = arcbox_net::darwin::smoltcp_device::ENHANCED_ETHERNET_MTU;


### PR DESCRIPTION
## Summary

Add a TCP fast path that bypasses smoltcp's per-segment TCP state machine for established connections, directly relaying TCP payload between guest frames and host TcpStreams.

### Architecture

```
Guest TCP segment → classify_ipv4() → 5-tuple lookup
  → HIT: extract payload → write to host TcpStream → generate 54-byte ACK → guest FD
  → MISS: normal smoltcp path (unchanged)

Host TcpStream readable → poll_fast_path()
  → read data → build ETH+IP+TCP frame (checksums) → guest FD
```

smoltcp still handles SYN gating, 3-way handshake, and FIN/RST teardown. Only data segments on established connections use the fast path.

### Why this works without full TCP

The transport between the fast path and the guest is VirtIO-net over AF_UNIX socketpair — reliable, in-order, no packet loss. We only need:
- Correct SEQ/ACK numbers (simple counters)
- Valid IP + TCP checksums (reuse existing utilities)
- FIN/RST detection for teardown (fall through to smoltcp)

### Changes

| File | Change |
|------|--------|
| `ethernet.rs` | `TcpFrameParams`, `tcp_checksum()`, `build_tcp_ack/data/fin/rst_frame()` |
| `tcp_bridge.rs` | `FastPathConn`, `try_fast_path_intercept()`, `poll_fast_path()`, `promote_to_fast_path()` |
| `smoltcp_device.rs` | `drain_fast_path()` — filters rx_queue before smoltcp sees frames |
| `datapath_loop.rs` | Wire drain_fast_path + poll_fast_path into event loop |

### Status

The fast-path infrastructure is complete and wired in. Connections must be explicitly promoted via `promote_to_fast_path()`. A follow-up will add automatic promotion in `detect_new_connections()`.

## Test plan

- [x] `cargo test -p arcbox-net` — 228 passed, 0 failed
- [x] `cargo clippy -p arcbox-net --lib` — zero errors/warnings
- [ ] E2E: `docker run -p 8080:80 nginx` + `curl localhost:8080`
- [ ] Benchmark: iperf3 with promoted fast-path connections