### PR TITLE
refactor(net): rename SmoltcpDevice → FrameClassifier

### DIFF
--- a/.agents/skills/e2e-testing.md
+++ b/.agents/skills/e2e-testing.md
@@ -76,7 +76,7 @@ make run-daemon
 ```
 INFO  Creating VMM: vcpus=4, memory=4096MB
 INFO  Added bridge NIC (VZNATNetworkDeviceAttachment) for L3 routing
-INFO  Network datapath started (smoltcp + socket proxy mode)
+INFO  Network datapath started (TCP shim + socket proxy mode)
 INFO  VMM started
 INFO  Learned guest MAC: xx:xx:xx:xx:xx:xx
 INFO  DHCP lease acquired  interface="eth0"
@@ -140,7 +140,7 @@ Two NICs on the VM:
 |-------|-------|-----|
 | Listener not bound | `lsof -i :8080` | Check `setup_port_forwarding` in container handler |
 | Wrong port connected | Log: RST-ACK (flags=0x14) | Confirm `initiate_inbound` uses host_port |
-| SYN not reaching guest | No TCP frame in log | Check smoltcp device tx_pending |
+| SYN not reaching guest | No TCP frame in log | Check classifier `take_gated_syns` and TcpBridge handshake path |
 
 ### Code changes not taking effect
 

--- a/common/arcbox-logging/src/lib.rs
+++ b/common/arcbox-logging/src/lib.rs
@@ -68,8 +68,8 @@ impl LogGuard {
 ///
 /// Panics if the log directory cannot be created.
 pub fn init(config: LogConfig) -> LogGuard {
-    // Bridge `log` crate → tracing so libraries using `log` (e.g. smoltcp)
-    // have their output captured by the tracing subscriber.
+    // Bridge `log` crate → tracing so third-party dependencies emitting via
+    // `log` have their output captured by the tracing subscriber.
     std::fs::create_dir_all(&config.log_dir).expect("failed to create log directory");
 
     let rotating_writer = SizeRotatingWriter::new(

--- a/guest/arcbox-agent/src/init.rs
+++ b/guest/arcbox-agent/src/init.rs
@@ -555,7 +555,7 @@ exit 0
     /// Install iptables FORWARD rules for sandbox networking.
     ///
     /// Each sandbox has a point-to-point TAP — no bridge or MASQUERADE needed.
-    /// The host-side smoltcp TcpBridge/SocketProxy terminates connections and
+    /// The host-side TcpBridge / SocketProxy terminates connections and
     /// creates new host sockets, so the original sandbox src IP is irrelevant
     /// for reply routing.
     ///

--- a/virt/arcbox-net-inject/src/inject.rs
+++ b/virt/arcbox-net-inject/src/inject.rs
@@ -1,7 +1,8 @@
 //! Dedicated OS thread for RX frame injection.
 //!
 //! Supports two input paths:
-//!   1. **Channel frames** (`rx`): pre-constructed Ethernet frames from smoltcp/DHCP/DNS.
+//!   1. **Channel frames** (`rx`): pre-constructed Ethernet frames from the
+//!      classifier / DHCP / DNS / ARP / handshake synthesizer.
 //!   2. **Inline connections** (`conn_rx`): promoted fast-path TCP sockets that
 //!      read directly into guest descriptor buffers (zero intermediate copies).
 
@@ -106,7 +107,7 @@ impl RxInjectThread {
                 self.poll_inline_conns(&mut inline_conns, &mut used_idx, &mut batch);
             }
 
-            // Phase 3: Drain channel frames (smoltcp/DHCP/DNS).
+            // Phase 3: Drain channel frames (classifier / DHCP / DNS / ARP).
             // Use the remaining coalescing timeout after inline polling.
             let elapsed = loop_start.elapsed();
             let remaining = COALESCE_TIMEOUT.saturating_sub(elapsed);

--- a/virt/arcbox-net/src/darwin/classifier.rs
+++ b/virt/arcbox-net/src/darwin/classifier.rs
@@ -8,9 +8,9 @@
 //! - **DHCP** (UDP:67), **DNS** (UDP:53 to gateway), **UDP**, **ICMP** →
 //!   stored in the `intercepted` queue for the datapath loop
 //!
-//! There is no userspace TCP state machine here and no smoltcp dependency.
-//! The struct is still named `SmoltcpDevice` for now to limit downstream
-//! churn; a follow-up rename will drop the legacy prefix.
+//! There is no userspace TCP state machine here. Connections are driven by
+//! [`TcpBridge`](super::tcp_bridge) and the in-kernel guest stack; this
+//! module is purely a demultiplexer.
 
 use std::collections::VecDeque;
 use std::io;
@@ -41,9 +41,9 @@ const PROTO_UDP: u8 = 17;
 
 /// TCP SYN connection info extracted during frame classification.
 ///
-/// SYN frames are held back from smoltcp (`gated_syns`) until the host
-/// connect completes. The full frame is stored so it can be injected
-/// into the rx_queue later.
+/// SYN frames are held back (`gated_syns`) until the host connect
+/// completes. The full frame is stored so it can be injected into
+/// the rx_queue later.
 #[derive(Debug, Clone)]
 pub struct TcpSynInfo {
     pub dst_port: u16,
@@ -54,7 +54,7 @@ pub struct TcpSynInfo {
     pub frame: Vec<u8>,
 }
 
-/// An intercepted frame from the guest that should not go through smoltcp.
+/// An intercepted frame from the guest destined for a non-TCP handler.
 #[derive(Debug)]
 pub struct InterceptedFrame {
     pub frame: FrameBuf,
@@ -78,7 +78,7 @@ pub enum InterceptedKind {
 ///
 /// Reads Ethernet frames, responds to ARP inline, and routes TCP / UDP /
 /// ICMP into the appropriate queues for downstream handlers.
-pub struct SmoltcpDevice {
+pub struct FrameClassifier {
     /// Raw FD of the host end of the socketpair.
     fd: RawFd,
     /// Gateway IP for DNS interception.
@@ -88,7 +88,7 @@ pub struct SmoltcpDevice {
     /// TCP frames queued for downstream drains (fast-path intercept,
     /// handshake completion). Frames not matched by either drain are
     /// silently dropped on the next classifier iteration — there is no
-    /// generic TCP stack to consume them.
+    /// userspace TCP stack to consume them.
     rx_queue: VecDeque<FrameBuf>,
     /// Frames intercepted from the guest (DHCP, DNS, UDP, ICMP).
     intercepted: Vec<InterceptedFrame>,
@@ -109,7 +109,7 @@ pub struct SmoltcpDevice {
     mtu: usize,
 }
 
-impl SmoltcpDevice {
+impl FrameClassifier {
     /// Pool capacity: 4096 buffers. Each buffer is `MAX_PACKET_SIZE` (64 KiB)
     /// in the pool, so total resident = ~256 MiB. This is acceptable because:
     /// - One pool per VM (not per connection)
@@ -164,10 +164,10 @@ impl SmoltcpDevice {
         self.rx_queue.clear();
     }
 
-    /// Drains all available frames from the guest FD, classifying each as
-    /// either a smoltcp frame (ARP/TCP) or an intercepted frame.
+    /// Drains all available frames from the guest FD, classifying each
+    /// into its downstream queue (ARP reply / TCP rx_queue / intercepted).
     ///
-    /// Must be called before `iface.poll()` to feed smoltcp with new data.
+    /// Must be called at the top of each datapath loop tick.
     /// Also learns the guest MAC address from frame source addresses.
     pub fn drain_guest_fd(&mut self, guest_mac: &mut Option<[u8; 6]>) {
         loop {
@@ -198,14 +198,14 @@ impl SmoltcpDevice {
         std::mem::take(&mut self.gated_syns)
     }
 
-    /// Filters fast-path TCP data frames from `rx_queue` before smoltcp sees them.
+    /// Filters fast-path TCP data frames from `rx_queue`.
     ///
     /// For each frame in `rx_queue`, calls `try_intercept` with a reference to
     /// the frame data. If the callback returns `Some(ack_frame)`, the frame is
     /// removed from the queue and the ACK is collected for injection to the guest.
     ///
     /// Frames that are not intercepted (callback returns `None`) remain in the
-    /// queue for smoltcp to process normally.
+    /// queue for the handshake drain or eventual drop by `clear_unmatched_rx`.
     pub fn drain_fast_path(
         &mut self,
         mut try_intercept: impl FnMut(&[u8]) -> Option<Vec<u8>>,
@@ -231,7 +231,7 @@ impl SmoltcpDevice {
         ack_frames
     }
 
-    /// Filters handshake-completion frames from `rx_queue` before smoltcp sees them.
+    /// Filters handshake-completion frames from `rx_queue`.
     ///
     /// Parallel to [`drain_fast_path`] but for frames that complete an
     /// in-progress shim handshake (guest ACK → PassiveOpen completion, or
@@ -536,7 +536,7 @@ mod tests {
     #[test]
     fn classify_arp_generates_reply() {
         let gateway_ip = Ipv4Addr::new(192, 168, 64, 1);
-        let mut device = SmoltcpDevice::new(0, gateway_ip, DEFAULT_ETHERNET_MTU);
+        let mut device = FrameClassifier::new(0, gateway_ip, DEFAULT_ETHERNET_MTU);
         device.set_gateway_mac([0x02, 0xAA, 0xBB, 0xCC, 0xDD, 0x01]);
         let mut guest_mac = None;
 
@@ -553,7 +553,7 @@ mod tests {
     #[test]
     fn classify_tcp_goes_to_rx_queue() {
         let gateway_ip = Ipv4Addr::new(192, 168, 64, 1);
-        let mut device = SmoltcpDevice::new(0, gateway_ip, DEFAULT_ETHERNET_MTU);
+        let mut device = FrameClassifier::new(0, gateway_ip, DEFAULT_ETHERNET_MTU);
         let mut guest_mac = None;
 
         device.classify_frame(FrameBuf::from(make_tcp_frame()), &mut guest_mac);
@@ -565,7 +565,7 @@ mod tests {
     #[test]
     fn classify_dhcp_intercepted() {
         let gateway_ip = Ipv4Addr::new(192, 168, 64, 1);
-        let mut device = SmoltcpDevice::new(0, gateway_ip, DEFAULT_ETHERNET_MTU);
+        let mut device = FrameClassifier::new(0, gateway_ip, DEFAULT_ETHERNET_MTU);
         let mut guest_mac = None;
 
         device.classify_frame(
@@ -581,7 +581,7 @@ mod tests {
     #[test]
     fn classify_dns_to_gateway_intercepted() {
         let gateway_ip = Ipv4Addr::new(192, 168, 64, 1);
-        let mut device = SmoltcpDevice::new(0, gateway_ip, DEFAULT_ETHERNET_MTU);
+        let mut device = FrameClassifier::new(0, gateway_ip, DEFAULT_ETHERNET_MTU);
         let mut guest_mac = None;
 
         device.classify_frame(
@@ -597,7 +597,7 @@ mod tests {
     #[test]
     fn classify_dns_to_external_is_udp() {
         let gateway_ip = Ipv4Addr::new(192, 168, 64, 1);
-        let mut device = SmoltcpDevice::new(0, gateway_ip, DEFAULT_ETHERNET_MTU);
+        let mut device = FrameClassifier::new(0, gateway_ip, DEFAULT_ETHERNET_MTU);
         let mut guest_mac = None;
 
         // DNS to 8.8.8.8 is regular UDP, not intercepted as DNS.
@@ -614,7 +614,7 @@ mod tests {
     #[test]
     fn classify_icmp_intercepted() {
         let gateway_ip = Ipv4Addr::new(192, 168, 64, 1);
-        let mut device = SmoltcpDevice::new(0, gateway_ip, DEFAULT_ETHERNET_MTU);
+        let mut device = FrameClassifier::new(0, gateway_ip, DEFAULT_ETHERNET_MTU);
         let mut guest_mac = None;
 
         device.classify_frame(FrameBuf::from(make_icmp_frame()), &mut guest_mac);
@@ -627,7 +627,7 @@ mod tests {
     #[test]
     fn classify_regular_udp_intercepted() {
         let gateway_ip = Ipv4Addr::new(192, 168, 64, 1);
-        let mut device = SmoltcpDevice::new(0, gateway_ip, DEFAULT_ETHERNET_MTU);
+        let mut device = FrameClassifier::new(0, gateway_ip, DEFAULT_ETHERNET_MTU);
         let mut guest_mac = None;
 
         device.classify_frame(
@@ -647,7 +647,8 @@ mod tests {
         set_nonblocking(host_fd.as_raw_fd());
 
         let gateway_ip = Ipv4Addr::new(192, 168, 64, 1);
-        let mut device = SmoltcpDevice::new(host_fd.as_raw_fd(), gateway_ip, DEFAULT_ETHERNET_MTU);
+        let mut device =
+            FrameClassifier::new(host_fd.as_raw_fd(), gateway_ip, DEFAULT_ETHERNET_MTU);
         device.set_gateway_mac([0x02, 0xAA, 0xBB, 0xCC, 0xDD, 0x01]);
         let mut guest_mac = None;
 
@@ -684,7 +685,7 @@ mod tests {
     #[test]
     fn classify_tcp_syn_is_gated() {
         let gateway_ip = Ipv4Addr::new(192, 168, 64, 1);
-        let mut device = SmoltcpDevice::new(0, gateway_ip, DEFAULT_ETHERNET_MTU);
+        let mut device = FrameClassifier::new(0, gateway_ip, DEFAULT_ETHERNET_MTU);
         let mut guest_mac = None;
 
         // Build a TCP SYN frame (flags = 0x02).
@@ -712,7 +713,7 @@ mod tests {
     #[test]
     fn classify_tcp_non_syn_goes_to_rx_queue() {
         let gateway_ip = Ipv4Addr::new(192, 168, 64, 1);
-        let mut device = SmoltcpDevice::new(0, gateway_ip, DEFAULT_ETHERNET_MTU);
+        let mut device = FrameClassifier::new(0, gateway_ip, DEFAULT_ETHERNET_MTU);
         let mut guest_mac = None;
 
         // Build a TCP ACK frame (flags = 0x10).

--- a/virt/arcbox-net/src/darwin/datapath_loop.rs
+++ b/virt/arcbox-net/src/darwin/datapath_loop.rs
@@ -7,7 +7,7 @@
 //!     ↕ VirtIO (VZ framework)
 //! VZFileHandleNetworkDeviceAttachment
 //!     ↕ socketpair FD (L2 Ethernet frames)
-//! SmoltcpDevice (frame classification only)
+//! FrameClassifier (demultiplexes by protocol)
 //!     ├─ ARP            → ArpResponder
 //!     ├─ TCP SYN        → TcpBridge::handle_outbound_syn
 //!     ├─ TCP (live)     → TcpBridge fast path / handshake-complete
@@ -31,8 +31,8 @@ use tokio::io::unix::AsyncFd;
 use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
 
+use crate::darwin::classifier::{FrameClassifier, InterceptedKind};
 use crate::darwin::inbound_relay::InboundCommand;
-use crate::darwin::smoltcp_device::{InterceptedKind, SmoltcpDevice};
 use crate::darwin::socket_proxy::SocketProxy;
 use crate::darwin::tcp_bridge::TcpBridge;
 use crate::datapath::FrameBuf;
@@ -54,10 +54,12 @@ impl AsRawFd for FdWrapper {
     }
 }
 
-/// Async network datapath bridging guest ↔ host through smoltcp + socket proxying.
+/// Async network datapath bridging guest ↔ host via `FrameClassifier`
+/// demultiplexing and socket proxying.
 ///
-/// smoltcp handles ARP and TCP (Phase 2). DHCP, DNS, UDP, and ICMP are
-/// intercepted before reaching smoltcp and handled by existing proxy modules.
+/// `FrameClassifier` routes ARP (inline reply) and TCP (fast-path /
+/// handshake drains). DHCP, DNS, UDP, and ICMP are intercepted and handled
+/// by the corresponding proxy modules.
 pub struct NetworkDatapath {
     /// Host end of the socketpair (guest L2 Ethernet frames).
     pub guest_fd: OwnedFd,
@@ -77,7 +79,7 @@ pub struct NetworkDatapath {
     pub gateway_mac: [u8; 6],
     /// Gateway IP address.
     pub gateway_ip: Ipv4Addr,
-    /// Guest IP address (for inbound TCP connections via smoltcp).
+    /// Guest IP address (for inbound TCP connections).
     pub guest_ip: Ipv4Addr,
     /// Cancellation token for graceful shutdown.
     pub cancel: CancellationToken,
@@ -177,7 +179,7 @@ impl NetworkDatapath {
         set_nonblocking(guest_fd.as_raw_fd())?;
 
         // Create the frame classifier wrapping the guest socketpair FD.
-        let mut device = SmoltcpDevice::new(guest_fd.as_raw_fd(), gateway_ip, mtu);
+        let mut device = FrameClassifier::new(guest_fd.as_raw_fd(), gateway_ip, mtu);
         device.set_gateway_mac(gateway_mac);
 
         // TCP shim: handshake synthesizer + fast-path data plane.
@@ -284,8 +286,7 @@ impl NetworkDatapath {
                     }
 
                     // Fast-path intercept: extract TCP data frames for established
-                    // fast-path connections BEFORE smoltcp sees them. This avoids
-                    // smoltcp's per-segment TCP state machine overhead.
+                    // fast-path connections and synthesize ACKs inline.
                     let fast_acks = device.drain_fast_path(|frame_data| {
                         tcp_bridge.try_fast_path_intercept(frame_data)
                     });
@@ -335,9 +336,8 @@ impl NetworkDatapath {
                     }
 
                     // New outbound SYNs: route to the hand-rolled handshake
-                    // synthesizer. No more smoltcp listen sockets / gate_syns
-                    // pipeline — the shim owns this path end-to-end and will
-                    // emit the SYN-ACK via poll_handshakes once the async
+                    // synthesizer. The shim owns this path end-to-end and
+                    // emits the SYN-ACK via poll_handshakes once the async
                     // host connect resolves.
                     let gated_syns = device.take_gated_syns();
                     let gmac = guest_mac.unwrap_or([0xFF; 6]);
@@ -454,7 +454,7 @@ impl NetworkDatapath {
 /// Dispatches an intercepted frame to the appropriate handler.
 #[allow(clippy::too_many_arguments)]
 fn handle_intercepted_frame(
-    intercepted: &crate::darwin::smoltcp_device::InterceptedFrame,
+    intercepted: &crate::darwin::classifier::InterceptedFrame,
     frame_sink: Option<&std::sync::Arc<dyn crate::direct_rx::FrameSink>>,
     guest_async: &AsyncFd<FdWrapper>,
     write_queue: &mut VecDeque<FrameBuf>,

--- a/virt/arcbox-net/src/darwin/inbound_relay.rs
+++ b/virt/arcbox-net/src/darwin/inbound_relay.rs
@@ -177,7 +177,7 @@ impl InboundRelay {
         let l4_start = ip_start + ihl;
 
         match protocol {
-            6 => false, // TCP is now handled by smoltcp
+            6 => false, // TCP is handled by TcpBridge, not the inbound relay
             17 => self.try_handle_udp_reply(frame, ip_start, l4_start),
             _ => false,
         }

--- a/virt/arcbox-net/src/darwin/mod.rs
+++ b/virt/arcbox-net/src/darwin/mod.rs
@@ -39,13 +39,13 @@
 //! vmnet.write_packet(&buf[..n])?;
 //! ```
 
+pub mod classifier;
 pub mod datapath_loop;
 pub mod dns_log;
 pub mod inbound_relay;
 pub mod nat;
 pub mod proxy_detect;
 pub mod proxy_tunnel;
-pub mod smoltcp_device;
 pub mod socket_proxy;
 pub mod tcp_bridge;
 pub mod tso_backend;

--- a/virt/arcbox-net/src/darwin/tcp_bridge.rs
+++ b/virt/arcbox-net/src/darwin/tcp_bridge.rs
@@ -104,11 +104,10 @@ enum HandshakeRole {
 /// In-progress TCP handshake — tracked until the 3-way is complete, at
 /// which point the connection is promoted to `FastPathConn`.
 ///
-/// Unlike smoltcp's socket, this struct holds only the fields the shim
-/// actually needs: the flow key, peer options to mirror/record, the ISNs
-/// on both sides, and retransmit bookkeeping. No send/recv buffers, no
-/// sliding window state, no congestion control — those are the host and
-/// guest kernels' responsibility.
+/// The struct holds only the fields the shim actually needs: the flow key,
+/// peer options to mirror/record, the ISNs on both sides, and retransmit
+/// bookkeeping. No send/recv buffers, no sliding window state, no
+/// congestion control — those are the host and guest kernels' responsibility.
 #[allow(dead_code)] // `flow_key` mirrors the HashMap key; `peer_mss` reserved for frame sizing
 struct HandshakeConn {
     flow_key: SynFlowKey,
@@ -256,9 +255,9 @@ impl TcpBridge {
 
     /// Checks if a TCP frame matches a fast-path connection.
     ///
-    /// Called from `classify_ipv4` before the frame reaches smoltcp.
-    /// Returns `Some(ack_frame)` if the frame was handled (payload written
-    /// to host stream, ACK generated), or `None` if not a fast-path match.
+    /// Called from the classifier's `drain_fast_path`. Returns
+    /// `Some(ack_frame)` if the frame was handled (payload written to
+    /// host stream, ACK generated), or `None` if not a fast-path match.
     pub fn try_fast_path_intercept(&mut self, frame: &[u8]) -> Option<Vec<u8>> {
         if frame.len() < ETH_HEADER_LEN + 40 {
             return None; // Too short for ETH + IP + TCP minimum
@@ -543,9 +542,9 @@ impl TcpBridge {
 
     /// Promotes a connection to the fast path.
     ///
-    /// Called when a smoltcp connection reaches ESTABLISHED and has a
-    /// pre-connected host stream. The connection is removed from smoltcp
-    /// and data transfer bypasses the TCP state machine entirely.
+    /// Called when a shim handshake reaches ESTABLISHED and has a
+    /// pre-connected host stream. The connection is moved into
+    /// `fast_path_conns` and subsequent data bypasses handshake bookkeeping.
     pub fn promote_to_fast_path(
         &mut self,
         key: SynFlowKey,

--- a/virt/arcbox-net/src/darwin/tso_backend.rs
+++ b/virt/arcbox-net/src/darwin/tso_backend.rs
@@ -4,12 +4,12 @@
 //!
 //! - **TSO fast path**: when the guest emits a packet with `gso_type != NONE`,
 //!   the TCP payload is extracted and written directly to a host `TcpStream`.
-//!   No smoltcp, no L2 framing — just payload relay. This is the path that
-//!   enables 50 Gbps port forwarding.
+//!   No classifier, no L2 framing — just payload relay. This is the path
+//!   that enables 50 Gbps port forwarding.
 //!
 //! - **Slow path**: normal (non-TSO) packets — ARP, DHCP, DNS, UDP, small
-//!   TCP — are forwarded to the existing smoltcp-based `NetworkDatapath` via
-//!   a channel, preserving full protocol compatibility.
+//!   TCP — are forwarded to the existing `NetworkDatapath` via a channel,
+//!   preserving full protocol compatibility.
 //!
 //! # TSO TX Flow (Guest → Host)
 //!
@@ -20,7 +20,7 @@
 //!   → TsoNetBackend extracts (src_ip, src_port, dst_ip, dst_port)
 //!   → Looks up or creates host TcpStream for this flow
 //!   → Writes entire payload to TcpStream in one call
-//!   → No smoltcp, no NAT, no framing overhead
+//!   → No classifier, no NAT, no framing overhead
 //! ```
 //!
 //! # TSO RX Flow (Host → Guest)
@@ -70,14 +70,14 @@ struct HostTcpConn {
 /// TSO-aware network backend.
 ///
 /// Maintains a map of guest TCP flows to host `TcpStream` connections.
-/// TSO packets bypass smoltcp entirely; non-TSO packets are forwarded
-/// to the slow path channel.
+/// TSO packets bypass the classifier entirely; non-TSO packets are
+/// forwarded to the slow path channel.
 pub struct TsoNetBackend {
     /// Active TCP connections keyed by guest-side flow.
     connections: HashMap<TcpFlowKey, HostTcpConn>,
-    /// Channel to forward non-TSO packets to the smoltcp datapath.
+    /// Channel to forward non-TSO packets to the classifier datapath.
     slow_path_tx: tokio::sync::mpsc::Sender<Vec<u8>>,
-    /// Channel to receive packets from the smoltcp datapath (RX path).
+    /// Channel to receive packets from the classifier datapath (RX path).
     slow_path_rx: std::sync::Mutex<tokio::sync::mpsc::Receiver<Vec<u8>>>,
     /// Packets ready for guest injection.
     rx_pending: std::collections::VecDeque<Vec<u8>>,
@@ -86,8 +86,8 @@ pub struct TsoNetBackend {
 impl TsoNetBackend {
     /// Creates a new TSO backend.
     ///
-    /// - `slow_path_tx`: sends non-TSO frames to the smoltcp datapath.
-    /// - `slow_path_rx`: receives frames from the smoltcp datapath for
+    /// - `slow_path_tx`: sends non-TSO frames to the classifier datapath.
+    /// - `slow_path_rx`: receives frames from the classifier datapath for
     ///   injection into the guest.
     pub fn new(
         slow_path_tx: tokio::sync::mpsc::Sender<Vec<u8>>,
@@ -227,7 +227,7 @@ impl TsoNetBackend {
 
 impl NetBackend for TsoNetBackend {
     fn send(&mut self, packet: &NetPacket) -> io::Result<usize> {
-        // Non-TSO packet: forward to smoltcp datapath via channel.
+        // Non-TSO packet: forward to classifier datapath via channel.
         let frame = packet.data.clone();
         self.slow_path_tx.try_send(frame).map_err(|e| {
             io::Error::new(

--- a/virt/arcbox-net/src/datapath/frame_buf.rs
+++ b/virt/arcbox-net/src/datapath/frame_buf.rs
@@ -4,10 +4,10 @@
 //! `Vec<u8>` on the hot path with a pool-backed allocation that avoids the
 //! system allocator entirely (O(1) atomic CAS vs ~50-100 ns malloc).
 //!
-//! Code that produces frames from external sources (smoltcp TX, DNS replies,
-//! ARP construction) can still use `FrameBuf::from(vec)` to wrap an existing
-//! `Vec<u8>` without copying. The datapath treats both variants uniformly
-//! via `Deref<Target = [u8]>`.
+//! Code that produces frames from external sources (handshake synthesizer,
+//! DNS replies, ARP construction) can still use `FrameBuf::from(vec)` to
+//! wrap an existing `Vec<u8>` without copying. The datapath treats both
+//! variants uniformly via `Deref<Target = [u8]>`.
 
 use std::ops::Deref;
 use std::sync::Arc;
@@ -19,7 +19,8 @@ use super::pool::PacketPool;
 /// - `Pooled`: data lives in a pre-allocated [`PacketPool`] slot. On drop,
 ///   the slot is returned to the pool (lock-free). This is the fast path.
 /// - `Heap`: data lives in a regular `Vec<u8>`. Used for frames that
-///   originate outside the pool (smoltcp TX, manually constructed frames).
+///   originate outside the pool (handshake replies, manually constructed
+///   frames).
 pub enum FrameBuf {
     /// Pool-backed frame. Automatically freed on drop.
     Pooled {

--- a/virt/arcbox-net/src/ethernet.rs
+++ b/virt/arcbox-net/src/ethernet.rs
@@ -338,8 +338,8 @@ pub struct TcpFrameParams {
 
 /// Builds a TCP ACK frame (no payload) to acknowledge data from the guest.
 ///
-/// Used by the TCP fast path to ACK guest data segments without going
-/// through smoltcp's TCP state machine.
+/// Used by the TCP fast path to ACK guest data segments using the
+/// hand-rolled TCP state machine in `TcpBridge`.
 #[must_use]
 pub fn build_tcp_ack_frame(p: &TcpFrameParams) -> Vec<u8> {
     let TcpFrameParams {
@@ -394,7 +394,7 @@ pub fn build_tcp_ack_frame(p: &TcpFrameParams) -> Vec<u8> {
 /// Builds a TCP data frame carrying payload from the host to the guest.
 ///
 /// Used by the TCP fast path to inject host TcpStream data into the guest
-/// without going through smoltcp's TCP state machine.
+/// via `TcpBridge`'s hand-rolled TCP state machine.
 #[must_use]
 pub fn build_tcp_data_frame(p: &TcpFrameParams, payload: &[u8]) -> Vec<u8> {
     let TcpFrameParams {

--- a/virt/arcbox-net/tests/datapath_test.rs
+++ b/virt/arcbox-net/tests/datapath_test.rs
@@ -168,19 +168,19 @@ async fn test_dhcp_full_cycle() {
 }
 
 // ---------------------------------------------------------------------------
-// Frame classification tests (via SmoltcpDevice directly)
+// Frame classification tests (via FrameClassifier directly)
 // ---------------------------------------------------------------------------
 
-/// Verifies that an ARP request injected through the socketpair is classified
-/// into the smoltcp rx_queue (not intercepted).
+/// Verifies that an ARP request injected through the socketpair is handled
+/// inline by the classifier (reply produced, not left in the rx queue).
 #[tokio::test]
 async fn test_frame_classification_arp() {
-    use arcbox_net::darwin::smoltcp_device::SmoltcpDevice;
+    use arcbox_net::darwin::classifier::FrameClassifier;
 
     let (host_fd, guest_fd) = mock_guest_nic();
     set_nonblocking(host_fd.as_raw_fd());
 
-    let mut device = SmoltcpDevice::new(host_fd.as_raw_fd(), GATEWAY_IP, 1500);
+    let mut device = FrameClassifier::new(host_fd.as_raw_fd(), GATEWAY_IP, 1500);
     let mut guest_mac = None;
 
     // Write an ARP request from the guest side.
@@ -189,7 +189,7 @@ async fn test_frame_classification_arp() {
 
     device.drain_guest_fd(&mut guest_mac);
 
-    // ARP should be in the smoltcp rx_queue, not intercepted.
+    // ARP is handled inline — not queued as an intercepted frame.
     let intercepted = device.take_intercepted();
     assert!(intercepted.is_empty(), "ARP should not be intercepted");
     assert_eq!(
@@ -203,12 +203,12 @@ async fn test_frame_classification_arp() {
 /// (held back for host connect).
 #[tokio::test]
 async fn test_frame_classification_tcp_syn() {
-    use arcbox_net::darwin::smoltcp_device::SmoltcpDevice;
+    use arcbox_net::darwin::classifier::FrameClassifier;
 
     let (host_fd, guest_fd) = mock_guest_nic();
     set_nonblocking(host_fd.as_raw_fd());
 
-    let mut device = SmoltcpDevice::new(host_fd.as_raw_fd(), GATEWAY_IP, 1500);
+    let mut device = FrameClassifier::new(host_fd.as_raw_fd(), GATEWAY_IP, 1500);
     let mut guest_mac = None;
 
     let syn = build_tcp_syn(
@@ -233,12 +233,12 @@ async fn test_frame_classification_tcp_syn() {
 /// Verifies that ICMP frames are classified as intercepted.
 #[tokio::test]
 async fn test_frame_classification_icmp() {
-    use arcbox_net::darwin::smoltcp_device::{InterceptedKind, SmoltcpDevice};
+    use arcbox_net::darwin::classifier::{FrameClassifier, InterceptedKind};
 
     let (host_fd, guest_fd) = mock_guest_nic();
     set_nonblocking(host_fd.as_raw_fd());
 
-    let mut device = SmoltcpDevice::new(host_fd.as_raw_fd(), GATEWAY_IP, 1500);
+    let mut device = FrameClassifier::new(host_fd.as_raw_fd(), GATEWAY_IP, 1500);
     let mut guest_mac = None;
 
     let icmp = build_icmp_echo(
@@ -262,12 +262,12 @@ async fn test_frame_classification_icmp() {
 /// with kind `Dhcp`.
 #[tokio::test]
 async fn test_frame_classification_dhcp() {
-    use arcbox_net::darwin::smoltcp_device::{InterceptedKind, SmoltcpDevice};
+    use arcbox_net::darwin::classifier::{FrameClassifier, InterceptedKind};
 
     let (host_fd, guest_fd) = mock_guest_nic();
     set_nonblocking(host_fd.as_raw_fd());
 
-    let mut device = SmoltcpDevice::new(host_fd.as_raw_fd(), GATEWAY_IP, 1500);
+    let mut device = FrameClassifier::new(host_fd.as_raw_fd(), GATEWAY_IP, 1500);
     let mut guest_mac = None;
 
     let discover = build_dhcp_discover(CLIENT_MAC, 0x1234);

--- a/virt/arcbox-net/tests/datapath_test.rs
+++ b/virt/arcbox-net/tests/datapath_test.rs
@@ -172,7 +172,8 @@ async fn test_dhcp_full_cycle() {
 // ---------------------------------------------------------------------------
 
 /// Verifies that an ARP request injected through the socketpair is handled
-/// inline by the classifier (reply produced, not left in the rx queue).
+/// inline by the classifier: an ARP reply is generated, the guest MAC is
+/// learned, and the frame is not queued for the slow intercept path.
 #[tokio::test]
 async fn test_frame_classification_arp() {
     use arcbox_net::darwin::classifier::FrameClassifier;
@@ -181,6 +182,9 @@ async fn test_frame_classification_arp() {
     set_nonblocking(host_fd.as_raw_fd());
 
     let mut device = FrameClassifier::new(host_fd.as_raw_fd(), GATEWAY_IP, 1500);
+    // Inline ARP responder needs the gateway MAC to synthesize a reply;
+    // without it the request is silently dropped.
+    device.set_gateway_mac(GATEWAY_MAC);
     let mut guest_mac = None;
 
     // Write an ARP request from the guest side.
@@ -196,6 +200,40 @@ async fn test_frame_classification_arp() {
         guest_mac,
         Some(CLIENT_MAC),
         "guest MAC should be learned from ARP"
+    );
+
+    // An ARP reply should have been generated for the gateway.
+    let replies = device.take_arp_replies();
+    assert_eq!(replies.len(), 1, "expected exactly one ARP reply");
+    let reply = &replies[0];
+    assert!(
+        reply.len() >= 42,
+        "ARP reply must be at least 42 bytes (Ethernet + ARP header), got {}",
+        reply.len()
+    );
+    // Ethernet dst: requester's MAC.
+    assert_eq!(
+        &reply[0..6],
+        &CLIENT_MAC,
+        "reply dst MAC should be the requester"
+    );
+    // Ethernet src: gateway's MAC.
+    assert_eq!(
+        &reply[6..12],
+        &GATEWAY_MAC,
+        "reply src MAC should be the gateway"
+    );
+    // EtherType: 0x0806 (ARP).
+    assert_eq!(
+        &reply[12..14],
+        &[0x08, 0x06],
+        "reply EtherType should be 0x0806"
+    );
+    // ARP opcode at offset 20..22: 2 (reply).
+    assert_eq!(
+        &reply[20..22],
+        &[0x00, 0x02],
+        "ARP opcode should be 2 (reply)"
     );
 }
 

--- a/virt/arcbox-net/tests/helpers/mock_nic.rs
+++ b/virt/arcbox-net/tests/helpers/mock_nic.rs
@@ -9,7 +9,7 @@ use std::os::fd::{FromRawFd, OwnedFd, RawFd};
 
 /// Creates a `SOCK_DGRAM` socketpair and returns `(host_fd, guest_fd)`.
 ///
-/// The host FD is passed into `NetworkDatapath` (or `SmoltcpDevice`).
+/// The host FD is passed into `NetworkDatapath` (or `FrameClassifier`).
 /// The guest FD is used by the test to write/read raw Ethernet frames.
 pub fn mock_guest_nic() -> (OwnedFd, OwnedFd) {
     let mut fds: [i32; 2] = [0; 2];

--- a/virt/arcbox-virtio-net/src/device.rs
+++ b/virt/arcbox-virtio-net/src/device.rs
@@ -640,7 +640,7 @@ impl VirtioNet {
             if packet_data.len() > VirtioNetHeader::SIZE {
                 let frame = &packet_data[VirtioNetHeader::SIZE..];
                 // Retry briefly on EAGAIN/ENOBUFS: the host-side socketpair
-                // peer (datapath / smoltcp) might be behind by a few frames
+                // peer (datapath classifier) might be behind by a few frames
                 // under bulk bursts (iperf3 -R and similar). Without this
                 // retry, guest TCP sees silent packet loss and retransmits,
                 // collapsing throughput to under 1 MB/s while the fast-path

--- a/virt/arcbox-vmm/src/vmm/darwin.rs
+++ b/virt/arcbox-vmm/src/vmm/darwin.rs
@@ -341,12 +341,12 @@ impl Vmm {
         // macOS 14+ Apple Silicon (P0) where VZ's setMaximumTransmissionUnit:
         // always succeeds. On macOS <14 the VZ setter is skipped via
         // respondsToSelector: (see arcbox-vz/device/network.rs), and the VZ
-        // device stays at 1500 while smoltcp gets 4000. This mismatch would
-        // cause frames >1500 to be dropped — acceptable since macOS <14 is not
-        // a supported target. If macOS <14 support is ever needed, plumb the
-        // actual MTU from NetworkDeviceConfiguration::mtu() through the
-        // hypervisor abstraction layer.
-        let net_mtu = arcbox_net::darwin::smoltcp_device::ENHANCED_ETHERNET_MTU;
+        // device stays at 1500 while the classifier gets 4000. This mismatch
+        // would cause frames >1500 to be dropped — acceptable since macOS <14
+        // is not a supported target. If macOS <14 support is ever needed,
+        // plumb the actual MTU from NetworkDeviceConfiguration::mtu() through
+        // the hypervisor abstraction layer.
+        let net_mtu = arcbox_net::darwin::classifier::ENHANCED_ETHERNET_MTU;
 
         let datapath = NetworkDatapath::new(
             host_fd,

--- a/virt/arcbox-vmm/src/vmm/darwin_hv/network.rs
+++ b/virt/arcbox-vmm/src/vmm/darwin_hv/network.rs
@@ -1,7 +1,7 @@
 //! Network datapath creation for the HV backend.
 //!
-//! Contains `create_hv_network_datapath` (primary NIC1 socketpair + smoltcp
-//! datapath) and `create_hv_bridge_nic` (NIC2 vmnet bridge). Both are
+//! Contains `create_hv_network_datapath` (primary NIC1 socketpair + frame
+//! classifier datapath) and `create_hv_bridge_nic` (NIC2 vmnet bridge). Both are
 //! `impl Vmm` methods that set up socketpairs, configure socket options,
 //! and spawn async tasks for frame forwarding.
 
@@ -162,7 +162,7 @@ impl Vmm {
         };
 
         // 5. Build and spawn the datapath.
-        let net_mtu = arcbox_net::darwin::smoltcp_device::ENHANCED_ETHERNET_MTU;
+        let net_mtu = arcbox_net::darwin::classifier::ENHANCED_ETHERNET_MTU;
         let mut datapath = NetworkDatapath::new(
             host_fd,
             socket_proxy,

--- a/virt/arcbox-vz/src/device/network.rs
+++ b/virt/arcbox-vz/src/device/network.rs
@@ -14,7 +14,7 @@ use std::os::unix::io::RawFd;
 /// We round to 4000 to stay safely under the threshold.
 ///
 /// This reduces frame count by ~2.7x vs the default 1500, directly reducing
-/// per-frame overhead through the entire smoltcp datapath.
+/// per-frame overhead through the entire datapath.
 /// The enhanced MTU value set on VZ network devices when the selector is
 /// available (macOS 14+). Exported so the VMM can pass it to the datapath.
 pub const VZ_NETWORK_MTU: u64 = 4000;


### PR DESCRIPTION
## Summary

smoltcp was removed in earlier commits (`06058a5`, `4237e0a`, `1fd1fe5`) but the struct and module name were kept as `SmoltcpDevice` / `smoltcp_device.rs` to minimize churn at removal time. The struct is purely a per-protocol frame demultiplexer now — it reads from the guest socketpair FD and routes frames to ARP / TCP-shim / DHCP / DNS / UDP / ICMP downstream queues. Nothing smoltcp-ish remains inside.

This PR is a pure rename + comment cleanup — zero behavior change.

## Changes

- `virt/arcbox-net/src/darwin/smoltcp_device.rs` → `classifier.rs`
- `SmoltcpDevice` → `FrameClassifier`
- Update `mod.rs` export and every call site (`datapath_loop.rs`, `darwin.rs`, `darwin_hv/network.rs`, integration tests)
- Scrub stale inline comments across `tcp_bridge.rs`, `tso_backend.rs`, `ethernet.rs`, `inbound_relay.rs`, `frame_buf.rs`, `net-inject/inject.rs`, `virtio-net/device.rs`, `vz/device/network.rs`, `arcbox-logging`, `arcbox-agent/init.rs`, and `.agents/skills/e2e-testing.md`

Intentionally left in place:
- `CHANGELOG.md` — historical release notes (auto-generated by release-please)
- `docs/virtio-improvements-plan.md` — historical plan doc
- `tcp_bridge.rs` module-level "Replaces the smoltcp-based implementation entirely" — valid historical context

## Test plan

- [x] `cargo fmt --all`
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — zero warnings
- [x] `cargo check --workspace --all-targets`
- [x] `cargo test -p arcbox-net` — 221 lib tests + 5 datapath integration tests pass (including `darwin::classifier::tests::*`)