### PR TITLE
fix(storage): increase data disk to 8 TiB and add btrfs auto-resize

### DIFF
--- a/app/arcbox-core/src/vm_lifecycle/mod.rs
+++ b/app/arcbox-core/src/vm_lifecycle/mod.rs
@@ -69,8 +69,13 @@ const BALLOON_SHRINK_DELAY_SECS: u64 = 10;
 
 /// Persistent guest dockerd data image name.
 const DOCKER_DATA_IMAGE_NAME: &str = "docker.img";
-/// Persistent guest dockerd data image size (64 GiB sparse file).
-const DOCKER_DATA_IMAGE_SIZE_BYTES: u64 = 64 * 1024 * 1024 * 1024;
+/// Persistent guest dockerd data image size (8 TiB sparse file).
+///
+/// This is the virtual size of the block device. The host file is sparse and
+/// only consumes actual disk space for written blocks. 8 TiB matches OrbStack
+/// and prevents users from hitting artificial limits.
+const DOCKER_DATA_IMAGE_SIZE_BYTES: u64 = 8 * 1024 * 1024 * 1024 * 1024;
+
 /// Extended VM lifecycle state.
 ///
 /// This extends the basic `MachineState` with additional states
@@ -322,43 +327,52 @@ impl VmLifecycleManager {
         })?;
 
         if current_len.len() < size_bytes {
-            // Pre-allocate the image file on macOS (APFS). This eliminates
-            // host-side space allocation overhead on every guest write,
-            // preventing double-CoW amplification (Btrfs CoW + APFS CoW).
+            // Pre-allocate a bounded initial chunk on macOS (APFS) to reduce
+            // double-CoW amplification (Btrfs CoW + APFS CoW) for the working
+            // set. The full virtual size is set via `set_len` below, but we
+            // never ask APFS to physically reserve all of it — at 8 TiB that
+            // would either fail outright or, on a large disk, consume the
+            // entire requested capacity. The bounded cap matches the previous
+            // default working set and is best-effort; failures are ignored.
             #[cfg(target_os = "macos")]
             {
                 use std::os::unix::io::AsRawFd;
-                let fd = file.as_raw_fd();
-                // fstore_t: fst_flags, fst_posmode, fst_offset, fst_length, fst_bytesalloc
-                #[repr(C)]
-                #[allow(clippy::struct_field_names)] // mirrors macOS fstore_t C struct
-                struct FStore {
-                    fst_flags: u32,
-                    fst_posmode: i32,
-                    fst_offset: i64,
-                    fst_length: i64,
-                    fst_bytesalloc: i64,
-                }
-                const F_ALLOCATEALL: u32 = 0x00000004;
-                const F_PEOFPOSMODE: i32 = 3;
-                const F_PREALLOCATE: libc::c_int = 42;
-                let mut store = FStore {
-                    fst_flags: F_ALLOCATEALL,
-                    fst_posmode: F_PEOFPOSMODE,
-                    fst_offset: 0,
-                    #[allow(clippy::cast_possible_wrap)]
-                    fst_length: size_bytes as i64,
-                    fst_bytesalloc: 0,
-                };
-                // Best-effort: if pre-allocation fails (e.g. not enough disk
-                // space), fall through to ftruncate which creates a sparse file.
-                let ret = unsafe { libc::fcntl(fd, F_PREALLOCATE, &mut store) };
-                if ret == 0 {
-                    tracing::info!(
-                        path = %path.display(),
-                        allocated_bytes = store.fst_bytesalloc,
-                        "pre-allocated docker data image (APFS)"
-                    );
+                /// Upper bound on initial APFS preallocation, in bytes.
+                const APFS_PREALLOC_CAP_BYTES: u64 = 64 * 1024 * 1024 * 1024;
+                let prealloc_target = size_bytes.min(APFS_PREALLOC_CAP_BYTES);
+                if current_len.len() < prealloc_target {
+                    let fd = file.as_raw_fd();
+                    // fstore_t: fst_flags, fst_posmode, fst_offset, fst_length, fst_bytesalloc
+                    #[repr(C)]
+                    #[allow(clippy::struct_field_names)] // mirrors macOS fstore_t C struct
+                    struct FStore {
+                        fst_flags: u32,
+                        fst_posmode: i32,
+                        fst_offset: i64,
+                        fst_length: i64,
+                        fst_bytesalloc: i64,
+                    }
+                    const F_ALLOCATEALL: u32 = 0x00000004;
+                    const F_PEOFPOSMODE: i32 = 3;
+                    const F_PREALLOCATE: libc::c_int = 42;
+                    let mut store = FStore {
+                        fst_flags: F_ALLOCATEALL,
+                        fst_posmode: F_PEOFPOSMODE,
+                        fst_offset: 0,
+                        #[allow(clippy::cast_possible_wrap)]
+                        fst_length: prealloc_target as i64,
+                        fst_bytesalloc: 0,
+                    };
+                    // Best-effort: if pre-allocation fails (e.g. not enough disk
+                    // space), fall through to ftruncate which creates a sparse file.
+                    let ret = unsafe { libc::fcntl(fd, F_PREALLOCATE, &mut store) };
+                    if ret == 0 {
+                        tracing::info!(
+                            path = %path.display(),
+                            allocated_bytes = store.fst_bytesalloc,
+                            "pre-allocated docker data image (APFS)"
+                        );
+                    }
                 }
             }
 

--- a/guest/arcbox-agent/src/agent/linux/btrfs.rs
+++ b/guest/arcbox-agent/src/agent/linux/btrfs.rs
@@ -93,8 +93,23 @@ pub(super) fn ensure_data_mount() -> Result<String, String> {
     }
 
     let device = docker_data_device();
-    if !Path::new(&device).exists() {
-        return Err(format!("data device missing: {}", device));
+
+    // Wait for the VirtIO block device to appear. The kernel may need a
+    // moment to probe and register the device after boot. The 5 s budget is
+    // a heuristic; if it expires the underlying kernel probe is stuck and
+    // raising it would just mask the symptom.
+    {
+        let mut attempts = 0;
+        while !Path::new(&device).exists() {
+            attempts += 1;
+            if attempts > 50 {
+                return Err(format!("data device {} not available after 5 s", device));
+            }
+            std::thread::sleep(std::time::Duration::from_millis(100));
+        }
+        if attempts > 0 {
+            tracing::info!(device, attempts, "waited for data device");
+        }
     }
 
     // Step 1: Format if not Btrfs.
@@ -133,6 +148,23 @@ pub(super) fn ensure_data_mount() -> Result<String, String> {
         }
     }
 
+    let mut notes = Vec::new();
+
+    // Step 2.5: Grow the Btrfs filesystem to fill the (possibly resized)
+    // block device. The host sparse image may have grown since the last
+    // boot (e.g. 64 GiB → 8 TiB upgrade). `BTRFS_IOC_RESIZE` with "max"
+    // is a no-op when the FS already fills the device, so this is safe to
+    // run unconditionally. Failures are surfaced as a note rather than
+    // aborting the mount — running on the old capacity is preferable to
+    // refusing to start.
+    match btrfs_resize_max(BTRFS_TEMP_MOUNT) {
+        Ok(note) => notes.push(note),
+        Err(e) => {
+            tracing::error!(error = %e, "btrfs resize max failed");
+            notes.push(format!("resize failed: {}", e));
+        }
+    }
+
     // Step 3: Create subvolumes if missing.
     for subvol in ["@docker", "@containerd", "@k3s", "@kubelet", "@cni"] {
         let subvol_path = format!("{}/{}", BTRFS_TEMP_MOUNT, subvol);
@@ -145,8 +177,6 @@ pub(super) fn ensure_data_mount() -> Result<String, String> {
             return Err(format!("failed to create subvolume {}: {}", subvol, e));
         }
     }
-
-    let mut notes = Vec::new();
 
     // Step 4: Bind mount subvolumes to final paths.
     for (subvol, target) in [
@@ -263,6 +293,43 @@ fn disable_cow_on_metadata_dirs(mount_point: &str) {
 // c_int on musl vs c_ulong on glibc).
 nix::ioctl_write_ptr!(btrfs_ioc_subvol_create, 0x94, 14, [u8; 4096]);
 
+// BTRFS_IOC_RESIZE = _IOW(0x94, 3, struct btrfs_ioctl_vol_args)
+nix::ioctl_write_ptr!(btrfs_ioc_resize, 0x94, 3, [u8; 4096]);
+
+/// Builds the `BTRFS_IOC_RESIZE` argument buffer.
+///
+/// Layout: `__s64 devid` (8 bytes) followed by a null-terminated name string
+/// (up to 4088 bytes). For `BTRFS_IOC_RESIZE` the default device is `devid=1`
+/// and the size token is e.g. `"max"`.
+fn build_resize_args(devid: i64, size: &str) -> Result<[u8; 4096], String> {
+    let size_bytes = size.as_bytes();
+    if size_bytes.len() >= 4088 {
+        return Err("resize size token too long".to_string());
+    }
+    let mut args = [0u8; 4096];
+    args[0..8].copy_from_slice(&devid.to_le_bytes());
+    args[8..8 + size_bytes.len()].copy_from_slice(size_bytes);
+    Ok(args)
+}
+
+/// Grows the Btrfs filesystem on `mount_point` to fill the underlying
+/// block device. Uses `BTRFS_IOC_RESIZE` with `"max"` — this is a no-op
+/// when the FS already occupies the full device.
+fn btrfs_resize_max(mount_point: &str) -> Result<String, String> {
+    use std::os::unix::io::AsRawFd;
+
+    let dir = std::fs::File::open(mount_point)
+        .map_err(|e| format!("open {} for resize: {}", mount_point, e))?;
+    let args = build_resize_args(1, "max")?;
+
+    // SAFETY: valid fd from File::open, args buffer matches kernel struct layout.
+    unsafe { btrfs_ioc_resize(dir.as_raw_fd(), &args) }
+        .map_err(|e| format!("BTRFS_IOC_RESIZE max on {}: {}", mount_point, e))?;
+
+    tracing::info!(mount_point, "btrfs resize max succeeded");
+    Ok(format!("resized {} to device max", mount_point))
+}
+
 /// Creates a Btrfs subvolume using the `BTRFS_IOC_SUBVOL_CREATE` ioctl.
 ///
 /// This avoids needing the full `btrfs-progs` CLI in the EROFS rootfs.
@@ -297,4 +364,27 @@ fn btrfs_create_subvolume(path: &str) -> Result<(), String> {
 
     tracing::info!("created Btrfs subvolume {}", path);
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::build_resize_args;
+
+    #[test]
+    fn resize_args_layout_matches_kernel_struct() {
+        let args = build_resize_args(1, "max").unwrap();
+        // devid=1 as little-endian i64 in the first 8 bytes.
+        assert_eq!(&args[0..8], &1i64.to_le_bytes());
+        // "max" then a NUL terminator from the zero-initialized buffer.
+        assert_eq!(&args[8..11], b"max");
+        assert_eq!(args[11], 0);
+        // Remainder must stay zero.
+        assert!(args[12..].iter().all(|b| *b == 0));
+    }
+
+    #[test]
+    fn resize_args_rejects_oversized_token() {
+        let huge = "x".repeat(4088);
+        assert!(build_resize_args(1, &huge).is_err());
+    }
 }


### PR DESCRIPTION
## Summary

The default `docker.img` sparse file is 64 GiB, which users hit too easily once they keep a working set of images and volumes. OrbStack ships 8 TiB. Since the host file is sparse, the virtual size costs nothing until blocks are actually written.

Changes:

- `app/arcbox-core/src/vm_lifecycle/mod.rs` — bump `DOCKER_DATA_IMAGE_SIZE_BYTES` from 64 GiB to 8 TiB, with a docstring explaining sparse semantics.
- `guest/arcbox-agent/src/agent/mod.rs`:
  - Wait up to 5 s (50 × 100 ms) for `/dev/vdb` to appear. The VirtIO block device registration races the agent on cold boot.
  - After the first mount, call `BTRFS_IOC_RESIZE` with `"max"` so an existing 64 GiB filesystem transparently grows to fill the (possibly enlarged) block device on the next boot. No-op when the FS already fills the device.

Rebased from an old `fix/data-disk-size` branch (single commit from 2026-03-05). Paths updated for the `vm_lifecycle.rs → vm_lifecycle/mod.rs` and `agent.rs → agent/mod.rs` splits; the `// =====` section divider the original introduced is intentionally dropped to match the current convention.

## Test plan

- [x] `cargo check -p arcbox-core` clean
- [ ] Cross-compile `arcbox-agent` for `aarch64-unknown-linux-musl` (rely on CI)
- [ ] E2E: upgrade a machine that had the 64 GiB image and verify the mount auto-grows on next boot (`df -h /mnt/data`)
- [ ] Fresh install: verify `docker.img` virtual size reports 8 TiB and actual disk use stays low until workload writes

## Notes

The 5 s timeout for `/dev/vdb` is a heuristic — if anyone sees it expire in practice, the underlying kernel probe is stuck and increasing the timeout would only mask the symptom.