### PR TITLE
chore: bump next release to 0.4.0 (release-please config)

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -19,6 +19,7 @@
   ],
   "packages": {
     ".": {
+      "release-as": "0.4.0",
       "extra-files": [
         {
           "type": "generic",


### PR DESCRIPTION
## Summary
- Adds `"release-as": "0.4.0"` to the `.` package in `release-please-config.json`
- Overrides release-please's default patch bump so the next release goes 0.3.21 → 0.4.0 instead of 0.3.22

## Why this, not PR #270
PR #270 used an empty commit with a `Release-As:` footer. Squash merge dropped the empty commit entirely (merge SHA equals base SHA), so master never saw the footer and release-please kept producing 0.3.22. This approach lands a real diff that squash merge will preserve.

## Follow-up after v0.4.0 releases
Remove the `"release-as": "0.4.0"` line once PR #188 merges and v0.4.0 is tagged — otherwise release-please will keep trying to re-release 0.4.0 on every run.

## Test plan
- [ ] Merge this PR
- [ ] Wait for Release Please workflow to complete
- [ ] Confirm PR #188 updates to `chore(master): release 0.4.0`
- [ ] After 0.4.0 is released, remove the `release-as` field in a follow-up PR