### PR TITLE
Mount host /private via VirtioFS and rewrite Docker bind paths

### DIFF
--- a/app/arcbox-core/src/machine.rs
+++ b/app/arcbox-core/src/machine.rs
@@ -7,7 +7,7 @@ use crate::error::{CoreError, Result};
 use crate::persistence::MachinePersistence;
 use crate::vm::{SharedDirConfig, VmConfig, VmId, VmManager};
 use arcbox_constants::ports::AGENT_PORT;
-use arcbox_constants::virtiofs::{MOUNT_USERS, TAG_ARCBOX, TAG_USERS};
+use arcbox_constants::virtiofs::{MOUNT_PRIVATE, MOUNT_USERS, TAG_ARCBOX, TAG_PRIVATE, TAG_USERS};
 use chrono::{DateTime, Utc};
 use std::collections::HashMap;
 use std::net::IpAddr;
@@ -231,6 +231,10 @@ impl MachineManager {
         if users_dir.is_dir() {
             shared_dirs.push(SharedDirConfig::new(MOUNT_USERS, TAG_USERS));
         }
+        let private_dir = std::path::Path::new(MOUNT_PRIVATE);
+        if private_dir.is_dir() {
+            shared_dirs.push(SharedDirConfig::new(MOUNT_PRIVATE, TAG_PRIVATE));
+        }
 
         // Load persisted machines
         let mut machines = HashMap::new();
@@ -338,6 +342,10 @@ impl MachineManager {
         let users_dir = std::path::Path::new(MOUNT_USERS);
         if users_dir.is_dir() {
             shared_dirs.push(SharedDirConfig::new(MOUNT_USERS, TAG_USERS));
+        }
+        let private_dir = std::path::Path::new(MOUNT_PRIVATE);
+        if private_dir.is_dir() {
+            shared_dirs.push(SharedDirConfig::new(MOUNT_PRIVATE, TAG_PRIVATE));
         }
 
         // Create underlying VM

--- a/app/arcbox-docker/src/handlers/container.rs
+++ b/app/arcbox-docker/src/handlers/container.rs
@@ -38,7 +38,10 @@ pub async fn create_container(
         .to_bytes();
 
     let body_bytes = crate::host_path::rewrite_create_body(body_bytes);
-    let req = Request::from_parts(parts, Body::from(body_bytes));
+    let mut req = Request::from_parts(parts, Body::from(body_bytes));
+    // Body may have changed size; remove Content-Length so the proxy
+    // recomputes framing from the actual body.
+    req.headers_mut().remove(axum::http::header::CONTENT_LENGTH);
     proxy(&state, &uri, req).await
 }
 

--- a/app/arcbox-docker/src/handlers/container.rs
+++ b/app/arcbox-docker/src/handlers/container.rs
@@ -19,7 +19,28 @@ crate::handlers::proxy_handler!(container_top);
 crate::handlers::proxy_handler!(container_stats);
 crate::handlers::proxy_handler!(container_changes);
 crate::handlers::proxy_handler!(prune_containers);
-crate::handlers::proxy_handler!(create_container);
+
+/// Create a container, resolving macOS symlinks in bind-mount source paths.
+///
+/// On macOS, `/tmp` → `/private/tmp` and `/var` → `/private/var`. The guest
+/// mounts host `/private` via VirtioFS while its `/tmp` and `/var` are
+/// isolated tmpfs. This handler resolves the top-level symlink so
+/// bind-mount paths land on the VirtioFS share.
+pub async fn create_container(
+    State(state): State<AppState>,
+    OriginalUri(uri): OriginalUri,
+    req: Request<Body>,
+) -> Result<Response> {
+    let (parts, body) = req.into_parts();
+    let body_bytes = http_body_util::BodyExt::collect(body)
+        .await
+        .map_err(|e| crate::error::DockerError::Server(format!("failed to read body: {e}")))?
+        .to_bytes();
+
+    let body_bytes = crate::host_path::rewrite_create_body(body_bytes);
+    let req = Request::from_parts(parts, Body::from(body_bytes));
+    proxy(&state, &uri, req).await
+}
 
 /// Extract container ID from URI path.
 ///

--- a/app/arcbox-docker/src/host_path.rs
+++ b/app/arcbox-docker/src/host_path.rs
@@ -5,8 +5,8 @@
 //! its own `/tmp` and `/var` as isolated tmpfs. This module resolves the
 //! top-level symlink so bind-mount source paths land on the VirtioFS share.
 //!
-//! On Linux hosts nothing is a symlink at the top level, so every function
-//! here is a no-op without any `#[cfg]` gating.
+//! The symlink resolution is `#[cfg(target_os = "macos")]`; on other hosts
+//! `resolve()` is a no-op.
 
 use bytes::Bytes;
 use std::borrow::Cow;
@@ -23,6 +23,7 @@ use std::path::{Component, Path};
 /// /var/folders/x/y  → /private/var/folders/x/y
 /// /Users/me/proj    → /Users/me/proj        (/Users is not a symlink)
 /// ```
+#[cfg(target_os = "macos")]
 pub fn resolve(path: &str) -> Cow<'_, str> {
     let p = Path::new(path);
     let mut components = p.components();
@@ -63,6 +64,11 @@ pub fn resolve(path: &str) -> Cow<'_, str> {
     } else {
         Cow::Owned(s.into_owned())
     }
+}
+
+#[cfg(not(target_os = "macos"))]
+pub fn resolve(path: &str) -> Cow<'_, str> {
+    Cow::Borrowed(path)
 }
 
 /// Rewrites bind-mount source paths in a container-create request body.

--- a/app/arcbox-docker/src/host_path.rs
+++ b/app/arcbox-docker/src/host_path.rs
@@ -1,0 +1,253 @@
+//! Host-to-guest path resolution for Docker bind mounts.
+//!
+//! On macOS, top-level directories like `/tmp`, `/var`, and `/etc` are symlinks
+//! into `/private`. The guest VM mounts host `/private` via VirtioFS but keeps
+//! its own `/tmp` and `/var` as isolated tmpfs. This module resolves the
+//! top-level symlink so bind-mount source paths land on the VirtioFS share.
+//!
+//! On Linux hosts nothing is a symlink at the top level, so every function
+//! here is a no-op without any `#[cfg]` gating.
+
+use bytes::Bytes;
+use std::borrow::Cow;
+use std::path::{Component, Path};
+
+/// Resolves the top-level symlink in a host path.
+///
+/// Checks whether the first path component (e.g. `/tmp`, `/var`) is a symlink
+/// and, if so, replaces it with the symlink target. Deeper symlinks are left
+/// untouched — only the macOS system-level mounts need resolving.
+///
+/// ```text
+/// /tmp/foo          → /private/tmp/foo      (macOS: /tmp → private/tmp)
+/// /var/folders/x/y  → /private/var/folders/x/y
+/// /Users/me/proj    → /Users/me/proj        (/Users is not a symlink)
+/// ```
+pub fn resolve(path: &str) -> Cow<'_, str> {
+    let p = Path::new(path);
+    let mut components = p.components();
+
+    // Must start with root `/`.
+    if components.next() != Some(Component::RootDir) {
+        return Cow::Borrowed(path);
+    }
+
+    // Grab the first real component (e.g. `tmp`, `var`).
+    let Some(first) = components.next() else {
+        return Cow::Borrowed(path);
+    };
+
+    let top = Path::new("/").join(first);
+    let Ok(target) = top.read_link() else {
+        // Not a symlink — return unchanged.
+        return Cow::Borrowed(path);
+    };
+
+    // Resolve relative targets: /tmp → private/tmp means /private/tmp.
+    let resolved = if target.is_relative() {
+        Path::new("/").join(&target)
+    } else {
+        target
+    };
+
+    let rest: std::path::PathBuf = components.collect();
+    let full = if rest.as_os_str().is_empty() {
+        resolved
+    } else {
+        resolved.join(rest)
+    };
+
+    let s = full.to_string_lossy();
+    if s == path {
+        Cow::Borrowed(path)
+    } else {
+        Cow::Owned(s.into_owned())
+    }
+}
+
+/// Rewrites bind-mount source paths in a container-create request body.
+///
+/// Handles `HostConfig.Binds` (string array) and `HostConfig.Mounts`
+/// (structured mount objects). Returns the original body unchanged if no
+/// paths need rewriting.
+pub fn rewrite_create_body(body: Bytes) -> Bytes {
+    let Ok(mut v) = serde_json::from_slice::<serde_json::Value>(&body) else {
+        return body;
+    };
+
+    let mut changed = false;
+
+    // HostConfig.Binds: ["host:container[:opts]", …]
+    if let Some(binds) = v
+        .pointer_mut("/HostConfig/Binds")
+        .and_then(|v| v.as_array_mut())
+    {
+        for entry in binds {
+            if let Some(s) = entry.as_str() {
+                if let Some(rewritten) = rewrite_bind_entry(s) {
+                    *entry = serde_json::Value::String(rewritten);
+                    changed = true;
+                }
+            }
+        }
+    }
+
+    // HostConfig.Mounts: [{Type: "bind", Source: "…", …}, …]
+    if let Some(mounts) = v
+        .pointer_mut("/HostConfig/Mounts")
+        .and_then(|v| v.as_array_mut())
+    {
+        for mount in mounts {
+            if mount.get("Type").and_then(|t| t.as_str()) != Some("bind") {
+                continue;
+            }
+            if let Some(src) = mount.get("Source").and_then(|s| s.as_str()) {
+                if let Cow::Owned(resolved) = resolve(src) {
+                    mount["Source"] = serde_json::Value::String(resolved);
+                    changed = true;
+                }
+            }
+        }
+    }
+
+    if changed {
+        serde_json::to_vec(&v).map_or(body, Bytes::from)
+    } else {
+        body
+    }
+}
+
+/// Rewrites the host-path portion of a Binds entry (`"host:container[:opts]"`).
+fn rewrite_bind_entry(entry: &str) -> Option<String> {
+    let colon = entry.find(':')?;
+    let host = &entry[..colon];
+    if let Cow::Owned(resolved) = resolve(host) {
+        Some(format!("{resolved}{}", &entry[colon..]))
+    } else {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolve_leaves_non_symlink_paths_unchanged() {
+        // /Users is a real directory on macOS, not a symlink.
+        assert_eq!(resolve("/Users/me/project"), "/Users/me/project");
+        assert_eq!(resolve("/nonexistent/path"), "/nonexistent/path");
+        assert_eq!(resolve("/"), "/");
+    }
+
+    #[test]
+    #[cfg(target_os = "macos")]
+    fn resolve_follows_macos_tmp_symlink() {
+        // On macOS, /tmp → private/tmp → /private/tmp.
+        assert_eq!(resolve("/tmp"), "/private/tmp");
+        assert_eq!(resolve("/tmp/foo"), "/private/tmp/foo");
+        assert_eq!(
+            resolve("/tmp/deep/nested/path"),
+            "/private/tmp/deep/nested/path"
+        );
+    }
+
+    #[test]
+    #[cfg(target_os = "macos")]
+    fn resolve_follows_macos_var_symlink() {
+        assert_eq!(resolve("/var"), "/private/var");
+        assert_eq!(resolve("/var/folders/xx/yy"), "/private/var/folders/xx/yy");
+        assert_eq!(resolve("/var/tmp/foo"), "/private/var/tmp/foo");
+    }
+
+    #[test]
+    #[cfg(target_os = "macos")]
+    fn resolve_follows_macos_etc_symlink() {
+        assert_eq!(resolve("/etc"), "/private/etc");
+        assert_eq!(resolve("/etc/hosts"), "/private/etc/hosts");
+    }
+
+    #[test]
+    #[cfg(target_os = "macos")]
+    fn resolve_already_private_is_unchanged() {
+        assert_eq!(resolve("/private/tmp/foo"), "/private/tmp/foo");
+        assert_eq!(
+            resolve("/private/var/folders/xx"),
+            "/private/var/folders/xx"
+        );
+    }
+
+    #[test]
+    fn rewrite_bind_entry_with_options() {
+        // Only testable on macOS where /tmp is a symlink.
+        if resolve("/tmp") == "/tmp" {
+            return; // Not macOS — skip.
+        }
+        assert_eq!(
+            rewrite_bind_entry("/tmp/foo:/app:ro"),
+            Some("/private/tmp/foo:/app:ro".to_string())
+        );
+    }
+
+    #[test]
+    fn rewrite_bind_entry_no_change() {
+        assert_eq!(rewrite_bind_entry("/Users/me/proj:/app"), None);
+    }
+
+    #[test]
+    fn rewrite_create_body_binds() {
+        if resolve("/tmp") == "/tmp" {
+            return;
+        }
+        let body = serde_json::json!({
+            "Image": "alpine",
+            "HostConfig": {
+                "Binds": ["/tmp/foo:/app", "/Users/me:/home:ro"]
+            }
+        });
+        let input = Bytes::from(serde_json::to_vec(&body).unwrap());
+        let output = rewrite_create_body(input);
+        let v: serde_json::Value = serde_json::from_slice(&output).unwrap();
+        let binds = v["HostConfig"]["Binds"].as_array().unwrap();
+        assert_eq!(binds[0], "/private/tmp/foo:/app");
+        assert_eq!(binds[1], "/Users/me:/home:ro");
+    }
+
+    #[test]
+    fn rewrite_create_body_mounts() {
+        if resolve("/tmp") == "/tmp" {
+            return;
+        }
+        let body = serde_json::json!({
+            "Image": "alpine",
+            "HostConfig": {
+                "Mounts": [
+                    {"Type": "bind", "Source": "/tmp/ctx", "Target": "/app"},
+                    {"Type": "volume", "Source": "myvolume", "Target": "/data"},
+                    {"Type": "bind", "Source": "/Users/me", "Target": "/home"}
+                ]
+            }
+        });
+        let input = Bytes::from(serde_json::to_vec(&body).unwrap());
+        let output = rewrite_create_body(input);
+        let v: serde_json::Value = serde_json::from_slice(&output).unwrap();
+        let mounts = v["HostConfig"]["Mounts"].as_array().unwrap();
+        assert_eq!(mounts[0]["Source"], "/private/tmp/ctx");
+        assert_eq!(mounts[1]["Source"], "myvolume"); // volume — untouched
+        assert_eq!(mounts[2]["Source"], "/Users/me"); // not a symlink
+    }
+
+    #[test]
+    fn rewrite_create_body_no_host_config_is_noop() {
+        let body = Bytes::from(br#"{"Image":"alpine"}"#.to_vec());
+        let output = rewrite_create_body(body.clone());
+        assert_eq!(output, body);
+    }
+
+    #[test]
+    fn rewrite_create_body_invalid_json_is_noop() {
+        let body = Bytes::from(b"not json".to_vec());
+        let output = rewrite_create_body(body.clone());
+        assert_eq!(output, body);
+    }
+}

--- a/app/arcbox-docker/src/lib.rs
+++ b/app/arcbox-docker/src/lib.rs
@@ -45,7 +45,7 @@ pub mod api;
 pub mod context;
 pub mod error;
 pub mod handlers;
-pub mod host_path;
+pub(crate) mod host_path;
 pub mod proxy;
 pub mod server;
 pub mod trace;

--- a/app/arcbox-docker/src/lib.rs
+++ b/app/arcbox-docker/src/lib.rs
@@ -45,6 +45,7 @@ pub mod api;
 pub mod context;
 pub mod error;
 pub mod handlers;
+pub mod host_path;
 pub mod proxy;
 pub mod server;
 pub mod trace;

--- a/common/arcbox-constants/src/virtiofs.rs
+++ b/common/arcbox-constants/src/virtiofs.rs
@@ -4,8 +4,14 @@ pub const TAG_ARCBOX: &str = "arcbox";
 /// Host `/Users` share tag.
 pub const TAG_USERS: &str = "users";
 
+/// Host `/private` share tag (macOS symlink targets: `/tmp`, `/var/folders`, etc.).
+pub const TAG_PRIVATE: &str = "private";
+
 /// Guest mountpoint for the internal ArcBox share.
 pub const MOUNT_ARCBOX: &str = "/arcbox";
 
 /// Guest mountpoint for the host `/Users` share.
 pub const MOUNT_USERS: &str = "/Users";
+
+/// Guest mountpoint for the host `/private` share.
+pub const MOUNT_PRIVATE: &str = "/private";

--- a/guest/arcbox-agent/src/init.rs
+++ b/guest/arcbox-agent/src/init.rs
@@ -32,7 +32,10 @@ mod platform {
         // Mount host /private for macOS symlink targets (/tmp, /var/folders).
         // Must come before tmpfs mounts so /private is available as a VirtioFS
         // target. Guest /tmp and /var remain isolated tmpfs.
-        mount_virtiofs_optional("private", "/private");
+        mount_virtiofs_optional(
+            arcbox_constants::virtiofs::TAG_PRIVATE,
+            arcbox_constants::virtiofs::MOUNT_PRIVATE,
+        );
 
         // Writable layers on top of read-only EROFS.
         mount_tmpfs("/tmp");
@@ -69,7 +72,10 @@ mod platform {
         setup_networking();
 
         // Optional host /Users share (non-fatal if not configured).
-        mount_virtiofs_optional("users", "/Users");
+        mount_virtiofs_optional(
+            arcbox_constants::virtiofs::TAG_USERS,
+            arcbox_constants::virtiofs::MOUNT_USERS,
+        );
 
         // Rosetta x86_64 translation (Apple Silicon only).
         // The host attaches a VirtioFS share containing the Rosetta binary.

--- a/guest/arcbox-agent/src/init.rs
+++ b/guest/arcbox-agent/src/init.rs
@@ -29,6 +29,11 @@ mod platform {
         // Docker Desktop and OrbStack both set 1048576 in their guest VMs.
         raise_fd_limits();
 
+        // Mount host /private for macOS symlink targets (/tmp, /var/folders).
+        // Must come before tmpfs mounts so /private is available as a VirtioFS
+        // target. Guest /tmp and /var remain isolated tmpfs.
+        mount_virtiofs_optional("private", "/private");
+
         // Writable layers on top of read-only EROFS.
         mount_tmpfs("/tmp");
         mount_tmpfs("/run");

--- a/guest/arcbox-agent/src/mount.rs
+++ b/guest/arcbox-agent/src/mount.rs
@@ -100,6 +100,7 @@ pub fn is_mounted(_path: &str) -> bool {
 ///
 /// This mounts:
 /// - "arcbox" tag -> /arcbox (data directory)
+/// - "private" tag -> /private (macOS symlink targets: /tmp, /var/folders, …)
 /// - "users" tag -> /Users (macOS /Users, bind-mounted to original path)
 pub fn mount_standard_shares() {
     // The /arcbox share may already be mounted by the trampoline (without

--- a/guest/arcbox-agent/src/mount.rs
+++ b/guest/arcbox-agent/src/mount.rs
@@ -3,7 +3,9 @@
 //! This module is only functional on Linux as it runs inside the guest VM.
 
 use anyhow::Result;
-use arcbox_constants::virtiofs::{MOUNT_ARCBOX, MOUNT_USERS, TAG_ARCBOX, TAG_USERS};
+use arcbox_constants::virtiofs::{
+    MOUNT_ARCBOX, MOUNT_PRIVATE, MOUNT_USERS, TAG_ARCBOX, TAG_PRIVATE, TAG_USERS,
+};
 
 /// Mount a filesystem.
 #[cfg(target_os = "linux")]
@@ -110,6 +112,17 @@ pub fn mount_standard_shares() {
         tracing::warn!("Failed to mount arcbox share: {}", e);
     } else {
         tracing::info!("Mounted arcbox share at {} (cache=always)", MOUNT_ARCBOX);
+    }
+
+    // Mount /private share for macOS symlink targets (/tmp → /private/tmp, etc.).
+    // The Docker API proxy rewrites bind-mount paths so they resolve here
+    // instead of hitting the guest's isolated tmpfs.
+    if !is_mounted(MOUNT_PRIVATE) {
+        if let Err(e) = mount_virtiofs(TAG_PRIVATE, MOUNT_PRIVATE) {
+            tracing::debug!("Private share not available: {}", e);
+        } else {
+            tracing::info!("Mounted private share at {}", MOUNT_PRIVATE);
+        }
     }
 
     // Mount /Users share for transparent macOS path support.


### PR DESCRIPTION
## Summary

- Add a VirtioFS share for host `/private` (macOS-only) so the guest can access `/private/tmp`, `/private/var/folders`, etc. Guest `/tmp` and `/var` remain isolated tmpfs — no host pollution.
- Resolve top-level symlinks in Docker bind-mount source paths (`HostConfig.Binds`, `HostConfig.Mounts`) before forwarding to guest dockerd. Uses `readlink` on the first path component rather than a hardcoded prefix list, so it handles any macOS system symlink and is a no-op on Linux.

Fixes `docker run -v /tmp/foo:/app` and `-v /var/folders/...:/app` which previously silently mounted empty directories.

## Test plan

- [ ] `cargo clippy --all-targets` and `cargo test` pass
- [ ] Boot VM — `mount | grep virtiofs` in guest shows `private on /private type virtiofs`
- [ ] Guest `/tmp` is still tmpfs (`mount | grep /tmp` shows tmpfs)
- [ ] `docker run --rm -v /tmp/test-arcbox:/mnt alpine ls /mnt` sees host files
- [ ] `docker run --rm -v /private/tmp/test-arcbox:/mnt alpine ls /mnt` same
- [ ] `docker run --rm -v /Users/...:/mnt alpine ls /mnt` still works (no regression)