### PR TITLE
feat(cli): fix `docker compose` by registering CLI plugins

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3782,6 +3782,7 @@ version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
+ "indexmap 2.13.0",
  "itoa",
  "memchr",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,7 +83,7 @@ anyhow = "1"
 
 # Serialization
 serde = { version = "1", features = ["derive"] }
-serde_json = "1"
+serde_json = { version = "1", features = ["preserve_order"] }
 
 # Logging
 tracing = "0.1"

--- a/app/arcbox-cli/src/commands/cli_plugins.rs
+++ b/app/arcbox-cli/src/commands/cli_plugins.rs
@@ -278,9 +278,13 @@ async fn update_extra_dirs(config_path: &Path, user_bin: &str, insert: bool) -> 
         let entry = obj
             .entry("cliPluginsExtraDirs")
             .or_insert_with(|| serde_json::Value::Array(Vec::new()));
-        let array = entry
-            .as_array_mut()
-            .context("cliPluginsExtraDirs is not an array")?;
+        let Some(array) = entry.as_array_mut() else {
+            // Pre-existing non-array value (string, number, …) is foreign
+            // state we did not create. Don't fail registration — the
+            // symlink-based discovery path is still in place, and the user
+            // is best served by leaving their oddly-shaped config alone.
+            return Ok(false);
+        };
         if array.iter().any(|v| v.as_str() == Some(user_bin)) {
             false
         } else {
@@ -677,5 +681,36 @@ mod tests {
         let auths = rewritten.find("auths").unwrap();
         let extra = rewritten.find("cliPluginsExtraDirs").unwrap();
         assert!(ctx < creds && creds < auths && auths < extra);
+    }
+
+    #[tokio::test]
+    async fn register_tolerates_non_array_extra_dirs() {
+        let tmp = tempdir().unwrap();
+        let user_bin = tmp.path().join("bin");
+        let docker_cfg = tmp.path().join("docker");
+        fs::create_dir_all(&user_bin).unwrap();
+        fs::create_dir_all(&docker_cfg).unwrap();
+        touch_exe(&user_bin, "docker-compose");
+
+        // Pre-existing config with cliPluginsExtraDirs as a string — foreign
+        // state we shouldn't blow up on.
+        fs::write(
+            docker_cfg.join("config.json"),
+            r#"{"cliPluginsExtraDirs":"/opt/plugins","auths":{"ghcr.io":{}}}"#,
+        )
+        .unwrap();
+
+        let outcome = register(&user_bin, &docker_cfg).await.unwrap();
+
+        // Symlink still gets created; only the config-side update is skipped.
+        assert_eq!(outcome.symlinks.len(), 1);
+        assert!(!outcome.config_updated);
+
+        // The original (foreign) value is preserved verbatim.
+        let cfg: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(docker_cfg.join("config.json")).unwrap())
+                .unwrap();
+        assert_eq!(cfg["cliPluginsExtraDirs"].as_str(), Some("/opt/plugins"));
+        assert!(cfg["auths"]["ghcr.io"].is_object());
     }
 }

--- a/app/arcbox-cli/src/commands/cli_plugins.rs
+++ b/app/arcbox-cli/src/commands/cli_plugins.rs
@@ -25,6 +25,9 @@
 //! correctly even when the user has switched to another Docker backend.
 //! This means `docker compose` keeps working after `abctl docker disable`
 //! — it just talks to whichever backend the user switched to.
+//!
+//! The Docker config directory is resolved via `DOCKER_CONFIG` (matching
+//! upstream `docker` CLI behaviour), falling back to `~/.docker`.
 
 use std::path::{Path, PathBuf};
 
@@ -52,8 +55,21 @@ pub struct RegistrationStatus {
     pub extra_dirs_entry_present: bool,
 }
 
-/// Resolves `~/.docker/` for the current user.
+/// Resolves the user's Docker config directory.
+///
+/// Honours the `DOCKER_CONFIG` environment variable (matching the
+/// upstream `docker` CLI). Falls back to `~/.docker` when the variable
+/// is unset or empty.
 pub fn default_docker_config_dir() -> Result<PathBuf> {
+    resolve_docker_config_dir(std::env::var_os("DOCKER_CONFIG"))
+}
+
+fn resolve_docker_config_dir(env_override: Option<std::ffi::OsString>) -> Result<PathBuf> {
+    if let Some(value) = env_override {
+        if !value.is_empty() {
+            return Ok(PathBuf::from(value));
+        }
+    }
     dirs::home_dir()
         .map(|h| h.join(".docker"))
         .context("could not determine home directory")
@@ -569,5 +585,18 @@ mod tests {
         let after = status(&user_bin, &docker_cfg).await;
         assert_eq!(after.symlinked.len(), 2);
         assert!(after.extra_dirs_entry_present);
+    }
+
+    #[test]
+    fn resolve_docker_config_dir_honors_env_override() {
+        let custom = PathBuf::from("/tmp/custom-docker");
+        let resolved = resolve_docker_config_dir(Some(custom.as_os_str().to_os_string())).unwrap();
+        assert_eq!(resolved, custom);
+    }
+
+    #[test]
+    fn resolve_docker_config_dir_ignores_empty_env() {
+        let resolved = resolve_docker_config_dir(Some(std::ffi::OsString::new())).unwrap();
+        assert!(resolved.ends_with(".docker"));
     }
 }

--- a/app/arcbox-cli/src/commands/cli_plugins.rs
+++ b/app/arcbox-cli/src/commands/cli_plugins.rs
@@ -132,7 +132,7 @@ pub async fn register(user_bin: &Path, docker_config_dir: &Path) -> Result<Outco
                     if existing == target {
                         continue;
                     }
-                    if !is_arcbox_bin_target(&existing, user_bin) {
+                    if !is_arcbox_bin_target(&existing, user_bin, &link) {
                         // Foreign symlink (e.g. Docker Desktop). Leave it
                         // alone — extraDirs below still makes ArcBox win at
                         // resolution time.
@@ -195,7 +195,7 @@ pub async fn unregister(user_bin: &Path, docker_config_dir: &Path) -> Result<Out
             let Ok(target) = tokio::fs::read_link(&link).await else {
                 continue;
             };
-            if !is_arcbox_bin_target(&target, user_bin) {
+            if !is_arcbox_bin_target(&target, user_bin, &link) {
                 continue;
             }
             if tokio::fs::remove_file(&link).await.is_ok() {
@@ -219,7 +219,7 @@ pub async fn status(user_bin: &Path, docker_config_dir: &Path) -> RegistrationSt
     for plugin in DOCKER_CLI_PLUGINS {
         let link = plugins_dir.join(plugin);
         if let Ok(target) = tokio::fs::read_link(&link).await {
-            if is_arcbox_bin_target(&target, user_bin) {
+            if is_arcbox_bin_target(&target, user_bin, &link) {
                 result.symlinked.push((*plugin).to_string());
             }
         }
@@ -242,9 +242,40 @@ pub async fn status(user_bin: &Path, docker_config_dir: &Path) -> RegistrationSt
     result
 }
 
-/// True if `target` is a path inside `user_bin` (i.e. a symlink ArcBox owns).
-fn is_arcbox_bin_target(target: &Path, user_bin: &Path) -> bool {
-    target.starts_with(user_bin)
+/// True if `target` (the value returned by `read_link(link)`) resolves to a
+/// path inside `user_bin` — i.e. a symlink ArcBox owns.
+///
+/// `read_link` may return a relative path; we resolve it against the
+/// symlink's parent directory before comparing, and lexically normalize
+/// both sides so `..`/`.` components don't trip the check. We don't
+/// canonicalize because canonicalize follows further symlinks (including
+/// the app-bundle symlinks under `user_bin`), which would yield a path
+/// outside `user_bin` and produce false negatives.
+fn is_arcbox_bin_target(target: &Path, user_bin: &Path, link: &Path) -> bool {
+    let resolved = if target.is_absolute() {
+        target.to_path_buf()
+    } else if let Some(parent) = link.parent() {
+        parent.join(target)
+    } else {
+        return false;
+    };
+    lexical_normalize(&resolved).starts_with(lexical_normalize(user_bin))
+}
+
+/// Lexical path normalization: collapses `.` and `..` components without
+/// touching the filesystem. Does not resolve symlinks.
+fn lexical_normalize(path: &Path) -> PathBuf {
+    let mut out = PathBuf::new();
+    for component in path.components() {
+        match component {
+            std::path::Component::ParentDir => {
+                out.pop();
+            }
+            std::path::Component::CurDir => {}
+            other => out.push(other.as_os_str()),
+        }
+    }
+    out
 }
 
 /// Reads `~/.docker/config.json`, adds or removes `user_bin` from the
@@ -712,5 +743,23 @@ mod tests {
                 .unwrap();
         assert_eq!(cfg["cliPluginsExtraDirs"].as_str(), Some("/opt/plugins"));
         assert!(cfg["auths"]["ghcr.io"].is_object());
+    }
+
+    #[test]
+    fn is_arcbox_bin_target_recognizes_relative_symlinks() {
+        let user_bin = PathBuf::from("/home/u/.arcbox/bin");
+        let link = PathBuf::from("/home/u/.docker/cli-plugins/docker-compose");
+
+        // Relative target that traverses up into ~/.arcbox/bin/.
+        let relative = PathBuf::from("../../.arcbox/bin/docker-compose");
+        assert!(is_arcbox_bin_target(&relative, &user_bin, &link));
+
+        // Foreign relative target — different parent.
+        let foreign = PathBuf::from("../../somewhere/else/docker-compose");
+        assert!(!is_arcbox_bin_target(&foreign, &user_bin, &link));
+
+        // Absolute target inside user_bin still works.
+        let absolute = user_bin.join("docker-compose");
+        assert!(is_arcbox_bin_target(&absolute, &user_bin, &link));
     }
 }

--- a/app/arcbox-cli/src/commands/cli_plugins.rs
+++ b/app/arcbox-cli/src/commands/cli_plugins.rs
@@ -313,10 +313,44 @@ async fn update_extra_dirs(config_path: &Path, user_bin: &str, insert: bool) -> 
     }
 
     let serialized = serde_json::to_string_pretty(&value)?;
-    tokio::fs::write(config_path, format!("{serialized}\n"))
-        .await
-        .with_context(|| format!("failed to write {}", config_path.display()))?;
+    atomic_write(config_path, format!("{serialized}\n").as_bytes()).await?;
     Ok(true)
+}
+
+/// Write `contents` to `path` atomically: write into a sibling temp file
+/// in the same directory, then `rename` over the destination.
+///
+/// `tokio::fs::write` opens with `O_TRUNC`, so a crash between truncate
+/// and write completion would leave the destination empty — catastrophic
+/// for files like `~/.docker/config.json` that hold the user's registry
+/// credentials.
+async fn atomic_write(path: &Path, contents: &[u8]) -> Result<()> {
+    let file_name = path
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or("arcbox-tmp");
+    // PID-scoped tmp name keeps concurrent processes from clobbering each
+    // other's in-flight writes. Same-directory tmp guarantees `rename` is
+    // atomic (same filesystem).
+    let tmp_name = format!(".{}.{}.tmp", file_name, std::process::id());
+    let tmp_path = path.with_file_name(tmp_name);
+
+    if let Err(e) = tokio::fs::write(&tmp_path, contents).await {
+        // Best-effort cleanup so a failed write doesn't leave a stale tmp.
+        tokio::fs::remove_file(&tmp_path).await.ok();
+        return Err(
+            anyhow::Error::from(e).context(format!("failed to write {}", tmp_path.display()))
+        );
+    }
+
+    tokio::fs::rename(&tmp_path, path).await.with_context(|| {
+        format!(
+            "failed to rename {} -> {}",
+            tmp_path.display(),
+            path.display()
+        )
+    })?;
+    Ok(())
 }
 
 #[cfg(test)]
@@ -598,5 +632,50 @@ mod tests {
     fn resolve_docker_config_dir_ignores_empty_env() {
         let resolved = resolve_docker_config_dir(Some(std::ffi::OsString::new())).unwrap();
         assert!(resolved.ends_with(".docker"));
+    }
+
+    #[tokio::test]
+    async fn atomic_write_leaves_no_tmp_files_on_success() {
+        let tmp = tempdir().unwrap();
+        let target = tmp.path().join("config.json");
+        atomic_write(&target, b"{}\n").await.unwrap();
+
+        assert_eq!(fs::read_to_string(&target).unwrap(), "{}\n");
+
+        // Nothing of the form `.config.json.<pid>.tmp` should remain.
+        let leftover = fs::read_dir(tmp.path())
+            .unwrap()
+            .filter_map(Result::ok)
+            .any(|e| e.file_name().to_string_lossy().ends_with(".tmp"));
+        assert!(!leftover, "atomic_write must clean up its tmp file");
+    }
+
+    #[tokio::test]
+    async fn register_preserves_top_level_key_order() {
+        // With serde_json's `preserve_order` feature, round-tripping a
+        // config object through `Value::Object` keeps insertion order
+        // intact — so users diffing config.json see only the
+        // cliPluginsExtraDirs append, not a spurious alphabetic resort.
+        let tmp = tempdir().unwrap();
+        let user_bin = tmp.path().join("bin");
+        let docker_cfg = tmp.path().join("docker");
+        fs::create_dir_all(&user_bin).unwrap();
+        fs::create_dir_all(&docker_cfg).unwrap();
+        touch_exe(&user_bin, "docker-compose");
+
+        fs::write(
+            docker_cfg.join("config.json"),
+            r#"{"currentContext":"desktop","credsStore":"osxkeychain","auths":{}}"#,
+        )
+        .unwrap();
+
+        register(&user_bin, &docker_cfg).await.unwrap();
+
+        let rewritten = fs::read_to_string(docker_cfg.join("config.json")).unwrap();
+        let ctx = rewritten.find("currentContext").unwrap();
+        let creds = rewritten.find("credsStore").unwrap();
+        let auths = rewritten.find("auths").unwrap();
+        let extra = rewritten.find("cliPluginsExtraDirs").unwrap();
+        assert!(ctx < creds && creds < auths && auths < extra);
     }
 }

--- a/app/arcbox-cli/src/commands/setup.rs
+++ b/app/arcbox-cli/src/commands/setup.rs
@@ -336,16 +336,19 @@ async fn status(format: OutputFormat) -> Result<()> {
     let zsh_comp = comp.join("zsh/_abctl");
     let comp_ok = tokio::fs::metadata(&zsh_comp).await.is_ok();
 
-    // Docker CLI plugin registration — only considered "ok" if the compose
-    // binary is present in `bin` and at least one plugin is registered. If
-    // the compose binary isn't even on disk (e.g. developer CLI-only build),
-    // report as not-applicable rather than failing.
-    let compose_present = bin.join("docker-compose").exists();
+    // Docker CLI plugin registration — only considered "ok" if at least
+    // one of our plugin binaries is on disk and is actually registered. If
+    // none are present (e.g. developer CLI-only build), report as
+    // not-applicable rather than failing.
+    let any_plugin_present = arcbox_constants::paths::DOCKER_CLI_PLUGINS
+        .iter()
+        .any(|p| bin.join(p).exists());
     let (plugin_status, plugin_detail) = match super::cli_plugins::default_docker_config_dir() {
         Ok(docker_cfg) => {
             let st = super::cli_plugins::status(&bin, &docker_cfg).await;
-            let ok = !compose_present || (!st.symlinked.is_empty() || st.extra_dirs_entry_present);
-            let detail = if compose_present {
+            let ok =
+                !any_plugin_present || (!st.symlinked.is_empty() || st.extra_dirs_entry_present);
+            let detail = if any_plugin_present {
                 Some(format!(
                     "{} symlinks, extraDirs: {}",
                     st.symlinked.len(),
@@ -356,7 +359,7 @@ async fn status(format: OutputFormat) -> Result<()> {
                     }
                 ))
             } else {
-                Some("skipped (compose binary not installed)".to_string())
+                Some("skipped (no Docker CLI plugin binaries present)".to_string())
             };
             (ok, detail)
         }

--- a/app/arcbox-cli/src/commands/setup.rs
+++ b/app/arcbox-cli/src/commands/setup.rs
@@ -148,11 +148,21 @@ async fn install(format: OutputFormat) -> Result<()> {
     //     `docker compose` (space-separated) and `docker buildx` resolve
     //     the same binaries as `docker-compose` / `docker-buildx` do on
     //     $PATH. See `cli_plugins` module docs for the rationale.
-    let plugins_registered = match super::cli_plugins::default_docker_config_dir() {
-        Ok(docker_cfg) => super::cli_plugins::register(&bin, &docker_cfg)
-            .await
-            .unwrap_or_default(),
-        Err(_) => super::cli_plugins::Outcome::default(),
+    //     Non-fatal: a failure here doesn't block the rest of install, but
+    //     we capture the error so the user can see why plugins are missing
+    //     instead of silently reporting 0 registered.
+    let (plugins_registered, plugin_error) = match super::cli_plugins::default_docker_config_dir() {
+        Ok(docker_cfg) => match super::cli_plugins::register(&bin, &docker_cfg).await {
+            Ok(o) => (o, None),
+            Err(e) => (
+                super::cli_plugins::Outcome::default(),
+                Some(format!("{e:#}")),
+            ),
+        },
+        Err(e) => (
+            super::cli_plugins::Outcome::default(),
+            Some(format!("{e:#}")),
+        ),
     };
 
     // 3. Write shell init scripts.
@@ -174,6 +184,7 @@ async fn install(format: OutputFormat) -> Result<()> {
                     "bin": symlink_path.display().to_string(),
                     "docker_tools": docker_tools_linked,
                     "docker_plugins": plugins_registered,
+                    "docker_plugins_error": plugin_error,
                     "shell_init": shell.display().to_string(),
                     "completions": comp.display().to_string(),
                     "profile": profile_path.as_ref().map(|p| p.display().to_string()),
@@ -202,6 +213,9 @@ async fn install(format: OutputFormat) -> Result<()> {
                     "  CLI plugins: {plugin_count} registered (`docker compose` / `docker buildx`)"
                 );
             }
+            if let Some(ref err) = plugin_error {
+                println!("  CLI plugins: WARN: {err}");
+            }
             println!("  Shell init:  {}", shell.display());
             println!("  Completions: {}", comp.display());
             if let Some(ref p) = profile_path {
@@ -226,12 +240,21 @@ async fn uninstall(format: OutputFormat) -> Result<()> {
     let comp = completions_dir()?;
 
     // Unregister Docker CLI plugins first — while `bin` still exists, so the
-    // symlink-target ownership check can resolve. Idempotent and non-fatal.
-    let plugins_unregistered = match super::cli_plugins::default_docker_config_dir() {
-        Ok(docker_cfg) => super::cli_plugins::unregister(&bin, &docker_cfg)
-            .await
-            .unwrap_or_default(),
-        Err(_) => super::cli_plugins::Outcome::default(),
+    // symlink-target ownership check can resolve. Idempotent and non-fatal,
+    // but we capture any error so it surfaces in output rather than vanishing.
+    let (plugins_unregistered, plugin_error) = match super::cli_plugins::default_docker_config_dir()
+    {
+        Ok(docker_cfg) => match super::cli_plugins::unregister(&bin, &docker_cfg).await {
+            Ok(o) => (o, None),
+            Err(e) => (
+                super::cli_plugins::Outcome::default(),
+                Some(format!("{e:#}")),
+            ),
+        },
+        Err(e) => (
+            super::cli_plugins::Outcome::default(),
+            Some(format!("{e:#}")),
+        ),
     };
 
     // Remove directories.
@@ -250,6 +273,7 @@ async fn uninstall(format: OutputFormat) -> Result<()> {
                 serde_json::to_string(&serde_json::json!({
                     "uninstalled": true,
                     "docker_plugins": plugins_unregistered,
+                    "docker_plugins_error": plugin_error,
                     "profile_cleaned": removed_from.as_ref().map(|p| p.display().to_string()),
                 }))?
             );
@@ -262,6 +286,9 @@ async fn uninstall(format: OutputFormat) -> Result<()> {
                     "  CLI plugins:  {} symlinks removed",
                     plugins_unregistered.symlinks.len()
                 );
+            }
+            if let Some(ref err) = plugin_error {
+                println!("  CLI plugins:  WARN: {err}");
             }
             if let Some(ref p) = removed_from {
                 println!("  Cleaned profile: {}", p.display());


### PR DESCRIPTION
## Summary

Users reported that `docker compose -f file.yml up` fails — `-f` leaks to the docker host binary — while `docker-compose -f file.yml up` (hyphenated) works fine. Root cause: ArcBox links `docker-compose` into `$PATH` via `DOCKER_CLI_TOOLS`, but never registers it as a Docker CLI plugin under `~/.docker/cli-plugins/` nor via `cliPluginsExtraDirs` in `~/.docker/config.json`. Upstream `docker` CLI's plugin discovery therefore fails, so `docker compose` (space-separated) is an unknown subcommand.

This PR wires both registration mechanisms at once:

- **Symlinks** under `~/.docker/cli-plugins/docker-{compose,buildx}` → `~/.arcbox/bin/<plugin>` (the idiomatic path)
- **`cliPluginsExtraDirs`** in `~/.docker/config.json` gets `~/.arcbox/bin` (fallback if the user wipes `~/.docker/cli-plugins/`)

Registration is bound to `abctl setup install` (and its `brew-postflight` entry point), **not** to `abctl docker enable`. `compose`/`buildx` are context-aware — they honour `DOCKER_HOST` and the current Docker context — so `docker compose` keeps working even after the user switches to another backend (`abctl docker disable` → Docker Desktop / colima / OrbStack).

## Design notes

- Operations are **idempotent**: repeat `setup install` does not duplicate symlinks or JSON entries.
- **Never overwrites foreign state**: pre-existing symlinks pointing elsewhere (e.g. Docker Desktop's compose) stay; the `config.json` `cliPluginsExtraDirs` entry is only appended if our path isn't already in the array; all other top-level keys (`currentContext`, `auths`, `credsStore`, …) are preserved byte-for-byte via `serde_json::Value` traversal.
- **Symmetric cleanup**: `setup uninstall` only removes symlinks that still point at `~/.arcbox/bin/` and only strips our entry from `cliPluginsExtraDirs`; an emptied array is deleted to avoid stale keys.
- `setup status` reports registration state. When the compose binary is absent (dev-only CLI build, no app bundle), plugin status reports "skipped" instead of failing — so a pure CLI install doesn't show as broken.

## Changes

- `common/arcbox-constants/src/paths.rs` — add `DOCKER_CLI_PLUGINS` (subset of `DOCKER_CLI_TOOLS`: `docker-buildx`, `docker-compose`).
- `app/arcbox-cli/src/commands/cli_plugins.rs` — new module with `register` / `unregister` / `status` / `default_docker_config_dir`. 10 unit tests covering idempotence, foreign-symlink safety, config-key preservation, empty-array cleanup, missing-binary skip, and missing-config tolerance.
- `app/arcbox-cli/src/commands/setup.rs` — install/uninstall/status integration; JSON and table output extended with plugin counts and detail.
- `app/arcbox-cli/src/commands/mod.rs` — module declaration.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p arcbox-cli --all-targets -- -D warnings`
- [x] `cargo test -p arcbox-cli` — 34 passed (10 new in `cli_plugins::tests`)
- [ ] Manual: on a fresh machine, `abctl setup install` → `docker compose -f tests/fixtures/compose.yml up` should resolve the plugin and connect to the arcbox socket
- [ ] Manual: `abctl docker disable` switches `currentContext` back to previous backend but `docker compose` still runs (connects to that backend)
- [ ] Manual: `abctl setup uninstall` removes only our symlinks and `cliPluginsExtraDirs` entry, leaving any Docker Desktop plugins and other config untouched
- [ ] Manual: `abctl setup status` reports `[+] Docker plugins  2 symlinks, extraDirs: yes` after install

## Related

User-reported in chat: `docker build` was fixed in 0.3.21 (commit b0039a33) via BuildKit upload-proxy + session upgrade routes, but `docker compose` was a separate, unrelated issue in the CLI plugin wiring layer — addressed here.