### PR TITLE
fix(net): defer fast-path promotion to first data frame

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ tests/resources/boot-assets-arm64-*
 # Scratch notes
 perf-issue.md
 issues.net.md
+docs/audit.md

--- a/docs/audit.md
+++ b/docs/audit.md
@@ -1,0 +1,929 @@
+# Codebase Audit Report
+
+> Date: 2026-03-29 (updated)  
+> Scope: full workspace (327 Rust files, ~110K LOC)  
+> Branch: `fix/daemon-shutdown-feedback`  
+> Version: `v0.3.13`  
+> Method: merged findings from three independent full-repo audits plus direct code verification
+
+## Executive Summary
+
+The repo still has strong macro-level layering: no obvious circular dependencies,
+clear crate families, good use of `CancellationToken`, and a mostly coherent
+`CommonError -> crate error -> transport` stack.
+
+The main problem is no longer architecture shape. It is structural drift inside
+the control plane and low-level virtualization layers:
+
+- startup correctness still depends on call order and nullable state
+- lifecycle truth is duplicated across multiple state models
+- daemon, CLI, and core repeat host layout and daemon contract logic
+- oversized files are no longer isolated exceptions
+- two VM stacks are still alive at the same time
+- CI signal is not strong enough to protect this amount of structural debt
+
+This revision intentionally re-ranks findings by compound-interest value rather
+than by local code smell.
+
+### Scale signals
+
+- `44` Rust files still contain `// ==== ...` style section dividers
+- `46` Rust files exceed `700` lines
+- `20` Rust files exceed `1000` lines
+- `9` Rust files exceed `1500` lines
+- `1,469` `.unwrap()` calls in non-test production code
+- `649` `map_err` call sites, `197` of which use `.to_string()` erasure
+- `50` literal `"lock poisoned"` error strings
+- `42` `#[allow(dead_code)]` annotations
+- `22` `Arc<Mutex<T>>` usages (guidelines require `RwLock` on hot paths)
+- `196` of `327` source files (60%) have zero test coverage
+
+That is not a "few large files" problem. It is a repo-wide maintenance pattern.
+
+### Priority order
+
+1. Tighten startup and daemon contracts
+2. Establish a single lifecycle truth and split the main control-plane god objects
+3. Converge the VM stack and fix `Vmm` / `VirtIO` abstraction leaks
+4. Replace stringly typed error flow and weak persistence semantics
+5. Upgrade CI from best-effort coverage to a reliable regression net
+6. Eliminate `unwrap()` / `Arc<Mutex>` debt in hot paths and daemon long-run code
+7. Remove `async-trait` crate where native async fn in traits (edition 2024) suffices
+
+### Scorecard
+
+| Dimension | Score | Strength | Main gap |
+|-----------|-------|----------|----------|
+| Top-level layering | 8 / 10 | Crate boundaries are mostly clean | Internal module boundaries are eroding |
+| Async / shutdown | 7 / 10 | Consistent `CancellationToken`, `spawn_blocking` discipline | Startup/shutdown ownership spread across too many files |
+| Error model | 5.5 / 10 | `CommonError` pattern is solid | 649 `map_err`, 197 `.to_string()` erasures, `VmmError` doesn't use `CommonError`, `guest` layer uses `anyhow` |
+| Module structure | 4.5 / 10 | Some crates are still tidy | Large-file debt is now systemic |
+| VM architecture | 5 / 10 | New native stack exists and is promising | Firecracker stack still coexists; abstractions leak |
+| Runtime safety | 4 / 10 | Tests generally use proper assertions | 1,469 `unwrap()` in non-test code; daemon is long-running |
+| Testing / CI | 5 / 10 | `virt/arcbox-net` (34/40), `virt/arcbox-virtio` (7/8) are strong | `arcbox-api` 0/8, `arcbox-daemon` 1/14, `arcbox-docker` 4/27, `arcbox-grpc` 0/1 |
+| Concurrency model | 5.5 / 10 | `RwLock` used in some managers | 22 `Arc<Mutex>` in VirtIO backends, VmInstance, SandboxInstance |
+| Developer experience | 5.5 / 10 | Makefile and docs are decent | Host layout, prerequisites, and contracts are duplicated and implicit |
+
+---
+
+## T1 · Startup Contract and Control-Plane Ownership <!-- ABX-263 -->
+
+**Compound value**: this is the highest-leverage fix in the repo. Every daemon,
+CLI, desktop, and runtime change passes through this boundary.
+
+### Evidence
+
+- `app/arcbox-daemon/src/context.rs:13-35`
+- `app/arcbox-daemon/src/services.rs:25-81`
+- `app/arcbox-daemon/src/startup/mod.rs:125-181`
+- `app/arcbox-api/src/grpc/mod.rs:24-40`
+
+### Problem
+
+The daemon startup contract is still modeled as "one mutable context bag that is
+partially initialized over time":
+
+- `DaemonContext` contains `Option<DaemonLock>`
+- runtime is an `Arc<OnceLock<Arc<Runtime>>>`
+- `DaemonContext::runtime()` panics if called too early
+- gRPC services are registered before runtime exists and return `UNAVAILABLE`
+  until the `OnceLock` is filled
+
+This works, but the correctness model is "everyone must remember the startup
+sequence" instead of "the type system makes illegal states unrepresentable".
+
+### Why this compounds
+
+- adding one new phase or service means touching `main.rs`, `startup/mod.rs`,
+  `services.rs`, and often `shutdown.rs`
+- behavior is hard to unit test because phase validity is implicit
+- the same startup contract must be re-learned by every caller and future maintainer
+
+### Recommendation
+
+Replace the current bag-of-state model with typed phases or an explicit
+supervisor:
+
+```text
+EarlyContext -> LockedContext -> RuntimeReadyContext -> ServingContext
+```
+
+or
+
+```text
+DaemonSupervisor
+  - owns startup phases
+  - owns background task group
+  - owns readiness state
+  - exposes stable operations to CLI / desktop / tests
+```
+
+### First cut
+
+1. Introduce a dedicated `daemon_contract` or `daemon_supervisor` module.
+2. Remove `DaemonContext::runtime()` panic path.
+3. Replace `Arc<OnceLock<Arc<Runtime>>>` with a phase-aware state holder.
+4. Make gRPC startup consume a "runtime-ready" type instead of probing readiness
+   from inside handlers.
+
+---
+
+## T2 · Lifecycle Has No Single Source of Truth <!-- ABX-264 -->
+
+**Compound value**: lifecycle drift silently infects runtime, persistence,
+recovery, and API semantics.
+
+### Evidence
+
+- `app/arcbox-core/src/vm_lifecycle.rs:82-120`
+- `app/arcbox-core/src/vm_lifecycle.rs:430-453`
+- `app/arcbox-core/src/machine.rs:18-31`
+- `app/arcbox-core/src/vm.rs:64-83`
+- `app/arcbox-core/src/persistence.rs:71-88`
+- `app/arcbox-core/src/vm_lifecycle.rs:1067-1072`
+
+### Problem
+
+The repo currently maintains multiple overlapping state models:
+
+- `VmLifecycleState`
+- `MachineState`
+- `VmState`
+- `PersistedState`
+- setup-facing readiness flags such as `SetupStatus.vm_running`
+
+The mappings are not lossless. Example:
+
+- `PersistedState::Running` becomes `MachineState::Stopped` on reload
+- idle transition publishes `Event::MachineStopped` even though the VM is not stopped
+
+That means state is already used for both "real machine lifecycle" and "external
+UI signal" and those meanings are diverging.
+
+### Why this compounds
+
+- every new lifecycle transition must be threaded through 4 to 5 representations
+- bug fixes in recovery or shutdown are prone to semantic drift
+- transport/API layers cannot rely on state names being precise
+
+### Recommendation
+
+Create one authoritative lifecycle state model and make all other layers derive
+views from it:
+
+- persistence stores a projection of the authoritative model
+- gRPC/CLI status expose read-only projections
+- event bus emits domain-specific events instead of overloading `MachineStopped`
+
+### Related issue: non-transactional transitions
+
+`MachineManager::start()` updates in-memory state and persistence separately, and
+persistence errors are dropped:
+
+- `app/arcbox-core/src/machine.rs:373-418`
+- `app/arcbox-core/src/persistence.rs:219-245`
+
+This should become an explicit transition object or repository transaction, not
+ad hoc dual writes.
+
+---
+
+## T3 · Structural Debt Program: Large Files Are Now Systemic <!-- ABX-265 -->
+
+**Compound value**: lower review cost, fewer merge conflicts, better ownership,
+safer refactors.
+
+The previous audit understated this problem by treating it as a short list of
+outliers. It is broader than that.
+
+### Repo-wide signal
+
+- `44` files already violate the repo's own "section divider means split" rule
+- `46` files exceed `700` lines
+- `20` files exceed `1000` lines
+
+### Highest-priority split targets
+
+| File | Lines | Why it matters |
+|------|-------|----------------|
+| `guest/arcbox-agent/src/agent.rs` | 2,169 | guest runtime ensure, Linux server, RPC, Docker proxy, tests all mixed |
+| `virt/arcbox-net/src/darwin/tcp_bridge.rs` | 2,036 | TCP state machine + conntrack + forwarding + options |
+| `virt/arcbox-fs/src/passthrough.rs` | 2,000 | file ops + handles + attrs + permissions |
+| `virt/arcbox-virtio/src/net.rs` | 1,628 | backend, protocol, queue logic, Linux TAP details mixed |
+| `app/arcbox-core/src/vm_lifecycle.rs` | 1,484 | lifecycle, config drift, startup, route reconcile, idle policy, shutdown |
+| `virt/arcbox-hypervisor/src/linux/ffi.rs` | 1,443 | ioctl numbers, FFI structs, wrappers, safety boundary mixed |
+| `virt/arcbox-fs/src/dispatcher.rs` | 1,410 | request dispatch and many operation families mixed |
+| `app/arcbox-core/src/vm.rs` | 1,098 | VM registry, VMM config translation, stop/snapshot/read helpers |
+| `app/arcbox-core/src/machine.rs` | 968 | registry, hydration, vsock/agent access, readiness, persistence, shutdown |
+
+### Recommended split order
+
+1. `app/arcbox-core/src/vm_lifecycle.rs`
+2. `app/arcbox-core/src/machine.rs`
+3. `guest/arcbox-agent/src/agent.rs`
+4. CLI command files: `setup.rs`, `boot.rs`, `docker.rs`, `daemon.rs`
+5. `virt/arcbox-hypervisor/src/linux/ffi.rs`
+6. `virt/arcbox-virtio/src/net.rs`
+
+### Suggested layouts
+
+**`app/arcbox-core/src/vm_lifecycle/`**
+
+```text
+mod.rs
+state.rs
+config.rs
+startup.rs
+default_machine.rs
+readiness.rs
+idle_policy.rs
+recovery.rs
+shutdown.rs
+serial.rs
+```
+
+**`guest/arcbox-agent/src/agent/`**
+
+```text
+mod.rs
+runtime_ensure.rs
+server.rs
+rpc_handlers.rs
+docker_proxy.rs
+system_info.rs
+linux_runtime.rs
+tests.rs
+```
+
+**`virt/arcbox-hypervisor/src/linux/ffi/`**
+
+```text
+mod.rs
+ioctl.rs
+bindings.rs
+system.rs
+vm_fd.rs
+vcpu_fd.rs
+dirty_log.rs
+```
+
+---
+
+## T4 · Host Layout and Daemon Contract Are Duplicated <!-- ABX-266 -->
+
+**Compound value**: every installation, startup, status, and path-related change
+gets cheaper and safer.
+
+### Evidence
+
+- `app/arcbox-cli/src/commands/daemon.rs:108-149`
+- `app/arcbox-cli/src/commands/daemon.rs:221-335`
+- `app/arcbox-daemon/src/startup/mod.rs:184-190`
+- `app/arcbox-cli/src/commands/setup.rs:114-130`
+- `app/arcbox-core/src/boot_assets.rs`
+
+### Problem
+
+The daemon contract is documented as load-bearing, but code still duplicates the
+same rules in multiple places:
+
+- `resolve_data_dir()` exists in both CLI and daemon
+- CLI writes `daemon.lock` itself when spawning the daemon
+- daemon later acquires the real flock and owns the lock for its lifetime
+- socket paths, log paths, boot asset paths, and install paths are assembled in
+  several command files
+
+### Why this compounds
+
+- any daemon lock or socket change risks silently drifting CLI behavior
+- new entrypoints will copy one of the existing implementations instead of
+  consuming a shared contract
+- path logic is difficult to test because it is not centralized
+
+### Recommendation
+
+Introduce a shared host-side contract layer:
+
+```text
+host_layout/
+  paths.rs
+  daemon_contract.rs
+  install_layout.rs
+```
+
+This layer should own:
+
+- canonical data/run/log/bin/boot paths
+- lock file and liveness probe semantics
+- canonical gRPC and Docker socket paths
+- daemon stop/status protocol
+
+CLI and daemon should stop recalculating these independently.
+
+---
+
+## T5 · VM Strategy Must Converge <!-- ABX-267 -->
+
+**Compound value**: this determines whether future virtualization work compounds
+or fragments.
+
+### Evidence
+
+- `virt/arcbox-vm/Cargo.toml:1-15`
+- `app/arcbox-core/Cargo.toml:12-19`
+- `virt/arcbox-vmm/src/vmm/mod.rs:27-33`
+- `virt/arcbox-vmm/src/vmm/mod.rs:176-220`
+- `virt/arcbox-hypervisor/src/traits.rs:36-69`
+
+### Problem A: two VM stacks still coexist
+
+The repo is still carrying:
+
+- `virt/arcbox-vm`: Firecracker/fc-sdk based VM stack
+- `arcbox-hypervisor + arcbox-vmm + arcbox-virtio`: new native stack used by `arcbox-core`
+
+This is the biggest architectural fork in the workspace.
+
+### Problem B: `Vmm` is not a true abstraction boundary
+
+`Vmm` currently uses:
+
+- `ManagedVm = Box<dyn Any + Send + Sync>`
+- `managed_execution: bool`
+- Darwin-specific resource fields on the top-level struct
+- `VirtualMachine::is_managed_execution()`
+
+That means platform differences are expressed by `cfg + Any + bool`, not by
+backend-specific types and capabilities.
+
+### Recommendation
+
+1. Pick one primary VM line and freeze the other from further expansion.
+2. Treat `virt/arcbox-vm` as migration/legacy/experimental scope, not as an equal
+   long-term platform.
+3. Refactor `Vmm` into:
+
+```text
+Vmm
+  - common lifecycle state machine
+  - backend strategy object
+  - explicit backend capabilities
+```
+
+Possible backend traits:
+
+- `ExecutionBackend`
+- `SnapshotBackend`
+- `NetworkBackendHooks`
+- `ConsoleBackend`
+
+---
+
+## T6 · VirtIO Boundary Is Not Closed Yet <!-- ABX-268 -->
+
+**Compound value**: once transport/device boundaries are correct, device work,
+snapshot work, and performance work all get easier.
+
+### Evidence
+
+- `virt/arcbox-vmm/src/device.rs:139-168`
+- `virt/arcbox-vmm/src/device.rs:629-660`
+- `virt/arcbox-virtio/src/queue.rs:120-166`
+- `virt/arcbox-virtio/src/net.rs:161-201`
+- `virt/arcbox-virtio/src/net.rs:522-543`
+- `virt/arcbox-virtio/src/fs.rs:444-460`
+
+### Problem
+
+There are effectively two queue worlds:
+
+- MMIO layer tracks real guest queue addresses in `VirtioMmioState`
+- device layer owns in-memory `VirtQueue` objects with their own descriptor and
+  ring state
+
+That means transport and device are not yet operating on one shared queue model.
+
+At the same time, `arcbox-virtio` still mixes in host resource management:
+
+- Linux TAP creation and host-side network setup logic appear inside `virtio-net`
+
+### Why this compounds
+
+- tests can pass against simulated queues while the real MMIO path remains incomplete
+- host-specific setup leaks into the device crate, making reuse and testing harder
+- snapshot semantics stay fuzzy because queue/device runtime state is split
+
+### Recommendation
+
+1. Define one queue abstraction backed by guest memory view, not duplicate queue state.
+2. Keep `arcbox-virtio` focused on protocol/device emulation.
+3. Push TAP/vmnet/IP/route lifecycle into `arcbox-net`.
+4. Make device crates consume injected backends such as `NetBackend`,
+   `BlockBackend`, `ConsoleIo`, not shell commands or host setup directly.
+
+---
+
+## T7 · Error Model Is Too Stringly Typed <!-- ABX-269 -->
+
+**Compound value**: better diagnostics, better transport mapping, safer refactors.
+
+### Evidence
+
+- `app/arcbox-core/src/error.rs:11-31`
+- `app/arcbox-api/src/error.rs:40-56`
+- `app/arcbox-api/src/grpc/machine.rs:70-118`
+- `app/arcbox-api/src/grpc/machine.rs:202-232`
+
+The repo still relies on:
+
+- `CoreError::Vm(String)`
+- `CoreError::Machine(String)`
+- many `Status::internal(e.to_string())`
+- many literal `"lock poisoned"` error strings
+
+Static scan result:
+
+- `"lock poisoned"` appears `53` times across the workspace
+
+### Why this compounds
+
+- transport-level behavior depends on error text, not on typed semantics
+- backtraces and original source error types are lost
+- error filtering in logs and tests becomes brittle
+
+### Recommendation
+
+1. Replace string-backed domain variants with structured enums.
+2. Add `From<DomainError> for tonic::Status` and `From<DomainError> for HTTP error`.
+3. Remove `.map_err(|e| Type(e.to_string()))` where a proper `From` chain is possible.
+4. Keep `anyhow` only in app shells, not in reusable library layers.
+
+### Related persistence issue
+
+Persistence updates are currently read-modify-write per field update:
+
+- `app/arcbox-core/src/persistence.rs:219-245`
+
+and callers often ignore failures:
+
+- `app/arcbox-core/src/machine.rs:405-407`
+
+This should become a `MachineRepository` with explicit atomic update methods and
+visible failures.
+
+---
+
+## T8 · Proto / gRPC API and Codegen Need Tightening <!-- ABX-270 -->
+
+**Compound value**: alpha is the cheapest time to remove API drift.
+
+### Evidence
+
+- `rpc/arcbox-protocol/build.rs:12-54`
+- `rpc/arcbox-grpc/build.rs:9-40`
+- `rpc/arcbox-protocol/src/lib.rs:35-110`
+- `app/arcbox-api/src/grpc/mod.rs:44+`
+
+### Problem A: build scripts write to source tree
+
+`arcbox-protocol/build.rs` writes generated files into `src/generated/` and even
+runs `rustfmt` during build.
+
+That creates:
+
+- dirty working tree risk
+- extra build-time tool assumptions (`protoc`, `rustfmt`)
+- avoidable incremental build noise
+
+### Problem B: duplicated API surface
+
+`arcbox-protocol` exports:
+
+- canonical `v1`
+- `sandbox_v1`
+- compatibility submodules like `common`, `machine`, `container`, `api`
+- many root-level re-exports again
+
+This is convenient short term but expands the supported API surface and makes
+refactoring more expensive.
+
+### Problem C: still-present semantic inconsistencies
+
+Preserve and act on the original audit's valid findings:
+
+- filter parameter mismatch across proto files
+- multiple timestamp representations
+- `x-machine` header is an implicit transport contract, not declared at schema level
+- `AgentPingResponse` lacks explicit protocol compatibility signaling
+
+### Recommendation
+
+Pick one of these models and be consistent:
+
+1. generated files are explicit artifacts checked in via `scripts/gen-proto.sh`
+2. generated files live only in `OUT_DIR`
+
+Also:
+
+- shrink compatibility exports to one clearly documented layer
+- define a single canonical public path
+- document transport metadata requirements or move them into request messages
+
+---
+
+## T9 · CI, Testing, and DX Signal Are Not Strong Enough <!-- ABX-271 -->
+
+**Compound value**: structural improvements only stick if CI can police them.
+
+### Evidence
+
+- `.github/workflows/ci.yml:47-54`
+- `.github/workflows/test-vm-linux.yml:3-23`
+- `.github/workflows/docker-api-e2e.yml:3-6`
+- `.pre-commit-config.yaml:11-16`
+
+### Current gaps
+
+- main CI excludes `arcbox-agent` from clippy, build, and test
+- Docker API E2E is `workflow_dispatch` only
+- Linux VM workflow is gated by narrow manual path filters
+- pre-commit excludes `arcbox-agent` from clippy as well
+
+### Original audit findings still valid
+
+- critical test coverage gaps remain in runtime port forwarding, Docker handlers,
+  Docker proxy, VirtIO device manager, daemon DNS service
+- shared test support is still duplicated across files
+- there is still no property-based testing or fuzzing program
+
+### Recommendation
+
+Restructure CI into three layers:
+
+1. **fast**
+   - fmt
+   - clippy
+   - unit tests
+   - run on every PR
+
+2. **medium**
+   - crate/domain integration tests
+   - Docker API compatibility smoke
+   - guest agent tests
+
+3. **slow**
+   - Linux VM / Firecracker / KVM jobs
+   - heavy hypervisor and snapshot tests
+
+Also:
+
+- stop excluding `arcbox-agent`
+- replace narrow path filters with package-aware triggers or broader dependency-closure paths
+- add a shared `tests/support/` or `arcbox-test-utils` crate
+
+---
+
+## T10 · Runtime Safety: 1,469 `unwrap()` Calls in Production Code <!-- ABX-272 -->
+
+**Compound value**: daemon and guest agent are long-running processes. Each
+`unwrap()` is a potential panic → crash → restart cycle. Fixing these
+systematically improves uptime and debuggability.
+
+### Evidence (static scan)
+
+| Category | Count |
+|----------|-------|
+| `.unwrap()` in non-test code | 1,469 |
+| `.expect()` in non-test code | 115 |
+| `"lock poisoned"` literal strings | 50 |
+
+### Hottest areas
+
+The highest concentrations are in the performance-critical virtualization layer:
+
+| File | `.unwrap()` count | Risk |
+|------|-------------------|------|
+| `virt/arcbox-virtio/src/net.rs` | high | VirtIO net hot path — panic kills VM |
+| `virt/arcbox-fs/src/passthrough.rs` | high | VirtioFS hot path — panic kills shared FS |
+| `virt/arcbox-net/src/darwin/tcp_bridge.rs` | high | Network bridge — panic drops all connections |
+| `guest/arcbox-agent/src/agent.rs` | high | Guest agent — panic requires VM reboot |
+| `app/arcbox-core/src/vm_lifecycle.rs` | high | VM lifecycle — panic orphans VM |
+
+### Why this compounds
+
+- a single `unwrap()` in a VirtIO handler panics a tokio worker thread, which
+  can cascade into the entire daemon or guest agent crashing
+- `"lock poisoned"` panics are especially insidious: they indicate a prior panic
+  has already occurred, and the second panic masks the root cause
+- replacing them with `?` or structured errors produces better diagnostics and
+  keeps the process alive
+
+### Recommendation
+
+1. **Immediate**: audit all `unwrap()` in `virt/` and `guest/` — replace with `?`
+   where the function returns `Result`, or `expect("reason")` for truly invariant cases.
+2. **Short-term**: add a clippy config to deny `unwrap_used` in non-test code for
+   `virt/` and `guest/` crates.
+3. **Medium-term**: extend the deny policy workspace-wide, allowing exceptions
+   only with `#[allow]` + comment.
+
+---
+
+## T11 · Concurrency Primitives: `Arc<Mutex<T>>` on Hot Paths <!-- ABX-273 -->
+
+**Compound value**: the AGENTS.md guideline to prefer `RwLock` on hot paths
+exists for a reason — the VirtIO and network data paths are throughput-critical.
+
+### Evidence
+
+22 instances of `Arc<Mutex<T>>` in non-test code, including:
+
+| Location | Type | Access pattern |
+|----------|------|----------------|
+| `virt/arcbox-virtio/src/net.rs:534` | `Arc<Mutex<dyn NetBackend>>` | read-heavy (packet send/recv) |
+| `virt/arcbox-virtio/src/console.rs:496` | `Arc<Mutex<dyn ConsoleIo>>` | read-heavy (console output) |
+| `virt/arcbox-virtio/src/vsock.rs:41` | `Arc<Mutex<dyn VsockBackend>>` | read-heavy |
+| `virt/arcbox-vmm/src/device.rs:341` | `Arc<Mutex<dyn VirtioDevice>>` | mixed, but reads dominate |
+| `virt/arcbox-vm/src/manager.rs:25` | `Arc<RwLock<HashMap<..., Arc<Mutex<VmInstance>>>>>` | double-lock nesting |
+| `virt/arcbox-vm/src/sandbox.rs:312` | `Arc<RwLock<HashMap<..., Arc<Mutex<SandboxInstance>>>>>` | double-lock nesting |
+
+### Why this compounds
+
+- `Mutex` serializes all readers, creating a throughput ceiling on packet
+  forwarding and FS operations
+- double-lock nesting (`RwLock<HashMap<_, Mutex<_>>>`) creates deadlock risk
+  and makes lock ordering harder to reason about
+- performance regressions from lock contention are silent — they don't fail
+  tests, they just slow down
+
+### Recommendation
+
+1. Replace `Arc<Mutex<dyn NetBackend>>` and similar with `Arc<RwLock<..>>` where
+   the backend is read during packet processing and only written during
+   config changes.
+2. For `VmInstance`/`SandboxInstance`, consider whether the inner `Mutex` can
+   become a `RwLock` or whether the double-layer nesting can be flattened.
+3. For truly contended hot paths (packet forwarding), evaluate lock-free
+   alternatives (`crossbeam` channels, atomic state machines).
+
+---
+
+## T12 · Error Model Fragmentation Across Crate Boundaries <!-- ABX-274 -->
+
+**Compound value**: consistent error types reduce `map_err` boilerplate across
+every call site and enable reliable programmatic error handling in transport layers.
+
+### Evidence (beyond T7's stringly-typed findings)
+
+#### `VmmError` does not participate in the `CommonError` hierarchy
+
+`virt/arcbox-vm/src/error.rs` defines `VmmError` with its own `NotFound`,
+`AlreadyExists`, `Io`, `Config` variants that duplicate `CommonError` semantics
+but are not convertible:
+
+```rust
+// VmmError has its own NotFound, AlreadyExists, Io — duplicating CommonError
+pub enum VmmError {
+    NotFound(String),       // same as CommonError::NotFound
+    AlreadyExists(String),  // same as CommonError::AlreadyExists
+    Io(#[from] std::io::Error), // same as CommonError::Io
+    Config(String),         // same as CommonError::Config
+    // ... plus domain-specific variants
+}
+```
+
+Every other virt crate (`VirtioError`, `FsError`, `NetError`) uses
+`#[from] CommonError`. `VmmError` is the outlier.
+
+#### `guest/arcbox-agent` uses `anyhow` in library code
+
+The agent is a long-running in-VM process, not a CLI tool. Its use of `anyhow`
+means the host side cannot programmatically match on agent error types. Files:
+
+- `guest/arcbox-agent/src/agent.rs`
+- `guest/arcbox-agent/src/rpc.rs`
+- `guest/arcbox-agent/src/mount.rs`
+- `guest/arcbox-agent/src/main.rs`
+
+#### `CoreError` manually delegates convenience constructors
+
+`app/arcbox-core/src/error.rs` redefines `config()`, `not_found()`,
+`already_exists()` as passthrough methods to `CommonError`. Every new
+`CommonError` variant requires updating `CoreError` too.
+
+### Recommendation
+
+1. Add `#[from] CommonError` to `VmmError` and remove its duplicate variants.
+2. Replace `anyhow` in `guest/arcbox-agent/src/` with a structured
+   `AgentError` using `thiserror`.
+3. Consider a `derive` macro or blanket trait for the `CoreError`-style
+   delegation pattern, or just rely on `From<CommonError>` and use
+   `CommonError::not_found(...)` at call sites directly.
+
+---
+
+## T13 · Test Coverage Is Polarized: Strong Virt, Weak App <!-- ABX-275 -->
+
+**Compound value**: the app layer is where bugs compound fastest — lifecycle,
+persistence, API contracts — but it has the least test coverage.
+
+### Per-crate coverage (files with at least one `#[test]`)
+
+| Crate | Tested / Total | Coverage |
+|-------|---------------|----------|
+| `virt/arcbox-net` | 34 / 40 | **85%** ✓ |
+| `virt/arcbox-virtio` | 7 / 8 | **88%** ✓ |
+| `runtime/arcbox-oci` | 4 / 6 | 67% |
+| `app/arcbox-core` | 10 / 16 | 63% |
+| `virt/arcbox-fs` | 4 / 7 | 57% |
+| `virt/arcbox-vm` | 7 / 13 | 54% |
+| `virt/arcbox-hypervisor` | 9 / 19 | 47% |
+| `virt/arcbox-vmm` | 9 / 14 | 64% |
+| `guest/arcbox-agent` | 4 / 13 | 31% |
+| `app/arcbox-cli` | 3 / 17 | **18%** ✗ |
+| `app/arcbox-docker` | 4 / 27 | **15%** ✗ |
+| `app/arcbox-daemon` | 1 / 14 | **7%** ✗ |
+| `runtime/arcbox-container` | 1 / 5 | **20%** ✗ |
+| `rpc/arcbox-transport` | 1 / 10 | **10%** ✗ |
+| `app/arcbox-api` | 0 / 8 | **0%** ✗ |
+| `rpc/arcbox-grpc` | 0 / 1 | **0%** ✗ |
+
+### Why this compounds
+
+- `arcbox-api` (0%) contains all gRPC service implementations — no unit tests
+  for request validation, error mapping, or state transitions
+- `arcbox-daemon` (7%) owns the startup contract (T1) — the most
+  high-leverage code path has almost no automated verification
+- `arcbox-docker` (15%) is the Docker compatibility layer — regressions here
+  break every `docker` command users run
+- `arcbox-transport` (10%) handles vsock/unix transport — failures here are
+  silent and hard to debug in production
+
+### Recommendation
+
+1. Prioritize test coverage for `arcbox-api` and `arcbox-daemon` — these are
+   the entry points for every user interaction.
+2. Extract `arcbox-docker` handler logic into testable pure functions separated
+   from axum framework code.
+3. Create a shared `arcbox-test-utils` crate (or `tests/support/`) for mock
+   runtimes, test VMs, and fixture management currently duplicated across test files.
+
+---
+
+## T14 · Workspace Hygiene: Dead Code, Stale Dependencies, Missed Edition Features <!-- ABX-276 -->
+
+**Compound value**: small per-item, but in aggregate these create noise that
+slows down every code review, every `cargo clippy` run, and every new
+contributor's onboarding.
+
+### Dead code suppression
+
+`42` instances of `#[allow(dead_code)]` plus `11` `#[allow(unused_*)]` across
+the workspace. These are either:
+
+- genuinely dead code that should be deleted
+- code that is only used on one platform and needs `#[cfg]` gating instead
+
+Each suppressed warning is a signal that the code's intent is unclear.
+
+### `async-trait` crate is no longer needed
+
+The workspace uses edition 2024 with `rust-version = "1.85"`, which supports
+native `async fn` in traits. There are still `9` uses of the `async-trait`
+proc macro. Each one adds:
+
+- a `Box<dyn Future>` allocation on every call
+- a hidden `Send` bound that may not be needed
+- macro expansion overhead in compile time
+
+### Dependency version inconsistency
+
+Several crates specify their own `tokio` version instead of using
+`workspace = true`:
+
+- `virt/arcbox-vz/Cargo.toml` — `tokio = { version = "1", ... }` (twice!)
+- `common/arcbox-asset/Cargo.toml` — `tokio = { version = "1", ... }`
+
+This can lead to feature flag mismatches and confusing build behavior.
+
+### Recommendation
+
+1. Audit all `#[allow(dead_code)]` — delete dead code or add proper `#[cfg]` gates.
+2. Replace `#[async_trait]` with native async fn in traits across all 9 call sites.
+3. Move all `tokio`/`tracing` dependencies to `workspace = true`.
+
+---
+
+## T15 · Focused Tactical Fixes Worth Keeping From the Original Audit <!-- ABX-277 -->
+
+These are not the highest-order structural issues, but they are still correct and
+worth preserving in the backlog.
+
+### Port forwarding atomicity
+
+Location:
+
+- `app/arcbox-core/src/runtime.rs` in `start_port_forwarding_macos`
+
+Issue:
+
+- partial success can leave listener state and tracked rule state diverged
+
+Fix:
+
+- use commit-or-rollback semantics for rule installation
+
+### `ExecInstance` state machine
+
+Location:
+
+- `runtime/arcbox-container/src/exec.rs`
+
+Issue:
+
+- boolean + optional fields allow invalid combinations
+
+Fix:
+
+- replace with a typed `ExecState` enum
+
+### Public API surface and dead feature flags
+
+The previous audit was directionally correct here:
+
+- some crates expose more modules than they should
+- several feature flags appear underused or undocumented
+
+These are useful cleanup tasks, but they should follow the bigger contract and
+boundary work above.
+
+---
+
+## Recommended Execution Order
+
+If engineering time is limited, this is the highest-leverage sequence:
+
+1. **Startup contract** (T1, T4)
+   - typed startup phases
+   - shared host layout
+   - shared daemon contract
+
+2. **Lifecycle truth** (T2)
+   - one authoritative lifecycle model
+   - repository-style persistence updates
+   - remove dual-write / swallowed state errors
+
+3. **Structural split program** (T3)
+   - `vm_lifecycle.rs`
+   - `machine.rs`
+   - `guest/agent.rs`
+   - CLI command monoliths
+
+4. **VM convergence** (T5, T6)
+   - freeze `arcbox-vm` growth
+   - move `Vmm` to backend strategy
+   - close the `VirtIO transport <-> device` boundary
+
+5. **Error model unification** (T7, T12)
+   - `VmmError` → `#[from] CommonError`
+   - `guest/arcbox-agent` → structured `AgentError`
+   - replace `.to_string()` erasure with `From` chains
+
+6. **Runtime safety** (T10, T11)
+   - eliminate `unwrap()` in `virt/` and `guest/` hot paths
+   - replace `Arc<Mutex>` with `RwLock` on read-heavy paths
+   - add clippy `unwrap_used` deny in CI
+
+7. **CI uplift** (T9, T13)
+   - stop excluding `arcbox-agent`
+   - move from best-effort workflows to layered enforcement
+   - prioritize test coverage for `arcbox-api` (0%), `arcbox-daemon` (7%),
+     `arcbox-docker` (15%)
+
+8. **Workspace hygiene** (T14)
+   - remove `async-trait` (9 uses → native async fn in traits)
+   - audit `#[allow(dead_code)]` (42 instances)
+   - consolidate non-workspace dependency declarations
+
+---
+
+## Positive Patterns Worth Preserving
+
+The repo still has several strong patterns that should survive the refactors:
+
+- crate-level layering is still understandable — no circular dependencies detected
+- extension traits such as `request.machine_id()` and `runtime.ready()` reduce handler noise
+- `CommonError` remains the right base pattern; most crates (except `arcbox-vm`) follow it
+- `CancellationToken` usage is consistent
+- `spawn_blocking` discipline is generally good
+- RAII ownership patterns like `DaemonLock` are sound
+- `virt/arcbox-net` (85% coverage) and `virt/arcbox-virtio` (88% coverage) are
+  reference models for test discipline — other crates should aspire to these levels
+- workspace-level clippy config (pedantic + nursery) with sensible allows shows
+  good lint hygiene intent
+- `profile.dev.package."*".opt-level = 2` is a smart default for dev builds
+  with many dependencies
+
+The codebase does not need a philosophical redesign. It needs boundary tightening,
+ownership clarification, and a deliberate debt paydown program in the control
+plane and virtualization layers.

--- a/virt/arcbox-net/src/darwin/datapath_loop.rs
+++ b/virt/arcbox-net/src/darwin/datapath_loop.rs
@@ -410,6 +410,11 @@ impl NetworkDatapath {
                 guest_mac,
             );
 
+            // Drain SYN frames from initiate_inbound.
+            for frame in tcp_bridge.pending_outbound_frames.drain(..) {
+                enqueue_or_write(&guest_async, FrameBuf::from(frame), &mut write_queue);
+            }
+
             // 2. smoltcp poll: processes injected SYN frames (from gate) +
             //    retransmissions + ACKs.
             let ts = smoltcp::time::Instant::now();
@@ -425,7 +430,8 @@ impl NetworkDatapath {
 
             // 5. Poll fast-path host streams for inbound data and inject
             //    constructed frames directly to guest (bypasses smoltcp).
-            for frame in tcp_bridge.poll_fast_path() {
+            let fp_frames = tcp_bridge.poll_fast_path();
+            for frame in fp_frames {
                 enqueue_or_write(&guest_async, FrameBuf::from(frame), &mut write_queue);
             }
 
@@ -501,15 +507,15 @@ fn handle_intercepted_frame(
 
 /// Processes one inbound command from `InboundListenerManager`.
 ///
-/// TCP accepted streams are bridged via smoltcp active-connect; UDP datagrams
+/// TCP accepted streams are bridged via direct SYN; UDP datagrams
 /// are routed through the socket proxy inbound path.
 #[allow(clippy::too_many_arguments)]
 fn process_inbound_cmd(
     cmd: InboundCommand,
     tcp_bridge: &mut TcpBridge,
     socket_proxy: &mut SocketProxy,
-    iface: &mut Interface,
-    sockets: &mut SocketSet<'_>,
+    _iface: &mut Interface,
+    _sockets: &mut SocketSet<'_>,
     guest_ip: Ipv4Addr,
     gateway_ip: Ipv4Addr,
     guest_mac: Option<[u8; 6]>,
@@ -523,7 +529,11 @@ fn process_inbound_cmd(
                 host_port,
                 stream.peer_addr().ok(),
             );
-            tcp_bridge.initiate_inbound(host_port, stream, guest_ip, gateway_ip, iface, sockets);
+            let syn = tcp_bridge.initiate_inbound(host_port, stream, guest_ip, gateway_ip);
+            // SYN frame is returned to caller for injection via enqueue_or_write.
+            // We can't write directly here because we don't have guest_async/write_queue.
+            // Store in tcp_bridge for later draining.
+            tcp_bridge.pending_outbound_frames.push(syn);
         }
         cmd @ InboundCommand::UdpReceived { .. } => {
             let mac = guest_mac.unwrap_or([0xFF; 6]);

--- a/virt/arcbox-net/src/darwin/datapath_loop.rs
+++ b/virt/arcbox-net/src/darwin/datapath_loop.rs
@@ -289,6 +289,9 @@ impl NetworkDatapath {
                         enqueue_or_write(&guest_async, FrameBuf::from(ack), &mut write_queue);
                     }
 
+                    // Clean up smoltcp sockets for newly promoted fast-path conns.
+                    tcp_bridge.cleanup_promoted(&mut sockets);
+
                     // Process intercepted frames (DHCP, DNS, UDP, ICMP).
                     let intercepted = device.take_intercepted();
                     for intercepted_frame in &intercepted {

--- a/virt/arcbox-net/src/darwin/tcp_bridge.rs
+++ b/virt/arcbox-net/src/darwin/tcp_bridge.rs
@@ -133,12 +133,6 @@ struct BridgedConn {
     host_disconnected: bool,
     /// Leftover bytes from a partial `send_slice` that need to be retried.
     pending_send: Option<Vec<u8>>,
-    /// Host stream held for fast-path promotion. When set, the relay task
-    /// has NOT been spawned — the stream is waiting for the socket to reach
-    /// ESTABLISHED before being promoted to `FastPathConn`.
-    held_stream: Option<tokio::net::TcpStream>,
-    /// Four-tuple key for fast-path lookup (set when held_stream is present).
-    flow_key: Option<SynFlowKey>,
 }
 
 /// Manages TCP connections bridged between the smoltcp socket pool and host
@@ -167,8 +161,20 @@ pub struct TcpBridge {
     /// (enables `host.docker.internal` support).
     gateway_ip: Ipv4Addr,
     /// Fast-path connections that bypass smoltcp for data transfer.
-    /// Keyed by (guest_src_ip, guest_src_port, dest_ip, dest_port).
     fast_path_conns: HashMap<SynFlowKey, FastPathConn>,
+    /// Pre-connected streams held for fast-path promotion. Stored when
+    /// a pre-connected stream arrives; consumed when the first data frame
+    /// triggers promotion in try_fast_path_intercept().
+    held_streams: HashMap<SynFlowKey, tokio::net::TcpStream>,
+    /// Socket handles for held-stream connections (maps flow key → handle).
+    /// Used by relay_all to check ESTABLISHED state without needing a BridgedConn.
+    held_handles: HashMap<SynFlowKey, SocketHandle>,
+    /// Connections that reached ESTABLISHED and are ready for fast-path
+    /// promotion on the next data frame.
+    fast_path_ready: HashSet<SynFlowKey>,
+    /// Sockets to remove after promotion. Filled by try_fast_path_intercept,
+    /// drained by the datapath loop after drain_fast_path.
+    pub promoted_cleanup: Vec<SynFlowKey>,
     /// Gateway MAC for constructing fast-path frames to the guest.
     fast_path_gateway_mac: [u8; 6],
     /// Guest MAC for constructing fast-path frames to the guest.
@@ -212,6 +218,10 @@ impl TcpBridge {
             proxy_env: None,
             gateway_ip,
             fast_path_conns: HashMap::new(),
+            held_streams: HashMap::new(),
+            held_handles: HashMap::new(),
+            fast_path_ready: HashSet::new(),
+            promoted_cleanup: Vec::new(),
             fast_path_gateway_mac: [0; 6],
             fast_path_guest_mac: None,
         }
@@ -267,6 +277,65 @@ impl TcpBridge {
             dst_ip,
             dst_port,
         };
+
+        // Check if this flow is ready for fast-path promotion (first data frame
+        // after ESTABLISHED). Promote inline before smoltcp sees the frame.
+        if self.fast_path_ready.contains(&key) {
+            let tcp_data_offset = ((frame[l4_start + 12] >> 4) as usize) * 4;
+            let payload_start = l4_start + tcp_data_offset;
+            let has_payload = payload_start < frame.len() && {
+                let ip_total =
+                    u16::from_be_bytes([frame[ip_start + 2], frame[ip_start + 3]]) as usize;
+                ip_start + ip_total > payload_start
+            };
+
+            // Only promote on data-bearing frames (not pure ACKs).
+            if has_payload {
+                if let Some(stream) = self.held_streams.remove(&key) {
+                    self.fast_path_ready.remove(&key);
+                    // SEQ/ACK from this frame: guest_ack = what guest expects as
+                    // our SEQ; guest_seq = guest's current byte offset.
+                    let guest_seq = u32::from_be_bytes([
+                        frame[l4_start + 4],
+                        frame[l4_start + 5],
+                        frame[l4_start + 6],
+                        frame[l4_start + 7],
+                    ]);
+                    let guest_ack = u32::from_be_bytes([
+                        frame[l4_start + 8],
+                        frame[l4_start + 9],
+                        frame[l4_start + 10],
+                        frame[l4_start + 11],
+                    ]);
+                    match stream.into_std() {
+                        Ok(std_stream) => {
+                            self.promote_to_fast_path(key, std_stream, guest_ack, guest_seq);
+                            tracing::info!(
+                                "Fast path: promoted on first data frame {}:{} → {}:{} seq={} ack={}",
+                                src_ip,
+                                src_port,
+                                dst_ip,
+                                dst_port,
+                                guest_ack,
+                                guest_seq
+                            );
+                            // Mark for cleanup: remove smoltcp socket + BridgedConn
+                            // so the relay task dies and the socket stops processing.
+                            self.promoted_cleanup.push(key);
+                            // Fall through to handle this frame via the now-active
+                            // fast_path_conns entry below.
+                        }
+                        Err(e) => {
+                            tracing::error!("Fast path: into_std failed: {e}");
+                            return None;
+                        }
+                    }
+                }
+            } else {
+                // Pure ACK during ready state — let smoltcp handle it.
+                return None;
+            }
+        }
 
         let conn = self.fast_path_conns.get_mut(&key)?;
 
@@ -503,6 +572,33 @@ impl TcpBridge {
                 host_eof: false,
             },
         );
+    }
+
+    /// Removes smoltcp sockets and BridgedConns for recently promoted
+    /// fast-path connections. Must be called after drain_fast_path().
+    pub fn cleanup_promoted(&mut self, sockets: &mut SocketSet<'_>) {
+        for key in self.promoted_cleanup.drain(..) {
+            // Use held_handles to find the socket directly.
+            let handle = self.held_handles.remove(&key);
+            if let Some(h) = handle {
+                // Remove BridgedConn if it exists (outbound path has one).
+                self.connections.remove(&h);
+                // Remove the smoltcp socket.
+                sockets.remove(h);
+                // Clean port_handles to prevent stale handle access.
+                for handles in self.port_handles.values_mut() {
+                    handles.retain(|ph| *ph != h);
+                }
+                self.port_handles.retain(|_, handles| !handles.is_empty());
+                tracing::debug!(
+                    "Fast path: cleaned up for {}:{} → {}:{}",
+                    key.src_ip,
+                    key.src_port,
+                    key.dst_ip,
+                    key.dst_port
+                );
+            }
+        }
     }
 
     /// Returns the number of active fast-path connections.
@@ -927,12 +1023,11 @@ impl TcpBridge {
 
         let handle = sockets.add(sock);
 
+        // Inbound connections: host initiates data first, so fast-path promotion
+        // (which triggers on the first guest data frame) doesn't work well.
+        // Use the normal relay path for inbound connections.
         let (h2g_tx, h2g_rx) = mpsc::channel::<Vec<u8>>(HOST_TO_GUEST_CHANNEL);
         let (g2h_tx, g2h_rx) = mpsc::channel::<Vec<u8>>(GUEST_TO_HOST_CHANNEL);
-
-        // Spawn a task that relays between the already-connected host TcpStream
-        // and the channels. Same pattern as host_conn_task but the stream is
-        // already connected.
         tokio::spawn(inbound_host_relay(stream, h2g_tx, g2h_rx));
 
         let guest_addr = SocketAddr::V4(SocketAddrV4::new(guest_ip, container_port));
@@ -947,8 +1042,6 @@ impl TcpBridge {
                 host_eof: false,
                 host_disconnected: false,
                 pending_send: None,
-                held_stream: None,
-                flow_key: None,
             },
         );
 
@@ -1001,11 +1094,6 @@ impl TcpBridge {
                 }
 
                 let sock = sockets.get_mut::<tcp::Socket>(handle);
-                if !sock.is_active() {
-                    continue;
-                }
-
-                // Socket accepted a SYN — extract the remote endpoint.
                 let Some(remote_ep) = sock.remote_endpoint() else {
                     continue;
                 };
@@ -1031,52 +1119,41 @@ impl TcpBridge {
                     dst_port: local_ep.port,
                 };
 
+                // Create channels for host↔guest data bridging.
+                let (h2g_tx, h2g_rx) = mpsc::channel::<Vec<u8>>(HOST_TO_GUEST_CHANNEL);
+                let (g2h_tx, g2h_rx) = mpsc::channel::<Vec<u8>>(GUEST_TO_HOST_CHANNEL);
+
                 // Try to use a pre-connected stream from the SYN gate.
-                // If available, hold it for fast-path promotion once ESTABLISHED.
-                // Otherwise, fall back to the normal channel-based relay.
                 if let Some(pre) = self.pre_connected.remove(&flow_key) {
                     tracing::debug!(
-                        "TCP bridge: holding pre-connected stream for fast-path: guest:{remote_addr} → {dest_addr}"
+                        "TCP bridge: pre-connected stream for guest:{remote_addr} → {dest_addr} (fast-path candidate)"
                     );
-                    // Create dummy channels (unused — fast path will take over).
-                    let (_h2g_tx, h2g_rx) = mpsc::channel::<Vec<u8>>(1);
-                    let (g2h_tx, _g2h_rx) = mpsc::channel::<Vec<u8>>(1);
-                    self.connections.insert(
-                        handle,
-                        BridgedConn {
-                            handle,
-                            remote: dest_addr,
-                            host_to_guest_rx: h2g_rx,
-                            guest_to_host_tx: Some(g2h_tx),
-                            host_eof: false,
-                            host_disconnected: false,
-                            pending_send: None,
-                            held_stream: Some(pre.stream),
-                            flow_key: Some(flow_key),
-                        },
-                    );
+                    // Store the pre-connected stream for fast-path promotion.
+                    // A separate relay connection handles the handshake period.
+                    // When fast path activates (on first data frame after
+                    // ESTABLISHED), the relay channels are dropped and the
+                    // pre-connected stream takes over via FastPathConn.
+                    self.held_streams.insert(flow_key, pre.stream);
+                    self.held_handles.insert(flow_key, handle);
                 } else {
                     tracing::debug!(
                         "TCP bridge: no pre-connected stream, spawning connect for guest:{remote_addr} → {dest_addr}"
                     );
-                    let (h2g_tx, h2g_rx) = mpsc::channel::<Vec<u8>>(HOST_TO_GUEST_CHANNEL);
-                    let (g2h_tx, g2h_rx) = mpsc::channel::<Vec<u8>>(GUEST_TO_HOST_CHANNEL);
-                    tokio::spawn(host_conn_task(dest_addr, h2g_tx, g2h_rx));
-                    self.connections.insert(
-                        handle,
-                        BridgedConn {
-                            handle,
-                            remote: dest_addr,
-                            host_to_guest_rx: h2g_rx,
-                            guest_to_host_tx: Some(g2h_tx),
-                            host_eof: false,
-                            host_disconnected: false,
-                            pending_send: None,
-                            held_stream: None,
-                            flow_key: None,
-                        },
-                    );
                 }
+                tokio::spawn(host_conn_task(dest_addr, h2g_tx, g2h_rx));
+
+                self.connections.insert(
+                    handle,
+                    BridgedConn {
+                        handle,
+                        remote: dest_addr,
+                        host_to_guest_rx: h2g_rx,
+                        guest_to_host_tx: Some(g2h_tx),
+                        host_eof: false,
+                        host_disconnected: false,
+                        pending_send: None,
+                    },
+                );
 
                 // This port's listen socket is now occupied. Remove from
                 // listening_ports and schedule a replacement.
@@ -1116,48 +1193,29 @@ impl TcpBridge {
     }
 
     /// Relays data between smoltcp sockets and host TcpStreams for all active
-    /// connections. Promotes held-stream connections to fast path when ESTABLISHED.
+    /// connections. Marks held-stream connections as fast-path ready when
+    /// ESTABLISHED — actual promotion happens in try_fast_path_intercept()
+    /// when the first data frame arrives (ensuring smoltcp data isn't lost).
     fn relay_all(&mut self, sockets: &mut SocketSet<'_>) {
-        // Check for connections ready to promote to fast path.
-        let mut to_promote = Vec::new();
-        for (handle, conn) in &self.connections {
-            if conn.held_stream.is_some() {
-                let sock = sockets.get::<tcp::Socket>(*handle);
-                if sock.state() == tcp::State::Established {
-                    to_promote.push(*handle);
-                }
+        // Check held_streams: if the corresponding smoltcp socket is ESTABLISHED,
+        // mark the flow as ready for fast-path activation.
+        let mut newly_ready = Vec::new();
+        for (key, &handle) in &self.held_handles {
+            // Check if the smoltcp socket has reached ESTABLISHED.
+            let sock = sockets.get::<tcp::Socket>(handle);
+            if sock.state() == tcp::State::Established {
+                newly_ready.push(*key);
             }
         }
-        for handle in to_promote {
-            if let Some(mut conn) = self.connections.remove(&handle) {
-                if let (Some(stream), Some(flow_key)) = (conn.held_stream.take(), conn.flow_key) {
-                    // smoltcp doesn't expose SEQ/ACK publicly. We initialize
-                    // with zeros — the first guest data frame's SEQ and ACK
-                    // fields will tell us the correct values, and
-                    // try_fast_path_intercept() will sync on first use.
-                    let our_seq = 0u32;
-                    let last_ack = 0u32;
-
-                    // Close the smoltcp socket — fast path takes over.
-                    sockets.get_mut::<tcp::Socket>(handle).abort();
-                    sockets.remove(handle);
-
-                    // Convert tokio stream to std for non-blocking sync I/O.
-                    match stream.into_std() {
-                        Ok(std_stream) => {
-                            self.promote_to_fast_path(flow_key, std_stream, our_seq, last_ack);
-                        }
-                        Err(e) => {
-                            tracing::error!(
-                                "Fast path: failed to convert tokio TcpStream to std: {e}. \
-                                 Connection lost (smoltcp socket already removed)."
-                            );
-                            // Both smoltcp socket and BridgedConn are gone. The host
-                            // stream will be dropped here. Guest will see a timeout.
-                        }
-                    }
-                }
-            }
+        for key in newly_ready {
+            self.fast_path_ready.insert(key);
+            tracing::info!(
+                "Fast path: ready for {}:{} → {}:{} (will activate on first data frame)",
+                key.src_ip,
+                key.src_port,
+                key.dst_ip,
+                key.dst_port
+            );
         }
 
         for conn in self.connections.values_mut() {
@@ -1888,8 +1946,6 @@ mod tests {
                 host_eof: false,
                 host_disconnected: false,
                 pending_send: Some(vec![0xAA; 32]),
-                held_stream: None,
-                flow_key: None,
             },
         );
 
@@ -1932,8 +1988,6 @@ mod tests {
                 host_eof: true,
                 host_disconnected: false,
                 pending_send: Some(vec![0xBB; 10]),
-                held_stream: None,
-                flow_key: None,
             },
         );
 
@@ -1985,8 +2039,6 @@ mod tests {
                 host_eof: false,
                 host_disconnected: false,
                 pending_send: None,
-                held_stream: None,
-                flow_key: None,
             },
         );
 
@@ -2025,8 +2077,6 @@ mod tests {
                 host_eof: false,
                 host_disconnected: false,
                 pending_send: None,
-                held_stream: None,
-                flow_key: None,
             },
         );
 
@@ -2071,8 +2121,8 @@ mod tests {
         );
 
         // The socket should be in SynSent state (attempting connect to guest).
-        let (handle, conn) = bridge.connections.iter().next().unwrap();
-        let sock = sockets.get_mut::<tcp::Socket>(*handle);
+        let (&handle, conn) = bridge.connections.iter().next().unwrap();
+        let sock = sockets.get_mut::<tcp::Socket>(handle);
         assert!(
             sock.is_open(),
             "Socket should be open after connect; state={:?}",

--- a/virt/arcbox-net/src/darwin/tcp_bridge.rs
+++ b/virt/arcbox-net/src/darwin/tcp_bridge.rs
@@ -162,6 +162,9 @@ pub struct TcpBridge {
     gateway_ip: Ipv4Addr,
     /// Fast-path connections that bypass smoltcp for data transfer.
     fast_path_conns: HashMap<SynFlowKey, FastPathConn>,
+    /// Direct handshakes waiting for guest ACK (SYN-ACK sent without smoltcp).
+    /// Read/write tasks already running — promotion just moves channels to FastPathConn.
+    pending_handshake: HashMap<SynFlowKey, PendingHandshake>,
     /// Pre-connected streams held for fast-path promotion. Stored when
     /// a pre-connected stream arrives; consumed when the first data frame
     /// triggers promotion in try_fast_path_intercept().
@@ -175,18 +178,47 @@ pub struct TcpBridge {
     /// Sockets to remove after promotion. Filled by try_fast_path_intercept,
     /// drained by the datapath loop after drain_fast_path.
     pub promoted_cleanup: Vec<SynFlowKey>,
+    /// Inbound connections in SYN_SENT state (we sent SYN, waiting for guest
+    /// SYN-ACK). Read/write tasks already running on the host stream.
+    pending_inbound: HashMap<SynFlowKey, PendingInbound>,
     /// Gateway MAC for constructing fast-path frames to the guest.
     fast_path_gateway_mac: [u8; 6],
     /// Guest MAC for constructing fast-path frames to the guest.
     fast_path_guest_mac: Option<[u8; 6]>,
+    /// Frames to inject into the guest FD (e.g. SYN from initiate_inbound).
+    pub pending_outbound_frames: Vec<Vec<u8>>,
 }
 
-/// A TCP connection promoted to the fast path — bypasses smoltcp entirely
-/// for data transfer. smoltcp handled the initial 3-way handshake; data
-/// frames are now intercepted at `classify_ipv4` and relayed directly.
+/// Tracks a direct handshake (SYN-ACK sent without smoltcp) waiting for
+/// the guest's ACK. The read/write tasks are already running.
+struct PendingHandshake {
+    our_isn: u32,
+    guest_isn: u32,
+    /// Sender for guest→host payload (connected to the write task).
+    host_tx: mpsc::Sender<Vec<u8>>,
+    /// Receiver for host→guest data (connected to the read task).
+    host_rx: mpsc::Receiver<Vec<u8>>,
+}
+
+/// Inbound connection in SYN_SENT state (we sent SYN to guest, waiting for
+/// SYN-ACK). The host stream's read/write tasks are already running.
+struct PendingInbound {
+    our_isn: u32,
+    host_tx: mpsc::Sender<Vec<u8>>,
+    host_rx: mpsc::Receiver<Vec<u8>>,
+    guest_ip: Ipv4Addr,
+    gateway_ip: Ipv4Addr,
+    container_port: u16,
+    eph_port: u16,
+}
+
+/// A TCP connection on the fast path — bypasses smoltcp entirely.
+/// I/O is handled by spawned tokio tasks connected via channels.
 struct FastPathConn {
-    /// Host-side TCP stream (std blocking — used from the sync datapath loop).
-    stream: std::net::TcpStream,
+    /// Sender for guest→host payload (write task owns the stream writer).
+    host_tx: mpsc::Sender<Vec<u8>>,
+    /// Receiver for host→guest data (read task owns the stream reader).
+    host_rx: mpsc::Receiver<Vec<u8>>,
     /// Our SEQ number for frames sent TO guest.
     our_seq: u32,
     /// Last ACK we sent to guest (= next SEQ we expect FROM guest).
@@ -199,8 +231,6 @@ struct FastPathConn {
     remote_port: u16,
     /// Guest port.
     guest_port: u16,
-    /// Read buffer for host → guest data (reused across polls).
-    read_buf: Vec<u8>,
     /// True if host stream has reached EOF.
     host_eof: bool,
 }
@@ -218,12 +248,15 @@ impl TcpBridge {
             proxy_env: None,
             gateway_ip,
             fast_path_conns: HashMap::new(),
+            pending_handshake: HashMap::new(),
+            pending_inbound: HashMap::new(),
             held_streams: HashMap::new(),
             held_handles: HashMap::new(),
             fast_path_ready: HashSet::new(),
             promoted_cleanup: Vec::new(),
             fast_path_gateway_mac: [0; 6],
             fast_path_guest_mac: None,
+            pending_outbound_frames: Vec::new(),
         }
     }
 
@@ -278,8 +311,106 @@ impl TcpBridge {
             dst_port,
         };
 
+        // Check if this is the guest's SYN-ACK for an inbound connection.
+        // SYN-ACK: flags = SYN|ACK (0x12).
+        if self.pending_inbound.contains_key(&key) && (flags & 0x12 == 0x12) {
+            if let Some(pi) = self.pending_inbound.remove(&key) {
+                let guest_isn = u32::from_be_bytes([
+                    frame[l4_start + 4],
+                    frame[l4_start + 5],
+                    frame[l4_start + 6],
+                    frame[l4_start + 7],
+                ]);
+                let our_seq = pi.our_isn.wrapping_add(1); // SYN consumed 1
+                let last_ack = guest_isn.wrapping_add(1); // SYN consumed 1
+
+                // Send ACK to complete the handshake.
+                let guest_mac = self.fast_path_guest_mac.unwrap_or([0xFF; 6]);
+                let ack_frame =
+                    crate::ethernet::build_tcp_ack_frame(&crate::ethernet::TcpFrameParams {
+                        src_ip: pi.gateway_ip,
+                        dst_ip: pi.guest_ip,
+                        src_port: pi.eph_port,
+                        dst_port: pi.container_port,
+                        seq: our_seq,
+                        ack: last_ack,
+                        window: 65535,
+                        src_mac: self.fast_path_gateway_mac,
+                        dst_mac: guest_mac,
+                    });
+
+                // Create FastPathConn.
+                self.fast_path_conns.insert(
+                    key,
+                    FastPathConn {
+                        host_tx: pi.host_tx,
+                        host_rx: pi.host_rx,
+                        our_seq,
+                        last_ack,
+                        remote_ip: pi.gateway_ip,
+                        guest_ip: pi.guest_ip,
+                        remote_port: pi.eph_port,
+                        guest_port: pi.container_port,
+                        host_eof: false,
+                    },
+                );
+
+                tracing::info!(
+                    "Fast path: inbound established gw:{}→guest:{} seq={our_seq} ack={last_ack}",
+                    pi.eph_port,
+                    pi.container_port
+                );
+
+                return Some(ack_frame);
+            }
+        }
+
+        // Check if this is the guest's ACK completing a direct outbound handshake.
+        if self.pending_handshake.contains_key(&key) && (flags & 0x10 != 0) && (flags & 0x02 == 0) {
+            if let Some(hs) = self.pending_handshake.remove(&key) {
+                let our_seq = hs.our_isn.wrapping_add(1); // SYN-ACK consumed 1
+                let last_ack = hs.guest_isn.wrapping_add(1); // SYN consumed 1
+
+                self.fast_path_conns.insert(
+                    key,
+                    FastPathConn {
+                        host_tx: hs.host_tx,
+                        host_rx: hs.host_rx,
+                        our_seq,
+                        last_ack,
+                        remote_ip: key.dst_ip,
+                        guest_ip: key.src_ip,
+                        remote_port: key.dst_port,
+                        guest_port: key.src_port,
+                        host_eof: false,
+                    },
+                );
+
+                tracing::info!(
+                    "Fast path: handshake complete {}:{} → {}:{} seq={our_seq} ack={last_ack} (conns={})",
+                    src_ip,
+                    src_port,
+                    dst_ip,
+                    dst_port,
+                    self.fast_path_conns.len()
+                );
+
+                // Check if ACK carries data — if so, fall through to fast_path_conns.
+                let tcp_data_offset = ((frame[l4_start + 12] >> 4) as usize) * 4;
+                let payload_start = l4_start + tcp_data_offset;
+                let ip_total =
+                    u16::from_be_bytes([frame[ip_start + 2], frame[ip_start + 3]]) as usize;
+                let has_payload =
+                    payload_start < frame.len() && ip_start + ip_total > payload_start;
+                if !has_payload {
+                    return Some(Vec::new()); // Pure ACK
+                }
+                // Fall through to fast_path_conns handling below.
+            }
+        }
+
         // Check if this flow is ready for fast-path promotion (first data frame
-        // after ESTABLISHED). Promote inline before smoltcp sees the frame.
+        // after ESTABLISHED via smoltcp path). Promote inline before smoltcp sees.
         if self.fast_path_ready.contains(&key) {
             let tcp_data_offset = ((frame[l4_start + 12] >> 4) as usize) * 4;
             let payload_start = l4_start + tcp_data_offset;
@@ -307,28 +438,18 @@ impl TcpBridge {
                         frame[l4_start + 10],
                         frame[l4_start + 11],
                     ]);
-                    match stream.into_std() {
-                        Ok(std_stream) => {
-                            self.promote_to_fast_path(key, std_stream, guest_ack, guest_seq);
-                            tracing::info!(
-                                "Fast path: promoted on first data frame {}:{} → {}:{} seq={} ack={}",
-                                src_ip,
-                                src_port,
-                                dst_ip,
-                                dst_port,
-                                guest_ack,
-                                guest_seq
-                            );
-                            // Mark for cleanup: remove smoltcp socket + BridgedConn
-                            // so the relay task dies and the socket stops processing.
-                            self.promoted_cleanup.push(key);
-                            // Fall through to handle this frame via the now-active
-                            // fast_path_conns entry below.
-                        }
-                        Err(e) => {
-                            tracing::error!("Fast path: into_std failed: {e}");
-                            return None;
-                        }
+                    {
+                        self.promote_to_fast_path(key, stream, guest_ack, guest_seq);
+                        tracing::info!(
+                            "Fast path: promoted on first data frame {}:{} → {}:{} seq={} ack={}",
+                            src_ip,
+                            src_port,
+                            dst_ip,
+                            dst_port,
+                            guest_ack,
+                            guest_seq
+                        );
+                        self.promoted_cleanup.push(key);
                     }
                 }
             } else {
@@ -402,25 +523,22 @@ impl TcpBridge {
         let payload_end = ip_end.min(frame.len());
         let payload_len = payload_end.saturating_sub(payload_start);
 
-        // Write payload to host stream (if any).
+        // Write payload to host via channel (write task handles async I/O).
         if payload_len > 0 {
-            use std::io::Write;
             let payload = &frame[payload_start..payload_start + payload_len];
-            match conn.stream.write(payload) {
-                Ok(n) => {
-                    conn.last_ack = conn.last_ack.wrapping_add(n as u32);
+            match conn.host_tx.try_send(payload.to_vec()) {
+                Ok(()) => {
+                    conn.last_ack = conn.last_ack.wrapping_add(payload_len as u32);
                     tracing::trace!(
-                        "Fast path TX: {src_ip}:{src_port}→{dst_ip}:{dst_port} {n} bytes"
+                        "Fast path TX: {src_ip}:{src_port}→{dst_ip}:{dst_port} {payload_len} bytes"
                     );
                 }
-                Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => {
-                    // Non-blocking stream not ready. Don't ACK — guest will
-                    // retransmit. Don't remove the connection.
-                    tracing::trace!("Fast path TX: WouldBlock, guest will retransmit");
-                    return Some(Vec::new()); // Signal interception but no ACK frame.
+                Err(mpsc::error::TrySendError::Full(_)) => {
+                    tracing::trace!("Fast path TX: channel full, guest will retransmit");
+                    return Some(Vec::new());
                 }
-                Err(e) => {
-                    tracing::warn!("Fast path TX write error: {e}");
+                Err(mpsc::error::TrySendError::Closed(_)) => {
+                    tracing::debug!("Fast path TX: write task closed");
                     self.fast_path_conns.remove(&key);
                     return None;
                 }
@@ -454,45 +572,33 @@ impl TcpBridge {
         let guest_mac = self.fast_path_guest_mac.unwrap_or([0xFF; 6]);
         let gw_mac = self.fast_path_gateway_mac;
 
+        if !self.fast_path_conns.is_empty() {
+            tracing::trace!(
+                "poll_fast_path: {} active conns",
+                self.fast_path_conns.len()
+            );
+        }
+
         for (key, conn) in &mut self.fast_path_conns {
             if conn.host_eof {
                 continue;
             }
 
-            use std::io::Read;
-            match conn.stream.read(&mut conn.read_buf) {
-                Ok(0) => {
-                    // Host EOF — send FIN to guest.
-                    conn.host_eof = true;
-                    let fin =
-                        crate::ethernet::build_tcp_fin_frame(&crate::ethernet::TcpFrameParams {
-                            src_ip: conn.remote_ip,
-                            dst_ip: conn.guest_ip,
-                            src_port: conn.remote_port,
-                            dst_port: conn.guest_port,
-                            seq: conn.our_seq,
-                            ack: conn.last_ack,
-                            window: 65535,
-                            src_mac: gw_mac,
-                            dst_mac: guest_mac,
-                        });
-                    conn.our_seq = conn.our_seq.wrapping_add(1); // FIN consumes 1 SEQ
-                    frames.push(fin);
-                    // Don't remove yet — keep the entry so the guest's FIN-ACK
-                    // response is handled by try_fast_path_intercept (which will
-                    // see the FIN flag and clean up).
-                }
-                Ok(n) => {
-                    // Segment into MSS-sized chunks to stay within MTU.
-                    // MSS = MTU - IP(20) - TCP(20). Use 3960 for MTU 4000,
-                    // 1460 for MTU 1500. Conservative default: 3960.
-                    const MSS: usize = 3960;
-                    let data = &conn.read_buf[..n];
-                    let mut offset = 0;
-                    while offset < data.len() {
-                        let chunk_end = (offset + MSS).min(data.len());
-                        let chunk = &data[offset..chunk_end];
-                        let data_frame = crate::ethernet::build_tcp_data_frame(
+            // Drain host→guest channel from the read task.
+            // VZ framework may silently drop frames exceeding the guest's
+            // VirtIO-net RX buffer. If setMaximumTransmissionUnit didn't take
+            // effect, guest expects MTU=1500 → max frame=1514.
+            const MSS: usize = 1460;
+            loop {
+                match conn.host_rx.try_recv() {
+                    Ok(data) if data.is_empty() => {
+                        tracing::debug!(
+                            "poll_fast_path: EOF for {}:{}",
+                            conn.remote_ip,
+                            conn.remote_port
+                        );
+                        conn.host_eof = true;
+                        let fin = crate::ethernet::build_tcp_fin_frame(
                             &crate::ethernet::TcpFrameParams {
                                 src_ip: conn.remote_ip,
                                 dst_ip: conn.guest_ip,
@@ -504,25 +610,49 @@ impl TcpBridge {
                                 src_mac: gw_mac,
                                 dst_mac: guest_mac,
                             },
-                            chunk,
                         );
-                        conn.our_seq = conn.our_seq.wrapping_add(chunk.len() as u32);
-                        frames.push(data_frame);
-                        offset = chunk_end;
+                        conn.our_seq = conn.our_seq.wrapping_add(1);
+                        frames.push(fin);
+                        break;
                     }
-                }
-                Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => {
-                    // No data available — expected for non-blocking.
-                }
-                Err(e) => {
-                    tracing::warn!(
-                        "Fast path RX error {}:{} → {}:{}: {e}",
-                        conn.remote_ip,
-                        conn.remote_port,
-                        conn.guest_ip,
-                        conn.guest_port
-                    );
-                    to_remove.push(*key);
+                    Ok(data) => {
+                        let mut offset = 0;
+                        while offset < data.len() {
+                            let chunk_end = (offset + MSS).min(data.len());
+                            let chunk = &data[offset..chunk_end];
+                            let data_frame = crate::ethernet::build_tcp_data_frame(
+                                &crate::ethernet::TcpFrameParams {
+                                    src_ip: conn.remote_ip,
+                                    dst_ip: conn.guest_ip,
+                                    src_port: conn.remote_port,
+                                    dst_port: conn.guest_port,
+                                    seq: conn.our_seq,
+                                    ack: conn.last_ack,
+                                    window: 65535,
+                                    src_mac: gw_mac,
+                                    dst_mac: guest_mac,
+                                },
+                                chunk,
+                            );
+                            let frame_seq = conn.our_seq;
+                            conn.our_seq = conn.our_seq.wrapping_add(chunk.len() as u32);
+                            tracing::trace!(
+                                "Fast path RX: {}:{} → {}:{} payload={}",
+                                conn.remote_ip,
+                                conn.remote_port,
+                                conn.guest_ip,
+                                conn.guest_port,
+                                chunk.len(),
+                            );
+                            frames.push(data_frame);
+                            offset = chunk_end;
+                        }
+                    }
+                    Err(mpsc::error::TryRecvError::Empty) => break,
+                    Err(mpsc::error::TryRecvError::Disconnected) => {
+                        to_remove.push(*key);
+                        break;
+                    }
                 }
             }
         }
@@ -542,12 +672,10 @@ impl TcpBridge {
     pub fn promote_to_fast_path(
         &mut self,
         key: SynFlowKey,
-        stream: std::net::TcpStream,
+        stream: tokio::net::TcpStream,
         our_seq: u32,
         last_ack: u32,
     ) {
-        // Set non-blocking for polling in the event loop.
-        stream.set_nonblocking(true).ok();
         stream.set_nodelay(true).ok();
 
         tracing::info!(
@@ -558,17 +686,55 @@ impl TcpBridge {
             key.dst_port,
         );
 
+        let (reader, writer) = stream.into_split();
+
+        let (write_tx, mut write_rx) = mpsc::channel::<Vec<u8>>(512);
+        tokio::spawn(async move {
+            use tokio::io::AsyncWriteExt;
+            let mut writer = writer;
+            while let Some(data) = write_rx.recv().await {
+                if let Err(e) = writer.write_all(&data).await {
+                    tracing::debug!("Fast path write task: {e}");
+                    break;
+                }
+            }
+        });
+
+        let (read_tx, read_rx) = mpsc::channel::<Vec<u8>>(512);
+        tokio::spawn(async move {
+            use tokio::io::AsyncReadExt;
+            let mut reader = reader;
+            let mut buf = vec![0u8; 32768];
+            loop {
+                match reader.read(&mut buf).await {
+                    Ok(0) => {
+                        let _ = read_tx.send(Vec::new()).await;
+                        break;
+                    }
+                    Ok(n) => {
+                        if read_tx.send(buf[..n].to_vec()).await.is_err() {
+                            break;
+                        }
+                    }
+                    Err(e) => {
+                        tracing::debug!("Fast path read task: {e}");
+                        break;
+                    }
+                }
+            }
+        });
+
         self.fast_path_conns.insert(
             key,
             FastPathConn {
-                stream,
+                host_tx: write_tx,
+                host_rx: read_rx,
                 our_seq,
                 last_ack,
                 remote_ip: key.dst_ip,
                 guest_ip: key.src_ip,
                 remote_port: key.dst_port,
                 guest_port: key.src_port,
-                read_buf: vec![0u8; 32768],
                 host_eof: false,
             },
         );
@@ -913,36 +1079,93 @@ impl TcpBridge {
             let pending = self.pending_syns.remove(&key).unwrap();
             match result {
                 Some(stream) => {
-                    // 1. Create a dedicated listen socket for this SYN.
-                    //    Each injected SYN needs its own listen socket because
-                    //    smoltcp transitions a listen socket to SYN-RECEIVED on
-                    //    accept. If multiple SYNs to the same port are injected
-                    //    in one batch, iface.poll() would RST the extras.
-                    if !self.create_listen_socket(key.dst_port, sockets) {
-                        // Listen failed — send RST instead of injecting SYN.
-                        if let Some(rst) = build_rst_from_syn(&pending.frame, gateway_mac) {
-                            rst_frames.push(rst);
-                            tracing::debug!("TCP SYN gate: listen failed, sending RST for {key:?}");
+                    // Generate SYN-ACK directly — no smoltcp involved.
+                    let our_isn = std::time::SystemTime::now()
+                        .duration_since(std::time::UNIX_EPOCH)
+                        .map(|d| d.as_nanos() as u32)
+                        .unwrap_or(1);
+                    let guest_mac = self.fast_path_guest_mac.unwrap_or([0xFF; 6]);
+                    // VZ framework silently drops frames > ~1514 bytes even when
+                    // setMaximumTransmissionUnit is set to 4000. The guest's
+                    // VirtIO-net RX buffer is sized for MTU=1500 regardless.
+                    let mss = 1460u16;
+
+                    let syn_ack = crate::ethernet::build_tcp_syn_ack_frame(
+                        &crate::ethernet::TcpFrameParams {
+                            src_ip: key.dst_ip,
+                            dst_ip: key.src_ip,
+                            src_port: key.dst_port,
+                            dst_port: key.src_port,
+                            seq: our_isn,
+                            ack: pending.syn_seq.wrapping_add(1),
+                            window: 65535,
+                            src_mac: gateway_mac,
+                            dst_mac: guest_mac,
+                        },
+                        mss,
+                        4, // window scale
+                    );
+                    rst_frames.push(syn_ack);
+
+                    // Spawn read/write tasks IMMEDIATELY — don't hold the stream.
+                    // This avoids the proxy tunnel timeout that killed held streams.
+                    stream.set_nodelay(true).ok();
+                    let (reader, writer) = stream.into_split();
+
+                    let (write_tx, mut write_rx) = mpsc::channel::<Vec<u8>>(512);
+                    tokio::spawn(async move {
+                        use tokio::io::AsyncWriteExt;
+                        let mut writer = writer;
+                        while let Some(data) = write_rx.recv().await {
+                            let len = data.len();
+                            if let Err(e) = writer.write_all(&data).await {
+                                tracing::debug!("Fast path write task error: {e}");
+                                break;
+                            }
+                            if let Err(e) = writer.flush().await {
+                                tracing::debug!("Fast path write task flush error: {e}");
+                                break;
+                            }
                         }
-                        continue;
-                    }
+                    });
 
-                    // 2. Inject the original SYN frame.
-                    device.inject_rx(pending.frame);
+                    let (read_tx, read_rx) = mpsc::channel::<Vec<u8>>(512);
+                    tokio::spawn(async move {
+                        use tokio::io::AsyncReadExt;
+                        let mut reader = reader;
+                        let mut buf = vec![0u8; 32768];
+                        loop {
+                            match reader.read(&mut buf).await {
+                                Ok(0) => {
+                                    tracing::debug!("Fast path read task: EOF");
+                                    let _ = read_tx.send(Vec::new()).await;
+                                    break;
+                                }
+                                Ok(n) => {
+                                    if read_tx.send(buf[..n].to_vec()).await.is_err() {
+                                        break;
+                                    }
+                                }
+                                Err(e) => {
+                                    tracing::debug!("Fast path read task error: {e}");
+                                    break;
+                                }
+                            }
+                        }
+                    });
 
-                    // 3. Store the pre-connected stream.
-                    self.pre_connected.insert(
+                    // Store channels + ISN for when guest ACK arrives.
+                    self.pending_handshake.insert(
                         key,
-                        PreConnected {
-                            stream,
-                            syn_seq: pending.syn_seq,
-                            created: StdInstant::now(),
+                        PendingHandshake {
+                            our_isn,
+                            guest_isn: pending.syn_seq,
+                            host_tx: write_tx,
+                            host_rx: read_rx,
                         },
                     );
 
-                    tracing::debug!(
-                        "TCP SYN gate: injected SYN + stored pre-connected stream for {key:?}"
-                    );
+                    tracing::info!("TCP SYN gate: direct SYN-ACK sent, tasks spawned for {key:?}");
                 }
                 None => {
                     // Build RST|ACK from the original SYN frame.
@@ -973,6 +1196,7 @@ impl TcpBridge {
     /// listen socket — smoltcp consumes a listen socket when it transitions
     /// to SYN-RECEIVED, so concurrent SYNs to the same port each need a
     /// dedicated listener.
+    #[allow(dead_code)]
     fn create_listen_socket(&mut self, port: u16, sockets: &mut SocketSet<'_>) -> bool {
         let rx_buf = tcp::SocketBuffer::new(vec![0u8; SOCKET_BUF_SIZE]);
         let tx_buf = tcp::SocketBuffer::new(vec![0u8; SOCKET_BUF_SIZE]);
@@ -996,58 +1220,119 @@ impl TcpBridge {
     /// already-accepted host `TcpStream`.
     ///
     /// Called when `InboundListenerManager` accepts a new host connection.
+    /// Initiates an inbound TCP connection to the guest (port forwarding).
+    ///
+    /// Returns a SYN frame to write to the guest FD. The host stream's
+    /// read/write tasks are spawned immediately. When the guest responds
+    /// with SYN-ACK, `try_fast_path_intercept` creates the FastPathConn.
     pub fn initiate_inbound(
         &mut self,
         container_port: u16,
         stream: tokio::net::TcpStream,
         guest_ip: Ipv4Addr,
         gateway_ip: Ipv4Addr,
-        iface: &mut Interface,
-        sockets: &mut SocketSet<'_>,
-    ) {
+    ) -> Vec<u8> {
         let eph_port = self.allocate_ephemeral();
+        let guest_mac = self.fast_path_guest_mac.unwrap_or([0xFF; 6]);
 
-        let rx_buf = tcp::SocketBuffer::new(vec![0u8; SOCKET_BUF_SIZE]);
-        let tx_buf = tcp::SocketBuffer::new(vec![0u8; SOCKET_BUF_SIZE]);
-        let mut sock = tcp::Socket::new(rx_buf, tx_buf);
-        sock.set_nagle_enabled(false);
-        sock.set_ack_delay(None);
+        let our_isn = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_nanos() as u32)
+            .unwrap_or(1)
+            .wrapping_add(eph_port as u32); // Vary ISN per port
 
-        let local_ep = IpEndpoint::new(gateway_ip.into(), eph_port);
-        let remote_ep = IpEndpoint::new(guest_ip.into(), container_port);
+        // Build SYN frame.
+        let syn = crate::ethernet::build_tcp_syn_ack_frame(
+            &crate::ethernet::TcpFrameParams {
+                src_ip: gateway_ip,
+                dst_ip: guest_ip,
+                src_port: eph_port,
+                dst_port: container_port,
+                seq: our_isn,
+                ack: 0, // SYN has no ACK
+                window: 65535,
+                src_mac: self.fast_path_gateway_mac,
+                dst_mac: guest_mac,
+            },
+            1460, // MSS
+            4,    // window scale
+        );
+        // Patch flags: change from SYN|ACK (0x12) to SYN (0x02).
+        let mut syn = syn;
+        let tcp = crate::ethernet::ETH_HEADER_LEN + 20;
+        syn[tcp + 13] = 0x02; // SYN only
+        syn[tcp + 8..tcp + 12].copy_from_slice(&0u32.to_be_bytes()); // Clear ACK
+        // Recompute TCP checksum.
+        syn[tcp + 16..tcp + 18].copy_from_slice(&[0, 0]);
+        let tcp_cksum = crate::ethernet::tcp_checksum(gateway_ip, guest_ip, &syn[tcp..]);
+        syn[tcp + 16..tcp + 18].copy_from_slice(&tcp_cksum.to_be_bytes());
 
-        if let Err(e) = sock.connect(iface.context(), remote_ep, local_ep) {
-            tracing::warn!("TCP bridge: inbound connect to guest:{container_port} failed: {e:?}");
-            return;
-        }
+        // Spawn read/write tasks on the host stream immediately.
+        stream.set_nodelay(true).ok();
+        let (reader, writer) = stream.into_split();
 
-        let handle = sockets.add(sock);
+        let (write_tx, mut write_rx) = mpsc::channel::<Vec<u8>>(512);
+        tokio::spawn(async move {
+            use tokio::io::AsyncWriteExt;
+            let mut writer = writer;
+            while let Some(data) = write_rx.recv().await {
+                if let Err(e) = writer.write_all(&data).await {
+                    tracing::debug!("Inbound write task: {e}");
+                    break;
+                }
+                let _ = writer.flush().await;
+            }
+        });
 
-        // Inbound connections: host initiates data first, so fast-path promotion
-        // (which triggers on the first guest data frame) doesn't work well.
-        // Use the normal relay path for inbound connections.
-        let (h2g_tx, h2g_rx) = mpsc::channel::<Vec<u8>>(HOST_TO_GUEST_CHANNEL);
-        let (g2h_tx, g2h_rx) = mpsc::channel::<Vec<u8>>(GUEST_TO_HOST_CHANNEL);
-        tokio::spawn(inbound_host_relay(stream, h2g_tx, g2h_rx));
+        let (read_tx, read_rx) = mpsc::channel::<Vec<u8>>(512);
+        tokio::spawn(async move {
+            use tokio::io::AsyncReadExt;
+            let mut reader = reader;
+            let mut buf = vec![0u8; 32768];
+            loop {
+                match reader.read(&mut buf).await {
+                    Ok(0) => {
+                        let _ = read_tx.send(Vec::new()).await;
+                        break;
+                    }
+                    Ok(n) => {
+                        if read_tx.send(buf[..n].to_vec()).await.is_err() {
+                            break;
+                        }
+                    }
+                    Err(e) => {
+                        tracing::debug!("Inbound read task: {e}");
+                        break;
+                    }
+                }
+            }
+        });
 
-        let guest_addr = SocketAddr::V4(SocketAddrV4::new(guest_ip, container_port));
+        // Flow key from the guest's perspective (guest will reply with SYN-ACK):
+        // src = guest, dst = gateway.
+        let flow_key = SynFlowKey {
+            src_ip: guest_ip,
+            src_port: container_port,
+            dst_ip: gateway_ip,
+            dst_port: eph_port,
+        };
 
-        self.connections.insert(
-            handle,
-            BridgedConn {
-                handle,
-                remote: guest_addr,
-                host_to_guest_rx: h2g_rx,
-                guest_to_host_tx: Some(g2h_tx),
-                host_eof: false,
-                host_disconnected: false,
-                pending_send: None,
+        self.pending_inbound.insert(
+            flow_key,
+            PendingInbound {
+                our_isn,
+                host_tx: write_tx,
+                host_rx: read_rx,
+                guest_ip,
+                gateway_ip,
+                container_port,
+                eph_port,
             },
         );
 
-        tracing::debug!(
-            "TCP bridge: inbound connect initiated  gw:{eph_port} → guest:{container_port}"
-        );
+        tracing::debug!("TCP bridge: inbound SYN sent  gw:{eph_port} → guest:{container_port}");
+
+        syn
     }
 
     /// Allocates the next inbound ephemeral port, wrapping at the end of the
@@ -1628,8 +1913,9 @@ async fn host_conn_task(
     let _ = tokio::join!(read_task, write_task);
 }
 
-/// Relays data between an already-connected host TcpStream and channels,
-/// for inbound (host→guest) connections where the stream is already accepted.
+/// Relays data between an already-connected host TcpStream and channels.
+/// Kept as fallback — currently unused (inbound goes through direct SYN path).
+#[allow(dead_code)]
 async fn inbound_host_relay(
     stream: tokio::net::TcpStream,
     h2g_tx: mpsc::Sender<Vec<u8>>,
@@ -2112,23 +2398,18 @@ mod tests {
         let (stream, _accepted) = tokio::join!(connect, listener.accept());
         let stream = stream.unwrap();
 
-        bridge.initiate_inbound(80, stream, GUEST_IP, GW_IP, &mut iface, &mut sockets);
+        let syn = bridge.initiate_inbound(80, stream, GUEST_IP, GW_IP);
 
+        // Should return a SYN frame and store pending_inbound.
+        assert!(!syn.is_empty(), "Should return SYN frame");
         assert_eq!(
-            bridge.active_count(),
+            bridge.pending_inbound.len(),
             1,
-            "Should have one inbound connection"
+            "Should have one pending inbound"
         );
-
-        // The socket should be in SynSent state (attempting connect to guest).
-        let (&handle, conn) = bridge.connections.iter().next().unwrap();
-        let sock = sockets.get_mut::<tcp::Socket>(handle);
-        assert!(
-            sock.is_open(),
-            "Socket should be open after connect; state={:?}",
-            sock.state()
-        );
-        assert_eq!(conn.remote, SocketAddr::V4(SocketAddrV4::new(GUEST_IP, 80)));
+        // Verify SYN flags in the frame.
+        let tcp_off = crate::ethernet::ETH_HEADER_LEN + 20;
+        assert_eq!(syn[tcp_off + 13], 0x02, "Should be SYN flag");
     }
 
     #[tokio::test]
@@ -2163,22 +2444,13 @@ mod tests {
         tokio::time::sleep(std::time::Duration::from_millis(50)).await;
 
         // Poll pending SYNs — should inject frame and store pre-connected stream.
-        let rst_frames = bridge.poll_pending_syns(&mut device, &mut sockets, GW_MAC);
-        assert!(
-            rst_frames.is_empty(),
-            "No RST should be generated on success"
-        );
+        let reply_frames = bridge.poll_pending_syns(&mut device, &mut sockets, GW_MAC);
+        assert!(!reply_frames.is_empty(), "SYN-ACK should be generated");
         assert!(bridge.pending_syns.is_empty(), "Pending should be consumed");
-        assert_eq!(
-            bridge.pre_connected.len(),
-            1,
-            "Should have pre-connected stream"
-        );
-
-        // The SYN frame should have been injected into device rx_queue.
-        assert_eq!(device.take_tx_pending().len(), 0); // TX is separate
-        // A listen socket should have been created for the port.
-        assert!(bridge.listening_ports.contains(&addr.port()));
+        assert_eq!(bridge.pending_handshake.len(), 1);
+        // No smoltcp listen socket or pre-connected stream — direct handshake.
+        assert!(bridge.pre_connected.is_empty());
+        assert!(!bridge.listening_ports.contains(&addr.port()));
     }
 
     /// Verifies that a SYN destined for the gateway IP is translated to
@@ -2212,13 +2484,10 @@ mod tests {
 
         tokio::time::sleep(std::time::Duration::from_millis(50)).await;
 
-        let rst_frames = bridge.poll_pending_syns(&mut device, &mut sockets, GW_MAC);
-        assert!(
-            rst_frames.is_empty(),
-            "Gateway IP connect should succeed via loopback translation"
-        );
+        let reply_frames = bridge.poll_pending_syns(&mut device, &mut sockets, GW_MAC);
+        assert!(!reply_frames.is_empty(), "SYN-ACK for gateway IP");
         assert!(bridge.pending_syns.is_empty());
-        assert_eq!(bridge.pre_connected.len(), 1);
+        assert_eq!(bridge.pending_handshake.len(), 1);
     }
 
     #[tokio::test]
@@ -2531,13 +2800,10 @@ mod tests {
         let _b = listener.accept().await.unwrap();
         tokio::time::sleep(std::time::Duration::from_millis(50)).await;
 
-        // Both should complete without RST.
-        let rst_frames = bridge.poll_pending_syns(&mut device, &mut sockets, GW_MAC);
-        assert!(
-            rst_frames.is_empty(),
-            "No RSTs should be generated for concurrent SYNs to the same port"
-        );
-        assert_eq!(bridge.pre_connected.len(), 2);
+        // Both should generate SYN-ACKs.
+        let reply_frames = bridge.poll_pending_syns(&mut device, &mut sockets, GW_MAC);
+        assert_eq!(reply_frames.len(), 2, "Two SYN-ACKs expected");
+        assert_eq!(bridge.pending_handshake.len(), 2);
         assert!(bridge.pending_syns.is_empty());
     }
 }

--- a/virt/arcbox-net/src/ethernet.rs
+++ b/virt/arcbox-net/src/ethernet.rs
@@ -483,6 +483,61 @@ pub fn build_tcp_rst_frame(p: &TcpFrameParams) -> Vec<u8> {
     frame
 }
 
+/// Builds a TCP SYN-ACK frame for the 3-way handshake (no smoltcp).
+///
+/// Options: MSS + Window Scale + SACK Permitted (12 bytes, matching smoltcp).
+/// `p.seq` = our ISN, `p.ack` = guest ISN + 1.
+#[must_use]
+pub fn build_tcp_syn_ack_frame(p: &TcpFrameParams, mss: u16, wscale: u8) -> Vec<u8> {
+    let tcp_hdr_len = 32; // 20 + 12 bytes options
+    let ip_total_len = 20 + tcp_hdr_len;
+    let frame_len = ETH_HEADER_LEN + ip_total_len;
+    let mut frame = vec![0u8; frame_len];
+
+    frame[0..6].copy_from_slice(&p.dst_mac);
+    frame[6..12].copy_from_slice(&p.src_mac);
+    frame[12..14].copy_from_slice(&0x0800u16.to_be_bytes());
+
+    let ip = ETH_HEADER_LEN;
+    frame[ip] = 0x45;
+    frame[ip + 2..ip + 4].copy_from_slice(&(ip_total_len as u16).to_be_bytes());
+    frame[ip + 6..ip + 8].copy_from_slice(&0x4000u16.to_be_bytes());
+    frame[ip + 8] = 64;
+    frame[ip + 9] = 6;
+    frame[ip + 12..ip + 16].copy_from_slice(&p.src_ip.octets());
+    frame[ip + 16..ip + 20].copy_from_slice(&p.dst_ip.octets());
+    let ip_cksum = ipv4_header_checksum(&frame[ip..ip + 20]);
+    frame[ip + 10..ip + 12].copy_from_slice(&ip_cksum.to_be_bytes());
+
+    let tcp = ip + 20;
+    frame[tcp..tcp + 2].copy_from_slice(&p.src_port.to_be_bytes());
+    frame[tcp + 2..tcp + 4].copy_from_slice(&p.dst_port.to_be_bytes());
+    frame[tcp + 4..tcp + 8].copy_from_slice(&p.seq.to_be_bytes());
+    frame[tcp + 8..tcp + 12].copy_from_slice(&p.ack.to_be_bytes());
+    frame[tcp + 12] = 0x80; // Data offset: 8 (32 bytes)
+    frame[tcp + 13] = 0x12; // SYN | ACK
+    frame[tcp + 14..tcp + 16].copy_from_slice(&p.window.to_be_bytes());
+    // MSS
+    frame[tcp + 20] = 2;
+    frame[tcp + 21] = 4;
+    frame[tcp + 22..tcp + 24].copy_from_slice(&mss.to_be_bytes());
+    // Window Scale
+    frame[tcp + 24] = 3;
+    frame[tcp + 25] = 3;
+    frame[tcp + 26] = wscale;
+    // SACK Permitted
+    frame[tcp + 27] = 4;
+    frame[tcp + 28] = 2;
+    // NOP padding
+    frame[tcp + 29] = 0;
+    frame[tcp + 30] = 0;
+    frame[tcp + 31] = 0;
+
+    let tcp_cksum = tcp_checksum(p.src_ip, p.dst_ip, &frame[tcp..]);
+    frame[tcp + 16..tcp + 18].copy_from_slice(&tcp_cksum.to_be_bytes());
+    frame
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
## Problem

PR #203 introduced fast-path promotion in `relay_all()` that caused connection resets. When smoltcp received the final ACK and first data frame (e.g. TLS ClientHello) in the same batch, the data was buffered in smoltcp's socket. Promotion then aborted the socket, destroying the buffered data. Guest never got a response → RST.

This broke Docker image pulls through proxy tunnels (Surge/Clash fake-IP).

## Fix

Defer promotion from `relay_all()` to `try_fast_path_intercept()`:

```
1. detect_new_connections(): store pre-connected stream in held_streams
   + spawn host_conn_task for relay during handshake
2. relay_all(): ESTABLISHED → mark in fast_path_ready (don't promote)
3. try_fast_path_intercept(): first DATA frame → inline promote
   (SEQ/ACK from frame headers, stream from held_streams)
```

The first data frame triggers promotion in `drain_fast_path()` BEFORE `iface.poll()`, so smoltcp never sees it → no data loss.

## Scope

Fast path currently activates for **outbound** connections with pre-connected streams (SYN gate). Inbound port forwarding (`initiate_inbound`) is not yet covered — follow-up needed.

## Test plan

- [x] `cargo test -p arcbox-net` — 228 passed
- [x] `docker run --rm alpine echo hello` → hello
- [x] Docker image pull through Surge proxy → works
- [x] iperf3 benchmark: ~2.3 Gbps (baseline, fast path not triggered for inbound)