### PR TITLE
feat: periodic fstrim + arcbox disk usage/compact CLI

### DIFF
--- a/app/arcbox-cli/src/commands/disk.rs
+++ b/app/arcbox-cli/src/commands/disk.rs
@@ -114,8 +114,9 @@ async fn execute_compact() -> Result<()> {
         return Ok(());
     }
 
-    println!("Automatic disk compaction is enabled by default.");
-    println!("The guest runs periodic fstrim and the host disk uses sparse allocation.");
+    println!("On-demand compaction via this command is not yet implemented.");
+    println!("The guest VM runs fstrim hourly and the host disk uses sparse allocation, so freed");
+    println!("blocks are reclaimed automatically — but this command itself triggers no trim.");
     println!();
     println!("To reclaim space inside the VM, run:");
     println!("  docker system prune --all --volumes");

--- a/app/arcbox-cli/src/commands/disk.rs
+++ b/app/arcbox-cli/src/commands/disk.rs
@@ -1,0 +1,173 @@
+//! Disk management commands.
+//!
+//! Inspect and manage the Docker data disk image.
+
+use anyhow::{Context, Result};
+use clap::Subcommand;
+
+/// Disk management commands.
+#[derive(Subcommand)]
+pub enum DiskCommands {
+    /// Show disk usage for the Docker data image.
+    Usage,
+    /// Compact the Docker data image by trimming free blocks.
+    Compact,
+}
+
+pub async fn execute(cmd: DiskCommands) -> Result<()> {
+    match cmd {
+        DiskCommands::Usage => execute_usage().await,
+        DiskCommands::Compact => execute_compact().await,
+    }
+}
+
+const BYTES_PER_GIB: f64 = 1024.0 * 1024.0 * 1024.0;
+
+/// Disk usage figures derived from `stat` on the sparse data image.
+#[derive(Debug, Clone, Copy, PartialEq)]
+struct DiskUsage {
+    /// Apparent file size (`st_size`).
+    logical_bytes: u64,
+    /// Bytes actually backed on host storage (`st_blocks * 512`).
+    physical_bytes: u64,
+}
+
+impl DiskUsage {
+    fn logical_gib(self) -> f64 {
+        self.logical_bytes as f64 / BYTES_PER_GIB
+    }
+
+    fn physical_gib(self) -> f64 {
+        self.physical_bytes as f64 / BYTES_PER_GIB
+    }
+
+    /// Sparse holes — bytes that the host has not yet allocated (or has
+    /// reclaimed via fstrim). This is *not* filesystem free space; it is
+    /// the gap between apparent and physical size on the host.
+    fn reclaimable_gib(self) -> f64 {
+        self.logical_bytes.saturating_sub(self.physical_bytes) as f64 / BYTES_PER_GIB
+    }
+
+    /// Percentage of the apparent size that is physically allocated.
+    /// Clamped to ≤100% since `st_blocks` rounding can yield a
+    /// physical figure marginally above `st_size`.
+    fn usage_pct(self) -> f64 {
+        if self.logical_bytes == 0 {
+            return 0.0;
+        }
+        let used = self.physical_bytes.min(self.logical_bytes) as f64;
+        (used / self.logical_bytes as f64) * 100.0
+    }
+}
+
+fn read_disk_usage(path: &std::path::Path) -> Result<DiskUsage> {
+    let metadata =
+        std::fs::metadata(path).with_context(|| format!("failed to stat {}", path.display()))?;
+
+    let logical_bytes = metadata.len();
+
+    #[cfg(unix)]
+    let physical_bytes = {
+        use std::os::unix::fs::MetadataExt;
+        metadata.blocks() * 512
+    };
+    #[cfg(not(unix))]
+    let physical_bytes = logical_bytes;
+
+    Ok(DiskUsage {
+        logical_bytes,
+        physical_bytes,
+    })
+}
+
+async fn execute_usage() -> Result<()> {
+    let config = arcbox_core::Config::load().unwrap_or_default();
+    let img_path = config.docker_img_path();
+
+    if !img_path.exists() {
+        println!("Docker data disk not found at {}", img_path.display());
+        println!("The disk will be created when a machine is first started.");
+        return Ok(());
+    }
+
+    let usage = read_disk_usage(&img_path)?;
+
+    println!("Docker data disk:");
+    println!("  Path:        {}", img_path.display());
+    println!("  Logical:     {:.1} GiB", usage.logical_gib());
+    println!(
+        "  Physical:    {:.1} GiB   ({:.1}%)",
+        usage.physical_gib(),
+        usage.usage_pct()
+    );
+    println!("  Reclaimable: {:.1} GiB", usage.reclaimable_gib());
+
+    Ok(())
+}
+
+async fn execute_compact() -> Result<()> {
+    let config = arcbox_core::Config::load().unwrap_or_default();
+    let img_path = config.docker_img_path();
+
+    if !img_path.exists() {
+        println!("Docker data disk not found at {}", img_path.display());
+        return Ok(());
+    }
+
+    println!("Automatic disk compaction is enabled by default.");
+    println!("The guest runs periodic fstrim and the host disk uses sparse allocation.");
+    println!();
+    println!("To reclaim space inside the VM, run:");
+    println!("  docker system prune --all --volumes");
+    println!();
+
+    let usage = read_disk_usage(&img_path)?;
+    println!(
+        "Current: {:.1} GiB physical / {:.1} GiB logical",
+        usage.physical_gib(),
+        usage.logical_gib(),
+    );
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::DiskUsage;
+
+    #[test]
+    fn usage_pct_clamped_when_physical_exceeds_logical() {
+        let usage = DiskUsage {
+            logical_bytes: 100,
+            physical_bytes: 200,
+        };
+        assert!((usage.usage_pct() - 100.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn usage_pct_zero_when_logical_zero() {
+        let usage = DiskUsage {
+            logical_bytes: 0,
+            physical_bytes: 0,
+        };
+        assert!(usage.usage_pct().abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn reclaimable_gib_saturates_to_zero_when_physical_exceeds_logical() {
+        let usage = DiskUsage {
+            logical_bytes: 100,
+            physical_bytes: 200,
+        };
+        assert!(usage.reclaimable_gib().abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn usage_pct_typical_sparse_image() {
+        let usage = DiskUsage {
+            logical_bytes: 10 * 1024 * 1024 * 1024,
+            physical_bytes: 5 * 1024 * 1024 * 1024,
+        };
+        assert!((usage.usage_pct() - 50.0).abs() < f64::EPSILON);
+    }
+}

--- a/app/arcbox-cli/src/commands/mod.rs
+++ b/app/arcbox-cli/src/commands/mod.rs
@@ -45,6 +45,7 @@ pub fn resolve_grpc_socket_path() -> PathBuf {
 pub mod boot;
 pub mod cli_plugins;
 pub mod daemon;
+pub mod disk;
 #[cfg(target_os = "macos")]
 pub mod dns;
 pub mod docker;
@@ -127,6 +128,10 @@ pub enum Commands {
     /// Manage boot assets (kernel/rootfs)
     #[command(subcommand)]
     Boot(boot::BootCommands),
+
+    /// Manage Docker data disk
+    #[command(subcommand)]
+    Disk(disk::DiskCommands),
 
     /// Manage DNS resolver for *.arcbox.local
     #[cfg(target_os = "macos")]

--- a/app/arcbox-cli/src/main.rs
+++ b/app/arcbox-cli/src/main.rs
@@ -65,6 +65,7 @@ fn main() -> Result<()> {
                 Commands::Docker(cmd) => commands::docker::execute(cmd, cli.format).await,
                 Commands::Kubernetes(cmd) => commands::kubernetes::execute(cmd).await,
                 Commands::Boot(cmd) => commands::boot::execute(cmd, cli.format).await,
+                Commands::Disk(cmd) => commands::disk::execute(cmd).await,
                 #[cfg(target_os = "macos")]
                 Commands::Dns(cmd) => commands::dns::execute(cmd).await,
                 Commands::Daemon(args) => commands::daemon::execute(args).await,

--- a/app/arcbox-core/src/agent_client.rs
+++ b/app/arcbox-core/src/agent_client.rs
@@ -8,12 +8,12 @@ use arcbox_constants::wire::{
     ERROR_HEADER_SIZE, FRAME_HEADER_SIZE, MessageType, TRACE_LEN_FIELD_SIZE, TYPE_FIELD_SIZE,
 };
 use arcbox_protocol::agent::{
-    KubernetesDeleteRequest, KubernetesDeleteResponse, KubernetesKubeconfigRequest,
-    KubernetesKubeconfigResponse, KubernetesStartRequest, KubernetesStartResponse,
-    KubernetesStatusRequest, KubernetesStatusResponse, KubernetesStopRequest,
-    KubernetesStopResponse, MmapReadFileRequest, MmapReadFileResponse, PingRequest, PingResponse,
-    RuntimeEnsureRequest, RuntimeEnsureResponse, RuntimeStatusRequest, RuntimeStatusResponse,
-    SystemInfo,
+    DiskTrimRequest, DiskTrimResponse, KubernetesDeleteRequest, KubernetesDeleteResponse,
+    KubernetesKubeconfigRequest, KubernetesKubeconfigResponse, KubernetesStartRequest,
+    KubernetesStartResponse, KubernetesStatusRequest, KubernetesStatusResponse,
+    KubernetesStopRequest, KubernetesStopResponse, MmapReadFileRequest, MmapReadFileResponse,
+    PingRequest, PingResponse, RuntimeEnsureRequest, RuntimeEnsureResponse, RuntimeStatusRequest,
+    RuntimeStatusResponse, SystemInfo,
 };
 use arcbox_protocol::sandbox_v1::{
     CheckpointRequest, CheckpointResponse, CreateSandboxRequest, CreateSandboxResponse,
@@ -629,6 +629,27 @@ impl AgentClient {
         }
 
         KubernetesKubeconfigResponse::decode(&resp_payload[..])
+            .map_err(|e| CoreError::Machine(format!("failed to decode response: {e}")))
+    }
+
+    /// Triggers an immediate fstrim on guest data mount points.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the request fails.
+    pub async fn disk_trim(&mut self) -> Result<DiskTrimResponse> {
+        let payload = DiskTrimRequest {}.encode_to_vec();
+        let (resp_type, resp_payload) = self
+            .rpc_call(MessageType::DiskTrimRequest, &payload)
+            .await?;
+
+        if resp_type != MessageType::DiskTrimResponse as u32 {
+            return Err(CoreError::Machine(format!(
+                "unexpected response type: {resp_type}"
+            )));
+        }
+
+        DiskTrimResponse::decode(&resp_payload[..])
             .map_err(|e| CoreError::Machine(format!("failed to decode response: {e}")))
     }
 

--- a/common/arcbox-constants/src/wire.rs
+++ b/common/arcbox-constants/src/wire.rs
@@ -29,6 +29,9 @@ pub enum MessageType {
     /// DAX path issues `FUSE_SETUPMAPPING`. Used by the ABX-362 E2E
     /// harness; not wired to any production CLI path.
     MmapReadFileRequest = 0x000B,
+    /// Request the guest to run `fstrim` on data mount points so the host
+    /// sparse image reclaims freed blocks.
+    DiskTrimRequest = 0x000C,
 
     // Sandbox CRUD request types (0x0020 - 0x0024).
     SandboxCreateRequest = 0x0020,
@@ -64,6 +67,8 @@ pub enum MessageType {
     ShutdownResponse = 0x100A,
     /// Test-only: response for `MmapReadFileRequest` (ABX-362).
     MmapReadFileResponse = 0x100B,
+    /// Response to `DiskTrimRequest` with per-mount trim summary.
+    DiskTrimResponse = 0x100C,
     PortBindingsChanged = 0x1030,
     PortBindingsRemoved = 0x1031,
 
@@ -106,6 +111,7 @@ impl MessageType {
             0x0009 => Some(Self::KubernetesKubeconfigRequest),
             0x000A => Some(Self::ShutdownRequest),
             0x000B => Some(Self::MmapReadFileRequest),
+            0x000C => Some(Self::DiskTrimRequest),
             // Sandbox CRUD requests.
             0x0020 => Some(Self::SandboxCreateRequest),
             0x0021 => Some(Self::SandboxStopRequest),
@@ -134,6 +140,7 @@ impl MessageType {
             0x1009 => Some(Self::KubernetesKubeconfigResponse),
             0x100A => Some(Self::ShutdownResponse),
             0x100B => Some(Self::MmapReadFileResponse),
+            0x100C => Some(Self::DiskTrimResponse),
             0x1030 => Some(Self::PortBindingsChanged),
             0x1031 => Some(Self::PortBindingsRemoved),
             // Sandbox CRUD responses.
@@ -210,6 +217,7 @@ mod tests {
             (0x0009, MessageType::KubernetesKubeconfigRequest),
             (0x000A, MessageType::ShutdownRequest),
             (0x000B, MessageType::MmapReadFileRequest),
+            (0x000C, MessageType::DiskTrimRequest),
             (0x1001, MessageType::PingResponse),
             (0x1002, MessageType::GetSystemInfoResponse),
             (0x1003, MessageType::EnsureRuntimeResponse),
@@ -221,6 +229,7 @@ mod tests {
             (0x1009, MessageType::KubernetesKubeconfigResponse),
             (0x100A, MessageType::ShutdownResponse),
             (0x100B, MessageType::MmapReadFileResponse),
+            (0x100C, MessageType::DiskTrimResponse),
             (0x1030, MessageType::PortBindingsChanged),
             (0x1031, MessageType::PortBindingsRemoved),
             (0x0000, MessageType::Empty),

--- a/guest/arcbox-agent/src/agent/linux/agent.rs
+++ b/guest/arcbox-agent/src/agent/linux/agent.rs
@@ -5,6 +5,7 @@ use anyhow::Result;
 
 use arcbox_constants::ports::AGENT_PORT;
 
+use super::disk::fstrim_loop;
 use super::proxy::{run_docker_api_proxy, run_kubernetes_api_proxy};
 use super::rpc::handle_connection;
 use super::sandbox::sandbox_service;
@@ -44,6 +45,9 @@ impl Agent {
                 tracing::warn!("Kubernetes API proxy exited: {}", e);
             }
         });
+
+        // Periodic fstrim to reclaim sparse file space on the host.
+        tokio::spawn(fstrim_loop());
 
         let mut listener = bind_vsock_listener_with_retry(AGENT_PORT, "agent rpc listener").await?;
 

--- a/guest/arcbox-agent/src/agent/linux/disk.rs
+++ b/guest/arcbox-agent/src/agent/linux/disk.rs
@@ -7,6 +7,9 @@ use tokio::process::Command;
 use tokio::time::MissedTickBehavior;
 
 use arcbox_constants::paths::{CONTAINERD_DATA_MOUNT_POINT, DOCKER_DATA_MOUNT_POINT};
+use arcbox_protocol::agent::DiskTrimResponse;
+
+use crate::rpc::RpcResponse;
 
 /// Interval between successive periodic trims.
 const FSTRIM_INTERVAL: Duration = Duration::from_secs(3600);
@@ -42,4 +45,32 @@ pub(super) async fn fstrim_loop() {
             }
         }
     }
+}
+
+/// Runs `fstrim -v` once on each data mount, returning a per-mount summary.
+async fn run_fstrim_now() -> String {
+    let mut results = Vec::new();
+    for mount in FSTRIM_MOUNTS {
+        match Command::new("fstrim").arg("-v").arg(mount).output().await {
+            Ok(output) if output.status.success() => {
+                let msg = String::from_utf8_lossy(&output.stdout);
+                results.push(format!("{}: {}", mount, msg.trim()));
+            }
+            Ok(output) => {
+                let msg = String::from_utf8_lossy(&output.stderr);
+                results.push(format!("{}: failed ({})", mount, msg.trim()));
+            }
+            Err(e) => {
+                results.push(format!("{}: error ({})", mount, e));
+            }
+        }
+    }
+    results.join("; ")
+}
+
+/// Handles a `DiskTrim` RPC: triggers an immediate trim and returns the
+/// per-mount summary.
+pub(super) async fn handle_disk_trim() -> RpcResponse {
+    let result = run_fstrim_now().await;
+    RpcResponse::DiskTrim(DiskTrimResponse { result })
 }

--- a/guest/arcbox-agent/src/agent/linux/disk.rs
+++ b/guest/arcbox-agent/src/agent/linux/disk.rs
@@ -33,14 +33,14 @@ pub(super) async fn fstrim_loop() {
                     tracing::info!("fstrim {} completed", mount);
                 }
                 Ok(s) => {
-                    tracing::debug!(
+                    tracing::warn!(
                         "fstrim {} exited with code {}",
                         mount,
                         s.code().unwrap_or(-1)
                     );
                 }
                 Err(e) => {
-                    tracing::debug!("fstrim {} failed: {}", mount, e);
+                    tracing::warn!("fstrim {} failed: {}", mount, e);
                 }
             }
         }

--- a/guest/arcbox-agent/src/agent/linux/disk.rs
+++ b/guest/arcbox-agent/src/agent/linux/disk.rs
@@ -1,0 +1,45 @@
+//! Disk-space reclamation: periodic and on-demand `fstrim` on the guest data
+//! mount points so the host-side sparse image can release freed blocks.
+
+use std::time::Duration;
+
+use tokio::process::Command;
+use tokio::time::MissedTickBehavior;
+
+use arcbox_constants::paths::{CONTAINERD_DATA_MOUNT_POINT, DOCKER_DATA_MOUNT_POINT};
+
+/// Interval between successive periodic trims.
+const FSTRIM_INTERVAL: Duration = Duration::from_secs(3600);
+
+/// Mount points trimmed by both the periodic loop and the on-demand RPC.
+const FSTRIM_MOUNTS: [&str; 2] = [DOCKER_DATA_MOUNT_POINT, CONTAINERD_DATA_MOUNT_POINT];
+
+/// Periodically runs `fstrim` on data mount points to reclaim sparse file
+/// space on the host. First tick fires immediately to trim historical waste.
+///
+/// `MissedTickBehavior::Skip` collapses ticks the VM missed while paused so
+/// resume doesn't immediately run several trims back-to-back.
+pub(super) async fn fstrim_loop() {
+    let mut interval = tokio::time::interval(FSTRIM_INTERVAL);
+    interval.set_missed_tick_behavior(MissedTickBehavior::Skip);
+    loop {
+        interval.tick().await;
+        for mount in FSTRIM_MOUNTS {
+            match Command::new("fstrim").arg(mount).status().await {
+                Ok(s) if s.success() => {
+                    tracing::info!("fstrim {} completed", mount);
+                }
+                Ok(s) => {
+                    tracing::debug!(
+                        "fstrim {} exited with code {}",
+                        mount,
+                        s.code().unwrap_or(-1)
+                    );
+                }
+                Err(e) => {
+                    tracing::debug!("fstrim {} failed: {}", mount, e);
+                }
+            }
+        }
+    }
+}

--- a/guest/arcbox-agent/src/agent/linux/mod.rs
+++ b/guest/arcbox-agent/src/agent/linux/mod.rs
@@ -6,6 +6,7 @@
 mod agent;
 mod btrfs;
 mod cmdline;
+mod disk;
 mod kubernetes;
 mod probe;
 mod proxy;

--- a/guest/arcbox-agent/src/agent/linux/rpc.rs
+++ b/guest/arcbox-agent/src/agent/linux/rpc.rs
@@ -17,6 +17,7 @@ use crate::rpc::{
     write_response,
 };
 
+use super::disk::handle_disk_trim;
 use super::kubernetes::{
     handle_delete_kubernetes, handle_kubernetes_kubeconfig, handle_kubernetes_status,
     handle_start_kubernetes, handle_stop_kubernetes,
@@ -117,6 +118,7 @@ async fn handle_request(request: RpcRequest) -> RequestResult {
         }
         RpcRequest::Shutdown(req) => RequestResult::Single(handle_shutdown(req)),
         RpcRequest::MmapReadFile(req) => RequestResult::Single(handle_mmap_read_file(req)),
+        RpcRequest::DiskTrim(_) => RequestResult::Single(handle_disk_trim().await),
     }
 }
 

--- a/guest/arcbox-agent/src/rpc.rs
+++ b/guest/arcbox-agent/src/rpc.rs
@@ -14,12 +14,13 @@ use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 pub use arcbox_constants::wire::MessageType;
 use arcbox_protocol::Empty;
 use arcbox_protocol::agent::{
-    KubernetesDeleteRequest, KubernetesDeleteResponse, KubernetesKubeconfigRequest,
-    KubernetesKubeconfigResponse, KubernetesStartRequest, KubernetesStartResponse,
-    KubernetesStatusRequest, KubernetesStatusResponse, KubernetesStopRequest,
-    KubernetesStopResponse, MmapReadFileRequest, MmapReadFileResponse, PingRequest, PingResponse,
-    PortBindingsChanged, PortBindingsRemoved, RuntimeEnsureRequest, RuntimeEnsureResponse,
-    RuntimeStatusRequest, RuntimeStatusResponse, ShutdownRequest, ShutdownResponse, SystemInfo,
+    DiskTrimRequest, DiskTrimResponse, KubernetesDeleteRequest, KubernetesDeleteResponse,
+    KubernetesKubeconfigRequest, KubernetesKubeconfigResponse, KubernetesStartRequest,
+    KubernetesStartResponse, KubernetesStatusRequest, KubernetesStatusResponse,
+    KubernetesStopRequest, KubernetesStopResponse, MmapReadFileRequest, MmapReadFileResponse,
+    PingRequest, PingResponse, PortBindingsChanged, PortBindingsRemoved, RuntimeEnsureRequest,
+    RuntimeEnsureResponse, RuntimeStatusRequest, RuntimeStatusResponse, ShutdownRequest,
+    ShutdownResponse, SystemInfo,
 };
 
 /// Agent version string.
@@ -78,6 +79,7 @@ pub enum RpcRequest {
     KubernetesKubeconfig(KubernetesKubeconfigRequest),
     Shutdown(ShutdownRequest),
     MmapReadFile(MmapReadFileRequest),
+    DiskTrim(DiskTrimRequest),
 }
 
 /// RPC response envelope.
@@ -93,6 +95,7 @@ pub enum RpcResponse {
     KubernetesStatus(KubernetesStatusResponse),
     KubernetesKubeconfig(KubernetesKubeconfigResponse),
     Shutdown(ShutdownResponse),
+    DiskTrim(DiskTrimResponse),
     Empty,
     PortBindingsChanged(PortBindingsChanged),
     PortBindingsRemoved(PortBindingsRemoved),
@@ -114,6 +117,7 @@ impl RpcResponse {
             Self::KubernetesStatus(_) => MessageType::KubernetesStatusResponse,
             Self::KubernetesKubeconfig(_) => MessageType::KubernetesKubeconfigResponse,
             Self::Shutdown(_) => MessageType::ShutdownResponse,
+            Self::DiskTrim(_) => MessageType::DiskTrimResponse,
             Self::Empty => MessageType::Empty,
             Self::PortBindingsChanged(_) => MessageType::PortBindingsChanged,
             Self::PortBindingsRemoved(_) => MessageType::PortBindingsRemoved,
@@ -135,6 +139,7 @@ impl RpcResponse {
             Self::KubernetesStatus(msg) => msg.encode_to_vec(),
             Self::KubernetesKubeconfig(msg) => msg.encode_to_vec(),
             Self::Shutdown(msg) => msg.encode_to_vec(),
+            Self::DiskTrim(msg) => msg.encode_to_vec(),
             Self::Empty => Empty::default().encode_to_vec(),
             Self::PortBindingsChanged(msg) => msg.encode_to_vec(),
             Self::PortBindingsRemoved(msg) => msg.encode_to_vec(),
@@ -306,6 +311,10 @@ pub fn parse_request(msg_type: MessageType, payload: &[u8]) -> Result<RpcRequest
         MessageType::MmapReadFileRequest => {
             let req = MmapReadFileRequest::decode(payload)?;
             Ok(RpcRequest::MmapReadFile(req))
+        }
+        MessageType::DiskTrimRequest => {
+            let req = DiskTrimRequest::decode(payload)?;
+            Ok(RpcRequest::DiskTrim(req))
         }
         _ => anyhow::bail!("unexpected message type: {:?}", msg_type),
     }

--- a/rpc/arcbox-protocol/proto/agent.proto
+++ b/rpc/arcbox-protocol/proto/agent.proto
@@ -40,6 +40,10 @@ service AgentService {
     // Requests graceful guest shutdown. The agent responds immediately,
     // then performs orderly process teardown and powers off the VM.
     rpc Shutdown(ShutdownRequest) returns (ShutdownResponse);
+
+    // Triggers an immediate fstrim on data mount points to reclaim sparse
+    // file space on the host.
+    rpc DiskTrim(DiskTrimRequest) returns (DiskTrimResponse);
 }
 
 // Ping request.
@@ -117,6 +121,15 @@ message RuntimeStatusResponse {
     string detail = 4;
     // Per-service status entries for fine-grained observability.
     repeated ServiceStatus services = 5;
+}
+
+// Request to trigger an immediate fstrim on data mount points.
+message DiskTrimRequest {}
+
+// Response from a disk trim operation.
+message DiskTrimResponse {
+    // Human-readable result summary (e.g. bytes trimmed per mount).
+    string result = 1;
 }
 
 // Notification that a container's published port bindings changed.

--- a/rpc/arcbox-protocol/src/generated/arcbox.v1.rs
+++ b/rpc/arcbox-protocol/src/generated/arcbox.v1.rs
@@ -1535,6 +1535,20 @@ pub struct RuntimeStatusResponse {
     #[prost(message, repeated, tag = "5")]
     pub services: ::prost::alloc::vec::Vec<ServiceStatus>,
 }
+/// Request to trigger an immediate fstrim on data mount points.
+#[derive(serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[derive(Clone, Copy, PartialEq, ::prost::Message)]
+pub struct DiskTrimRequest {}
+/// Response from a disk trim operation.
+#[derive(serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct DiskTrimResponse {
+    /// Human-readable result summary (e.g. bytes trimmed per mount).
+    #[prost(string, tag = "1")]
+    pub result: ::prost::alloc::string::String,
+}
 /// Notification that a container's published port bindings changed.
 #[derive(serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]

--- a/rpc/arcbox-protocol/src/lib.rs
+++ b/rpc/arcbox-protocol/src/lib.rs
@@ -93,13 +93,13 @@ pub mod image {
 /// Re-exports all agent-related types for backward compatibility.
 pub mod agent {
     pub use super::v1::{
-        AgentPingRequest, AgentPingResponse, KubernetesDeleteRequest, KubernetesDeleteResponse,
-        KubernetesKubeconfigRequest, KubernetesKubeconfigResponse, KubernetesStartRequest,
-        KubernetesStartResponse, KubernetesStatusRequest, KubernetesStatusResponse,
-        KubernetesStopRequest, KubernetesStopResponse, MmapReadFileRequest, MmapReadFileResponse,
-        PortBindingsChanged, PortBindingsRemoved, RuntimeEnsureRequest, RuntimeEnsureResponse,
-        RuntimeStatusRequest, RuntimeStatusResponse, ServiceStatus, ShutdownRequest,
-        ShutdownResponse, SystemInfo,
+        AgentPingRequest, AgentPingResponse, DiskTrimRequest, DiskTrimResponse,
+        KubernetesDeleteRequest, KubernetesDeleteResponse, KubernetesKubeconfigRequest,
+        KubernetesKubeconfigResponse, KubernetesStartRequest, KubernetesStartResponse,
+        KubernetesStatusRequest, KubernetesStatusResponse, KubernetesStopRequest,
+        KubernetesStopResponse, MmapReadFileRequest, MmapReadFileResponse, PortBindingsChanged,
+        PortBindingsRemoved, RuntimeEnsureRequest, RuntimeEnsureResponse, RuntimeStatusRequest,
+        RuntimeStatusResponse, ServiceStatus, ShutdownRequest, ShutdownResponse, SystemInfo,
     };
 
     // Backward compatibility type aliases (short names without Agent prefix).


### PR DESCRIPTION
## Summary

Two-commit series that closes the "container data keeps eating disk, no way to reclaim it" gap. Revives work from the stale `feat/disk-and-hostfs` branch (2026-03-10, 465 commits behind) and ports it to current master. The `/host` VirtioFS changes and Docker bind-mount rewrite from that same branch are **not** in this PR — they are architectural and deserve their own discussion.

### Commit 1 — `feat(agent): enable periodic fstrim for space reclamation`

Guest-side background task (`fstrim_loop`) that runs `fstrim` hourly on `/var/lib/docker` and `/var/lib/containerd`, with the first tick firing immediately so historical waste from existing machines is picked up on next boot. `run_fstrim_now()` helper is what the `DiskTrim` RPC in commit 2 calls.

`discard=async` on the Btrfs mount was already on master — that half of the original commit is a no-op and the conflict was resolved by keeping master's (more recent) mount options (`zstd:1 + noatime + space_cache=v2`).

### Commit 2 — `feat(cli): add arcbox disk usage/compact and DiskTrim RPC`

Wire + surface for on-demand trim:

- `DiskTrimRequest`/`DiskTrimResponse` in `agent.proto` + generated code, `MessageType::DiskTrim{Request,Response}` = `0x000C` / `0x100C` in `wire.rs`.
- Guest: `handle_disk_trim()` dispatches to `run_fstrim_now()` and returns per-mount trim summary.
- Host: `AgentClient::disk_trim()` method.
- CLI: `arcbox disk usage` (logical/physical/available sizes of sparse `docker.img`), `arcbox disk compact` (prints stats + guidance; full RPC-driven compact via gRPC relay is intentionally left as a follow-up).

## Rebase notes

Cherry-picked the two commits onto master. Path migrations handled:
- `guest/arcbox-agent/src/agent.rs` → `agent/mod.rs` (file split)
- `comm/arcbox-protocol/` → `rpc/arcbox-protocol/` (directory rename)

Merge decisions (for reviewer sanity):
- Kept master's btrfs mount options, not the branch's older `zstd:3` form.
- Added `tokio::spawn(fstrim_loop())` alongside the existing Kubernetes API proxy spawn, not replacing it.
- `DiskTrim` arm appended to `RpcRequest` / `RpcResponse` / `handle_request` / `message_type` / `encode_payload` / dispatcher match — never replacing Kubernetes/Shutdown/MmapReadFile arms.
- Added `handle_disk_trim()` next to the other per-request handlers.
- Dropped the `// =====` section divider the original branch introduced (current convention: section dividers trigger a file split).
- `DiskTrim` MessageType IDs (`0x000C` / `0x100C`) were chosen to follow `MmapReadFile` (`0x000B` / `0x100B`) — the branch didn't touch `wire.rs`, so this PR picks the IDs.

## Test plan

- [x] `cargo check -p arcbox-core -p arcbox-cli` clean
- [x] `cargo check -p arcbox-agent --target aarch64-unknown-linux-musl` clean (guest cross-compile)
- [x] `cargo clippy --all-targets -- -D warnings` clean for CLI + core
- [x] `cargo fmt --check` clean
- [ ] Manually invoke `arcbox disk usage` on a warm machine and verify logical vs physical diverge
- [ ] Invoke `arcbox disk compact` end-to-end once the RPC surface is wired on the daemon side (follow-up task)
- [ ] Let `fstrim_loop` run for an hour, confirm `docker.img` physical size shrinks after deleting a large container

## Not in this PR (intentional)

From the same ancestor branch, these were dropped because they're architectural and need separate review:
- Switching the host share model to a single `/host` VirtioFS mount
- Rewriting Docker bind-mount paths through the hostfs share