### PR TITLE
feat(vm): symlink indirection for dm-snapshot checkpoint/restore

### DIFF
--- a/virt/arcbox-vm/src/sandbox.rs
+++ b/virt/arcbox-vm/src/sandbox.rs
@@ -881,13 +881,10 @@ impl SandboxManager {
             (snap_dir.join("vmstate"), snap_dir.join("mem"))
         };
 
-        // Store kernel/rootfs only in jailer mode — needed when restoring.
-        let (snap_kernel, snap_rootfs) = if self.config.firecracker.jailer.is_some() {
-            (Some(kernel_path), Some(rootfs_path))
-        } else {
-            (None, None)
-        };
-
+        // Store kernel/rootfs template paths so restore can re-derive them.
+        // Jailer mode needs them for chroot staging; direct mode needs the
+        // rootfs path to set up a fresh dm-snapshot and retarget the
+        // vmstate-recorded symlink.
         let meta = self.snapshots.register(
             sandbox_id,
             Some(name),
@@ -895,8 +892,8 @@ impl SandboxManager {
             vmstate_path,
             Some(mem_path),
             None,
-            snap_kernel,
-            snap_rootfs,
+            Some(kernel_path),
+            Some(rootfs_path),
         )?;
 
         let snap_dir_path = meta
@@ -1041,119 +1038,146 @@ impl SandboxManager {
             (proc, original_vsock_path)
         };
 
+        // Track resources that need cleanup if anything between
+        // `cow_manager.setup` and the final instance registration fails:
+        //
+        // - `pending_cow`: a CowHandle has no Drop impl, so a `?` propagating
+        //   the error would silently leak the dm device + loop + COW file.
+        // - `pending_origin_dir` (direct mode only): we recreate the original
+        //   sandbox's vm_dir so the vmstate-recorded symlink + vsock paths
+        //   resolve.  Without cleanup, every failed restore leaks one dir.
+        //
+        // On success, both are moved onto the SandboxInstance.
+        let mut pending_cow: Option<CowHandle> = None;
+        let mut pending_origin_dir: Option<PathBuf> = None;
+
         // In jailer mode the restored FC process also runs inside a chroot and
         // cannot access the catalog's host-absolute paths.  Copy the snapshot
         // files into the new sandbox's chroot and use chroot-relative paths.
-        let (effective_vmstate, effective_mem, cow_handle) = if let Some(ref jc) = fc_cfg.jailer {
-            let base = jc.chroot_base_dir.as_deref().unwrap_or("/srv/jailer");
-            let cr = chroot_root(&fc_cfg.binary, base, &new_id);
-            let snap_in_chroot = cr.join("snapshots").join(&spec.snapshot_id);
-            std::fs::create_dir_all(&snap_in_chroot).map_err(VmmError::Io)?;
-            let uid = nix::unistd::Uid::from_raw(jc.uid);
-            let gid = nix::unistd::Gid::from_raw(jc.gid);
-            nix::unistd::chown(&snap_in_chroot, Some(uid), Some(gid))
-                .map_err(|e| VmmError::Process(format!("chown snap dir: {e}")))?;
+        let setup_result: Result<(String, Option<String>)> = async {
+            if let Some(ref jc) = fc_cfg.jailer {
+                let base = jc.chroot_base_dir.as_deref().unwrap_or("/srv/jailer");
+                let cr = chroot_root(&fc_cfg.binary, base, &new_id);
+                let snap_in_chroot = cr.join("snapshots").join(&spec.snapshot_id);
+                std::fs::create_dir_all(&snap_in_chroot).map_err(VmmError::Io)?;
+                let uid = nix::unistd::Uid::from_raw(jc.uid);
+                let gid = nix::unistd::Gid::from_raw(jc.gid);
+                nix::unistd::chown(&snap_in_chroot, Some(uid), Some(gid))
+                    .map_err(|e| VmmError::Process(format!("chown snap dir: {e}")))?;
 
-            // Stage kernel (always copied, ~16MB).
-            if let Some(k) = snap_meta.kernel_path.as_deref() {
-                stage_kernel_for_jailer(&cr, k, jc.uid, jc.gid).await?;
-            }
+                // Stage kernel (always copied, ~16MB).
+                if let Some(k) = snap_meta.kernel_path.as_deref() {
+                    stage_kernel_for_jailer(&cr, k, jc.uid, jc.gid).await?;
+                }
 
-            // Stage rootfs: try dm-snapshot + mknod, fall back to full copy.
-            // Mirrors the boot path so restored sandboxes get the same CoW
-            // semantics (block-level sharing of the template, sparse COW).
-            let cow = if let Some(r) = snap_meta.rootfs_path.as_deref() {
-                match self.cow_manager.setup(&new_id, r).await {
-                    Ok(handle) => {
-                        match stage_rootfs_device_for_jailer(&cr, &handle.dm_device, jc.uid, jc.gid)
+                // Stage rootfs: try dm-snapshot + mknod, fall back to full copy.
+                // Mirrors the boot path so restored sandboxes get the same CoW
+                // semantics (block-level sharing of the template, sparse COW).
+                if let Some(r) = snap_meta.rootfs_path.as_deref() {
+                    match self.cow_manager.setup(&new_id, r).await {
+                        Ok(handle) => {
+                            match stage_rootfs_device_for_jailer(
+                                &cr,
+                                &handle.dm_device,
+                                jc.uid,
+                                jc.gid,
+                            )
                             .await
-                        {
-                            Ok(_) => Some(handle),
-                            Err(e) => {
-                                debug!(
-                                    sandbox_id = %new_id,
-                                    error = %e,
-                                    "mknod failed on restore, falling back to rootfs copy"
-                                );
-                                self.cow_manager.teardown(&handle).await;
-                                stage_rootfs_copy_for_jailer(&cr, r, jc.uid, jc.gid).await?;
-                                None
+                            {
+                                Ok(_) => pending_cow = Some(handle),
+                                Err(e) => {
+                                    debug!(
+                                        sandbox_id = %new_id,
+                                        error = %e,
+                                        "mknod failed on restore, falling back to rootfs copy"
+                                    );
+                                    self.cow_manager.teardown(&handle).await;
+                                    stage_rootfs_copy_for_jailer(&cr, r, jc.uid, jc.gid).await?;
+                                }
                             }
                         }
-                    }
-                    Err(e) => {
-                        debug!(
-                            sandbox_id = %new_id,
-                            error = %e,
-                            "dm-snapshot unavailable on restore, copying rootfs"
-                        );
-                        stage_rootfs_copy_for_jailer(&cr, r, jc.uid, jc.gid).await?;
-                        None
-                    }
-                }
-            } else {
-                None
-            };
-
-            // Copy vmstate into chroot.
-            let dst_vmstate = snap_in_chroot.join("vmstate");
-            tokio::fs::copy(&snap_meta.vmstate_path, &dst_vmstate)
-                .await
-                .map_err(VmmError::Io)?;
-            nix::unistd::chown(&dst_vmstate, Some(uid), Some(gid))
-                .map_err(|e| VmmError::Process(format!("chown vmstate: {e}")))?;
-
-            let effective_mem = if let Some(ref mf) = snap_meta.mem_path
-                && mf.exists()
-            {
-                let dst_mem = snap_in_chroot.join("mem");
-                tokio::fs::copy(mf, &dst_mem).await.map_err(VmmError::Io)?;
-                nix::unistd::chown(&dst_mem, Some(uid), Some(gid))
-                    .map_err(|e| VmmError::Process(format!("chown mem: {e}")))?;
-                Some(format!("/snapshots/{}/mem", spec.snapshot_id))
-            } else {
-                None
-            };
-
-            (
-                format!("/snapshots/{}/vmstate", spec.snapshot_id),
-                effective_mem,
-                cow,
-            )
-        } else {
-            // Direct mode: set up a fresh dm-snapshot for the restored sandbox
-            // and retarget the vmstate-recorded `{original_vm_dir}/rootfs.link`
-            // at the new device.  FC reopens the symlink path on restore.
-            let cow = if let Some(r) = snap_meta.rootfs_path.as_deref() {
-                match self.cow_manager.setup(&new_id, r).await {
-                    Ok(handle) => {
-                        let original_vm_dir = PathBuf::from(&fc_cfg.data_dir)
-                            .join("sandboxes")
-                            .join(&snap_meta.vm_id);
-                        match create_rootfs_symlink(&original_vm_dir, &handle.dm_device) {
-                            Ok(_) => Some(handle),
-                            Err(e) => {
-                                // P1 fix: symlink failed — release the dm device
-                                // (and its loop + COW file) before propagating.
-                                self.cow_manager.teardown(&handle).await;
-                                return Err(e);
-                            }
+                        Err(e) => {
+                            debug!(
+                                sandbox_id = %new_id,
+                                error = %e,
+                                "dm-snapshot unavailable on restore, copying rootfs"
+                            );
+                            stage_rootfs_copy_for_jailer(&cr, r, jc.uid, jc.gid).await?;
                         }
                     }
-                    Err(e) => {
-                        debug!(
-                            sandbox_id = %new_id,
-                            error = %e,
-                            "dm-snapshot unavailable for restore"
-                        );
-                        None
+                }
+
+                // Copy vmstate into chroot.
+                let dst_vmstate = snap_in_chroot.join("vmstate");
+                tokio::fs::copy(&snap_meta.vmstate_path, &dst_vmstate)
+                    .await
+                    .map_err(VmmError::Io)?;
+                nix::unistd::chown(&dst_vmstate, Some(uid), Some(gid))
+                    .map_err(|e| VmmError::Process(format!("chown vmstate: {e}")))?;
+
+                let effective_mem = if let Some(ref mf) = snap_meta.mem_path
+                    && mf.exists()
+                {
+                    let dst_mem = snap_in_chroot.join("mem");
+                    tokio::fs::copy(mf, &dst_mem).await.map_err(VmmError::Io)?;
+                    nix::unistd::chown(&dst_mem, Some(uid), Some(gid))
+                        .map_err(|e| VmmError::Process(format!("chown mem: {e}")))?;
+                    Some(format!("/snapshots/{}/mem", spec.snapshot_id))
+                } else {
+                    None
+                };
+
+                Ok((
+                    format!("/snapshots/{}/vmstate", spec.snapshot_id),
+                    effective_mem,
+                ))
+            } else {
+                // Direct mode: set up a fresh dm-snapshot for the restored sandbox
+                // and retarget the vmstate-recorded `{original_vm_dir}/rootfs.link`
+                // at the new device.  FC reopens the symlink path on restore.
+                if let Some(r) = snap_meta.rootfs_path.as_deref() {
+                    match self.cow_manager.setup(&new_id, r).await {
+                        Ok(handle) => {
+                            let original_vm_dir = PathBuf::from(&fc_cfg.data_dir)
+                                .join("sandboxes")
+                                .join(&snap_meta.vm_id);
+                            match create_rootfs_symlink(&original_vm_dir, &handle.dm_device) {
+                                Ok(_) => {
+                                    pending_cow = Some(handle);
+                                    pending_origin_dir = Some(original_vm_dir);
+                                }
+                                Err(e) => {
+                                    self.cow_manager.teardown(&handle).await;
+                                    return Err(e);
+                                }
+                            }
+                        }
+                        Err(e) => {
+                            debug!(
+                                sandbox_id = %new_id,
+                                error = %e,
+                                "dm-snapshot unavailable for restore"
+                            );
+                        }
                     }
                 }
-            } else {
-                None
-            };
 
-            (vmstate_str, mem_file, cow)
+                Ok((vmstate_str, mem_file))
+            }
+        }
+        .await;
+
+        let (effective_vmstate, effective_mem) = match setup_result {
+            Ok(x) => x,
+            Err(e) => {
+                cleanup_pending_restore(
+                    &self.cow_manager,
+                    pending_cow,
+                    pending_origin_dir.as_deref(),
+                )
+                .await;
+                return Err(e);
+            }
         };
 
         // Build the restore parameters.
@@ -1177,11 +1201,18 @@ impl SandboxManager {
         // In jailer mode, the actual socket path is inside the chroot; use the
         // path reported by the process handle instead of vm_dir's socket_path.
         let effective_socket = process.socket_path().to_owned();
-        let vm = Arc::new(
-            fc_sdk::restore(effective_socket.to_str().unwrap(), load_params)
-                .await
-                .map_err(VmmError::from)?,
-        );
+        let vm = match fc_sdk::restore(effective_socket.to_str().unwrap(), load_params).await {
+            Ok(v) => Arc::new(v),
+            Err(e) => {
+                cleanup_pending_restore(
+                    &self.cow_manager,
+                    pending_cow.take(),
+                    pending_origin_dir.as_deref(),
+                )
+                .await;
+                return Err(VmmError::from(e));
+            }
+        };
 
         // Synchronise the guest clock to the host after restore.  The sandbox
         // clock is frozen at snapshot creation time; correct it before any
@@ -1214,18 +1245,10 @@ impl SandboxManager {
         instance.process = Some(process);
         instance.vm = Some(vm);
         instance.vsock_uds_path = Some(actual_vsock_path);
-        instance.cow_handle = cow_handle;
-        // Direct mode only: track the original sandbox's vm_dir so we can
-        // remove it (and the embedded `rootfs.link` symlink) on teardown.
-        // Jailer mode keeps all restore artifacts inside the new chroot,
-        // which is already cleaned up by `remove_sandbox_impl`.
-        if fc_cfg.jailer.is_none() {
-            instance.restore_origin_dir = Some(
-                PathBuf::from(&fc_cfg.data_dir)
-                    .join("sandboxes")
-                    .join(&snap_meta.vm_id),
-            );
-        }
+        // Hand off pending resources to the instance — they're now tracked
+        // for teardown via `remove_sandbox_impl` and won't leak.
+        instance.cow_handle = pending_cow.take();
+        instance.restore_origin_dir = pending_origin_dir.take();
         instance.state = SandboxState::Ready;
         instance.ready_at = Some(Utc::now());
 
@@ -1515,7 +1538,32 @@ fn create_rootfs_symlink(vm_dir: &Path, dm_device: &str) -> Result<String> {
     let link_path = vm_dir.join("rootfs.link");
     let _ = std::fs::remove_file(&link_path);
     std::os::unix::fs::symlink(dm_device, &link_path).map_err(VmmError::Io)?;
-    Ok(link_path.to_str().unwrap().to_owned())
+    link_path
+        .to_str()
+        .map(str::to_owned)
+        .ok_or_else(|| VmmError::Config(format!("non-UTF-8 path: {}", link_path.display())))
+}
+
+/// Release dm-snapshot + recreated origin directory after a failed restore.
+///
+/// `CowHandle` has no Drop impl, so dropping it would leak the dm device,
+/// loop device, and sparse COW file.  This must be called on every error
+/// path between `cow_manager.setup` and the point where the handle is
+/// handed off to the SandboxInstance.
+async fn cleanup_pending_restore(
+    cow_manager: &CowManager,
+    cow: Option<CowHandle>,
+    origin_dir: Option<&Path>,
+) {
+    if let Some(handle) = cow {
+        cow_manager.teardown(&handle).await;
+    }
+    if let Some(dir) = origin_dir
+        && let Err(e) = tokio::fs::remove_dir_all(dir).await
+        && e.kind() != std::io::ErrorKind::NotFound
+    {
+        warn!(dir = %dir.display(), err = %e, "failed to clean up restore origin dir");
+    }
 }
 
 /// Perform the actual Firecracker boot: spawn process, configure, start VM.

--- a/virt/arcbox-vm/src/sandbox.rs
+++ b/virt/arcbox-vm/src/sandbox.rs
@@ -181,6 +181,10 @@ pub struct SandboxInstance {
     pub error: Option<String>,
     /// dm-snapshot CoW handle (present when snapshot-based rootfs is active).
     pub cow_handle: Option<CowHandle>,
+    /// For restored sandboxes only: the original sandbox's vm_dir, recreated
+    /// so the vmstate-recorded `rootfs.link` symlink (and FC vsock socket)
+    /// resolve correctly.  Removed alongside the sandbox.
+    pub restore_origin_dir: Option<PathBuf>,
 }
 
 impl SandboxInstance {
@@ -206,6 +210,7 @@ impl SandboxInstance {
             last_exit_code: None,
             error: None,
             cow_handle: None,
+            restore_origin_dir: None,
         }
     }
 
@@ -1039,7 +1044,7 @@ impl SandboxManager {
         // In jailer mode the restored FC process also runs inside a chroot and
         // cannot access the catalog's host-absolute paths.  Copy the snapshot
         // files into the new sandbox's chroot and use chroot-relative paths.
-        let (effective_vmstate, effective_mem) = if let Some(ref jc) = fc_cfg.jailer {
+        let (effective_vmstate, effective_mem, cow_handle) = if let Some(ref jc) = fc_cfg.jailer {
             let base = jc.chroot_base_dir.as_deref().unwrap_or("/srv/jailer");
             let cr = chroot_root(&fc_cfg.binary, base, &new_id);
             let snap_in_chroot = cr.join("snapshots").join(&spec.snapshot_id);
@@ -1049,13 +1054,46 @@ impl SandboxManager {
             nix::unistd::chown(&snap_in_chroot, Some(uid), Some(gid))
                 .map_err(|e| VmmError::Process(format!("chown snap dir: {e}")))?;
 
-            // Stage kernel and rootfs into the new chroot (same layout as boot).
-            if let (Some(k), Some(r)) = (
-                snap_meta.kernel_path.as_deref(),
-                snap_meta.rootfs_path.as_deref(),
-            ) {
-                stage_files_for_jailer(&cr, k, r, jc.uid, jc.gid).await?;
+            // Stage kernel (always copied, ~16MB).
+            if let Some(k) = snap_meta.kernel_path.as_deref() {
+                stage_kernel_for_jailer(&cr, k, jc.uid, jc.gid).await?;
             }
+
+            // Stage rootfs: try dm-snapshot + mknod, fall back to full copy.
+            // Mirrors the boot path so restored sandboxes get the same CoW
+            // semantics (block-level sharing of the template, sparse COW).
+            let cow = if let Some(r) = snap_meta.rootfs_path.as_deref() {
+                match self.cow_manager.setup(&new_id, r).await {
+                    Ok(handle) => {
+                        match stage_rootfs_device_for_jailer(&cr, &handle.dm_device, jc.uid, jc.gid)
+                            .await
+                        {
+                            Ok(_) => Some(handle),
+                            Err(e) => {
+                                debug!(
+                                    sandbox_id = %new_id,
+                                    error = %e,
+                                    "mknod failed on restore, falling back to rootfs copy"
+                                );
+                                self.cow_manager.teardown(&handle).await;
+                                stage_rootfs_copy_for_jailer(&cr, r, jc.uid, jc.gid).await?;
+                                None
+                            }
+                        }
+                    }
+                    Err(e) => {
+                        debug!(
+                            sandbox_id = %new_id,
+                            error = %e,
+                            "dm-snapshot unavailable on restore, copying rootfs"
+                        );
+                        stage_rootfs_copy_for_jailer(&cr, r, jc.uid, jc.gid).await?;
+                        None
+                    }
+                }
+            } else {
+                None
+            };
 
             // Copy vmstate into chroot.
             let dst_vmstate = snap_in_chroot.join("vmstate");
@@ -1080,9 +1118,42 @@ impl SandboxManager {
             (
                 format!("/snapshots/{}/vmstate", spec.snapshot_id),
                 effective_mem,
+                cow,
             )
         } else {
-            (vmstate_str, mem_file)
+            // Direct mode: set up a fresh dm-snapshot for the restored sandbox
+            // and retarget the vmstate-recorded `{original_vm_dir}/rootfs.link`
+            // at the new device.  FC reopens the symlink path on restore.
+            let cow = if let Some(r) = snap_meta.rootfs_path.as_deref() {
+                match self.cow_manager.setup(&new_id, r).await {
+                    Ok(handle) => {
+                        let original_vm_dir = PathBuf::from(&fc_cfg.data_dir)
+                            .join("sandboxes")
+                            .join(&snap_meta.vm_id);
+                        match create_rootfs_symlink(&original_vm_dir, &handle.dm_device) {
+                            Ok(_) => Some(handle),
+                            Err(e) => {
+                                // P1 fix: symlink failed — release the dm device
+                                // (and its loop + COW file) before propagating.
+                                self.cow_manager.teardown(&handle).await;
+                                return Err(e);
+                            }
+                        }
+                    }
+                    Err(e) => {
+                        debug!(
+                            sandbox_id = %new_id,
+                            error = %e,
+                            "dm-snapshot unavailable for restore"
+                        );
+                        None
+                    }
+                }
+            } else {
+                None
+            };
+
+            (vmstate_str, mem_file, cow)
         };
 
         // Build the restore parameters.
@@ -1143,6 +1214,18 @@ impl SandboxManager {
         instance.process = Some(process);
         instance.vm = Some(vm);
         instance.vsock_uds_path = Some(actual_vsock_path);
+        instance.cow_handle = cow_handle;
+        // Direct mode only: track the original sandbox's vm_dir so we can
+        // remove it (and the embedded `rootfs.link` symlink) on teardown.
+        // Jailer mode keeps all restore artifacts inside the new chroot,
+        // which is already cleaned up by `remove_sandbox_impl`.
+        if fc_cfg.jailer.is_none() {
+            instance.restore_origin_dir = Some(
+                PathBuf::from(&fc_cfg.data_dir)
+                    .join("sandboxes")
+                    .join(&snap_meta.vm_id),
+            );
+        }
         instance.state = SandboxState::Ready;
         instance.ready_at = Some(Utc::now());
 
@@ -1422,20 +1505,17 @@ async fn stage_rootfs_device_for_jailer(
     Ok("/rootfs.ext4".to_string())
 }
 
-/// Copy kernel and rootfs into the jailer chroot and set ownership.
+/// Create a stable `{vm_dir}/rootfs.link` symlink pointing at the dm-snapshot
+/// device.  Returns the symlink path as a string for Firecracker to use as the
+/// rootfs.  The vmstate records this path verbatim, so on restore we can
+/// retarget the symlink at a freshly-created dm-snapshot without FC noticing.
 ///
-/// Returns `(kernel_guest_path, rootfs_guest_path)` — paths relative to the
-/// chroot root (e.g., `"/vmlinux"`, `"/rootfs.ext4"`).
-async fn stage_files_for_jailer(
-    chroot_root: &Path,
-    kernel_src: &str,
-    rootfs_src: &str,
-    uid: u32,
-    gid: u32,
-) -> Result<(String, String)> {
-    let k = stage_kernel_for_jailer(chroot_root, kernel_src, uid, gid).await?;
-    let r = stage_rootfs_copy_for_jailer(chroot_root, rootfs_src, uid, gid).await?;
-    Ok((k, r))
+/// Removes any stale symlink first so a previous crash doesn't cause EEXIST.
+fn create_rootfs_symlink(vm_dir: &Path, dm_device: &str) -> Result<String> {
+    let link_path = vm_dir.join("rootfs.link");
+    let _ = std::fs::remove_file(&link_path);
+    std::os::unix::fs::symlink(dm_device, &link_path).map_err(VmmError::Io)?;
+    Ok(link_path.to_str().unwrap().to_owned())
 }
 
 /// Perform the actual Firecracker boot: spawn process, configure, start VM.
@@ -1534,11 +1614,19 @@ async fn do_boot(
             (k, r, "/run/firecracker.vsock".to_string(), vsock_host, cow)
         } else {
             // Direct mode: try dm-snapshot CoW, fall back to using rootfs directly.
+            // When CoW is active, create a stable `{vm_dir}/rootfs.link` symlink
+            // pointing at the dm device.  Firecracker records the symlink path
+            // (not the ephemeral dm device name) in the vmstate, so a restored
+            // sandbox can recreate a new dm-snapshot and retarget the symlink
+            // transparently.
             let (rootfs, cow) = match cow_manager.setup(id, &spec.rootfs).await {
-                Ok(handle) => {
-                    let path = handle.dm_device.clone();
-                    (path, Some(handle))
-                }
+                Ok(handle) => match create_rootfs_symlink(vm_dir, &handle.dm_device) {
+                    Ok(link) => (link, Some(handle)),
+                    Err(e) => {
+                        cow_manager.teardown(&handle).await;
+                        return Err(e);
+                    }
+                },
                 Err(e) => {
                     debug!(
                         sandbox_id = %id,
@@ -1635,6 +1723,13 @@ async fn do_boot(
             // Clean up dm-snapshot if boot fails after setup.
             if let Some(ref handle) = cow_handle {
                 cow_manager.teardown(handle).await;
+                // The rootfs.link symlink now points at a torn-down device.
+                // Remove it so subsequent retries see a clean slate.  Only
+                // applies to direct mode — jailer mode uses a chroot-internal
+                // device node which is removed when the chroot is destroyed.
+                if fc_cfg.jailer.is_none() {
+                    let _ = std::fs::remove_file(vm_dir.join("rootfs.link"));
+                }
             }
             return Err(VmmError::from(e));
         }
@@ -1722,6 +1817,18 @@ async fn remove_sandbox_impl(
         && e.kind() != std::io::ErrorKind::NotFound
     {
         warn!(sandbox_id = %id, err = %e, "failed to remove sandbox dir");
+    }
+
+    // For restored sandboxes: also remove the original sandbox's vm_dir,
+    // which we recreated during restore to host the vmstate-recorded
+    // `rootfs.link` symlink and FC vsock socket.  Without this every
+    // restore-and-remove cycle would leak one orphaned directory.
+    let origin_dir = arc.lock().unwrap().restore_origin_dir.clone();
+    if let Some(dir) = origin_dir
+        && let Err(e) = tokio::fs::remove_dir_all(&dir).await
+        && e.kind() != std::io::ErrorKind::NotFound
+    {
+        warn!(sandbox_id = %id, err = %e, "failed to remove restore origin dir");
     }
 
     instances.write().unwrap().remove(id);

--- a/virt/arcbox-vm/src/sandbox.rs
+++ b/virt/arcbox-vm/src/sandbox.rs
@@ -973,6 +973,21 @@ impl SandboxManager {
 
         let fc_cfg = &self.config.firecracker;
 
+        // Track resources that need cleanup if anything between this point
+        // and the final instance registration fails:
+        //
+        // - `pending_cow`: a CowHandle has no Drop impl, so a `?` propagating
+        //   the error would silently leak the dm device + loop + COW file.
+        // - `pending_origin_dir` (direct mode only): we recreate the original
+        //   sandbox's vm_dir so the vmstate-recorded symlink + vsock paths
+        //   resolve.  Set as soon as the dir is created so any later failure
+        //   (CoW setup, fc_sdk::restore) cleans it up, not only the CoW Ok
+        //   branch.
+        //
+        // On success, both are moved onto the SandboxInstance.
+        let mut pending_cow: Option<CowHandle> = None;
+        let mut pending_origin_dir: Option<PathBuf> = None;
+
         // Determine the actual host-side vsock UDS path FC will bind to on restore
         // and ensure the socket path is clear before spawning.
         //
@@ -982,7 +997,7 @@ impl SandboxManager {
         // - Direct mode: the vmstate stores the ABSOLUTE host path from the original
         //   sandbox. We must recreate that directory and delete any stale socket so FC
         //   can bind successfully.
-        let (process, actual_vsock_path) = if let Some(ref jc) = fc_cfg.jailer {
+        let (mut process, actual_vsock_path) = if let Some(ref jc) = fc_cfg.jailer {
             let base = jc.chroot_base_dir.as_deref().unwrap_or("/srv/jailer");
             let cr = chroot_root(&fc_cfg.binary, base, &new_id);
             // Ensure the `run/` directory exists inside the new chroot so FC can
@@ -1026,6 +1041,10 @@ impl SandboxManager {
             {
                 return Err(VmmError::Io(e));
             }
+            // Track the dir for cleanup — any failure past this point (FC spawn,
+            // CoW setup, fc_sdk::restore) must remove it, not only the CoW Ok
+            // branch.
+            pending_origin_dir = Some(original_vm_dir.clone());
 
             // Pre-create log/metrics files — Firecracker requires them to
             // exist at startup (same as the boot path in do_boot).
@@ -1037,19 +1056,6 @@ impl SandboxManager {
                 spawn_direct(fc_cfg, &new_id, &socket_path, &log_path, &metrics_path).await?;
             (proc, original_vsock_path)
         };
-
-        // Track resources that need cleanup if anything between
-        // `cow_manager.setup` and the final instance registration fails:
-        //
-        // - `pending_cow`: a CowHandle has no Drop impl, so a `?` propagating
-        //   the error would silently leak the dm device + loop + COW file.
-        // - `pending_origin_dir` (direct mode only): we recreate the original
-        //   sandbox's vm_dir so the vmstate-recorded symlink + vsock paths
-        //   resolve.  Without cleanup, every failed restore leaks one dir.
-        //
-        // On success, both are moved onto the SandboxInstance.
-        let mut pending_cow: Option<CowHandle> = None;
-        let mut pending_origin_dir: Option<PathBuf> = None;
 
         // In jailer mode the restored FC process also runs inside a chroot and
         // cannot access the catalog's host-absolute paths.  Copy the snapshot
@@ -1135,32 +1141,30 @@ impl SandboxManager {
                 // Direct mode: set up a fresh dm-snapshot for the restored sandbox
                 // and retarget the vmstate-recorded `{original_vm_dir}/rootfs.link`
                 // at the new device.  FC reopens the symlink path on restore.
-                if let Some(r) = snap_meta.rootfs_path.as_deref() {
-                    match self.cow_manager.setup(&new_id, r).await {
-                        Ok(handle) => {
-                            let original_vm_dir = PathBuf::from(&fc_cfg.data_dir)
-                                .join("sandboxes")
-                                .join(&snap_meta.vm_id);
-                            match create_rootfs_symlink(&original_vm_dir, &handle.dm_device) {
-                                Ok(_) => {
-                                    pending_cow = Some(handle);
-                                    pending_origin_dir = Some(original_vm_dir);
-                                }
-                                Err(e) => {
-                                    self.cow_manager.teardown(&handle).await;
-                                    return Err(e);
-                                }
-                            }
-                        }
-                        Err(e) => {
-                            debug!(
-                                sandbox_id = %new_id,
-                                error = %e,
-                                "dm-snapshot unavailable for restore"
-                            );
-                        }
-                    }
+                //
+                // Unlike boot, direct-mode restore has no usable fallback:  the
+                // vmstate-recorded path is the symlink, so the only way for FC to
+                // open the rootfs is for that symlink to exist.  If dm-snapshot
+                // isn't available we fail explicitly rather than silently letting
+                // `fc_sdk::restore` fault on a missing file.
+                let rootfs = snap_meta.rootfs_path.as_deref().ok_or_else(|| {
+                    VmmError::Config(
+                        "snapshot has no rootfs_path; cannot restore in direct mode".into(),
+                    )
+                })?;
+                let handle = self.cow_manager.setup(&new_id, rootfs).await.map_err(|e| {
+                    VmmError::DeviceMapper(format!(
+                        "dm-snapshot setup failed during direct-mode restore: {e}"
+                    ))
+                })?;
+                let original_vm_dir = PathBuf::from(&fc_cfg.data_dir)
+                    .join("sandboxes")
+                    .join(&snap_meta.vm_id);
+                if let Err(e) = create_rootfs_symlink(&original_vm_dir, &handle.dm_device) {
+                    self.cow_manager.teardown(&handle).await;
+                    return Err(e);
                 }
+                pending_cow = Some(handle);
 
                 Ok((vmstate_str, mem_file))
             }
@@ -1170,6 +1174,10 @@ impl SandboxManager {
         let (effective_vmstate, effective_mem) = match setup_result {
             Ok(x) => x,
             Err(e) => {
+                // FC was spawned but hasn't yet been told to load the vmstate,
+                // so it shouldn't have the dm device open.  Kill it anyway
+                // before teardown so the cleanup is unconditionally safe.
+                kill_and_reap_fc(&mut process).await;
                 cleanup_pending_restore(
                     &self.cow_manager,
                     pending_cow,
@@ -1204,6 +1212,10 @@ impl SandboxManager {
         let vm = match fc_sdk::restore(effective_socket.to_str().unwrap(), load_params).await {
             Ok(v) => Arc::new(v),
             Err(e) => {
+                // FC has likely opened the dm-snapshot block device by now
+                // (vmstate load reopens all recorded drives).  Kill and wait
+                // before teardown so `dmsetup remove` doesn't hit EBUSY.
+                kill_and_reap_fc(&mut process).await;
                 cleanup_pending_restore(
                     &self.cow_manager,
                     pending_cow.take(),
@@ -1566,6 +1578,26 @@ async fn cleanup_pending_restore(
     }
 }
 
+/// SIGKILL Firecracker and wait for it to exit (bounded timeout).
+///
+/// Required before `cow_manager.teardown` on any failure path where FC may
+/// have opened the dm-snapshot block device: `dmsetup remove` returns EBUSY
+/// while a process still holds the device, leaking the dm device + loop +
+/// sparse COW file.  `FirecrackerProcess::drop` sends SIGKILL but never
+/// reaps, so by the time teardown runs FC may still be alive.
+async fn kill_and_reap_fc(process: &mut fc_sdk::FirecrackerProcess) {
+    if let Some(pid) = process.pid()
+        && pid > 0
+    {
+        let _ = nix::sys::signal::kill(
+            #[allow(clippy::cast_possible_wrap)]
+            nix::unistd::Pid::from_raw(pid as i32),
+            nix::sys::signal::Signal::SIGKILL,
+        );
+    }
+    let _ = tokio::time::timeout(std::time::Duration::from_secs(5), process.wait()).await;
+}
+
 /// Perform the actual Firecracker boot: spawn process, configure, start VM.
 ///
 /// Returns `(FirecrackerProcess, Arc<Vm>, vsock_uds_path, Option<CowHandle>)`
@@ -1605,7 +1637,7 @@ async fn do_boot(
     }
 
     // Spawn the Firecracker process (direct or via Jailer).
-    let process = if let Some(ref jc) = fc_cfg.jailer {
+    let mut process = if let Some(ref jc) = fc_cfg.jailer {
         spawn_jailer(jc, fc_cfg, id).await?
     } else {
         spawn_direct(fc_cfg, id, &socket_path, &log_path, &metrics_path).await?
@@ -1770,6 +1802,10 @@ async fn do_boot(
         Err(e) => {
             // Clean up dm-snapshot if boot fails after setup.
             if let Some(ref handle) = cow_handle {
+                // FC has likely opened the dm-snapshot block device by this
+                // point.  Kill and wait before teardown so `dmsetup remove`
+                // doesn't hit EBUSY and leak the dm/loop/COW resources.
+                kill_and_reap_fc(&mut process).await;
                 cow_manager.teardown(handle).await;
                 // The rootfs.link symlink now points at a torn-down device.
                 // Remove it so subsequent retries see a clean slate.  Only


### PR DESCRIPTION
## Summary

- Add symlink indirection layer between Firecracker and dm-snapshot devices, inspired by E2B's architecture. FC's vmstate records a stable symlink path (`{vm_dir}/rootfs.link`) instead of the ephemeral `/dev/mapper/arcbox-snap-{id}` device path. On restore, a new dm-snapshot is created and the symlink is retargeted — FC reopens the same path transparently.
- Wire dm-snapshot CoW into `restore_sandbox()` for both jailer and direct modes, eliminating full rootfs copies on restore.
- Store `cow_handle` on restored `SandboxInstance` so `remove_sandbox_impl()` properly tears down the dm-snapshot.
- Remove unused `stage_files_for_jailer()` — all call sites now use the split `stage_kernel_for_jailer()` + `stage_rootfs_*_for_jailer()`.

### How it works

**Boot (direct mode):**
```
cow_manager.setup() → /dev/mapper/arcbox-snap-{id}
symlink: {vm_dir}/rootfs.link → /dev/mapper/arcbox-snap-{id}
FC receives: {vm_dir}/rootfs.link (stable path, saved in vmstate)
```

**Restore (direct mode):**
```
cow_manager.setup() → /dev/mapper/arcbox-snap-{new_id}
symlink: {original_vm_dir}/rootfs.link → /dev/mapper/arcbox-snap-{new_id}
FC loads vmstate → opens {original_vm_dir}/rootfs.link → new device
```

**Restore (jailer mode):**
```
cow_manager.setup() → /dev/mapper/arcbox-snap-{new_id}
mknod: {chroot}/rootfs.ext4 → (major, minor) of new dm device
FC loads vmstate → opens /rootfs.ext4 (chroot-relative) → new device
```

## Test plan

- [x] Create sandbox → checkpoint → remove → restore → verify `ready` state
- [x] Verified `dm-snapshot created` log for both original and restored sandbox
- [x] Verified `dm-snapshot teardown complete` on remove of both
- [x] `cargo clippy` and `cargo fmt` pass with zero warnings
- [ ] CI