### PR TITLE
feat(vm): dm-snapshot based block-level CoW for sandbox rootfs

### DIFF
--- a/guest/arcbox-agent/src/main.rs
+++ b/guest/arcbox-agent/src/main.rs
@@ -61,7 +61,7 @@ async fn main() -> Result<()> {
                 tracing_subscriber::registry()
                     .with(
                         tracing_subscriber::EnvFilter::try_from_default_env()
-                            .unwrap_or_else(|_| "arcbox_agent=info".into()),
+                            .unwrap_or_else(|_| "arcbox_agent=info,arcbox_vm=info".into()),
                     )
                     .with(
                         tracing_subscriber::fmt::layer()
@@ -82,7 +82,7 @@ async fn main() -> Result<()> {
                 tracing_subscriber::registry()
                     .with(
                         tracing_subscriber::EnvFilter::try_from_default_env()
-                            .unwrap_or_else(|_| "arcbox_agent=info".into()),
+                            .unwrap_or_else(|_| "arcbox_agent=info,arcbox_vm=info".into()),
                     )
                     .with(
                         tracing_subscriber::fmt::layer()
@@ -98,7 +98,7 @@ async fn main() -> Result<()> {
         tracing_subscriber::registry()
             .with(
                 tracing_subscriber::EnvFilter::try_from_default_env()
-                    .unwrap_or_else(|_| "arcbox_agent=info".into()),
+                    .unwrap_or_else(|_| "arcbox_agent=info,arcbox_vm=info".into()),
             )
             .with(
                 tracing_subscriber::fmt::layer()

--- a/virt/arcbox-vm/src/error.rs
+++ b/virt/arcbox-vm/src/error.rs
@@ -39,6 +39,10 @@ pub enum VmmError {
     #[error("snapshot error: {0}")]
     Snapshot(String),
 
+    /// Device-mapper / dm-snapshot error.
+    #[error("device-mapper error: {0}")]
+    DeviceMapper(String),
+
     /// Process lifecycle error.
     #[error("process error: {0}")]
     Process(String),

--- a/virt/arcbox-vm/src/lib.rs
+++ b/virt/arcbox-vm/src/lib.rs
@@ -36,6 +36,7 @@ pub mod file_io;
 pub mod network;
 pub mod sandbox;
 pub mod snapshot;
+pub mod snapshot_cow;
 pub mod spawn;
 pub mod store;
 pub mod vsock;

--- a/virt/arcbox-vm/src/sandbox.rs
+++ b/virt/arcbox-vm/src/sandbox.rs
@@ -19,7 +19,7 @@ use fc_sdk::VmBuilder;
 use fc_sdk::types::{BootSource, Drive, NetworkInterface, Vsock};
 use nix::unistd::{Gid, Uid, chown};
 use tokio::sync::broadcast;
-use tracing::{error, info, warn};
+use tracing::{debug, error, info, warn};
 use uuid::Uuid;
 
 use crate::boot_proto::KernelIpParam;
@@ -1429,7 +1429,7 @@ async fn do_boot(
                     (path, Some(handle))
                 }
                 Err(e) => {
-                    warn!(
+                    debug!(
                         sandbox_id = %id,
                         error = %e,
                         "dm-snapshot unavailable, using rootfs directly"

--- a/virt/arcbox-vm/src/sandbox.rs
+++ b/virt/arcbox-vm/src/sandbox.rs
@@ -27,6 +27,7 @@ use crate::config::VmmConfig;
 use crate::error::{Result, VmmError};
 use crate::network::{NetworkAllocation, NetworkManager};
 use crate::snapshot::SnapshotCatalog;
+use crate::snapshot_cow::{CowHandle, CowManager};
 use crate::spawn::{spawn_direct, spawn_jailer};
 use crate::vsock::{self, ExecInputMsg, OutputChunk, StartCommand};
 
@@ -178,6 +179,8 @@ pub struct SandboxInstance {
     pub last_exit_code: Option<i32>,
     /// Human-readable error (only set when state == `Failed`).
     pub error: Option<String>,
+    /// dm-snapshot CoW handle (present when snapshot-based rootfs is active).
+    pub cow_handle: Option<CowHandle>,
 }
 
 impl SandboxInstance {
@@ -202,6 +205,7 @@ impl SandboxInstance {
             last_exited_at: None,
             last_exit_code: None,
             error: None,
+            cow_handle: None,
         }
     }
 
@@ -315,6 +319,7 @@ pub struct SandboxManager {
     snapshots: Arc<SnapshotCatalog>,
     config: Arc<VmmConfig>,
     events_tx: broadcast::Sender<SandboxEvent>,
+    cow_manager: Arc<CowManager>,
 }
 
 impl SandboxManager {
@@ -327,6 +332,10 @@ impl SandboxManager {
         )?);
         let snapshots = Arc::new(SnapshotCatalog::new(&config.firecracker.data_dir));
         let (events_tx, _) = broadcast::channel(EVENT_CHANNEL_CAPACITY);
+        let cow_manager = Arc::new(
+            CowManager::new(&config.firecracker.data_dir)
+                .map_err(|e| VmmError::Config(format!("CowManager init: {e}")))?,
+        );
 
         Ok(Self {
             instances: Arc::new(RwLock::new(HashMap::new())),
@@ -334,6 +343,7 @@ impl SandboxManager {
             snapshots,
             config: Arc::new(config),
             events_tx,
+            cow_manager,
         })
     }
 
@@ -427,6 +437,7 @@ impl SandboxManager {
             let network = Arc::clone(&self.network);
             let config = Arc::clone(&self.config);
             let events_tx = self.events_tx.clone();
+            let cow_manager = Arc::clone(&self.cow_manager);
             let id_clone = id.clone();
             let spec_clone = spec.clone();
             let net_alloc_clone = net_alloc;
@@ -440,6 +451,7 @@ impl SandboxManager {
                     network,
                     config,
                     events_tx,
+                    cow_manager,
                 )
                 .await;
             });
@@ -451,11 +463,15 @@ impl SandboxManager {
             let network = Arc::clone(&self.network);
             let events_tx = self.events_tx.clone();
             let config2 = Arc::clone(&self.config);
+            let cow2 = Arc::clone(&self.cow_manager);
             let id2 = id.clone();
             let ttl = spec.ttl_seconds;
             tokio::spawn(async move {
                 tokio::time::sleep(Duration::from_secs(ttl as u64)).await;
-                remove_sandbox_impl(&id2, true, &instances, &network, &events_tx, &config2).await;
+                remove_sandbox_impl(
+                    &id2, true, &instances, &network, &events_tx, &config2, &cow2,
+                )
+                .await;
             });
         }
 
@@ -544,6 +560,7 @@ impl SandboxManager {
             &self.network,
             &self.events_tx,
             &self.config,
+            &self.cow_manager,
         )
         .await;
         info!(sandbox_id = %id, "sandbox removed");
@@ -1136,11 +1153,15 @@ impl SandboxManager {
             let network = Arc::clone(&self.network);
             let events_tx = self.events_tx.clone();
             let config2 = Arc::clone(&self.config);
+            let cow2 = Arc::clone(&self.cow_manager);
             let id2 = new_id.clone();
             let ttl = spec.ttl_seconds;
             tokio::spawn(async move {
                 tokio::time::sleep(Duration::from_secs(ttl as u64)).await;
-                remove_sandbox_impl(&id2, true, &instances, &network, &events_tx, &config2).await;
+                remove_sandbox_impl(
+                    &id2, true, &instances, &network, &events_tx, &config2, &cow2,
+                )
+                .await;
             });
         }
 
@@ -1241,9 +1262,19 @@ async fn boot_sandbox(
     network: Arc<NetworkManager>,
     config: Arc<VmmConfig>,
     events_tx: broadcast::Sender<SandboxEvent>,
+    cow_manager: Arc<CowManager>,
 ) {
-    match do_boot(&id, &spec, net_alloc.as_ref(), &vm_dir, &config).await {
-        Ok((process, vm, vsock_uds_path)) => {
+    match do_boot(
+        &id,
+        &spec,
+        net_alloc.as_ref(),
+        &vm_dir,
+        &config,
+        &cow_manager,
+    )
+    .await
+    {
+        Ok((process, vm, vsock_uds_path, cow_handle)) => {
             let ready_at = Utc::now();
 
             let value = instances.read().unwrap().get(&id).cloned();
@@ -1257,6 +1288,7 @@ async fn boot_sandbox(
                 inst.process = Some(process);
                 inst.vm = Some(vm);
                 inst.vsock_uds_path = Some(vsock_uds_path);
+                inst.cow_handle = cow_handle;
                 inst.state = SandboxState::Ready;
                 inst.ready_at = Some(ready_at);
             }
@@ -1332,15 +1364,23 @@ async fn stage_files_for_jailer(
 
 /// Perform the actual Firecracker boot: spawn process, configure, start VM.
 ///
-/// Returns `(FirecrackerProcess, Arc<Vm>, vsock_uds_path)` on success.
-/// `vsock_uds_path` is the host-side absolute path to the vsock UDS socket.
+/// Returns `(FirecrackerProcess, Arc<Vm>, vsock_uds_path, Option<CowHandle>)`
+/// on success.  The `CowHandle` is `Some` when dm-snapshot CoW is active
+/// (direct mode only in Phase 1).
+#[allow(clippy::type_complexity)]
 async fn do_boot(
     id: &str,
     spec: &SandboxSpec,
     net_alloc: Option<&NetworkAllocation>,
     vm_dir: &Path,
     config: &VmmConfig,
-) -> Result<(fc_sdk::FirecrackerProcess, Arc<fc_sdk::Vm>, PathBuf)> {
+    cow_manager: &CowManager,
+) -> Result<(
+    fc_sdk::FirecrackerProcess,
+    Arc<fc_sdk::Vm>,
+    PathBuf,
+    Option<CowHandle>,
+)> {
     let log_path = vm_dir.join("firecracker.log");
     let metrics_path = vm_dir.join("firecracker.metrics");
     // socket_path is used only for the direct (non-jailer) mode spawn.
@@ -1371,22 +1411,39 @@ async fn do_boot(
     // In jailer mode the files must exist inside the chroot, and paths passed
     // to the FC API are relative to the chroot root.  In direct mode the
     // host-absolute paths from the spec are used as-is.
-    let (kernel_path, rootfs_path, vsock_fc_path, vsock_host_path) =
+    let (kernel_path, rootfs_path, vsock_fc_path, vsock_host_path, cow_handle) =
         if let Some(ref jc) = fc_cfg.jailer {
+            // Jailer mode: full copy into chroot (dm-snapshot deferred to Phase 2).
             let base = jc.chroot_base_dir.as_deref().unwrap_or("/srv/jailer");
             let cr = chroot_root(&fc_cfg.binary, base, id);
             let (k, r) =
                 stage_files_for_jailer(&cr, &spec.kernel, &spec.rootfs, jc.uid, jc.gid).await?;
             // FC creates the vsock socket at this path inside the chroot.
             let vsock_host = cr.join("run/firecracker.vsock");
-            (k, r, "/run/firecracker.vsock".to_string(), vsock_host)
+            (k, r, "/run/firecracker.vsock".to_string(), vsock_host, None)
         } else {
+            // Direct mode: try dm-snapshot CoW, fall back to using rootfs directly.
+            let (rootfs, cow) = match cow_manager.setup(id, &spec.rootfs).await {
+                Ok(handle) => {
+                    let path = handle.dm_device.clone();
+                    (path, Some(handle))
+                }
+                Err(e) => {
+                    warn!(
+                        sandbox_id = %id,
+                        error = %e,
+                        "dm-snapshot unavailable, using rootfs directly"
+                    );
+                    (spec.rootfs.clone(), None)
+                }
+            };
             let vsock_path = vm_dir.join("firecracker.vsock");
             (
                 spec.kernel.clone(),
-                spec.rootfs.clone(),
+                rootfs,
                 vsock_path.to_str().unwrap().to_owned(),
                 vsock_path,
+                cow,
             )
         };
 
@@ -1461,8 +1518,17 @@ async fn do_boot(
         vsock_id: None,
     });
 
-    let vm = Arc::new(builder.start().await.map_err(VmmError::from)?);
-    Ok((process, vm, vsock_host_path))
+    let vm = match builder.start().await {
+        Ok(v) => Arc::new(v),
+        Err(e) => {
+            // Clean up dm-snapshot if boot fails after setup.
+            if let Some(ref handle) = cow_handle {
+                let _ = cow_manager.teardown(handle).await;
+            }
+            return Err(VmmError::from(e));
+        }
+    };
+    Ok((process, vm, vsock_host_path, cow_handle))
 }
 
 // =============================================================================
@@ -1478,6 +1544,7 @@ async fn remove_sandbox_impl(
     network: &Arc<NetworkManager>,
     events_tx: &broadcast::Sender<SandboxEvent>,
     config: &Arc<VmmConfig>,
+    cow_manager: &Arc<CowManager>,
 ) {
     let entry = instances.read().unwrap().get(id).cloned();
     let Some(arc) = entry else {
@@ -1506,6 +1573,18 @@ async fn remove_sandbox_impl(
     if let Some(ref mut proc) = fc_process {
         let _ = tokio::time::timeout(std::time::Duration::from_secs(5), proc.wait()).await;
     }
+
+    // Teardown dm-snapshot CoW device (must happen after FC process exits
+    // because Firecracker holds the block device open).
+    {
+        let cow_handle = arc.lock().unwrap().cow_handle.take();
+        if let Some(ref handle) = cow_handle
+            && let Err(e) = cow_manager.teardown(handle).await
+        {
+            warn!(sandbox_id = %id, error = %e, "dm-snapshot teardown failed");
+        }
+    }
+
     // Release network resources (destroys TAP via ioctl).
     {
         let inst = arc.lock().unwrap();

--- a/virt/arcbox-vm/src/snapshot_cow.rs
+++ b/virt/arcbox-vm/src/snapshot_cow.rs
@@ -235,18 +235,29 @@ impl CowManager {
         let dmsetup = self.dmsetup_bin.as_deref().unwrap_or("dmsetup");
 
         // 1. Remove dm device.
-        if let Err(e) = dmsetup_remove(dmsetup, &handle.dm_name).await {
-            warn!(dm = %handle.dm_name, error = %e, "failed to remove dm device");
+        let dm_removed = dmsetup_remove(dmsetup, &handle.dm_name).await.is_ok();
+        if !dm_removed {
+            warn!(dm = %handle.dm_name, "failed to remove dm device");
         }
 
         // 2. Detach COW loop device.
-        if let Err(e) = losetup_detach(BUSYBOX, &handle.cow_loop).await {
-            warn!(loop_dev = %handle.cow_loop, error = %e, "failed to detach cow loop");
+        let loop_detached = losetup_detach(BUSYBOX, &handle.cow_loop).await.is_ok();
+        if !loop_detached {
+            warn!(loop_dev = %handle.cow_loop, "failed to detach cow loop");
         }
 
-        // 3. Delete COW sparse file.
-        if let Err(e) = std::fs::remove_file(&handle.cow_file) {
-            warn!(file = %handle.cow_file.display(), error = %e, "failed to remove cow file");
+        // 3. Delete COW sparse file only after both dm and loop are released.
+        //    Unlinking while still referenced would delay space reclamation
+        //    until the last kernel reference drops.
+        if dm_removed && loop_detached {
+            if let Err(e) = std::fs::remove_file(&handle.cow_file) {
+                warn!(file = %handle.cow_file.display(), error = %e, "failed to remove cow file");
+            }
+        } else {
+            warn!(
+                file = %handle.cow_file.display(),
+                "skipping cow file removal — backing resources not fully released"
+            );
         }
 
         // 4. Release template refcount.

--- a/virt/arcbox-vm/src/snapshot_cow.rs
+++ b/virt/arcbox-vm/src/snapshot_cow.rs
@@ -1,0 +1,605 @@
+//! Block-level copy-on-write for sandbox rootfs via dm-snapshot.
+//!
+//! Instead of copying the full rootfs ext4 image for every sandbox,
+//! `CowManager` creates a dm-snapshot backed by a sparse COW file.
+//! The template image is shared read-only across all sandboxes that
+//! use the same rootfs; only written blocks consume disk space.
+//!
+//! Requires `CONFIG_DM_SNAPSHOT=y` in the guest kernel and the
+//! `dmsetup` binary on `PATH` or at `/arcbox/bin/dmsetup`.
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::sync::Mutex;
+
+use tokio::sync::Mutex as AsyncMutex;
+use tracing::{debug, info, warn};
+
+use crate::error::{Result, VmmError};
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/// Busybox binary (used for `losetup` and `blockdev` applets).
+const BUSYBOX: &str = "/bin/busybox";
+
+/// Candidate paths for the `dmsetup` binary.
+const DMSETUP_CANDIDATES: &[&str] = &["/arcbox/bin/dmsetup", "/usr/sbin/dmsetup"];
+
+/// dm-snapshot chunk size in 512-byte sectors (4096 bytes = 8 sectors).
+const SNAPSHOT_CHUNK_SECTORS: u64 = 8;
+
+/// Device-mapper name prefix for sandbox snapshots.
+const DM_NAME_PREFIX: &str = "arcbox-snap-";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/// Tracks a read-only loop device for a template rootfs image.
+struct TemplateEntry {
+    /// Loop device path, e.g. `/dev/loop0`.
+    loop_device: String,
+    /// Template size in 512-byte sectors.
+    sectors: u64,
+    /// Number of active sandboxes using this template.
+    refcount: usize,
+}
+
+/// Per-sandbox CoW state.  Stored in `SandboxInstance` for cleanup.
+#[derive(Debug, Clone)]
+pub struct CowHandle {
+    /// dm device name, e.g. `arcbox-snap-<sandbox_id>`.
+    pub dm_name: String,
+    /// Absolute device path, e.g. `/dev/mapper/arcbox-snap-<sandbox_id>`.
+    pub dm_device: String,
+    /// Loop device backing the sparse COW file.
+    pub cow_loop: String,
+    /// Path to the sparse COW file on disk.
+    pub cow_file: PathBuf,
+    /// Original template rootfs path (used to release the template refcount).
+    pub template_path: PathBuf,
+}
+
+/// Manages template loop devices and per-sandbox dm-snapshot lifecycle.
+pub struct CowManager {
+    templates: Mutex<HashMap<PathBuf, TemplateEntry>>,
+    /// Serializes `losetup -f` + `losetup DEV FILE` to prevent TOCTOU races
+    /// where concurrent callers get the same free loop device.
+    losetup_lock: AsyncMutex<()>,
+    cow_dir: PathBuf,
+    dmsetup_bin: Option<String>,
+}
+
+// ---------------------------------------------------------------------------
+// CowManager
+// ---------------------------------------------------------------------------
+
+impl CowManager {
+    /// Create a new manager.  `data_dir` is the Firecracker data directory
+    /// (e.g. `/var/lib/firecracker-vmm`); COW files are stored under
+    /// `{data_dir}/cow/`.
+    pub fn new(data_dir: &str) -> std::io::Result<Self> {
+        let cow_dir = PathBuf::from(data_dir).join("cow");
+        std::fs::create_dir_all(&cow_dir)?;
+
+        let dmsetup_bin = DMSETUP_CANDIDATES
+            .iter()
+            .find(|p| Path::new(p).exists())
+            .map(|s| (*s).to_string());
+
+        if dmsetup_bin.is_none() {
+            warn!("dmsetup not found; dm-snapshot CoW will be unavailable");
+        }
+
+        let mgr = Self {
+            templates: Mutex::new(HashMap::new()),
+            losetup_lock: AsyncMutex::new(()),
+            cow_dir,
+            dmsetup_bin,
+        };
+
+        // Clean up orphaned dm devices and COW files from a previous crash.
+        mgr.cleanup_stale_sync();
+
+        Ok(mgr)
+    }
+
+    /// Create a dm-snapshot for `sandbox_id` using `rootfs_path` as template.
+    ///
+    /// Returns a [`CowHandle`] whose `dm_device` field can be passed to
+    /// Firecracker as the rootfs block device.
+    pub async fn setup(&self, sandbox_id: &str, rootfs_path: &str) -> Result<CowHandle> {
+        let dmsetup = self
+            .dmsetup_bin
+            .as_deref()
+            .ok_or_else(|| VmmError::DeviceMapper("dmsetup binary not found".into()))?;
+
+        let template = PathBuf::from(rootfs_path);
+
+        // --- 1. Acquire template loop device (shared, refcounted) -----------
+        //
+        // Check the cache first (under the lock), then drop the lock before
+        // any async work.  If the template is new, create the loop device
+        // outside the lock and insert afterwards.
+        let (template_loop, sectors) = {
+            let existing = {
+                let mut templates = self.templates.lock().unwrap();
+                if let Some(entry) = templates.get_mut(&template) {
+                    entry.refcount += 1;
+                    debug!(
+                        template = %rootfs_path,
+                        loop_dev = %entry.loop_device,
+                        refcount = entry.refcount,
+                        "reusing template loop device"
+                    );
+                    Some((entry.loop_device.clone(), entry.sectors))
+                } else {
+                    None
+                }
+            }; // MutexGuard dropped here.
+
+            if let Some(cached) = existing {
+                cached
+            } else {
+                // First time seeing this template — create a read-only loop device.
+                // Hold losetup_lock to prevent TOCTOU race on `-f` + attach.
+                let losetup_guard = self.losetup_lock.lock().await;
+                let loop_dev = losetup_attach(BUSYBOX, Path::new(rootfs_path), true).await?;
+                drop(losetup_guard);
+                let sectors = blockdev_getsz(BUSYBOX, &loop_dev).await.inspect_err(|_| {
+                    let ld = loop_dev.clone();
+                    tokio::spawn(async move {
+                        let _ = losetup_detach(BUSYBOX, &ld).await;
+                    });
+                })?;
+                debug!(
+                    template = %rootfs_path,
+                    loop_dev = %loop_dev,
+                    sectors,
+                    "attached new template loop device"
+                );
+                {
+                    let mut templates = self.templates.lock().unwrap();
+                    templates.insert(
+                        template.clone(),
+                        TemplateEntry {
+                            loop_device: loop_dev.clone(),
+                            sectors,
+                            refcount: 1,
+                        },
+                    );
+                }
+                (loop_dev, sectors)
+            }
+        };
+
+        // --- 2. Create sparse COW file (O(1), no actual I/O) ---------------
+        let cow_file = self.cow_dir.join(format!("arcbox-cow-{sandbox_id}.img"));
+        let cow_size = sectors * 512;
+        if let Err(e) = create_sparse_file(&cow_file, cow_size).await {
+            self.release_template(&template);
+            return Err(e);
+        }
+
+        // --- 3. Attach COW file as a loop device ----------------------------
+        let cow_loop_result = {
+            let losetup_guard = self.losetup_lock.lock().await;
+            let result = losetup_attach(BUSYBOX, &cow_file, false).await;
+            drop(losetup_guard);
+            result
+        };
+        let cow_loop = match cow_loop_result {
+            Ok(dev) => dev,
+            Err(e) => {
+                let _ = std::fs::remove_file(&cow_file);
+                self.release_template(&template);
+                return Err(e);
+            }
+        };
+
+        // --- 4. Create dm-snapshot device -----------------------------------
+        let dm_name = format!("{DM_NAME_PREFIX}{sandbox_id}");
+        let table =
+            format!("0 {sectors} snapshot {template_loop} {cow_loop} P {SNAPSHOT_CHUNK_SECTORS}");
+
+        if let Err(e) = dmsetup_create(dmsetup, &dm_name, &table).await {
+            let _ = losetup_detach(BUSYBOX, &cow_loop).await;
+            let _ = std::fs::remove_file(&cow_file);
+            self.release_template(&template);
+            return Err(e);
+        }
+
+        let dm_device = format!("/dev/mapper/{dm_name}");
+        info!(
+            sandbox_id,
+            dm_device = %dm_device,
+            cow_file = %cow_file.display(),
+            "dm-snapshot created"
+        );
+
+        Ok(CowHandle {
+            dm_name,
+            dm_device,
+            cow_loop,
+            cow_file,
+            template_path: template,
+        })
+    }
+
+    /// Tear down a dm-snapshot.  Best-effort: each step logs errors but
+    /// continues to the next so resources are not leaked.
+    pub async fn teardown(&self, handle: &CowHandle) -> Result<()> {
+        let dmsetup = self.dmsetup_bin.as_deref().unwrap_or("dmsetup");
+
+        // 1. Remove dm device.
+        if let Err(e) = dmsetup_remove(dmsetup, &handle.dm_name).await {
+            warn!(dm = %handle.dm_name, error = %e, "failed to remove dm device");
+        }
+
+        // 2. Detach COW loop device.
+        if let Err(e) = losetup_detach(BUSYBOX, &handle.cow_loop).await {
+            warn!(loop_dev = %handle.cow_loop, error = %e, "failed to detach cow loop");
+        }
+
+        // 3. Delete COW sparse file.
+        if let Err(e) = std::fs::remove_file(&handle.cow_file) {
+            warn!(file = %handle.cow_file.display(), error = %e, "failed to remove cow file");
+        }
+
+        // 4. Release template refcount.
+        self.release_template(&handle.template_path);
+
+        info!(sandbox = %handle.dm_name, "dm-snapshot teardown complete");
+        Ok(())
+    }
+
+    /// Synchronous version of [`cleanup_stale`](Self::cleanup_stale) for use
+    /// during construction (before a tokio runtime is guaranteed).
+    fn cleanup_stale_sync(&self) {
+        let dmsetup = match self.dmsetup_bin.as_deref() {
+            Some(bin) => bin,
+            None => return,
+        };
+
+        // Remove stale dm devices.
+        if let Ok(output) = Command::new(dmsetup)
+            .args(["ls", "--target", "snapshot"])
+            .output()
+        {
+            let stdout = String::from_utf8_lossy(&output.stdout);
+            for line in stdout.lines() {
+                if let Some(name) = line.split_whitespace().next()
+                    && name.starts_with(DM_NAME_PREFIX)
+                {
+                    debug!(dm = %name, "removing stale dm-snapshot");
+                    let _ = Command::new(dmsetup).args(["remove", name]).output();
+                }
+            }
+        }
+
+        // Remove stale COW files and detach associated loop devices.
+        let entries = match std::fs::read_dir(&self.cow_dir) {
+            Ok(e) => e,
+            Err(_) => return,
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path
+                .file_name()
+                .and_then(|n| n.to_str())
+                .is_some_and(|n| n.starts_with("arcbox-cow-"))
+            {
+                if let Ok(output) = Command::new(BUSYBOX)
+                    .args(["losetup", "-j", path.to_str().unwrap_or("")])
+                    .output()
+                {
+                    let stdout = String::from_utf8_lossy(&output.stdout);
+                    for line in stdout.lines() {
+                        if let Some(dev) = line.split(':').next() {
+                            let _ = Command::new(BUSYBOX)
+                                .args(["losetup", "-d", dev.trim()])
+                                .output();
+                        }
+                    }
+                }
+                debug!(file = %path.display(), "removing stale cow file");
+                let _ = std::fs::remove_file(&path);
+            }
+        }
+    }
+
+    /// Remove orphaned dm-snapshot devices and COW files left over from a
+    /// previous crash.  Called once at startup.
+    pub async fn cleanup_stale(&self) {
+        let dmsetup = match self.dmsetup_bin.as_deref() {
+            Some(bin) => bin,
+            None => return,
+        };
+
+        // Remove stale dm devices.
+        let mut cmd = Command::new(dmsetup);
+        cmd.args(["ls", "--target", "snapshot"]);
+        if let Ok(output) = run_cmd(cmd).await {
+            let stdout = String::from_utf8_lossy(&output.stdout);
+            for line in stdout.lines() {
+                if let Some(name) = line.split_whitespace().next()
+                    && name.starts_with(DM_NAME_PREFIX)
+                {
+                    debug!(dm = %name, "removing stale dm-snapshot");
+                    let _ = dmsetup_remove(dmsetup, name).await;
+                }
+            }
+        }
+
+        // Remove stale COW files and detach associated loop devices.
+        let entries = match std::fs::read_dir(&self.cow_dir) {
+            Ok(e) => e,
+            Err(_) => return,
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path
+                .file_name()
+                .and_then(|n| n.to_str())
+                .is_some_and(|n| n.starts_with("arcbox-cow-"))
+            {
+                // Try to find and detach any loop device backed by this file.
+                let mut cmd = Command::new(BUSYBOX);
+                cmd.args(["losetup", "-j", path.to_str().unwrap_or("")]);
+                if let Ok(output) = run_cmd(cmd).await {
+                    let stdout = String::from_utf8_lossy(&output.stdout);
+                    for line in stdout.lines() {
+                        if let Some(dev) = line.split(':').next() {
+                            let _ = losetup_detach(BUSYBOX, dev.trim()).await;
+                        }
+                    }
+                }
+                debug!(file = %path.display(), "removing stale cow file");
+                let _ = std::fs::remove_file(&path);
+            }
+        }
+    }
+
+    /// Decrement the refcount for a template; detach its loop device when
+    /// the count reaches zero.
+    fn release_template(&self, template_path: &Path) {
+        let mut templates = self.templates.lock().unwrap();
+        let should_detach = if let Some(entry) = templates.get_mut(template_path) {
+            entry.refcount = entry.refcount.saturating_sub(1);
+            if entry.refcount == 0 {
+                Some(entry.loop_device.clone())
+            } else {
+                None
+            }
+        } else {
+            None
+        };
+
+        if let Some(loop_dev) = should_detach {
+            templates.remove(template_path);
+            // Fire-and-forget detach (we are under a sync Mutex, cannot await).
+            tokio::spawn(async move {
+                if let Err(e) = losetup_detach(BUSYBOX, &loop_dev).await {
+                    warn!(loop_dev = %loop_dev, error = %e, "failed to detach template loop");
+                }
+            });
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Shell helpers
+// ---------------------------------------------------------------------------
+
+/// Run a synchronous [`Command`] on a blocking thread.
+///
+/// `tokio::process::Command` conflicts with the PID-1 SIGCHLD reaper
+/// (`spawn_reaper`), causing `ECHILD` errors.  Using `std::process::Command`
+/// inside `spawn_blocking` avoids this because `waitpid` is called
+/// synchronously before the signal can be stolen.
+async fn run_cmd(mut cmd: Command) -> Result<std::process::Output> {
+    tokio::task::spawn_blocking(move || cmd.output())
+        .await
+        .map_err(|e| VmmError::DeviceMapper(format!("spawn_blocking join: {e}")))?
+        .map_err(|e| VmmError::DeviceMapper(format!("command spawn: {e}")))
+}
+
+/// Attach a file as a loop device.  Returns the device path (e.g. `/dev/loop0`).
+///
+/// Uses busybox-compatible two-step approach: `busybox losetup -f` to find a
+/// free device, then `busybox losetup [-r] DEV FILE` to attach.
+async fn losetup_attach(bin: &str, path: &Path, read_only: bool) -> Result<String> {
+    let path_str = path
+        .to_str()
+        .ok_or_else(|| VmmError::DeviceMapper("non-UTF-8 path".into()))?;
+
+    // Step 1: find a free loop device.
+    let mut find_cmd = Command::new(bin);
+    find_cmd.args(["losetup", "-f"]);
+    let output = run_cmd(find_cmd).await?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(VmmError::DeviceMapper(format!("losetup -f: {stderr}")));
+    }
+    let dev = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if dev.is_empty() {
+        return Err(VmmError::DeviceMapper(
+            "losetup -f returned empty device".into(),
+        ));
+    }
+
+    // Step 2: attach the file to that device.
+    let mut attach_cmd = Command::new(bin);
+    if read_only {
+        attach_cmd.args(["losetup", "-r", &dev, path_str]);
+    } else {
+        attach_cmd.args(["losetup", &dev, path_str]);
+    }
+    let output = run_cmd(attach_cmd).await?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(VmmError::DeviceMapper(format!(
+            "losetup {dev} {}: {stderr}",
+            path.display()
+        )));
+    }
+
+    Ok(dev)
+}
+
+/// Detach a loop device.
+async fn losetup_detach(bin: &str, dev: &str) -> Result<()> {
+    let mut cmd = Command::new(bin);
+    cmd.args(["losetup", "-d", dev]);
+
+    let output = run_cmd(cmd).await?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(VmmError::DeviceMapper(format!(
+            "losetup -d {dev}: {stderr}"
+        )));
+    }
+    Ok(())
+}
+
+/// Get the size of a block device in 512-byte sectors.
+async fn blockdev_getsz(bin: &str, dev: &str) -> Result<u64> {
+    let mut cmd = Command::new(bin);
+    cmd.args(["blockdev", "--getsz", dev]);
+
+    let output = run_cmd(cmd).await?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(VmmError::DeviceMapper(format!(
+            "blockdev --getsz {dev}: {stderr}"
+        )));
+    }
+
+    String::from_utf8_lossy(&output.stdout)
+        .trim()
+        .parse::<u64>()
+        .map_err(|e| VmmError::DeviceMapper(format!("blockdev parse: {e}")))
+}
+
+/// Create a dm-snapshot device via `dmsetup create`.
+async fn dmsetup_create(bin: &str, name: &str, table: &str) -> Result<()> {
+    let mut cmd = Command::new(bin);
+    cmd.args(["create", name, "--table", table]);
+
+    let output = run_cmd(cmd).await?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(VmmError::DeviceMapper(format!(
+            "dmsetup create {name}: {stderr}"
+        )));
+    }
+    Ok(())
+}
+
+/// Remove a dm device via `dmsetup remove`.
+async fn dmsetup_remove(bin: &str, name: &str) -> Result<()> {
+    let mut cmd = Command::new(bin);
+    cmd.args(["remove", name]);
+
+    let output = run_cmd(cmd).await?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(VmmError::DeviceMapper(format!(
+            "dmsetup remove {name}: {stderr}"
+        )));
+    }
+    Ok(())
+}
+
+/// Create a sparse file of the given size in bytes.
+async fn create_sparse_file(path: &Path, size: u64) -> Result<()> {
+    let path = path.to_path_buf();
+    tokio::task::spawn_blocking(move || {
+        let file = std::fs::File::create(&path)
+            .map_err(|e| VmmError::DeviceMapper(format!("create cow file: {e}")))?;
+        file.set_len(size)
+            .map_err(|e| VmmError::DeviceMapper(format!("truncate cow file: {e}")))?;
+        Ok(())
+    })
+    .await
+    .map_err(|e| VmmError::DeviceMapper(format!("spawn_blocking join: {e}")))?
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_dm_name_format() {
+        let name = format!("{DM_NAME_PREFIX}test-sandbox-123");
+        assert_eq!(name, "arcbox-snap-test-sandbox-123");
+    }
+
+    #[test]
+    fn test_cow_file_path() {
+        let cow_dir = PathBuf::from("/var/lib/firecracker-vmm/cow");
+        let path = cow_dir.join(format!("arcbox-cow-{}.img", "sandbox-1"));
+        assert_eq!(
+            path,
+            PathBuf::from("/var/lib/firecracker-vmm/cow/arcbox-cow-sandbox-1.img")
+        );
+    }
+
+    #[test]
+    fn test_snapshot_table_format() {
+        let sectors = 2097152_u64; // 1 GiB
+        let table =
+            format!("0 {sectors} snapshot /dev/loop0 /dev/loop1 P {SNAPSHOT_CHUNK_SECTORS}");
+        assert_eq!(table, "0 2097152 snapshot /dev/loop0 /dev/loop1 P 8");
+    }
+
+    #[tokio::test]
+    async fn test_release_template_refcount() {
+        let mgr = CowManager {
+            templates: Mutex::new(HashMap::new()),
+            losetup_lock: AsyncMutex::new(()),
+            cow_dir: PathBuf::from("/tmp"),
+            dmsetup_bin: None,
+        };
+
+        let path = PathBuf::from("/tmp/template.ext4");
+        {
+            let mut t = mgr.templates.lock().unwrap();
+            t.insert(
+                path.clone(),
+                TemplateEntry {
+                    loop_device: "/dev/loop99".into(),
+                    sectors: 1024,
+                    refcount: 2,
+                },
+            );
+        }
+
+        // First release: refcount 2 → 1, entry stays.
+        mgr.release_template(&path);
+        {
+            let t = mgr.templates.lock().unwrap();
+            assert_eq!(t.get(&path).unwrap().refcount, 1);
+        }
+
+        // Second release: refcount 1 → 0, entry removed.
+        // (losetup_detach is spawned but won't run in sync test — that's fine,
+        // we just verify the map entry is removed.)
+        mgr.release_template(&path);
+        {
+            let t = mgr.templates.lock().unwrap();
+            assert!(!t.contains_key(&path));
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Introduce `CowManager` (`snapshot_cow.rs`) that uses Linux dm-snapshot to share a single read-only template ext4 image across sandboxes. Each sandbox gets a sparse COW file backed by a dm-snapshot device — only written blocks consume disk space, eliminating the need for full rootfs copies.
- Wire dm-snapshot into the sandbox lifecycle in direct mode (`jailer: None`). `do_boot()` creates a snapshot device at `/dev/mapper/arcbox-snap-{id}` and passes it to Firecracker; `remove_sandbox_impl()` tears it down after the process exits. Falls back to direct rootfs usage if dm-snapshot is unavailable.
- Fix agent tracing filter to include `arcbox_vm=info` so CowManager diagnostics are visible in `agent.log`.

### Key design decisions

- **`std::process::Command` + `spawn_blocking`** instead of `tokio::process::Command` to avoid SIGCHLD conflicts with the PID-1 reaper in arcbox-agent.
- **`AsyncMutex`** serializes busybox `losetup -f` + `losetup DEV FILE` two-step operations to prevent TOCTOU races on concurrent sandbox creation.
- **`cleanup_stale_sync()`** runs synchronously at `CowManager::new()` to remove orphaned dm devices and COW files from previous crashes.
- **Conditional COW file deletion** in `teardown()` — only unlinks the backing file after both dm device and loop device are successfully released.
- **Jailer mode and checkpoint/restore unchanged** (Phase 2/3).

### Prerequisites

- `CONFIG_DM_SNAPSHOT=y` in guest kernel (merged in arcboxlabs/kernel#5)
- Static `dmsetup` binary at `/arcbox/bin/dmsetup` via VirtioFS

### Benchmark (1GB rootfs, 1536MB memory, 5 sandboxes)

| Sandbox | Boot time |
|---------|-----------|
| 1 | 204ms |
| 2 | 175ms |
| 3 | 170ms |
| 4 | 163ms |
| 5 | 240ms |
| **Avg** | **190ms** |

## Test plan

- [x] E2E: 5 sandboxes created with dm-snapshot, all reached `ready` state
- [x] Verified `dm-snapshot created` and `dm-snapshot teardown complete` in agent.log
- [x] Template loop device reuse confirmed (refcount increments on subsequent sandboxes)
- [x] Fallback path works when dmsetup is absent (warn at init, debug per-boot)
- [x] `cargo clippy` and `cargo fmt` pass with zero warnings
- [ ] CI