### PR TITLE
fix(agent): make ensure_runtime non-blocking to avoid daemon RPC timeout

### DIFF
--- a/app/arcbox-cli/src/commands/cli_plugins.rs
+++ b/app/arcbox-cli/src/commands/cli_plugins.rs
@@ -1,0 +1,517 @@
+//! Docker CLI plugin registration.
+//!
+//! Makes `docker compose` and `docker buildx` (space-separated subcommands)
+//! discoverable by the upstream `docker` CLI, which looks plugins up via:
+//!
+//!   1. `cliPluginsExtraDirs` in `~/.docker/config.json`
+//!   2. `~/.docker/cli-plugins/<name>`
+//!   3. `/usr/local/lib/docker/cli-plugins/<name>`
+//!   4. `/usr/lib/docker/cli-plugins/<name>`
+//!
+//! We wire up both (1) and (2) for belt-and-suspenders coverage:
+//!
+//! - **(2) symlinks** are the idiomatic registration mechanism and are what
+//!   most users expect to see when auditing their Docker setup.
+//! - **(1) extraDirs** serves as a fallback if a user wipes
+//!   `~/.docker/cli-plugins/` or hasn't got it at all (it doesn't exist on
+//!   a fresh machine without Docker Desktop installed).
+//!
+//! Both point at `~/.arcbox/bin/<name>`, which `setup::install()` has
+//! already populated with symlinks into the app bundle or runtime bin.
+//!
+//! Plugin registration is per-user and decoupled from Docker context
+//! `enable`/`disable`. Compose/buildx themselves are context-aware (they
+//! honour `DOCKER_HOST` / the current context), so the binaries work
+//! correctly even when the user has switched to another Docker backend.
+//! This means `docker compose` keeps working after `abctl docker disable`
+//! — it just talks to whichever backend the user switched to.
+
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+use serde::Serialize;
+
+use arcbox_constants::paths::DOCKER_CLI_PLUGINS;
+
+/// Summary of what a register/unregister call did.
+#[derive(Debug, Default, Serialize)]
+pub struct Outcome {
+    /// Plugin symlinks created or removed under `~/.docker/cli-plugins/`.
+    pub symlinks: Vec<PathBuf>,
+    /// Whether `cliPluginsExtraDirs` in `~/.docker/config.json` was modified.
+    pub config_updated: bool,
+}
+
+/// Current registration state — reported by `setup status`.
+#[derive(Debug, Default, Serialize)]
+pub struct RegistrationStatus {
+    /// Plugins with a valid symlink under `~/.docker/cli-plugins/` pointing
+    /// into `user_bin`.
+    pub symlinked: Vec<String>,
+    /// Whether `user_bin` appears in `cliPluginsExtraDirs`.
+    pub extra_dirs_entry_present: bool,
+}
+
+/// Resolves `~/.docker/` for the current user.
+pub fn default_docker_config_dir() -> Result<PathBuf> {
+    dirs::home_dir()
+        .map(|h| h.join(".docker"))
+        .context("could not determine home directory")
+}
+
+/// Registers ArcBox's compose/buildx binaries as Docker CLI plugins.
+///
+/// Creates `<docker_config_dir>/cli-plugins/<plugin>` symlinks pointing to
+/// `<user_bin>/<plugin>`, and adds `<user_bin>` to `cliPluginsExtraDirs`
+/// in `<docker_config_dir>/config.json` (preserving all other keys).
+///
+/// Idempotent: safe to call repeatedly. Never overwrites a symlink pointing
+/// anywhere other than `user_bin` — that means pre-existing Docker Desktop
+/// plugins keep precedence if they were there first.
+pub async fn register(user_bin: &Path, docker_config_dir: &Path) -> Result<Outcome> {
+    let mut outcome = Outcome::default();
+
+    // (B) symlinks
+    let plugins_dir = docker_config_dir.join("cli-plugins");
+    tokio::fs::create_dir_all(&plugins_dir)
+        .await
+        .with_context(|| format!("failed to create {}", plugins_dir.display()))?;
+
+    for plugin in DOCKER_CLI_PLUGINS {
+        let target = user_bin.join(plugin);
+        if !target.exists() {
+            // Nothing to register for this plugin — the binary wasn't linked
+            // into ~/.arcbox/bin/ (e.g. missing from the app bundle). Skip
+            // silently rather than creating a dangling symlink.
+            continue;
+        }
+
+        let link = plugins_dir.join(plugin);
+        match tokio::fs::symlink_metadata(&link).await {
+            Ok(meta) if meta.file_type().is_symlink() => {
+                if let Ok(existing) = tokio::fs::read_link(&link).await {
+                    if existing == target {
+                        continue;
+                    }
+                    if !is_arcbox_bin_target(&existing, user_bin) {
+                        // Foreign symlink (e.g. Docker Desktop). Leave it alone.
+                        continue;
+                    }
+                    tokio::fs::remove_file(&link).await.ok();
+                }
+            }
+            Ok(_) => {
+                // Regular file or directory — not ours to touch.
+                continue;
+            }
+            Err(_) => {}
+        }
+
+        #[cfg(unix)]
+        tokio::fs::symlink(&target, &link).await.with_context(|| {
+            format!(
+                "failed to create plugin symlink {} -> {}",
+                link.display(),
+                target.display()
+            )
+        })?;
+        outcome.symlinks.push(link);
+    }
+
+    // (A) cliPluginsExtraDirs
+    let config_path = docker_config_dir.join("config.json");
+    let user_bin_str = user_bin.to_string_lossy().into_owned();
+    outcome.config_updated = update_extra_dirs(&config_path, &user_bin_str, true).await?;
+
+    Ok(outcome)
+}
+
+/// Reverses [`register`]. Only removes resources that still point at
+/// `user_bin` — never touches foreign symlinks or extraDirs entries.
+pub async fn unregister(user_bin: &Path, docker_config_dir: &Path) -> Result<Outcome> {
+    let mut outcome = Outcome::default();
+
+    let plugins_dir = docker_config_dir.join("cli-plugins");
+    if plugins_dir.is_dir() {
+        for plugin in DOCKER_CLI_PLUGINS {
+            let link = plugins_dir.join(plugin);
+            let Ok(meta) = tokio::fs::symlink_metadata(&link).await else {
+                continue;
+            };
+            if !meta.file_type().is_symlink() {
+                continue;
+            }
+            let Ok(target) = tokio::fs::read_link(&link).await else {
+                continue;
+            };
+            if !is_arcbox_bin_target(&target, user_bin) {
+                continue;
+            }
+            if tokio::fs::remove_file(&link).await.is_ok() {
+                outcome.symlinks.push(link);
+            }
+        }
+    }
+
+    let config_path = docker_config_dir.join("config.json");
+    let user_bin_str = user_bin.to_string_lossy().into_owned();
+    outcome.config_updated = update_extra_dirs(&config_path, &user_bin_str, false).await?;
+
+    Ok(outcome)
+}
+
+/// Reports the current registration state for status output.
+pub async fn status(user_bin: &Path, docker_config_dir: &Path) -> RegistrationStatus {
+    let mut result = RegistrationStatus::default();
+
+    let plugins_dir = docker_config_dir.join("cli-plugins");
+    for plugin in DOCKER_CLI_PLUGINS {
+        let link = plugins_dir.join(plugin);
+        if let Ok(target) = tokio::fs::read_link(&link).await {
+            if is_arcbox_bin_target(&target, user_bin) {
+                result.symlinked.push((*plugin).to_string());
+            }
+        }
+    }
+
+    let config_path = docker_config_dir.join("config.json");
+    if let Ok(content) = tokio::fs::read_to_string(&config_path).await {
+        if let Ok(serde_json::Value::Object(obj)) =
+            serde_json::from_str::<serde_json::Value>(&content)
+        {
+            if let Some(serde_json::Value::Array(arr)) = obj.get("cliPluginsExtraDirs") {
+                let user_bin_str = user_bin.to_string_lossy();
+                result.extra_dirs_entry_present = arr
+                    .iter()
+                    .any(|v| v.as_str() == Some(user_bin_str.as_ref()));
+            }
+        }
+    }
+
+    result
+}
+
+/// True if `target` is a path inside `user_bin` (i.e. a symlink ArcBox owns).
+fn is_arcbox_bin_target(target: &Path, user_bin: &Path) -> bool {
+    target.starts_with(user_bin)
+}
+
+/// Reads `~/.docker/config.json`, adds or removes `user_bin` from the
+/// `cliPluginsExtraDirs` array (preserving all other keys), and writes it
+/// back. Returns `true` if the file was modified.
+async fn update_extra_dirs(config_path: &Path, user_bin: &str, insert: bool) -> Result<bool> {
+    // Load or start fresh. Missing file treated as empty object.
+    let mut value: serde_json::Value = match tokio::fs::read_to_string(config_path).await {
+        Ok(s) if s.trim().is_empty() => serde_json::json!({}),
+        Ok(s) => serde_json::from_str(&s)
+            .with_context(|| format!("failed to parse {}", config_path.display()))?,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            if !insert {
+                // Nothing to unregister when the file doesn't exist.
+                return Ok(false);
+            }
+            serde_json::json!({})
+        }
+        Err(e) => {
+            return Err(
+                anyhow::Error::from(e).context(format!("failed to read {}", config_path.display()))
+            );
+        }
+    };
+
+    let obj = value
+        .as_object_mut()
+        .context("Docker config.json is not a JSON object")?;
+
+    let modified = if insert {
+        let entry = obj
+            .entry("cliPluginsExtraDirs")
+            .or_insert_with(|| serde_json::Value::Array(Vec::new()));
+        let array = entry
+            .as_array_mut()
+            .context("cliPluginsExtraDirs is not an array")?;
+        if array.iter().any(|v| v.as_str() == Some(user_bin)) {
+            false
+        } else {
+            array.push(serde_json::Value::String(user_bin.to_string()));
+            true
+        }
+    } else {
+        let Some(entry) = obj.get_mut("cliPluginsExtraDirs") else {
+            return Ok(false);
+        };
+        let Some(array) = entry.as_array_mut() else {
+            return Ok(false);
+        };
+        let before = array.len();
+        array.retain(|v| v.as_str() != Some(user_bin));
+        let changed = array.len() != before;
+        if array.is_empty() {
+            obj.remove("cliPluginsExtraDirs");
+        }
+        changed
+    };
+
+    if !modified {
+        return Ok(false);
+    }
+
+    // Ensure parent directory exists (covers first-ever write).
+    if let Some(parent) = config_path.parent() {
+        tokio::fs::create_dir_all(parent).await.ok();
+    }
+
+    let serialized = serde_json::to_string_pretty(&value)?;
+    tokio::fs::write(config_path, format!("{serialized}\n"))
+        .await
+        .with_context(|| format!("failed to write {}", config_path.display()))?;
+    Ok(true)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::tempdir;
+
+    /// Creates a dummy executable at `<dir>/<name>` so symlink creation has a
+    /// real target to point at.
+    fn touch_exe(dir: &Path, name: &str) -> PathBuf {
+        let path = dir.join(name);
+        fs::write(&path, b"#!/bin/sh\nexit 0\n").unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mut perm = fs::metadata(&path).unwrap().permissions();
+            perm.set_mode(0o755);
+            fs::set_permissions(&path, perm).unwrap();
+        }
+        path
+    }
+
+    #[tokio::test]
+    async fn register_creates_symlinks_and_extra_dirs() {
+        let tmp = tempdir().unwrap();
+        let user_bin = tmp.path().join("arcbox-bin");
+        let docker_cfg = tmp.path().join("docker");
+        fs::create_dir_all(&user_bin).unwrap();
+        touch_exe(&user_bin, "docker-compose");
+        touch_exe(&user_bin, "docker-buildx");
+
+        let outcome = register(&user_bin, &docker_cfg).await.unwrap();
+
+        assert_eq!(outcome.symlinks.len(), 2);
+        assert!(outcome.config_updated);
+
+        // Symlinks point to our binaries.
+        let compose_link = docker_cfg.join("cli-plugins/docker-compose");
+        assert_eq!(
+            fs::read_link(&compose_link).unwrap(),
+            user_bin.join("docker-compose")
+        );
+
+        // config.json contains extraDirs with user_bin.
+        let cfg: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(docker_cfg.join("config.json")).unwrap())
+                .unwrap();
+        let dirs = cfg
+            .get("cliPluginsExtraDirs")
+            .and_then(|v| v.as_array())
+            .unwrap();
+        assert_eq!(dirs.len(), 1);
+        assert_eq!(dirs[0].as_str(), Some(user_bin.to_string_lossy().as_ref()));
+    }
+
+    #[tokio::test]
+    async fn register_is_idempotent() {
+        let tmp = tempdir().unwrap();
+        let user_bin = tmp.path().join("bin");
+        let docker_cfg = tmp.path().join("docker");
+        fs::create_dir_all(&user_bin).unwrap();
+        touch_exe(&user_bin, "docker-compose");
+        touch_exe(&user_bin, "docker-buildx");
+
+        let first = register(&user_bin, &docker_cfg).await.unwrap();
+        assert!(first.config_updated);
+        assert_eq!(first.symlinks.len(), 2);
+
+        let second = register(&user_bin, &docker_cfg).await.unwrap();
+        assert!(!second.config_updated);
+        assert!(second.symlinks.is_empty());
+    }
+
+    #[tokio::test]
+    async fn register_preserves_other_config_keys() {
+        let tmp = tempdir().unwrap();
+        let user_bin = tmp.path().join("bin");
+        let docker_cfg = tmp.path().join("docker");
+        fs::create_dir_all(&user_bin).unwrap();
+        fs::create_dir_all(&docker_cfg).unwrap();
+        touch_exe(&user_bin, "docker-compose");
+
+        fs::write(
+            docker_cfg.join("config.json"),
+            r#"{"currentContext":"desktop-linux","auths":{"ghcr.io":{}}}"#,
+        )
+        .unwrap();
+
+        register(&user_bin, &docker_cfg).await.unwrap();
+
+        let cfg: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(docker_cfg.join("config.json")).unwrap())
+                .unwrap();
+        assert_eq!(cfg["currentContext"].as_str(), Some("desktop-linux"));
+        assert!(cfg["auths"]["ghcr.io"].is_object());
+        assert!(cfg["cliPluginsExtraDirs"].is_array());
+    }
+
+    #[tokio::test]
+    async fn register_skips_foreign_symlinks() {
+        let tmp = tempdir().unwrap();
+        let user_bin = tmp.path().join("bin");
+        let docker_cfg = tmp.path().join("docker");
+        let other_bin = tmp.path().join("other");
+        fs::create_dir_all(&user_bin).unwrap();
+        fs::create_dir_all(&other_bin).unwrap();
+        fs::create_dir_all(docker_cfg.join("cli-plugins")).unwrap();
+        touch_exe(&user_bin, "docker-compose");
+        let foreign_target = touch_exe(&other_bin, "docker-compose");
+
+        // Pre-existing foreign symlink (simulating Docker Desktop).
+        let foreign_link = docker_cfg.join("cli-plugins/docker-compose");
+        std::os::unix::fs::symlink(&foreign_target, &foreign_link).unwrap();
+
+        let outcome = register(&user_bin, &docker_cfg).await.unwrap();
+
+        // The foreign symlink must be untouched.
+        assert_eq!(fs::read_link(&foreign_link).unwrap(), foreign_target);
+        assert!(!outcome.symlinks.contains(&foreign_link));
+    }
+
+    #[tokio::test]
+    async fn register_skips_missing_plugin_binary() {
+        let tmp = tempdir().unwrap();
+        let user_bin = tmp.path().join("bin");
+        let docker_cfg = tmp.path().join("docker");
+        fs::create_dir_all(&user_bin).unwrap();
+        // Only compose exists; buildx is missing.
+        touch_exe(&user_bin, "docker-compose");
+
+        let outcome = register(&user_bin, &docker_cfg).await.unwrap();
+
+        assert_eq!(outcome.symlinks.len(), 1);
+        assert!(!docker_cfg.join("cli-plugins/docker-buildx").exists());
+    }
+
+    #[tokio::test]
+    async fn unregister_removes_only_our_symlinks() {
+        let tmp = tempdir().unwrap();
+        let user_bin = tmp.path().join("bin");
+        let docker_cfg = tmp.path().join("docker");
+        let other_bin = tmp.path().join("other");
+        fs::create_dir_all(&user_bin).unwrap();
+        fs::create_dir_all(&other_bin).unwrap();
+        fs::create_dir_all(docker_cfg.join("cli-plugins")).unwrap();
+        touch_exe(&user_bin, "docker-compose");
+        touch_exe(&user_bin, "docker-buildx");
+        let foreign_target = touch_exe(&other_bin, "docker-buildx");
+
+        register(&user_bin, &docker_cfg).await.unwrap();
+
+        // Replace buildx with a foreign symlink before unregistering.
+        let buildx_link = docker_cfg.join("cli-plugins/docker-buildx");
+        fs::remove_file(&buildx_link).unwrap();
+        std::os::unix::fs::symlink(&foreign_target, &buildx_link).unwrap();
+
+        let outcome = unregister(&user_bin, &docker_cfg).await.unwrap();
+
+        // compose removed, buildx preserved.
+        assert!(
+            !docker_cfg.join("cli-plugins/docker-compose").exists(),
+            "our compose symlink should be gone"
+        );
+        assert_eq!(fs::read_link(&buildx_link).unwrap(), foreign_target);
+        assert_eq!(outcome.symlinks.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn unregister_removes_only_our_extra_dirs_entry() {
+        let tmp = tempdir().unwrap();
+        let user_bin = tmp.path().join("bin");
+        let docker_cfg = tmp.path().join("docker");
+        fs::create_dir_all(&user_bin).unwrap();
+        fs::create_dir_all(&docker_cfg).unwrap();
+        touch_exe(&user_bin, "docker-compose");
+
+        fs::write(
+            docker_cfg.join("config.json"),
+            format!(
+                r#"{{"cliPluginsExtraDirs":["/opt/other/cli-plugins","{}"]}}"#,
+                user_bin.to_string_lossy()
+            ),
+        )
+        .unwrap();
+
+        unregister(&user_bin, &docker_cfg).await.unwrap();
+
+        let cfg: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(docker_cfg.join("config.json")).unwrap())
+                .unwrap();
+        let dirs = cfg["cliPluginsExtraDirs"].as_array().unwrap();
+        assert_eq!(dirs.len(), 1);
+        assert_eq!(dirs[0].as_str(), Some("/opt/other/cli-plugins"));
+    }
+
+    #[tokio::test]
+    async fn unregister_drops_empty_extra_dirs_key() {
+        let tmp = tempdir().unwrap();
+        let user_bin = tmp.path().join("bin");
+        let docker_cfg = tmp.path().join("docker");
+        fs::create_dir_all(&user_bin).unwrap();
+        touch_exe(&user_bin, "docker-compose");
+
+        register(&user_bin, &docker_cfg).await.unwrap();
+        unregister(&user_bin, &docker_cfg).await.unwrap();
+
+        let cfg: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(docker_cfg.join("config.json")).unwrap())
+                .unwrap();
+        assert!(
+            cfg.get("cliPluginsExtraDirs").is_none(),
+            "empty extraDirs array should be removed"
+        );
+    }
+
+    #[tokio::test]
+    async fn unregister_is_idempotent_on_missing_config() {
+        let tmp = tempdir().unwrap();
+        let user_bin = tmp.path().join("bin");
+        let docker_cfg = tmp.path().join("docker");
+        fs::create_dir_all(&user_bin).unwrap();
+
+        // No ~/.docker at all — must not panic or error.
+        let outcome = unregister(&user_bin, &docker_cfg).await.unwrap();
+        assert!(outcome.symlinks.is_empty());
+        assert!(!outcome.config_updated);
+    }
+
+    #[tokio::test]
+    async fn status_reports_registration() {
+        let tmp = tempdir().unwrap();
+        let user_bin = tmp.path().join("bin");
+        let docker_cfg = tmp.path().join("docker");
+        fs::create_dir_all(&user_bin).unwrap();
+        touch_exe(&user_bin, "docker-compose");
+        touch_exe(&user_bin, "docker-buildx");
+
+        let before = status(&user_bin, &docker_cfg).await;
+        assert!(before.symlinked.is_empty());
+        assert!(!before.extra_dirs_entry_present);
+
+        register(&user_bin, &docker_cfg).await.unwrap();
+
+        let after = status(&user_bin, &docker_cfg).await;
+        assert_eq!(after.symlinked.len(), 2);
+        assert!(after.extra_dirs_entry_present);
+    }
+}

--- a/app/arcbox-cli/src/commands/cli_plugins.rs
+++ b/app/arcbox-cli/src/commands/cli_plugins.rs
@@ -62,20 +62,42 @@ pub fn default_docker_config_dir() -> Result<PathBuf> {
 /// Registers ArcBox's compose/buildx binaries as Docker CLI plugins.
 ///
 /// Creates `<docker_config_dir>/cli-plugins/<plugin>` symlinks pointing to
-/// `<user_bin>/<plugin>`, and adds `<user_bin>` to `cliPluginsExtraDirs`
-/// in `<docker_config_dir>/config.json` (preserving all other keys).
+/// `<user_bin>/<plugin>`, and — only if at least one plugin binary actually
+/// exists under `user_bin` — adds `user_bin` to `cliPluginsExtraDirs` in
+/// `<docker_config_dir>/config.json` (preserving all other keys).
 ///
-/// Idempotent: safe to call repeatedly. Never overwrites a symlink pointing
-/// anywhere other than `user_bin` — that means pre-existing Docker Desktop
-/// plugins keep precedence if they were there first.
+/// ## Precedence caveat
+///
+/// Docker resolves plugins in this order: `cliPluginsExtraDirs` →
+/// `~/.docker/cli-plugins/` → system dirs. Because `extraDirs` is searched
+/// *first*, once `user_bin` is registered there, ArcBox's plugin wins even
+/// when a foreign symlink (e.g. Docker Desktop's) is present at
+/// `~/.docker/cli-plugins/<name>`. We keep the foreign symlink in place so
+/// a human auditing `~/.docker/cli-plugins/` still sees it, but it is no
+/// longer the selected binary at CLI invocation time.
+///
+/// This matches the practical expectation: if the user has ArcBox
+/// installed, they almost certainly want ArcBox's compose/buildx over
+/// Docker Desktop's (which would target Desktop's socket, not ArcBox's).
+/// `unregister()` removes `user_bin` from `extraDirs` so Desktop becomes
+/// selectable again on uninstall.
+///
+/// ## Idempotence
+///
+/// Safe to call repeatedly. Never overwrites a foreign symlink — those are
+/// left untouched. Never mutates `config.json` if no plugin binary was
+/// shipped (avoids churn on builds that don't bundle compose/buildx).
 pub async fn register(user_bin: &Path, docker_config_dir: &Path) -> Result<Outcome> {
     let mut outcome = Outcome::default();
 
-    // (B) symlinks
+    // (B) symlinks — also tracks whether any plugin binary was actually
+    //     present so we know to register (A) extraDirs.
     let plugins_dir = docker_config_dir.join("cli-plugins");
     tokio::fs::create_dir_all(&plugins_dir)
         .await
         .with_context(|| format!("failed to create {}", plugins_dir.display()))?;
+
+    let mut any_plugin_present = false;
 
     for plugin in DOCKER_CLI_PLUGINS {
         let target = user_bin.join(plugin);
@@ -85,6 +107,7 @@ pub async fn register(user_bin: &Path, docker_config_dir: &Path) -> Result<Outco
             // silently rather than creating a dangling symlink.
             continue;
         }
+        any_plugin_present = true;
 
         let link = plugins_dir.join(plugin);
         match tokio::fs::symlink_metadata(&link).await {
@@ -94,7 +117,9 @@ pub async fn register(user_bin: &Path, docker_config_dir: &Path) -> Result<Outco
                         continue;
                     }
                     if !is_arcbox_bin_target(&existing, user_bin) {
-                        // Foreign symlink (e.g. Docker Desktop). Leave it alone.
+                        // Foreign symlink (e.g. Docker Desktop). Leave it
+                        // alone — extraDirs below still makes ArcBox win at
+                        // resolution time.
                         continue;
                     }
                     tokio::fs::remove_file(&link).await.ok();
@@ -108,20 +133,30 @@ pub async fn register(user_bin: &Path, docker_config_dir: &Path) -> Result<Outco
         }
 
         #[cfg(unix)]
-        tokio::fs::symlink(&target, &link).await.with_context(|| {
-            format!(
-                "failed to create plugin symlink {} -> {}",
-                link.display(),
-                target.display()
-            )
-        })?;
-        outcome.symlinks.push(link);
+        {
+            tokio::fs::symlink(&target, &link).await.with_context(|| {
+                format!(
+                    "failed to create plugin symlink {} -> {}",
+                    link.display(),
+                    target.display()
+                )
+            })?;
+            outcome.symlinks.push(link);
+        }
+        #[cfg(not(unix))]
+        {
+            let _ = link;
+        }
     }
 
-    // (A) cliPluginsExtraDirs
-    let config_path = docker_config_dir.join("config.json");
-    let user_bin_str = user_bin.to_string_lossy().into_owned();
-    outcome.config_updated = update_extra_dirs(&config_path, &user_bin_str, true).await?;
+    // (A) cliPluginsExtraDirs — only when we actually have plugins to
+    //     advertise. Skipping the mutation on plugin-less installs keeps
+    //     config.json clean.
+    if any_plugin_present {
+        let config_path = docker_config_dir.join("config.json");
+        let user_bin_str = user_bin.to_string_lossy().into_owned();
+        outcome.config_updated = update_extra_dirs(&config_path, &user_bin_str, true).await?;
+    }
 
     Ok(outcome)
 }
@@ -386,6 +421,27 @@ mod tests {
         // The foreign symlink must be untouched.
         assert_eq!(fs::read_link(&foreign_link).unwrap(), foreign_target);
         assert!(!outcome.symlinks.contains(&foreign_link));
+    }
+
+    #[tokio::test]
+    async fn register_without_plugin_binaries_leaves_config_untouched() {
+        let tmp = tempdir().unwrap();
+        let user_bin = tmp.path().join("bin");
+        let docker_cfg = tmp.path().join("docker");
+        fs::create_dir_all(&user_bin).unwrap();
+        // No plugin binaries touched into user_bin.
+
+        let outcome = register(&user_bin, &docker_cfg).await.unwrap();
+
+        assert!(outcome.symlinks.is_empty());
+        assert!(
+            !outcome.config_updated,
+            "config.json must not be mutated when no plugins are present"
+        );
+        assert!(
+            !docker_cfg.join("config.json").exists(),
+            "config.json must not be created when nothing is registered"
+        );
     }
 
     #[tokio::test]

--- a/app/arcbox-cli/src/commands/mod.rs
+++ b/app/arcbox-cli/src/commands/mod.rs
@@ -43,6 +43,7 @@ pub fn resolve_grpc_socket_path() -> PathBuf {
 }
 
 pub mod boot;
+pub mod cli_plugins;
 pub mod daemon;
 #[cfg(target_os = "macos")]
 pub mod dns;

--- a/app/arcbox-cli/src/commands/setup.rs
+++ b/app/arcbox-cli/src/commands/setup.rs
@@ -55,6 +55,7 @@ struct StatusOutput {
     shell_init: ComponentStatus,
     profile_injected: ComponentStatus,
     completions: ComponentStatus,
+    docker_plugins: ComponentStatus,
 }
 
 /// Per-component installation status.
@@ -143,6 +144,17 @@ async fn install(format: OutputFormat) -> Result<()> {
     //     Tools may be in the app bundle (xbin/) or ~/.arcbox/runtime/bin/.
     let docker_tools_linked = link_docker_tools_to_user_bin(&exe, &bin).await;
 
+    // 2c. Register docker-compose / docker-buildx as Docker CLI plugins so
+    //     `docker compose` (space-separated) and `docker buildx` resolve
+    //     the same binaries as `docker-compose` / `docker-buildx` do on
+    //     $PATH. See `cli_plugins` module docs for the rationale.
+    let plugins_registered = match super::cli_plugins::default_docker_config_dir() {
+        Ok(docker_cfg) => super::cli_plugins::register(&bin, &docker_cfg)
+            .await
+            .unwrap_or_default(),
+        Err(_) => super::cli_plugins::Outcome::default(),
+    };
+
     // 3. Write shell init scripts.
     write_shell_init_scripts(&shell).await?;
 
@@ -161,6 +173,7 @@ async fn install(format: OutputFormat) -> Result<()> {
                     "installed": true,
                     "bin": symlink_path.display().to_string(),
                     "docker_tools": docker_tools_linked,
+                    "docker_plugins": plugins_registered,
                     "shell_init": shell.display().to_string(),
                     "completions": comp.display().to_string(),
                     "profile": profile_path.as_ref().map(|p| p.display().to_string()),
@@ -181,6 +194,12 @@ async fn install(format: OutputFormat) -> Result<()> {
                 println!(
                     "  Docker:      {docker_tools_linked} tools linked to {}",
                     bin.display()
+                );
+            }
+            let plugin_count = plugins_registered.symlinks.len();
+            if plugin_count > 0 || plugins_registered.config_updated {
+                println!(
+                    "  CLI plugins: {plugin_count} registered (`docker compose` / `docker buildx`)"
                 );
             }
             println!("  Shell init:  {}", shell.display());
@@ -206,6 +225,15 @@ async fn uninstall(format: OutputFormat) -> Result<()> {
     let shell = shell_dir()?;
     let comp = completions_dir()?;
 
+    // Unregister Docker CLI plugins first — while `bin` still exists, so the
+    // symlink-target ownership check can resolve. Idempotent and non-fatal.
+    let plugins_unregistered = match super::cli_plugins::default_docker_config_dir() {
+        Ok(docker_cfg) => super::cli_plugins::unregister(&bin, &docker_cfg)
+            .await
+            .unwrap_or_default(),
+        Err(_) => super::cli_plugins::Outcome::default(),
+    };
+
     // Remove directories.
     remove_dir_if_exists(&bin).await;
     remove_dir_if_exists(&shell).await;
@@ -221,6 +249,7 @@ async fn uninstall(format: OutputFormat) -> Result<()> {
                 "{}",
                 serde_json::to_string(&serde_json::json!({
                     "uninstalled": true,
+                    "docker_plugins": plugins_unregistered,
                     "profile_cleaned": removed_from.as_ref().map(|p| p.display().to_string()),
                 }))?
             );
@@ -228,6 +257,12 @@ async fn uninstall(format: OutputFormat) -> Result<()> {
         OutputFormat::Quiet => {}
         OutputFormat::Table => {
             println!("ArcBox CLI shell integration removed.");
+            if !plugins_unregistered.symlinks.is_empty() || plugins_unregistered.config_updated {
+                println!(
+                    "  CLI plugins:  {} symlinks removed",
+                    plugins_unregistered.symlinks.len()
+                );
+            }
             if let Some(ref p) = removed_from {
                 println!("  Cleaned profile: {}", p.display());
             }
@@ -274,7 +309,34 @@ async fn status(format: OutputFormat) -> Result<()> {
     let zsh_comp = comp.join("zsh/_abctl");
     let comp_ok = tokio::fs::metadata(&zsh_comp).await.is_ok();
 
-    let all_ok = symlink_ok && init_ok && profile_injected && comp_ok;
+    // Docker CLI plugin registration — only considered "ok" if the compose
+    // binary is present in `bin` and at least one plugin is registered. If
+    // the compose binary isn't even on disk (e.g. developer CLI-only build),
+    // report as not-applicable rather than failing.
+    let compose_present = bin.join("docker-compose").exists();
+    let (plugin_status, plugin_detail) = match super::cli_plugins::default_docker_config_dir() {
+        Ok(docker_cfg) => {
+            let st = super::cli_plugins::status(&bin, &docker_cfg).await;
+            let ok = !compose_present || (!st.symlinked.is_empty() || st.extra_dirs_entry_present);
+            let detail = if compose_present {
+                Some(format!(
+                    "{} symlinks, extraDirs: {}",
+                    st.symlinked.len(),
+                    if st.extra_dirs_entry_present {
+                        "yes"
+                    } else {
+                        "no"
+                    }
+                ))
+            } else {
+                Some("skipped (compose binary not installed)".to_string())
+            };
+            (ok, detail)
+        }
+        Err(_) => (true, Some("skipped (no home directory)".to_string())),
+    };
+
+    let all_ok = symlink_ok && init_ok && profile_injected && comp_ok && plugin_status;
 
     match format {
         OutputFormat::Json => {
@@ -300,6 +362,11 @@ async fn status(format: OutputFormat) -> Result<()> {
                     path: Some(comp.display().to_string()),
                     detail: None,
                 },
+                docker_plugins: ComponentStatus {
+                    ok: plugin_status,
+                    path: None,
+                    detail: plugin_detail,
+                },
             };
             println!("{}", serde_json::to_string(&output)?);
         }
@@ -323,6 +390,11 @@ async fn status(format: OutputFormat) -> Result<()> {
                     .unwrap_or_default(),
             );
             print_check("Completions", comp_ok, &comp.display().to_string());
+            print_check(
+                "Docker plugins",
+                plugin_status,
+                plugin_detail.as_deref().unwrap_or(""),
+            );
             println!();
             if all_ok {
                 println!("Status: installed");

--- a/common/arcbox-constants/src/paths.rs
+++ b/common/arcbox-constants/src/paths.rs
@@ -64,6 +64,22 @@ pub const DOCKER_CLI_TOOLS: &[&str] = &[
     "docker-credential-osxkeychain",
 ];
 
+/// Subset of `DOCKER_CLI_TOOLS` that are Docker CLI plugins — binaries that
+/// upstream `docker` discovers via its plugin mechanism and invokes as
+/// `docker <name>` (e.g. `docker compose`, `docker buildx`).
+///
+/// Upstream Docker CLI searches these paths in order for plugin binaries:
+///   1. entries listed in `cliPluginsExtraDirs` in `~/.docker/config.json`
+///   2. `~/.docker/cli-plugins/`
+///   3. `/usr/local/lib/docker/cli-plugins/`
+///   4. `/usr/lib/docker/cli-plugins/`
+///
+/// Putting a plugin only in `$PATH` (as a standalone `docker-compose` binary)
+/// is *not* enough — `docker compose` (with a space) will fail to find it.
+/// Excludes the `docker` host binary itself and credential helpers (which
+/// are discovered via a different, credsStore-based mechanism).
+pub const DOCKER_CLI_PLUGINS: &[&str] = &["docker-buildx", "docker-compose"];
+
 /// Returns true if a symlink target looks like it belongs to an ArcBox app bundle.
 ///
 /// Used by multiple subsystems (privileged helper, brew hooks, setup install)

--- a/common/arcbox-constants/src/status.rs
+++ b/common/arcbox-constants/src/status.rs
@@ -1,6 +1,15 @@
 /// Runtime ensure status: runtime started in this request.
 pub const RUNTIME_STARTED: &str = "started";
 
+/// Runtime ensure status: runtime start is in progress; poll again.
+///
+/// The agent returns this immediately instead of blocking the RPC for the
+/// full cold-boot window (up to ~90s for containerd + dockerd). The host's
+/// blocking vsock transport has a short per-RPC deadline (~5s); a blocking
+/// agent would cause the daemon to close the socketpair mid-call and the
+/// agent's eventual response write would fail with EPIPE.
+pub const RUNTIME_STARTING: &str = "starting";
+
 /// Runtime ensure status: runtime was already available.
 pub const RUNTIME_REUSED: &str = "reused";
 

--- a/guest/arcbox-agent/src/agent/ensure_runtime.rs
+++ b/guest/arcbox-agent/src/agent/ensure_runtime.rs
@@ -1,15 +1,33 @@
 //! EnsureRuntime state machine (platform-independent, testable).
+//!
+//! Non-blocking semantics: the RPC never awaits the start sequence inline.
+//! The first caller transitions `NotStarted`/`Failed` → `Starting`, spawns
+//! the actual start work as a background task, and returns `STATUS_STARTING`
+//! immediately. Subsequent callers see `Starting` and also return
+//! `STATUS_STARTING`. Once the background task publishes its result, further
+//! calls return cached `Ready`/`Failed` via `STATUS_REUSED`/`STATUS_FAILED`.
+//!
+//! Why non-blocking: the host-side vsock transport uses a short per-RPC
+//! deadline (~5s). Blocking the RPC for the full cold-boot window (up to
+//! ~90s waiting on containerd + dockerd) causes the daemon to close the
+//! socketpair mid-call, and the agent's eventual response write fails with
+//! EPIPE. Returning immediately keeps the RPC well under the deadline and
+//! lets the daemon poll with its own backoff.
 
+use std::future::Future;
+use std::sync::Arc;
 use std::sync::OnceLock;
 
-// STATUS_STARTED is used in the linux-only runtime start path and tests.
+// STATUS_STARTED is still a valid terminal status the start task can report
+// internally (persisted via `RuntimeState::Ready`'s message); callers see
+// STATUS_REUSED once state is settled.
 #[allow(unused_imports)]
 pub use arcbox_constants::status::{
     RUNTIME_FAILED as STATUS_FAILED, RUNTIME_REUSED as STATUS_REUSED,
-    RUNTIME_STARTED as STATUS_STARTED,
+    RUNTIME_STARTED as STATUS_STARTED, RUNTIME_STARTING as STATUS_STARTING,
 };
 use arcbox_protocol::agent::RuntimeEnsureResponse;
-use tokio::sync::{Mutex, Notify};
+use tokio::sync::Mutex;
 
 /// Runtime lifecycle state.
 #[derive(Debug, Clone)]
@@ -17,22 +35,18 @@ use tokio::sync::{Mutex, Notify};
 pub enum RuntimeState {
     /// No ensure has been attempted yet.
     NotStarted,
-    /// An ensure operation is in progress (first caller drives it).
+    /// A background start task is running.
     Starting,
     /// Runtime is confirmed ready.
     Ready { endpoint: String, message: String },
-    /// Last ensure attempt failed; may retry on next start_if_needed=true.
+    /// Last start attempt failed; a new `start_if_needed=true` call will retry.
     Failed { message: String },
 }
 
-/// Global singleton guard that serializes EnsureRuntime attempts and caches
-/// the outcome so that repeated / concurrent calls are idempotent.
+/// Global guard that serializes start attempts and caches the outcome.
 #[allow(dead_code)]
 pub struct RuntimeGuard {
     pub state: Mutex<RuntimeState>,
-    /// Notified when a Starting -> Ready/Failed transition completes so
-    /// that concurrent waiters can proceed.
-    pub notify: Notify,
 }
 
 impl RuntimeGuard {
@@ -40,40 +54,53 @@ impl RuntimeGuard {
     pub fn new() -> Self {
         Self {
             state: Mutex::new(RuntimeState::NotStarted),
-            notify: Notify::new(),
         }
     }
 }
 
-/// Returns the global RuntimeGuard singleton.
-#[allow(dead_code)]
-pub fn runtime_guard() -> &'static RuntimeGuard {
-    static GUARD: OnceLock<RuntimeGuard> = OnceLock::new();
-    GUARD.get_or_init(RuntimeGuard::new)
+impl Default for RuntimeGuard {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
-/// Platform-independent, idempotent EnsureRuntime handler.
+/// Returns the global `RuntimeGuard` singleton as an `Arc`.
 ///
-/// - First caller with `start_if_needed=true` transitions NotStarted -> Starting -> Ready/Failed.
-/// - Concurrent callers wait for the first caller to finish and share the result.
-/// - After Ready, subsequent calls return "reused" immediately.
-/// - After Failed, a new `start_if_needed=true` call retries.
-/// - `start_if_needed=false` only probes without attempting to start.
-///
-/// `start_fn` is invoked only by the driver; it performs the actual start sequence.
-/// `probe_fn` is invoked for start_if_needed=false to report current status.
+/// Arc (rather than `&'static`) so the same guard can be cloned into the
+/// background start task without leaking or requiring `'static` bounds on
+/// the future.
 #[allow(dead_code)]
-pub async fn ensure_runtime<F, P>(
-    guard: &RuntimeGuard,
+pub fn runtime_guard() -> Arc<RuntimeGuard> {
+    static GUARD: OnceLock<Arc<RuntimeGuard>> = OnceLock::new();
+    GUARD.get_or_init(|| Arc::new(RuntimeGuard::new())).clone()
+}
+
+/// Non-blocking EnsureRuntime handler.
+///
+/// - If state is `Ready`: returns the cached endpoint/message with `STATUS_REUSED`.
+/// - If `start_if_needed == false`: awaits `probe_fn` and returns its result.
+/// - If state is `Starting`: returns `STATUS_STARTING` immediately (daemon polls).
+/// - Otherwise: transitions state to `Starting`, spawns `make_start()` as a
+///   background task, and returns `STATUS_STARTING`.
+///
+/// The background task awaits the start future and publishes the outcome to
+/// `guard.state` (transitioning to `Ready` or `Failed`).
+///
+/// `make_start` is `FnOnce() -> Fut` (not a bare `Fut`) so the caller does not
+/// construct the future when we're already starting or ready — avoids wasted
+/// allocations on the hot polling path.
+#[allow(dead_code)]
+pub async fn ensure_runtime<F, Fut>(
+    guard: Arc<RuntimeGuard>,
     start_if_needed: bool,
-    start_fn: F,
-    probe_fn: P,
+    make_start: F,
+    probe_fn: impl Future<Output = RuntimeEnsureResponse>,
 ) -> RuntimeEnsureResponse
 where
-    F: std::future::Future<Output = RuntimeEnsureResponse>,
-    P: std::future::Future<Output = RuntimeEnsureResponse>,
+    F: FnOnce() -> Fut,
+    Fut: Future<Output = RuntimeEnsureResponse> + Send + 'static,
 {
-    // Fast path: if already Ready, return immediately.
+    // Fast path: Ready → return cached state.
     {
         let state = guard.state.lock().await;
         if let RuntimeState::Ready { endpoint, message } = &*state {
@@ -86,17 +113,16 @@ where
         }
     }
 
-    // Probe-only mode: do not attempt to start.
     if !start_if_needed {
         return probe_fn.await;
     }
 
-    // Attempt to become the driver of the start sequence.
-    let i_am_driver = {
+    // Decide whether to become the driver (spawn the background task).
+    let become_driver = {
         let mut state = guard.state.lock().await;
         match &*state {
             RuntimeState::Ready { endpoint, message } => {
-                // Another caller finished while we waited for the lock.
+                // Another call finished while we waited for the lock.
                 return RuntimeEnsureResponse {
                     ready: true,
                     endpoint: endpoint.clone(),
@@ -112,70 +138,282 @@ where
         }
     };
 
-    if i_am_driver {
-        // We are the driver: perform the actual start sequence.
-        let response = start_fn.await;
-
-        // Publish outcome to the state machine.
-        let mut state = guard.state.lock().await;
-        if response.ready {
-            *state = RuntimeState::Ready {
-                endpoint: response.endpoint.clone(),
-                message: response.message.clone(),
+    if become_driver {
+        let fut = make_start();
+        let guard_for_task = Arc::clone(&guard);
+        tokio::spawn(async move {
+            let response = fut.await;
+            let mut state = guard_for_task.state.lock().await;
+            *state = if response.ready {
+                RuntimeState::Ready {
+                    endpoint: response.endpoint.clone(),
+                    message: response.message.clone(),
+                }
+            } else {
+                RuntimeState::Failed {
+                    message: response.message.clone(),
+                }
             };
-        } else {
-            *state = RuntimeState::Failed {
-                message: response.message.clone(),
-            };
-        }
-        // Wake all waiters.
-        guard.notify.notify_waiters();
-
-        return response;
+        });
     }
 
-    // We are a waiter: wait for the driver to finish.
-    loop {
-        // Register for notification BEFORE checking state to prevent lost
-        // wakeups.  If the driver calls notify_waiters() between our state
-        // check and the await, the future is already enabled and will
-        // resolve immediately.
-        let notified = guard.notify.notified();
-        tokio::pin!(notified);
-        notified.as_mut().enable();
+    // Either we just spawned, or another caller is already driving. Return
+    // the pending marker so the daemon polls with backoff.
+    RuntimeEnsureResponse {
+        ready: false,
+        endpoint: String::new(),
+        message: "runtime start in progress".to_string(),
+        status: STATUS_STARTING.to_string(),
+    }
+}
 
-        let state = guard.state.lock().await;
-        match &*state {
-            RuntimeState::Ready { endpoint, message } => {
-                return RuntimeEnsureResponse {
-                    ready: true,
-                    endpoint: endpoint.clone(),
-                    message: message.clone(),
-                    status: STATUS_REUSED.to_string(),
-                };
-            }
-            RuntimeState::Failed { message } => {
-                return RuntimeEnsureResponse {
-                    ready: false,
-                    endpoint: String::new(),
-                    message: message.clone(),
-                    status: STATUS_FAILED.to_string(),
-                };
-            }
-            RuntimeState::Starting => {
-                // Release lock before waiting.
-                drop(state);
-                notified.await;
-            }
-            RuntimeState::NotStarted => {
-                // Should not happen, but treat as failed.
-                return RuntimeEnsureResponse {
-                    ready: false,
-                    endpoint: String::new(),
-                    message: "unexpected state: NotStarted after notify".to_string(),
-                    status: STATUS_FAILED.to_string(),
-                };
-            }
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicU32, Ordering};
+    use std::time::Duration;
+
+    fn make_ready_response() -> RuntimeEnsureResponse {
+        RuntimeEnsureResponse {
+            ready: true,
+            endpoint: "vsock:2375".to_string(),
+            message: "docker socket ready".to_string(),
+            status: STATUS_STARTED.to_string(),
         }
+    }
+
+    fn make_failed_response() -> RuntimeEnsureResponse {
+        RuntimeEnsureResponse {
+            ready: false,
+            endpoint: String::new(),
+            message: "docker socket missing".to_string(),
+            status: STATUS_FAILED.to_string(),
+        }
+    }
+
+    /// Waits for the background task to settle state into Ready or Failed.
+    async fn wait_settled(guard: &RuntimeGuard, deadline_ms: u64) -> RuntimeState {
+        let deadline = std::time::Instant::now() + Duration::from_millis(deadline_ms);
+        loop {
+            {
+                let state = guard.state.lock().await;
+                match &*state {
+                    RuntimeState::Ready { .. } | RuntimeState::Failed { .. } => {
+                        return state.clone();
+                    }
+                    _ => {}
+                }
+            }
+            if std::time::Instant::now() >= deadline {
+                let state = guard.state.lock().await;
+                return state.clone();
+            }
+            tokio::time::sleep(Duration::from_millis(2)).await;
+        }
+    }
+
+    #[tokio::test]
+    async fn first_call_returns_starting_and_state_becomes_ready() {
+        let guard = Arc::new(RuntimeGuard::new());
+
+        let r = ensure_runtime(
+            Arc::clone(&guard),
+            true,
+            || async { make_ready_response() },
+            async { unreachable!("probe should not be called when start_if_needed=true") },
+        )
+        .await;
+
+        assert!(!r.ready);
+        assert_eq!(r.status, STATUS_STARTING);
+
+        let settled = wait_settled(&guard, 500).await;
+        assert!(
+            matches!(&settled, RuntimeState::Ready { .. }),
+            "expected Ready, got {:?}",
+            settled
+        );
+    }
+
+    #[tokio::test]
+    async fn second_call_after_ready_returns_reused() {
+        let guard = Arc::new(RuntimeGuard::new());
+
+        // Drive start + wait for Ready.
+        let _ = ensure_runtime(
+            Arc::clone(&guard),
+            true,
+            || async { make_ready_response() },
+            async { unreachable!() },
+        )
+        .await;
+        let _ = wait_settled(&guard, 500).await;
+
+        // Subsequent call hits fast path.
+        let r = ensure_runtime(
+            Arc::clone(&guard),
+            true,
+            || async { panic!("start_fn should not be called after Ready") },
+            async { unreachable!() },
+        )
+        .await;
+
+        assert!(r.ready);
+        assert_eq!(r.status, STATUS_REUSED);
+        assert_eq!(r.endpoint, "vsock:2375");
+    }
+
+    #[tokio::test]
+    async fn call_while_starting_returns_starting() {
+        let guard = Arc::new(RuntimeGuard::new());
+        let gate = Arc::new(tokio::sync::Notify::new());
+        let gate_for_start = Arc::clone(&gate);
+
+        // First call spawns start that blocks on `gate` — state stays Starting.
+        let r1 = ensure_runtime(
+            Arc::clone(&guard),
+            true,
+            move || {
+                let gate = gate_for_start;
+                async move {
+                    gate.notified().await;
+                    make_ready_response()
+                }
+            },
+            async { unreachable!() },
+        )
+        .await;
+        assert_eq!(r1.status, STATUS_STARTING);
+
+        // Second call while Starting returns immediately with Starting.
+        let r2 = ensure_runtime(
+            Arc::clone(&guard),
+            true,
+            || async { panic!("start_fn must not re-run while Starting") },
+            async { unreachable!() },
+        )
+        .await;
+        assert!(!r2.ready);
+        assert_eq!(r2.status, STATUS_STARTING);
+
+        // Release the start task and wait for settlement.
+        gate.notify_one();
+        let settled = wait_settled(&guard, 500).await;
+        assert!(matches!(settled, RuntimeState::Ready { .. }));
+    }
+
+    #[tokio::test]
+    async fn failed_start_transitions_to_failed_and_retry_can_succeed() {
+        let guard = Arc::new(RuntimeGuard::new());
+
+        let _ = ensure_runtime(
+            Arc::clone(&guard),
+            true,
+            || async { make_failed_response() },
+            async { unreachable!() },
+        )
+        .await;
+        let settled = wait_settled(&guard, 500).await;
+        assert!(matches!(settled, RuntimeState::Failed { .. }));
+
+        // Retry: new start is spawned.
+        let r = ensure_runtime(
+            Arc::clone(&guard),
+            true,
+            || async { make_ready_response() },
+            async { unreachable!() },
+        )
+        .await;
+        assert_eq!(r.status, STATUS_STARTING);
+        let settled = wait_settled(&guard, 500).await;
+        assert!(matches!(settled, RuntimeState::Ready { .. }));
+    }
+
+    #[tokio::test]
+    async fn probe_only_does_not_spawn_start() {
+        let guard = Arc::new(RuntimeGuard::new());
+
+        let r = ensure_runtime(
+            Arc::clone(&guard),
+            false,
+            || async { panic!("start_fn must not run when start_if_needed=false") },
+            async { make_failed_response() },
+        )
+        .await;
+
+        assert!(!r.ready);
+        assert_eq!(r.status, STATUS_FAILED);
+
+        // State untouched.
+        let state = guard.state.lock().await;
+        assert!(matches!(&*state, RuntimeState::NotStarted));
+    }
+
+    #[tokio::test]
+    async fn concurrent_callers_spawn_start_exactly_once() {
+        let guard = Arc::new(RuntimeGuard::new());
+        let start_count = Arc::new(AtomicU32::new(0));
+        let barrier = Arc::new(tokio::sync::Barrier::new(5));
+
+        let mut handles = Vec::new();
+        for _ in 0..5 {
+            let guard = Arc::clone(&guard);
+            let start_count = Arc::clone(&start_count);
+            let barrier = Arc::clone(&barrier);
+
+            handles.push(tokio::spawn(async move {
+                barrier.wait().await;
+                ensure_runtime(
+                    guard,
+                    true,
+                    move || {
+                        let start_count = Arc::clone(&start_count);
+                        async move {
+                            start_count.fetch_add(1, Ordering::SeqCst);
+                            tokio::time::sleep(Duration::from_millis(20)).await;
+                            make_ready_response()
+                        }
+                    },
+                    async { unreachable!() },
+                )
+                .await
+            }));
+        }
+
+        for h in handles {
+            let r = h.await.unwrap();
+            assert_eq!(r.status, STATUS_STARTING);
+        }
+
+        let settled = wait_settled(&guard, 500).await;
+        assert!(matches!(settled, RuntimeState::Ready { .. }));
+        assert_eq!(start_count.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn probe_after_ready_returns_reused_without_running_probe() {
+        let guard = Arc::new(RuntimeGuard::new());
+
+        // Start + settle.
+        let _ = ensure_runtime(
+            Arc::clone(&guard),
+            true,
+            || async { make_ready_response() },
+            async { unreachable!() },
+        )
+        .await;
+        let _ = wait_settled(&guard, 500).await;
+
+        // Probe-only: fast path hits Ready before probe_fn is awaited.
+        let r = ensure_runtime(
+            Arc::clone(&guard),
+            false,
+            || async { panic!("start_fn must not run") },
+            async { panic!("probe_fn must not run when state is already Ready") },
+        )
+        .await;
+
+        assert!(r.ready);
+        assert_eq!(r.status, STATUS_REUSED);
     }
 }

--- a/guest/arcbox-agent/src/agent/ensure_runtime.rs
+++ b/guest/arcbox-agent/src/agent/ensure_runtime.rs
@@ -4,8 +4,13 @@
 //! The first caller transitions `NotStarted`/`Failed` → `Starting`, spawns
 //! the actual start work as a background task, and returns `STATUS_STARTING`
 //! immediately. Subsequent callers see `Starting` and also return
-//! `STATUS_STARTING`. Once the background task publishes its result, further
-//! calls return cached `Ready`/`Failed` via `STATUS_REUSED`/`STATUS_FAILED`.
+//! `STATUS_STARTING`. Once the background task publishes its result:
+//! - `Ready` → callers get cached endpoint/message with `STATUS_REUSED`.
+//! - `Failed` → the *next* caller with `start_if_needed=true` transitions
+//!   back to `Starting` and spawns a fresh start; callers don't observe a
+//!   cached failed response because the expected recovery mode is "ask the
+//!   agent to try again." Probe-only (`start_if_needed=false`) callers
+//!   bypass the state machine and re-run `probe_fn`.
 //!
 //! Why non-blocking: the host-side vsock transport uses a short per-RPC
 //! deadline (~5s). Blocking the RPC for the full cold-boot window (up to
@@ -15,6 +20,7 @@
 //! lets the daemon poll with its own backoff.
 
 use std::future::Future;
+use std::panic::AssertUnwindSafe;
 use std::sync::Arc;
 use std::sync::OnceLock;
 
@@ -27,6 +33,7 @@ pub use arcbox_constants::status::{
     RUNTIME_STARTED as STATUS_STARTED, RUNTIME_STARTING as STATUS_STARTING,
 };
 use arcbox_protocol::agent::RuntimeEnsureResponse;
+use futures::FutureExt;
 use tokio::sync::Mutex;
 
 /// Runtime lifecycle state.
@@ -66,9 +73,10 @@ impl Default for RuntimeGuard {
 
 /// Returns the global `RuntimeGuard` singleton as an `Arc`.
 ///
-/// Arc (rather than `&'static`) so the same guard can be cloned into the
-/// background start task without leaking or requiring `'static` bounds on
-/// the future.
+/// `Arc` (rather than `&'static RuntimeGuard`) lets callers cheaply clone the
+/// guard and move an owned handle into the background start task — the
+/// singleton state stays shared, but the spawn doesn't require borrowing
+/// from a `'static` reference.
 #[allow(dead_code)]
 pub fn runtime_guard() -> Arc<RuntimeGuard> {
     static GUARD: OnceLock<Arc<RuntimeGuard>> = OnceLock::new();
@@ -78,27 +86,31 @@ pub fn runtime_guard() -> Arc<RuntimeGuard> {
 /// Non-blocking EnsureRuntime handler.
 ///
 /// - If state is `Ready`: returns the cached endpoint/message with `STATUS_REUSED`.
-/// - If `start_if_needed == false`: awaits `probe_fn` and returns its result.
+/// - If `start_if_needed == false`: invokes `probe_fn` and returns its result.
 /// - If state is `Starting`: returns `STATUS_STARTING` immediately (daemon polls).
-/// - Otherwise: transitions state to `Starting`, spawns `make_start()` as a
-///   background task, and returns `STATUS_STARTING`.
+/// - Otherwise (`NotStarted` or `Failed`): transitions state to `Starting`,
+///   spawns `make_start()` as a background task, and returns `STATUS_STARTING`.
 ///
 /// The background task awaits the start future and publishes the outcome to
-/// `guard.state` (transitioning to `Ready` or `Failed`).
+/// `guard.state` (transitioning to `Ready` or `Failed`). If the start future
+/// panics, the task catches the unwind and publishes a `Failed` state so the
+/// state machine always settles and the daemon's poll loop can make progress.
 ///
-/// `make_start` is `FnOnce() -> Fut` (not a bare `Fut`) so the caller does not
-/// construct the future when we're already starting or ready — avoids wasted
-/// allocations on the hot polling path.
+/// Both `make_start` and `probe_fn` are `FnOnce() -> Fut` (not bare futures)
+/// so the caller does not construct a future on hot `Ready`/`Starting`
+/// polling paths where neither will be invoked.
 #[allow(dead_code)]
-pub async fn ensure_runtime<F, Fut>(
+pub async fn ensure_runtime<F, Fut, P, PFut>(
     guard: Arc<RuntimeGuard>,
     start_if_needed: bool,
     make_start: F,
-    probe_fn: impl Future<Output = RuntimeEnsureResponse>,
+    probe_fn: P,
 ) -> RuntimeEnsureResponse
 where
     F: FnOnce() -> Fut,
     Fut: Future<Output = RuntimeEnsureResponse> + Send + 'static,
+    P: FnOnce() -> PFut,
+    PFut: Future<Output = RuntimeEnsureResponse>,
 {
     // Fast path: Ready → return cached state.
     {
@@ -114,7 +126,7 @@ where
     }
 
     if !start_if_needed {
-        return probe_fn.await;
+        return probe_fn().await;
     }
 
     // Decide whether to become the driver (spawn the background task).
@@ -142,7 +154,26 @@ where
         let fut = make_start();
         let guard_for_task = Arc::clone(&guard);
         tokio::spawn(async move {
-            let response = fut.await;
+            // Catch panics from the start future so a bug there can't leave
+            // state stuck at `Starting` forever. `AssertUnwindSafe` is sound
+            // here: we discard the inner future on panic and publish a
+            // fresh `Failed` state directly.
+            let response = match AssertUnwindSafe(fut).catch_unwind().await {
+                Ok(resp) => resp,
+                Err(panic_payload) => {
+                    let message = panic_message(&panic_payload);
+                    tracing::error!(
+                        "ensure_runtime start task panicked: {}; marking runtime Failed",
+                        message
+                    );
+                    RuntimeEnsureResponse {
+                        ready: false,
+                        endpoint: String::new(),
+                        message: format!("runtime start panicked: {message}"),
+                        status: STATUS_FAILED.to_string(),
+                    }
+                }
+            };
             let mut state = guard_for_task.state.lock().await;
             *state = if response.ready {
                 RuntimeState::Ready {
@@ -164,6 +195,17 @@ where
         endpoint: String::new(),
         message: "runtime start in progress".to_string(),
         status: STATUS_STARTING.to_string(),
+    }
+}
+
+/// Best-effort extraction of a human-readable message from a panic payload.
+fn panic_message(payload: &Box<dyn std::any::Any + Send>) -> String {
+    if let Some(s) = payload.downcast_ref::<&'static str>() {
+        (*s).to_string()
+    } else if let Some(s) = payload.downcast_ref::<String>() {
+        s.clone()
+    } else {
+        "panic payload was not a string".to_string()
     }
 }
 
@@ -220,7 +262,7 @@ mod tests {
             Arc::clone(&guard),
             true,
             || async { make_ready_response() },
-            async { unreachable!("probe should not be called when start_if_needed=true") },
+            || async { unreachable!("probe should not be called when start_if_needed=true") },
         )
         .await;
 
@@ -244,7 +286,7 @@ mod tests {
             Arc::clone(&guard),
             true,
             || async { make_ready_response() },
-            async { unreachable!() },
+            || async { unreachable!() },
         )
         .await;
         let _ = wait_settled(&guard, 500).await;
@@ -254,7 +296,7 @@ mod tests {
             Arc::clone(&guard),
             true,
             || async { panic!("start_fn should not be called after Ready") },
-            async { unreachable!() },
+            || async { unreachable!() },
         )
         .await;
 
@@ -280,7 +322,7 @@ mod tests {
                     make_ready_response()
                 }
             },
-            async { unreachable!() },
+            || async { unreachable!() },
         )
         .await;
         assert_eq!(r1.status, STATUS_STARTING);
@@ -290,7 +332,7 @@ mod tests {
             Arc::clone(&guard),
             true,
             || async { panic!("start_fn must not re-run while Starting") },
-            async { unreachable!() },
+            || async { unreachable!() },
         )
         .await;
         assert!(!r2.ready);
@@ -310,7 +352,7 @@ mod tests {
             Arc::clone(&guard),
             true,
             || async { make_failed_response() },
-            async { unreachable!() },
+            || async { unreachable!() },
         )
         .await;
         let settled = wait_settled(&guard, 500).await;
@@ -321,7 +363,7 @@ mod tests {
             Arc::clone(&guard),
             true,
             || async { make_ready_response() },
-            async { unreachable!() },
+            || async { unreachable!() },
         )
         .await;
         assert_eq!(r.status, STATUS_STARTING);
@@ -337,7 +379,7 @@ mod tests {
             Arc::clone(&guard),
             false,
             || async { panic!("start_fn must not run when start_if_needed=false") },
-            async { make_failed_response() },
+            || async { make_failed_response() },
         )
         .await;
 
@@ -374,7 +416,7 @@ mod tests {
                             make_ready_response()
                         }
                     },
-                    async { unreachable!() },
+                    || async { unreachable!() },
                 )
                 .await
             }));
@@ -391,6 +433,42 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn panic_in_start_task_transitions_to_failed() {
+        let guard = Arc::new(RuntimeGuard::new());
+
+        let r = ensure_runtime(
+            Arc::clone(&guard),
+            true,
+            || async { panic!("boom from start_fn") },
+            || async { unreachable!() },
+        )
+        .await;
+        assert_eq!(r.status, STATUS_STARTING);
+
+        // Without the catch_unwind guard, state would stay Starting forever.
+        // With it, the panic is converted into Failed so the daemon's poll
+        // loop has a terminal state to observe.
+        let settled = wait_settled(&guard, 500).await;
+        assert!(
+            matches!(&settled, RuntimeState::Failed { .. }),
+            "expected Failed after panic, got {:?}",
+            settled
+        );
+
+        // A subsequent start_if_needed=true call retries cleanly.
+        let r = ensure_runtime(
+            Arc::clone(&guard),
+            true,
+            || async { make_ready_response() },
+            || async { unreachable!() },
+        )
+        .await;
+        assert_eq!(r.status, STATUS_STARTING);
+        let settled = wait_settled(&guard, 500).await;
+        assert!(matches!(settled, RuntimeState::Ready { .. }));
+    }
+
+    #[tokio::test]
     async fn probe_after_ready_returns_reused_without_running_probe() {
         let guard = Arc::new(RuntimeGuard::new());
 
@@ -399,7 +477,7 @@ mod tests {
             Arc::clone(&guard),
             true,
             || async { make_ready_response() },
-            async { unreachable!() },
+            || async { unreachable!() },
         )
         .await;
         let _ = wait_settled(&guard, 500).await;
@@ -409,7 +487,7 @@ mod tests {
             Arc::clone(&guard),
             false,
             || async { panic!("start_fn must not run") },
-            async { panic!("probe_fn must not run when state is already Ready") },
+            || async { panic!("probe_fn must not run when state is already Ready") },
         )
         .await;
 

--- a/guest/arcbox-agent/src/agent/mod.rs
+++ b/guest/arcbox-agent/src/agent/mod.rs
@@ -1184,7 +1184,7 @@ mod linux {
             guard,
             req.start_if_needed,
             || do_ensure_runtime_start(),
-            do_ensure_runtime_probe(),
+            || do_ensure_runtime_probe(),
         )
         .await;
 

--- a/guest/arcbox-agent/src/agent/mod.rs
+++ b/guest/arcbox-agent/src/agent/mod.rs
@@ -495,7 +495,16 @@ mod linux {
                         tracing::info!("Accepted connection from {:?}", peer_addr);
                         tokio::spawn(async move {
                             if let Err(e) = handle_connection(stream).await {
-                                tracing::error!("Connection error: {}", e);
+                                // A routine daemon-side teardown (host closes the
+                                // socketpair while the agent is writing a response)
+                                // surfaces as BrokenPipe / ConnectionReset /
+                                // UnexpectedEof. Log at warn — the daemon will
+                                // reopen on its next poll iteration.
+                                if is_peer_closed_error(&e) {
+                                    tracing::warn!("Connection closed by peer: {}", e);
+                                } else {
+                                    tracing::error!("Connection error: {}", e);
+                                }
                             }
                         });
                     }
@@ -702,6 +711,25 @@ mod linux {
         fn default() -> Self {
             Self::new()
         }
+    }
+
+    /// True when `err`'s chain contains an `io::Error` whose kind indicates
+    /// that the peer closed the socket. These are routine during daemon
+    /// shutdown or retry-driven teardown, not agent-side faults.
+    fn is_peer_closed_error(err: &anyhow::Error) -> bool {
+        err.chain().any(|cause| {
+            cause
+                .downcast_ref::<std::io::Error>()
+                .is_some_and(|io_err| {
+                    matches!(
+                        io_err.kind(),
+                        std::io::ErrorKind::BrokenPipe
+                            | std::io::ErrorKind::ConnectionReset
+                            | std::io::ErrorKind::ConnectionAborted
+                            | std::io::ErrorKind::UnexpectedEof
+                    )
+                })
+        })
     }
 
     /// Handles a single vsock connection.
@@ -1142,17 +1170,20 @@ mod linux {
         RpcResponse::SystemInfo(info)
     }
 
-    /// Idempotent, concurrency-safe EnsureRuntime handler.
+    /// Idempotent, non-blocking EnsureRuntime handler.
     ///
-    /// Delegates to the platform-independent `ensure_runtime` module, injecting
-    /// the actual start and probe functions that depend on Linux system state.
+    /// The first driver spawns [`do_ensure_runtime_start`] as a background
+    /// task and returns `STATUS_STARTING` immediately; subsequent callers see
+    /// the in-progress state and also return `STATUS_STARTING`. The daemon
+    /// polls until the state settles into `Ready`/`Failed`. See
+    /// [`ensure_runtime::ensure_runtime`] for the rationale.
     async fn handle_ensure_runtime(req: RuntimeEnsureRequest) -> RpcResponse {
         let guard = ensure_runtime::runtime_guard();
 
         let response = ensure_runtime::ensure_runtime(
             guard,
             req.start_if_needed,
-            do_ensure_runtime_start(),
+            || do_ensure_runtime_start(),
             do_ensure_runtime_probe(),
         )
         .await;
@@ -2385,388 +2416,5 @@ mod tests {
     #[test]
     fn test_agent_creation() {
         let _agent = Agent::new();
-    }
-
-    // =========================================================================
-    // EnsureRuntime State Machine Tests
-    // =========================================================================
-
-    use crate::agent::ensure_runtime::{
-        self, RuntimeGuard, RuntimeState, STATUS_FAILED, STATUS_REUSED, STATUS_STARTED,
-    };
-    use arcbox_protocol::agent::RuntimeEnsureResponse;
-    use std::sync::Arc;
-    use std::sync::atomic::{AtomicU32, Ordering};
-
-    /// Helper: creates a successful RuntimeEnsureResponse.
-    fn make_ready_response() -> RuntimeEnsureResponse {
-        RuntimeEnsureResponse {
-            ready: true,
-            endpoint: "vsock:2375".to_string(),
-            message: "docker socket ready".to_string(),
-            status: STATUS_STARTED.to_string(),
-        }
-    }
-
-    /// Helper: creates a failed RuntimeEnsureResponse.
-    fn make_failed_response() -> RuntimeEnsureResponse {
-        RuntimeEnsureResponse {
-            ready: false,
-            endpoint: String::new(),
-            message: "docker socket missing".to_string(),
-            status: STATUS_FAILED.to_string(),
-        }
-    }
-
-    #[tokio::test]
-    async fn test_ensure_runtime_first_call_started() {
-        let guard = RuntimeGuard::new();
-        let response =
-            ensure_runtime::ensure_runtime(&guard, true, async { make_ready_response() }, async {
-                unreachable!("probe should not be called when start_if_needed=true")
-            })
-            .await;
-
-        assert!(response.ready);
-        assert_eq!(response.status, STATUS_STARTED);
-        assert_eq!(response.endpoint, "vsock:2375");
-    }
-
-    #[tokio::test]
-    async fn test_ensure_runtime_second_call_reused() {
-        let guard = RuntimeGuard::new();
-
-        // First call: starts runtime.
-        let r1 =
-            ensure_runtime::ensure_runtime(&guard, true, async { make_ready_response() }, async {
-                unreachable!()
-            })
-            .await;
-        assert_eq!(r1.status, STATUS_STARTED);
-
-        // Second call: should reuse.
-        let r2 = ensure_runtime::ensure_runtime(
-            &guard,
-            true,
-            async { panic!("start_fn should not be called for reuse") },
-            async { unreachable!() },
-        )
-        .await;
-        assert!(r2.ready);
-        assert_eq!(r2.status, STATUS_REUSED);
-    }
-
-    #[tokio::test]
-    async fn test_ensure_runtime_20_sequential_calls_no_error() {
-        let guard = RuntimeGuard::new();
-
-        for i in 0..20 {
-            let response = ensure_runtime::ensure_runtime(
-                &guard,
-                true,
-                async { make_ready_response() },
-                async { unreachable!() },
-            )
-            .await;
-            assert!(response.ready, "call {} should succeed", i);
-            if i == 0 {
-                assert_eq!(response.status, STATUS_STARTED);
-            } else {
-                assert_eq!(response.status, STATUS_REUSED);
-            }
-        }
-    }
-
-    #[tokio::test]
-    async fn test_ensure_runtime_probe_only_no_start() {
-        let guard = RuntimeGuard::new();
-
-        let response = ensure_runtime::ensure_runtime(
-            &guard,
-            false,
-            async { panic!("start_fn should not be called when start_if_needed=false") },
-            async {
-                RuntimeEnsureResponse {
-                    ready: false,
-                    endpoint: String::new(),
-                    message: "docker not available".to_string(),
-                    status: STATUS_FAILED.to_string(),
-                }
-            },
-        )
-        .await;
-
-        assert!(!response.ready);
-        assert_eq!(response.status, STATUS_FAILED);
-    }
-
-    #[tokio::test]
-    async fn test_ensure_runtime_failed_then_retry_succeeds() {
-        let guard = RuntimeGuard::new();
-
-        // First call: fails.
-        let r1 =
-            ensure_runtime::ensure_runtime(&guard, true, async { make_failed_response() }, async {
-                unreachable!()
-            })
-            .await;
-        assert!(!r1.ready);
-        assert_eq!(r1.status, STATUS_FAILED);
-
-        // Second call: retry, now succeeds.
-        let r2 =
-            ensure_runtime::ensure_runtime(&guard, true, async { make_ready_response() }, async {
-                unreachable!()
-            })
-            .await;
-        assert!(r2.ready);
-        assert_eq!(r2.status, STATUS_STARTED);
-
-        // Third call: reused.
-        let r3 = ensure_runtime::ensure_runtime(
-            &guard,
-            true,
-            async { panic!("should not start again") },
-            async { unreachable!() },
-        )
-        .await;
-        assert!(r3.ready);
-        assert_eq!(r3.status, STATUS_REUSED);
-    }
-
-    #[tokio::test]
-    async fn test_ensure_runtime_concurrent_5_callers_consistent() {
-        let guard = Arc::new(RuntimeGuard::new());
-        let start_count = Arc::new(AtomicU32::new(0));
-        let barrier = Arc::new(tokio::sync::Barrier::new(5));
-
-        let mut handles = Vec::new();
-        for _ in 0..5 {
-            let guard = Arc::clone(&guard);
-            let start_count = Arc::clone(&start_count);
-            let barrier = Arc::clone(&barrier);
-
-            handles.push(tokio::spawn(async move {
-                // Synchronize all 5 tasks to start concurrently.
-                barrier.wait().await;
-
-                ensure_runtime::ensure_runtime(
-                    &guard,
-                    true,
-                    async {
-                        start_count.fetch_add(1, Ordering::SeqCst);
-                        // Simulate some startup delay.
-                        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
-                        make_ready_response()
-                    },
-                    async { unreachable!() },
-                )
-                .await
-            }));
-        }
-
-        let mut results = Vec::new();
-        for handle in handles {
-            results.push(handle.await.unwrap());
-        }
-
-        // All 5 should report ready.
-        for (i, r) in results.iter().enumerate() {
-            assert!(r.ready, "caller {} should see ready", i);
-        }
-
-        // Exactly 1 should have status "started", rest "reused".
-        let started_count = results
-            .iter()
-            .filter(|r| r.status == STATUS_STARTED)
-            .count();
-        let reused_count = results.iter().filter(|r| r.status == STATUS_REUSED).count();
-        assert_eq!(started_count, 1, "exactly one caller should be the driver");
-        assert_eq!(reused_count, 4, "other callers should get reused");
-
-        // start_fn should have been invoked exactly once.
-        assert_eq!(start_count.load(Ordering::SeqCst), 1);
-    }
-
-    #[tokio::test]
-    async fn test_ensure_runtime_concurrent_5_callers_failure_consistent() {
-        let guard = Arc::new(RuntimeGuard::new());
-        let barrier = Arc::new(tokio::sync::Barrier::new(5));
-
-        let mut handles = Vec::new();
-        for _ in 0..5 {
-            let guard = Arc::clone(&guard);
-            let barrier = Arc::clone(&barrier);
-
-            handles.push(tokio::spawn(async move {
-                barrier.wait().await;
-                ensure_runtime::ensure_runtime(
-                    &guard,
-                    true,
-                    async {
-                        tokio::time::sleep(std::time::Duration::from_millis(30)).await;
-                        make_failed_response()
-                    },
-                    async { unreachable!() },
-                )
-                .await
-            }));
-        }
-
-        let mut results = Vec::new();
-        for handle in handles {
-            results.push(handle.await.unwrap());
-        }
-
-        // All 5 should report not ready.
-        for (i, r) in results.iter().enumerate() {
-            assert!(!r.ready, "caller {} should see not ready", i);
-            assert_eq!(r.status, STATUS_FAILED, "caller {} should get failed", i);
-        }
-    }
-
-    #[tokio::test]
-    async fn test_ensure_runtime_no_lost_wakeup_when_driver_finishes_fast() {
-        // Repeat to make the regression deterministic enough: this used to
-        // hang intermittently when notify happened before waiter registered.
-        for _ in 0..50 {
-            let guard = Arc::new(RuntimeGuard::new());
-            let entered_start_fn = Arc::new(tokio::sync::Notify::new());
-            let (release_tx, release_rx) = tokio::sync::oneshot::channel::<()>();
-
-            let guard_driver = Arc::clone(&guard);
-            let entered_start_fn_driver = Arc::clone(&entered_start_fn);
-            let driver = tokio::spawn(async move {
-                ensure_runtime::ensure_runtime(
-                    &guard_driver,
-                    true,
-                    async move {
-                        entered_start_fn_driver.notify_waiters();
-                        let _ = release_rx.await;
-                        make_ready_response()
-                    },
-                    async { unreachable!() },
-                )
-                .await
-            });
-
-            // Ensure state has transitioned to Starting before spawning waiter.
-            entered_start_fn.notified().await;
-
-            let guard_waiter = Arc::clone(&guard);
-            let waiter = tokio::spawn(async move {
-                ensure_runtime::ensure_runtime(
-                    &guard_waiter,
-                    true,
-                    async { panic!("waiter should never run start_fn") },
-                    async { unreachable!() },
-                )
-                .await
-            });
-
-            // Give waiter a chance to enter wait path, then let driver finish.
-            tokio::task::yield_now().await;
-            tokio::time::sleep(std::time::Duration::from_millis(1)).await;
-            let _ = release_tx.send(());
-
-            let driver_resp = tokio::time::timeout(std::time::Duration::from_millis(500), driver)
-                .await
-                .expect("driver timed out")
-                .expect("driver task failed");
-            let waiter_resp = tokio::time::timeout(std::time::Duration::from_millis(500), waiter)
-                .await
-                .expect("waiter timed out")
-                .expect("waiter task failed");
-
-            assert!(driver_resp.ready);
-            assert_eq!(driver_resp.status, STATUS_STARTED);
-            assert!(waiter_resp.ready);
-            assert_eq!(waiter_resp.status, STATUS_REUSED);
-        }
-    }
-
-    #[tokio::test]
-    async fn test_ensure_runtime_state_machine_transitions() {
-        let guard = RuntimeGuard::new();
-
-        // Initially NotStarted.
-        {
-            let state = guard.state.lock().await;
-            assert!(matches!(&*state, RuntimeState::NotStarted));
-        }
-
-        // After successful ensure: Ready.
-        let _ =
-            ensure_runtime::ensure_runtime(&guard, true, async { make_ready_response() }, async {
-                unreachable!()
-            })
-            .await;
-        {
-            let state = guard.state.lock().await;
-            assert!(
-                matches!(&*state, RuntimeState::Ready { .. }),
-                "expected Ready, got {:?}",
-                *state
-            );
-        }
-    }
-
-    #[tokio::test]
-    async fn test_ensure_runtime_state_machine_failed_to_ready() {
-        let guard = RuntimeGuard::new();
-
-        // Fail first.
-        let _ =
-            ensure_runtime::ensure_runtime(&guard, true, async { make_failed_response() }, async {
-                unreachable!()
-            })
-            .await;
-        {
-            let state = guard.state.lock().await;
-            assert!(
-                matches!(&*state, RuntimeState::Failed { .. }),
-                "expected Failed, got {:?}",
-                *state
-            );
-        }
-
-        // Retry succeeds.
-        let _ =
-            ensure_runtime::ensure_runtime(&guard, true, async { make_ready_response() }, async {
-                unreachable!()
-            })
-            .await;
-        {
-            let state = guard.state.lock().await;
-            assert!(
-                matches!(&*state, RuntimeState::Ready { .. }),
-                "expected Ready after retry, got {:?}",
-                *state
-            );
-        }
-    }
-
-    #[tokio::test]
-    async fn test_ensure_runtime_probe_after_ready_returns_reused() {
-        let guard = RuntimeGuard::new();
-
-        // Start first.
-        let _ =
-            ensure_runtime::ensure_runtime(&guard, true, async { make_ready_response() }, async {
-                unreachable!()
-            })
-            .await;
-
-        // Probe (start_if_needed=false) should return reused immediately
-        // from the cached state, without calling probe_fn.
-        let r = ensure_runtime::ensure_runtime(
-            &guard,
-            false,
-            async { panic!("start_fn should not be called") },
-            async { panic!("probe_fn should not be called when state is Ready") },
-        )
-        .await;
-        assert!(r.ready);
-        assert_eq!(r.status, STATUS_REUSED);
     }
 }


### PR DESCRIPTION
## Summary

The agent's `handle_ensure_runtime` previously awaited the full runtime-start sequence inline (up to ~90s on cold boot, polling for dockerd readiness). The host-side vsock `BlockingVsockTransport` uses a 5s deadline per RPC, so the daemon would close the socketpair mid-call and the agent's eventual response write would fail with EPIPE.

Symptoms users saw:
- Daemon spam: `guest docker endpoint on vsock port 2375 not ready within 60000ms`
- Agent log spam: `ERROR Connection error: failed to write message`
- First `docker run` after fresh daemon: red-error experience, sometimes required retry

## What changed

- **`ensure_runtime` is now spawn-and-return**: first caller transitions `NotStarted`/`Failed` -> `Starting`, spawns the start sequence as a background task, and returns `STATUS_STARTING` immediately. Concurrent callers see `Starting` and also return `STATUS_STARTING`. Once the background task publishes state -> `Ready`/`Failed`, subsequent callers get cached `STATUS_REUSED` / `STATUS_FAILED`.
- **New status constant**: `RUNTIME_STARTING = "starting"`.
- **Log downgrade**: "Connection error" -> "Connection closed by peer" at `warn!` level when the `io::Error` chain indicates peer disconnect (`BrokenPipe`/`ConnectionReset`/`ConnectionAborted`/`UnexpectedEof`) — these are routine daemon-side retry teardowns, not agent faults.
- **7 new unit tests** cover fast-path Ready, Starting-returns-quickly, Failed -> Ready retry, probe-only, probe-after-Ready, and concurrent-callers-spawn-exactly-once. All green on host target.
- Daemon-side `wait_guest_endpoint_ready` already retries on `ready=false` with backoff, so no daemon change is needed.

## Test plan

- [x] `cargo test -p arcbox-agent --lib --bins` — 33 tests pass (7 new)
- [x] `cargo build -p arcbox-agent --target aarch64-unknown-linux-musl --release` — clean
- [x] `cargo build -p arcbox-daemon -p arcbox-cli -p arcbox-helper` — clean
- [x] e2e on macOS:
  - Fresh daemon + first `docker ps` / `curl /_ping`: ~3s (dominated by vsock cold-boot, no longer 60s timeout)
  - Subsequent calls: sub-100ms
  - `docker run -d alpine sleep 30` + `docker logs` + `docker rm -f`: works
  - `docker run -d -p 8082:80 nginx:alpine` + `curl localhost:8082`: HTTP 200 OK
  - daemon.log: zero `"guest docker endpoint ... not ready"` errors
  - agent.log: zero `ERROR`-level connection errors
  - Vsock agent-port (1024) RPCs complete in <1ms each (was ~5s mid-boot)

## Known unrelated issue

`docker run` in foreground/attach mode (without `-d`) prints container stdout correctly but CLI hangs after container exit — separate docker-attach HTTP-upgrade proxy bug, to be investigated in a follow-up PR.