### PR TITLE
chore: pin pstramp v0.2.0 in assets.lock

### DIFF
--- a/app/arcbox-docker-tools/src/lockfile.rs
+++ b/app/arcbox-docker-tools/src/lockfile.rs
@@ -17,11 +17,18 @@ pub struct AssetsLock {
 }
 
 /// Tool installation group.
+///
+/// New groups must be added here even if this crate does not consume them —
+/// `parse_tools()` deserializes the entire `[[tools]]` array before filtering,
+/// so an unknown group value would fail parsing for every caller. The
+/// `Desktop` variant is consumed by `arcbox-desktop` (host-only binaries
+/// embedded in the app bundle) and is inert for docker/kubernetes callers.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum ToolGroup {
     Docker,
     Kubernetes,
+    Desktop,
 }
 
 /// Per-architecture metadata for a tool.
@@ -98,12 +105,18 @@ name = "kubectl"
 group = "kubernetes"
 version = "1.35.3"
 arch.arm64.sha256 = "ddd"
+
+[[tools]]
+name = "pstramp"
+group = "desktop"
+version = "0.2.0"
+arch.arm64.sha256 = "eee"
 "#;
 
     #[test]
     fn parse_tool_entries() {
         let tools = parse_tools(SAMPLE).unwrap();
-        assert_eq!(tools.len(), 3);
+        assert_eq!(tools.len(), 4);
         assert_eq!(tools[0].name, "docker");
         assert_eq!(tools[0].group, ToolGroup::Docker);
         assert_eq!(tools[0].version, "29.3.1");
@@ -125,6 +138,12 @@ arch.arm64.sha256 = "ddd"
         let kubernetes_tools = parse_tools_for_group(SAMPLE, ToolGroup::Kubernetes).unwrap();
         assert_eq!(kubernetes_tools.len(), 1);
         assert_eq!(kubernetes_tools[0].name, "kubectl");
+
+        // Desktop group should parse cleanly even though this crate does not
+        // consume it — docker/kubernetes flows must coexist with desktop tools.
+        let desktop_tools = parse_tools_for_group(SAMPLE, ToolGroup::Desktop).unwrap();
+        assert_eq!(desktop_tools.len(), 1);
+        assert_eq!(desktop_tools[0].name, "pstramp");
     }
 
     #[test]

--- a/assets.lock
+++ b/assets.lock
@@ -1,11 +1,10 @@
 # ArcBox asset lock — pins versions and checksums for reproducible builds.
 #
-# The [[tools]] section serves two purposes:
-#   1. Host-side CLI: downloaded to ~/.arcbox/runtime/bin/ and symlinked into
-#      the user's PATH (abctl docker setup / abctl setup install).
-#   2. Guest-side daemon: the same binaries are exposed to the VM via VirtioFS
-#      at /arcbox/runtime/bin and launched by arcbox-agent (dockerd, containerd,
-#      runc, etc.).
+# The [[tools]] section pins third-party and internal binaries:
+#   - group "docker"/"kubernetes": downloaded to ~/.arcbox/runtime/bin/ and
+#     exposed to the VM via VirtioFS. Used by both host CLI and guest daemon.
+#   - group "desktop": host-only binaries embedded in the app bundle
+#     (e.g. pstramp for PTY session isolation).
 #
 # Because both paths read from this single lockfile, the Docker CLI and the
 # guest dockerd are always the same version — there is no CLI/daemon version
@@ -43,6 +42,13 @@ group = "docker"
 version = "0.9.5"
 arch.arm64.sha256 = "bc216761bc10e5a707f52d4e5b4050dd7ee7a2daae63c35a97ed7fed2ea64822"
 arch.x86_64.sha256 = "578294a426d86322a17f998cf814258fe7aa764bf505354fcebee51a7456266c"
+
+[[tools]]
+name = "pstramp"
+group = "desktop"
+version = "0.2.0"
+arch.arm64.sha256 = "48448a426bb994e45b603588b19b62629f07d6040f1501235e969c07ecc57413"
+arch.x86_64.sha256 = "eb3cc921de1aed02348821f4a653705a33b012b6a1da7466e577673c5ce80609"
 
 [[tools]]
 name = "kubectl"


### PR DESCRIPTION
## Summary
- Add pstramp to assets.lock with version pinning and SHA256 checksums
- Update lockfile header to document the new `desktop` tool group
- Companion PR in arcbox-desktop updates the release workflow to read from assets.lock with checksum verification

Previously the desktop release workflow fetched the latest pstramp release without version pinning or integrity checks.

Closes ABXD-91