### PR TITLE
refactor(net): extract vmnet bindings into arcbox-vmnet crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -515,6 +515,7 @@ dependencies = [
  "arcbox-dns",
  "arcbox-error",
  "arcbox-virtio",
+ "arcbox-vmnet",
  "bytes",
  "chrono",
  "crossbeam-channel",
@@ -736,6 +737,7 @@ dependencies = [
  "arcbox-net",
  "arcbox-net-inject",
  "arcbox-virtio",
+ "arcbox-vmnet",
  "bytes",
  "chrono",
  "crossbeam-channel",
@@ -755,6 +757,18 @@ dependencies = [
  "vm-fdt",
  "vm-memory",
  "vm-superio",
+]
+
+[[package]]
+name = "arcbox-vmnet"
+version = "0.4.1"
+dependencies = [
+ "libc",
+ "thiserror",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "uuid",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ members = [
     "virt/arcbox-vm",
     "virt/arcbox-fs",
     "virt/arcbox-net",
+    "virt/arcbox-vmnet",
     "virt/arcbox-dhcp",
 
     # ============================================
@@ -204,6 +205,7 @@ arcbox-virtio-balloon = { version = "0.4.1", path = "virt/arcbox-virtio-balloon"
 arcbox-vm = { version = "0.4.1", path = "virt/arcbox-vm" } # x-release-please-version
 arcbox-fs = { version = "0.4.1", path = "virt/arcbox-fs" } # x-release-please-version
 arcbox-net = { version = "0.4.1", path = "virt/arcbox-net" } # x-release-please-version
+arcbox-vmnet = { version = "0.4.1", path = "virt/arcbox-vmnet" } # x-release-please-version
 arcbox-dhcp = { version = "0.4.1", path = "virt/arcbox-dhcp" } # x-release-please-version
 arcbox-container = { version = "0.4.1", path = "runtime/arcbox-container" } # x-release-please-version
 arcbox-protocol = { version = "0.4.1", path = "rpc/arcbox-protocol" } # x-release-please-version

--- a/virt/arcbox-net/Cargo.toml
+++ b/virt/arcbox-net/Cargo.toml
@@ -30,12 +30,15 @@ serde_json.workspace = true
 serde = { workspace = true, features = ["derive"] }
 crossbeam-channel = "0.5"
 
+[target.'cfg(target_os = "macos")'.dependencies]
+arcbox-vmnet = { workspace = true }
+
 [dev-dependencies]
 tokio = { workspace = true, features = ["test-util"] }
 
 [features]
 default = []
-vmnet = []
+vmnet = ["arcbox-vmnet/vmnet"]
 
 [lints]
 workspace = true

--- a/virt/arcbox-net/src/backend.rs
+++ b/virt/arcbox-net/src/backend.rs
@@ -114,12 +114,12 @@ impl NetworkBackend for TapBackend {
 
 /// vmnet backend for macOS.
 ///
-/// This is a wrapper around the low-level `Vmnet` implementation that
-/// conforms to the `NetworkBackend` trait.
+/// Wraps `arcbox_vmnet::Vmnet` so it conforms to the `NetworkBackend` trait
+/// and surfaces vmnet errors as [`crate::NetError`].
 #[cfg(target_os = "macos")]
 pub struct VmnetBackend {
     /// Inner vmnet interface.
-    inner: crate::darwin::Vmnet,
+    inner: arcbox_vmnet::Vmnet,
 }
 
 #[cfg(target_os = "macos")]
@@ -131,10 +131,10 @@ impl VmnetBackend {
     /// Returns an error if the vmnet interface cannot be created.
     /// This typically requires root privileges or appropriate entitlements.
     pub fn new(mac: [u8; 6], mtu: u16) -> Result<Self> {
-        let config = crate::darwin::VmnetConfig::shared()
+        let config = arcbox_vmnet::VmnetConfig::shared()
             .with_mac(mac)
             .with_mtu(mtu);
-        let inner = crate::darwin::Vmnet::new(config)?;
+        let inner = arcbox_vmnet::Vmnet::new(config)?;
         Ok(Self { inner })
     }
 
@@ -143,8 +143,8 @@ impl VmnetBackend {
     /// # Errors
     ///
     /// Returns an error if the vmnet interface cannot be created.
-    pub fn with_config(config: crate::darwin::VmnetConfig) -> Result<Self> {
-        let inner = crate::darwin::Vmnet::new(config)?;
+    pub fn with_config(config: arcbox_vmnet::VmnetConfig) -> Result<Self> {
+        let inner = arcbox_vmnet::Vmnet::new(config)?;
         Ok(Self { inner })
     }
 
@@ -154,7 +154,7 @@ impl VmnetBackend {
     ///
     /// Returns an error if the vmnet interface cannot be created.
     pub fn new_shared() -> Result<Self> {
-        let inner = crate::darwin::Vmnet::new_shared()?;
+        let inner = arcbox_vmnet::Vmnet::new_shared()?;
         Ok(Self { inner })
     }
 
@@ -164,7 +164,7 @@ impl VmnetBackend {
     ///
     /// Returns an error if the vmnet interface cannot be created.
     pub fn new_host_only() -> Result<Self> {
-        let inner = crate::darwin::Vmnet::new_host_only()?;
+        let inner = arcbox_vmnet::Vmnet::new_host_only()?;
         Ok(Self { inner })
     }
 
@@ -174,7 +174,7 @@ impl VmnetBackend {
     ///
     /// Returns an error if the vmnet interface cannot be created.
     pub fn new_bridged(interface: &str) -> Result<Self> {
-        let inner = crate::darwin::Vmnet::new_bridged(interface)?;
+        let inner = arcbox_vmnet::Vmnet::new_bridged(interface)?;
         Ok(Self { inner })
     }
 
@@ -199,11 +199,11 @@ impl VmnetBackend {
 #[cfg(target_os = "macos")]
 impl NetworkBackend for VmnetBackend {
     fn send(&self, data: &[u8]) -> Result<usize> {
-        self.inner.write_packet(data)
+        Ok(self.inner.write_packet(data)?)
     }
 
     fn recv(&self, buf: &mut [u8]) -> Result<usize> {
-        self.inner.read_packet(buf)
+        Ok(self.inner.read_packet(buf)?)
     }
 
     fn mac(&self) -> [u8; 6] {

--- a/virt/arcbox-net/src/darwin/mod.rs
+++ b/virt/arcbox-net/src/darwin/mod.rs
@@ -30,7 +30,9 @@ pub mod tcp_bridge;
 pub mod tso_backend;
 pub mod tun;
 
-pub use arcbox_vmnet::{Vmnet, VmnetConfig, VmnetInterfaceInfo, VmnetMode, VmnetRelay};
+#[cfg(feature = "vmnet")]
+pub use arcbox_vmnet::VmnetRelay;
+pub use arcbox_vmnet::{Vmnet, VmnetConfig, VmnetInterfaceInfo, VmnetMode};
 pub use nat::DarwinNatNetwork;
 pub use tun::DarwinTun;
 

--- a/virt/arcbox-net/src/darwin/mod.rs
+++ b/virt/arcbox-net/src/darwin/mod.rs
@@ -9,35 +9,14 @@
 //!
 //! - **Virtualization.framework**: High-level VM network attachment
 //!   (VZNATNetworkDeviceAttachment, VZBridgedNetworkDeviceAttachment)
-//! - **vmnet.framework**: Low-level packet I/O (for advanced use cases)
+//! - **vmnet.framework**: Low-level packet I/O — see the dedicated
+//!   [`arcbox_vmnet`] crate
 //!
 //! # Network Modes
 //!
 //! - **NAT (Shared)**: VMs share host's network connection via NAT
 //! - **Host-Only**: VMs can only communicate with host
 //! - **Bridged**: VMs appear as separate devices on the network
-//!
-//! # vmnet.framework
-//!
-//! The vmnet backend provides direct access to virtual network interfaces:
-//!
-//! ```ignore
-//! use arcbox_net::darwin::{Vmnet, VmnetConfig, VmnetMode};
-//!
-//! // Create a NAT (shared) network.
-//! let vmnet = Vmnet::new_shared()?;
-//!
-//! // Or create with custom configuration.
-//! let config = VmnetConfig::shared()
-//!     .with_mac([0x02, 0x00, 0x00, 0x00, 0x00, 0x01])
-//!     .with_mtu(1500);
-//! let vmnet = Vmnet::new(config)?;
-//!
-//! // Read/write packets.
-//! let mut buf = [0u8; 1500];
-//! let n = vmnet.read_packet(&mut buf)?;
-//! vmnet.write_packet(&buf[..n])?;
-//! ```
 
 pub mod classifier;
 pub mod datapath_loop;
@@ -50,14 +29,10 @@ pub mod socket_proxy;
 pub mod tcp_bridge;
 pub mod tso_backend;
 pub mod tun;
-pub mod vmnet;
-pub mod vmnet_ffi;
-#[cfg(feature = "vmnet")]
-pub mod vmnet_relay;
 
+pub use arcbox_vmnet::{Vmnet, VmnetConfig, VmnetInterfaceInfo, VmnetMode, VmnetRelay};
 pub use nat::DarwinNatNetwork;
 pub use tun::DarwinTun;
-pub use vmnet::{Vmnet, VmnetConfig, VmnetInterfaceInfo, VmnetMode};
 
 use std::net::Ipv4Addr;
 

--- a/virt/arcbox-net/src/error.rs
+++ b/virt/arcbox-net/src/error.rs
@@ -88,7 +88,9 @@ impl From<std::io::Error> for NetError {
 impl From<arcbox_vmnet::VmnetError> for NetError {
     fn from(err: arcbox_vmnet::VmnetError) -> Self {
         match err {
-            arcbox_vmnet::VmnetError::Config(msg) => Self::Common(CommonError::config(msg)),
+            arcbox_vmnet::VmnetError::Config(msg) => {
+                Self::Common(CommonError::config(format!("vmnet: {msg}")))
+            }
             arcbox_vmnet::VmnetError::Io(io) => Self::Common(CommonError::from(io)),
         }
     }
@@ -105,5 +107,31 @@ impl NetError {
     #[must_use]
     pub fn io(err: std::io::Error) -> Self {
         Self::Common(CommonError::from(err))
+    }
+}
+
+#[cfg(all(test, target_os = "macos"))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn vmnet_config_error_keeps_origin_prefix() {
+        let err: NetError =
+            arcbox_vmnet::VmnetError::config("bridge mode requires interface name").into();
+        let s = err.to_string();
+        assert!(
+            s.contains("vmnet: bridge mode requires interface name"),
+            "missing origin prefix: {s}"
+        );
+    }
+
+    #[test]
+    fn vmnet_io_error_passes_through() {
+        let io = std::io::Error::new(std::io::ErrorKind::PermissionDenied, "denied");
+        let err: NetError = arcbox_vmnet::VmnetError::Io(io).into();
+        match err {
+            NetError::Common(common) if common.is_io() => {}
+            other => panic!("expected Common(io), got {other:?}"),
+        }
     }
 }

--- a/virt/arcbox-net/src/error.rs
+++ b/virt/arcbox-net/src/error.rs
@@ -84,6 +84,16 @@ impl From<std::io::Error> for NetError {
     }
 }
 
+#[cfg(target_os = "macos")]
+impl From<arcbox_vmnet::VmnetError> for NetError {
+    fn from(err: arcbox_vmnet::VmnetError) -> Self {
+        match err {
+            arcbox_vmnet::VmnetError::Config(msg) => Self::Common(CommonError::config(msg)),
+            arcbox_vmnet::VmnetError::Io(io) => Self::Common(CommonError::from(io)),
+        }
+    }
+}
+
 impl NetError {
     /// Creates a configuration error.
     #[must_use]

--- a/virt/arcbox-vmm/Cargo.toml
+++ b/virt/arcbox-vmm/Cargo.toml
@@ -35,6 +35,9 @@ arcbox-fs = { version = "0.4.0", path = "../arcbox-fs" }
 arcbox-net-inject = { version = "0.4.0", path = "../arcbox-net-inject" }
 crossbeam-channel = "0.5"
 
+[target.'cfg(target_os = "macos")'.dependencies]
+arcbox-vmnet = { workspace = true }
+
 [dev-dependencies]
 tokio = { workspace = true, features = ["test-util"] }
 tempfile = "3"
@@ -49,7 +52,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 default = ["gic"]
 criu = []
 gic = ["arcbox-hv/gic"]
-vmnet = ["arcbox-net/vmnet"]
+vmnet = ["arcbox-net/vmnet", "arcbox-vmnet/vmnet"]
 
 [lints]
 workspace = true

--- a/virt/arcbox-vmm/src/vmm/darwin.rs
+++ b/virt/arcbox-vmm/src/vmm/darwin.rs
@@ -388,8 +388,7 @@ impl Vmm {
     /// Returns a `VirtioDeviceConfig` with the VZ-side raw fd.
     #[cfg(feature = "vmnet")]
     fn create_vmnet_bridge_nic(&mut self) -> Result<VirtioDeviceConfig> {
-        use arcbox_net::darwin::vmnet::{Vmnet, VmnetConfig};
-        use arcbox_net::darwin::vmnet_relay::VmnetRelay;
+        use arcbox_vmnet::{Vmnet, VmnetConfig, VmnetRelay};
 
         // Parse MAC from config.
         let config = if let Some(ref mac_str) = self.config.bridge_nic_mac {

--- a/virt/arcbox-vmm/src/vmm/darwin_hv/network.rs
+++ b/virt/arcbox-vmm/src/vmm/darwin_hv/network.rs
@@ -237,8 +237,7 @@ impl Vmm {
         memory_manager: &mut crate::memory::MemoryManager,
         irq_chip: &crate::irq::IrqChip,
     ) -> Result<()> {
-        use arcbox_net::darwin::vmnet::{Vmnet, VmnetConfig};
-        use arcbox_net::darwin::vmnet_relay::VmnetRelay;
+        use arcbox_vmnet::{Vmnet, VmnetConfig, VmnetRelay};
 
         // Parse MAC from config (stable per VM for bridge FDB lookup).
         let config = if let Some(ref mac_str) = self.config.bridge_nic_mac {

--- a/virt/arcbox-vmm/src/vmm/mod.rs
+++ b/virt/arcbox-vmm/src/vmm/mod.rs
@@ -273,7 +273,7 @@ pub struct Vmm {
     >,
     /// vmnet bridge interface for the bridge NIC (`vmnet` feature only).
     #[cfg(all(target_os = "macos", feature = "vmnet"))]
-    vmnet_bridge: Option<std::sync::Arc<arcbox_net::darwin::Vmnet>>,
+    vmnet_bridge: Option<std::sync::Arc<arcbox_vmnet::Vmnet>>,
     /// Cancellation token for the vmnet relay task.
     #[cfg(all(target_os = "macos", feature = "vmnet"))]
     vmnet_relay_cancel: Option<tokio_util::sync::CancellationToken>,
@@ -513,7 +513,7 @@ impl Vmm {
     /// Only populated when `vmnet` feature is enabled and interface started.
     #[cfg(all(target_os = "macos", feature = "vmnet"))]
     #[must_use]
-    pub fn vmnet_interface_info(&self) -> Option<arcbox_net::darwin::VmnetInterfaceInfo> {
+    pub fn vmnet_interface_info(&self) -> Option<arcbox_vmnet::VmnetInterfaceInfo> {
         self.vmnet_bridge
             .as_ref()
             .and_then(|v| v.interface_info().cloned())

--- a/virt/arcbox-vmnet/Cargo.toml
+++ b/virt/arcbox-vmnet/Cargo.toml
@@ -1,0 +1,30 @@
+[package]
+name = "arcbox-vmnet"
+description = "Safe Rust bindings for Apple's vmnet.framework"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+authors.workspace = true
+keywords = ["vmnet", "macos", "apple", "network", "virtualization"]
+categories = ["os::macos-apis", "network-programming", "virtualization"]
+
+[target.'cfg(target_os = "macos")'.dependencies]
+libc = { workspace = true }
+thiserror = { workspace = true }
+tokio = { workspace = true, features = ["sync", "rt", "io-util", "net"] }
+tokio-util = "0.7"
+tracing = { workspace = true }
+uuid = { workspace = true }
+
+[features]
+default = []
+# Enable the proper Objective-C completion-handler ABI for vmnet_start_interface.
+# Without this feature, the interface starts with a NULL handler and falls back
+# to default packet-size / generated MAC. The proper path requires the
+# `com.apple.vm.networking` entitlement (or root) at runtime.
+vmnet = []
+
+[lints]
+workspace = true

--- a/virt/arcbox-vmnet/src/error.rs
+++ b/virt/arcbox-vmnet/src/error.rs
@@ -1,0 +1,29 @@
+//! Errors returned by `arcbox-vmnet`.
+
+use thiserror::Error;
+
+/// Result alias for vmnet operations.
+pub type Result<T> = std::result::Result<T, VmnetError>;
+
+/// Errors that can occur while configuring or driving a vmnet interface.
+#[derive(Debug, Error)]
+pub enum VmnetError {
+    /// Configuration is invalid or vmnet rejected the start request.
+    ///
+    /// Typical causes: missing entitlement / not running as root, malformed
+    /// MAC, missing bridge interface, vmnet returned a non-success status.
+    #[error("vmnet configuration error: {0}")]
+    Config(String),
+
+    /// I/O error from `vmnet_read` / `vmnet_write` or an underlying syscall.
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
+}
+
+impl VmnetError {
+    /// Creates a configuration error.
+    #[must_use]
+    pub fn config(msg: impl Into<String>) -> Self {
+        Self::Config(msg.into())
+    }
+}

--- a/virt/arcbox-vmnet/src/ffi.rs
+++ b/virt/arcbox-vmnet/src/ffi.rs
@@ -1,17 +1,17 @@
 //! vmnet.framework FFI bindings.
 //!
-//! This module provides low-level bindings to Apple's vmnet.framework
-//! for creating virtual network interfaces on macOS.
+//! Low-level bindings to Apple's vmnet.framework for creating virtual
+//! network interfaces on macOS.
 //!
 //! # Architecture
 //!
-//! vmnet.framework uses Grand Central Dispatch (GCD) for asynchronous operations.
-//! All callbacks are delivered on dispatch queues.
+//! vmnet.framework uses Grand Central Dispatch (GCD) for asynchronous
+//! operations. All callbacks are delivered on dispatch queues.
 //!
 //! # References
 //!
-//! - Apple vmnet documentation: https://developer.apple.com/documentation/vmnet
-//! - lima-vm/socket_vmnet: https://github.com/lima-vm/socket_vmnet
+//! - Apple vmnet documentation: <https://developer.apple.com/documentation/vmnet>
+//! - lima-vm/socket_vmnet: <https://github.com/lima-vm/socket_vmnet>
 
 use std::ffi::{c_char, c_void};
 use std::os::raw::c_int;
@@ -111,6 +111,7 @@ pub struct VmnetPacket {
 /// IO vector for scatter-gather I/O.
 #[repr(C)]
 #[derive(Debug)]
+#[allow(non_camel_case_types)]
 pub struct iovec {
     /// Pointer to data.
     pub iov_base: *mut c_void,

--- a/virt/arcbox-vmnet/src/interface.rs
+++ b/virt/arcbox-vmnet/src/interface.rs
@@ -1,18 +1,7 @@
-//! vmnet.framework backend implementation.
+//! High-level vmnet.framework interface.
 //!
-//! This module provides a high-level Rust interface to Apple's vmnet.framework
-//! for creating virtual network interfaces on macOS.
-//!
-//! # Modes
-//!
-//! - **Shared (NAT)**: VMs share host network via NAT, with DHCP
-//! - **Host-only**: Isolated network between VMs and host
-//! - **Bridged**: VMs appear as separate devices on physical network
-//!
-//! # Requirements
-//!
-//! - macOS 11.0 or later
-//! - Privileged user or appropriate entitlements
+//! Provides a safe Rust wrapper around vmnet.framework for creating virtual
+//! network interfaces on macOS in shared (NAT), host-only, or bridged mode.
 
 use std::ffi::CString;
 use std::net::Ipv4Addr;
@@ -20,13 +9,12 @@ use std::os::raw::c_int;
 use std::ptr;
 use std::sync::atomic::{AtomicBool, Ordering};
 
-use super::vmnet_ffi::*;
-use crate::backend::NetworkBackend;
-use crate::error::{NetError, Result};
+use crate::error::{Result, VmnetError};
+use crate::ffi::*;
 
-/// Information returned by vmnet_start_interface completion handler.
+/// Information returned by `vmnet_start_interface` completion handler.
 ///
-/// Only available when the `vmnet` feature is enabled (proper block ABI).
+/// Only fully populated when the `vmnet` feature is enabled (proper block ABI).
 #[derive(Debug, Clone)]
 pub struct VmnetInterfaceInfo {
     /// MAC address assigned by vmnet.
@@ -41,8 +29,9 @@ pub struct VmnetInterfaceInfo {
 const DEFAULT_MTU: u16 = 1500;
 
 /// Default maximum packet size (Ethernet frame + VLAN tag).
-/// The actual value is returned by vmnet_start_interface completion handler,
-/// but without proper Objective-C block support, we use this default.
+///
+/// The actual value is returned by `vmnet_start_interface`'s completion handler,
+/// but without proper Objective-C block support we use this default.
 const DEFAULT_MAX_PACKET_SIZE: usize = 1518;
 
 /// vmnet interface configuration.
@@ -198,7 +187,7 @@ pub struct Vmnet {
     interface_info: Option<VmnetInterfaceInfo>,
 }
 
-// Safety: Vmnet uses thread-safe primitives and vmnet.framework is thread-safe.
+// SAFETY: Vmnet uses thread-safe primitives and vmnet.framework is thread-safe.
 unsafe impl Send for Vmnet {}
 unsafe impl Sync for Vmnet {}
 
@@ -215,13 +204,11 @@ impl Vmnet {
         // Create dispatch queue for vmnet operations.
         let queue_label = CString::new("com.arcbox.vmnet").unwrap();
 
-        // Safety: dispatch_queue_create is safe to call with valid parameters.
+        // SAFETY: dispatch_queue_create is safe to call with valid parameters.
         let queue = unsafe { dispatch_queue_create(queue_label.as_ptr(), ptr::null()) };
 
         if queue.is_null() {
-            return Err(NetError::config(
-                "failed to create dispatch queue".to_string(),
-            ));
+            return Err(VmnetError::config("failed to create dispatch queue"));
         }
 
         // Build XPC configuration dictionary.
@@ -230,9 +217,7 @@ impl Vmnet {
             let dict = xpc_dictionary_create(ptr::null(), ptr::null(), 0);
             if dict.is_null() {
                 dispatch_release(queue.cast());
-                return Err(NetError::config(
-                    "failed to create xpc config dictionary".to_string(),
-                ));
+                return Err(VmnetError::config("failed to create xpc config dictionary"));
             }
 
             // Set operating mode.
@@ -290,9 +275,7 @@ impl Vmnet {
                     } else {
                         xpc_release(dict);
                         dispatch_release(queue.cast());
-                        return Err(NetError::config(
-                            "bridge mode requires interface name".to_string(),
-                        ));
+                        return Err(VmnetError::config("bridge mode requires interface name"));
                     }
                 }
             }
@@ -322,9 +305,10 @@ impl Vmnet {
 
     /// Starts vmnet with a proper Objective-C block completion handler.
     ///
-    /// Extracts MAC, MTU, and max_packet_size from the interface_param dictionary
-    /// returned by vmnet. This path is only available when the `vmnet` feature is
-    /// enabled (requires `com.apple.vm.networking` entitlement or root).
+    /// Extracts MAC, MTU, and `max_packet_size` from the `interface_param`
+    /// dictionary returned by vmnet. This path is only available when the
+    /// `vmnet` feature is enabled (requires `com.apple.vm.networking`
+    /// entitlement or root).
     #[cfg(feature = "vmnet")]
     fn start_with_completion_handler(
         config_dict: XpcObjectT,
@@ -340,9 +324,7 @@ impl Vmnet {
                 xpc_release(config_dict);
                 dispatch_release(queue.cast());
             }
-            return Err(NetError::config(
-                "failed to create dispatch semaphore".to_string(),
-            ));
+            return Err(VmnetError::config("failed to create dispatch semaphore"));
         }
 
         // SAFETY: create_vmnet_completion_block takes a valid semaphore.
@@ -366,9 +348,8 @@ impl Vmnet {
             // A small leak is preferable to a crash. The dispatch queue is
             // also leaked to keep the handler's execution context valid.
             unsafe { xpc_release(config_dict) };
-            return Err(NetError::config(
-                "vmnet_start_interface timed out after 10s (completion handler never fired)"
-                    .to_string(),
+            return Err(VmnetError::config(
+                "vmnet_start_interface timed out after 10s (completion handler never fired)",
             ));
         }
 
@@ -390,7 +371,7 @@ impl Vmnet {
                 dispatch_release(sema);
                 dispatch_release(queue.cast());
             }
-            return Err(NetError::config(format!(
+            return Err(VmnetError::config(format!(
                 "vmnet_start_interface failed: {} (requires entitlement or root)",
                 status.message()
             )));
@@ -412,7 +393,7 @@ impl Vmnet {
                 // SAFETY: mac_ptr is a valid C string from XPC.
                 let mac_cstr = unsafe { CStr::from_ptr(mac_ptr) };
                 if let Ok(mac_str) = mac_cstr.to_str() {
-                    if let Ok(parsed) = super::parse_mac(mac_str) {
+                    if let Some(parsed) = parse_mac(mac_str) {
                         info.mac = parsed;
                     }
                 }
@@ -444,10 +425,10 @@ impl Vmnet {
 
         // If the user specified a MAC, prefer it. Otherwise use what vmnet returned.
         let mac = config.mac.unwrap_or(info.mac);
-        let mtu = if config.mtu != DEFAULT_MTU {
-            config.mtu
-        } else {
+        let mtu = if config.mtu == DEFAULT_MTU {
             info.mtu
+        } else {
+            config.mtu
         };
         let max_packet_size = info.max_packet_size;
 
@@ -461,10 +442,10 @@ impl Vmnet {
         Ok((interface, mac, mtu, max_packet_size, Some(final_info)))
     }
 
-    /// Starts vmnet with NULL handler (synchronous, no interface_param).
+    /// Starts vmnet with NULL handler (synchronous, no `interface_param`).
     ///
     /// Fallback when the `vmnet` feature is not enabled. Uses default values
-    /// for max_packet_size since the completion handler is not invoked.
+    /// for `max_packet_size` since the completion handler is not invoked.
     #[cfg(not(feature = "vmnet"))]
     fn start_with_null_handler(
         config_dict: XpcObjectT,
@@ -478,12 +459,12 @@ impl Vmnet {
 
         if interface.is_null() {
             unsafe { dispatch_release(queue.cast()) };
-            return Err(NetError::config(
-                "failed to start vmnet interface (requires root or entitlements)".to_string(),
+            return Err(VmnetError::config(
+                "failed to start vmnet interface (requires root or entitlements)",
             ));
         }
 
-        let mac = config.mac.unwrap_or_else(super::generate_mac);
+        let mac = config.mac.unwrap_or_else(generate_mac);
 
         Ok((interface, mac, config.mtu, DEFAULT_MAX_PACKET_SIZE, None))
     }
@@ -529,6 +510,18 @@ impl Vmnet {
         self.running.load(Ordering::Acquire)
     }
 
+    /// Returns the assigned MAC address.
+    #[must_use]
+    pub fn mac(&self) -> [u8; 6] {
+        self.mac
+    }
+
+    /// Returns the negotiated MTU.
+    #[must_use]
+    pub fn mtu(&self) -> u16 {
+        self.mtu
+    }
+
     /// Returns the maximum packet size.
     #[must_use]
     pub fn max_packet_size(&self) -> usize {
@@ -542,7 +535,7 @@ impl Vmnet {
     /// Returns an error if the read operation fails.
     pub fn read_packet(&self, buf: &mut [u8]) -> Result<usize> {
         if !self.is_running() {
-            return Err(NetError::config("interface not running".to_string()));
+            return Err(VmnetError::config("interface not running"));
         }
 
         // Create iovec for the buffer.
@@ -561,7 +554,7 @@ impl Vmnet {
 
         let mut pktcnt: c_int = 1;
 
-        // Safety: vmnet_read is safe when called with valid parameters.
+        // SAFETY: vmnet_read is safe when called with valid parameters.
         let status = unsafe { vmnet_read(self.interface, &raw mut packet, &raw mut pktcnt) };
 
         if !status.is_success() {
@@ -569,7 +562,7 @@ impl Vmnet {
                 // No packets available.
                 return Ok(0);
             }
-            return Err(NetError::io(std::io::Error::other(status.message())));
+            return Err(VmnetError::Io(std::io::Error::other(status.message())));
         }
 
         if pktcnt == 0 {
@@ -586,11 +579,11 @@ impl Vmnet {
     /// Returns an error if the write operation fails.
     pub fn write_packet(&self, data: &[u8]) -> Result<usize> {
         if !self.is_running() {
-            return Err(NetError::config("interface not running".to_string()));
+            return Err(VmnetError::config("interface not running"));
         }
 
         if data.len() > self.max_packet_size {
-            return Err(NetError::config(format!(
+            return Err(VmnetError::config(format!(
                 "packet too large: {} > {}",
                 data.len(),
                 self.max_packet_size
@@ -615,15 +608,15 @@ impl Vmnet {
 
         let mut pktcnt: c_int = 1;
 
-        // Safety: vmnet_write is safe when called with valid parameters.
+        // SAFETY: vmnet_write is safe when called with valid parameters.
         let status = unsafe { vmnet_write(self.interface, &raw mut packet, &raw mut pktcnt) };
 
         if !status.is_success() {
-            return Err(NetError::io(std::io::Error::other(status.message())));
+            return Err(VmnetError::Io(std::io::Error::other(status.message())));
         }
 
         if pktcnt == 0 {
-            return Err(NetError::io(std::io::Error::new(
+            return Err(VmnetError::Io(std::io::Error::new(
                 std::io::ErrorKind::WouldBlock,
                 "no packets written",
             )));
@@ -635,29 +628,11 @@ impl Vmnet {
     /// Stops the vmnet interface.
     pub fn stop(&self) {
         if self.running.swap(false, Ordering::AcqRel) {
-            // Safety: vmnet_stop_interface is safe when called with valid parameters.
+            // SAFETY: vmnet_stop_interface is safe when called with valid parameters.
             unsafe {
                 vmnet_stop_interface(self.interface, self.queue, ptr::null());
             }
         }
-    }
-}
-
-impl NetworkBackend for Vmnet {
-    fn send(&self, data: &[u8]) -> Result<usize> {
-        self.write_packet(data)
-    }
-
-    fn recv(&self, buf: &mut [u8]) -> Result<usize> {
-        self.read_packet(buf)
-    }
-
-    fn mac(&self) -> [u8; 6] {
-        self.mac
-    }
-
-    fn mtu(&self) -> u16 {
-        self.mtu
     }
 }
 
@@ -666,17 +641,55 @@ impl Drop for Vmnet {
         self.stop();
 
         // Release the dispatch queue.
-        // Safety: dispatch_release is safe for a valid queue.
+        // SAFETY: dispatch_release is safe for a valid queue.
         unsafe {
             dispatch_release(self.queue.cast());
         }
     }
 }
 
+/// Parses a MAC address from a colon-separated hex string ("aa:bb:cc:dd:ee:ff").
+///
+/// Returns `None` if the string is malformed.
+#[cfg(any(feature = "vmnet", test))]
+fn parse_mac(s: &str) -> Option<[u8; 6]> {
+    let parts: Vec<&str> = s.split(':').collect();
+    if parts.len() != 6 {
+        return None;
+    }
+    let mut mac = [0u8; 6];
+    for (i, part) in parts.iter().enumerate() {
+        mac[i] = u8::from_str_radix(part, 16).ok()?;
+    }
+    Some(mac)
+}
+
+/// Generates a random MAC address with the locally administered bit set.
+#[cfg(not(feature = "vmnet"))]
+fn generate_mac() -> [u8; 6] {
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    let seed = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos() as u64;
+
+    let mut state = seed;
+    let mut mac = [0u8; 6];
+
+    for byte in &mut mac {
+        state = state.wrapping_mul(6364136223846793005).wrapping_add(1);
+        *byte = (state >> 32) as u8;
+    }
+
+    // Set locally administered bit, clear multicast bit.
+    mac[0] = (mac[0] & 0xFC) | 0x02;
+    mac
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::net::Ipv4Addr;
 
     #[test]
     fn test_vmnet_config_default() {
@@ -763,8 +776,20 @@ mod tests {
         assert_eq!(config.mtu, cloned.mtu);
     }
 
+    #[test]
+    fn test_parse_mac() {
+        assert_eq!(
+            parse_mac("02:ab:cd:ef:12:34"),
+            Some([0x02, 0xAB, 0xCD, 0xEF, 0x12, 0x34])
+        );
+        assert!(parse_mac("invalid").is_none());
+        assert!(parse_mac("02:ab:cd:ef:12").is_none());
+        assert!(parse_mac("02:ab:cd:ef:12:34:56").is_none());
+        assert!(parse_mac("02:ab:cd:ef:12:gg").is_none());
+    }
+
     // Integration tests that require root/entitlements.
-    // Run with: sudo cargo test -p arcbox-net vmnet_integration -- --ignored
+    // Run with: sudo cargo test -p arcbox-vmnet vmnet_integration -- --ignored
     #[test]
     #[ignore = "requires macOS vmnet entitlements and root"]
     fn test_vmnet_create_shared() {
@@ -811,7 +836,6 @@ mod tests {
         let vmnet = Vmnet::new_shared().expect("Failed to create vmnet");
         let mut buf = [0u8; 1500];
 
-        // Reading with no data should return 0 or BufferExhausted.
         let result = vmnet.read_packet(&mut buf);
         assert!(result.is_ok());
         assert_eq!(result.unwrap(), 0);
@@ -822,13 +846,9 @@ mod tests {
     fn test_vmnet_write_packet() {
         let vmnet = Vmnet::new_shared().expect("Failed to create vmnet");
 
-        // Create a minimal Ethernet frame (14 bytes header + payload).
         let mut packet = vec![0u8; 64];
-        // Destination MAC (broadcast).
         packet[0..6].copy_from_slice(&[0xff, 0xff, 0xff, 0xff, 0xff, 0xff]);
-        // Source MAC.
         packet[6..12].copy_from_slice(&vmnet.mac());
-        // EtherType (0x0800 = IPv4).
         packet[12..14].copy_from_slice(&[0x08, 0x00]);
 
         let result = vmnet.write_packet(&packet);

--- a/virt/arcbox-vmnet/src/interface.rs
+++ b/virt/arcbox-vmnet/src/interface.rs
@@ -265,18 +265,22 @@ impl Vmnet {
                     }
                 }
                 VmnetMode::Bridged => {
-                    if let Some(ref iface) = config.bridge_interface {
-                        let s = std::ffi::CString::new(iface.as_str()).unwrap();
-                        xpc_dictionary_set_string(
-                            dict,
-                            vmnet_shared_interface_name_key,
-                            s.as_ptr(),
-                        );
-                    } else {
+                    let Some(ref iface) = config.bridge_interface else {
                         xpc_release(dict);
                         dispatch_release(queue.cast());
                         return Err(VmnetError::config("bridge mode requires interface name"));
-                    }
+                    };
+                    let s = match std::ffi::CString::new(iface.as_str()) {
+                        Ok(s) => s,
+                        Err(_) => {
+                            xpc_release(dict);
+                            dispatch_release(queue.cast());
+                            return Err(VmnetError::config(
+                                "bridge interface name contains a NUL byte",
+                            ));
+                        }
+                    };
+                    xpc_dictionary_set_string(dict, vmnet_shared_interface_name_key, s.as_ptr());
                 }
             }
 
@@ -423,8 +427,17 @@ impl Vmnet {
             dispatch_release(sema);
         }
 
-        // If the user specified a MAC, prefer it. Otherwise use what vmnet returned.
-        let mac = config.mac.unwrap_or(info.mac);
+        // Prefer user-specified MAC; otherwise the one vmnet returned. If
+        // both are absent (vmnet did not populate the dictionary or parsing
+        // failed), fall back to a generated locally-administered MAC so we
+        // never advertise the all-zero address.
+        let mac = config.mac.unwrap_or_else(|| {
+            if info.mac == [0u8; 6] {
+                generate_mac()
+            } else {
+                info.mac
+            }
+        });
         let mtu = if config.mtu == DEFAULT_MTU {
             info.mtu
         } else {
@@ -665,7 +678,6 @@ fn parse_mac(s: &str) -> Option<[u8; 6]> {
 }
 
 /// Generates a random MAC address with the locally administered bit set.
-#[cfg(not(feature = "vmnet"))]
 fn generate_mac() -> [u8; 6] {
     use std::time::{SystemTime, UNIX_EPOCH};
 

--- a/virt/arcbox-vmnet/src/lib.rs
+++ b/virt/arcbox-vmnet/src/lib.rs
@@ -1,0 +1,40 @@
+//! Safe Rust bindings for Apple's vmnet.framework.
+//!
+//! This crate exposes:
+//! - Low-level FFI declarations for `vmnet`, Core Foundation, GCD dispatch,
+//!   XPC, and the Objective-C block ABI required by `vmnet_start_interface`.
+//! - A high-level [`Vmnet`] interface for creating shared (NAT), host-only,
+//!   and bridged virtual network interfaces.
+//! - A [`VmnetRelay`] that bridges vmnet's blocking read/write API to a
+//!   `socketpair` consumed by `VZFileHandleNetworkDeviceAttachment`.
+//!
+//! # Operating modes
+//!
+//! - **Shared (NAT)** — VMs share the host's network connection via NAT,
+//!   with vmnet providing DHCP and DNS.
+//! - **Host-only** — Isolated network between VMs and host, optionally
+//!   with per-interface isolation via UUID.
+//! - **Bridged** — VMs appear as separate L2 devices on a physical network.
+//!
+//! # Requirements
+//!
+//! - macOS 11.0 or later.
+//! - The `com.apple.vm.networking` entitlement, or root, is required to
+//!   start a vmnet interface.
+//!
+//! # Feature flags
+//!
+//! - `vmnet` — Enable the proper Objective-C completion-handler ABI for
+//!   `vmnet_start_interface`. Without it, the interface starts with a
+//!   NULL handler and falls back to default packet-size / generated MAC.
+
+#![cfg(target_os = "macos")]
+
+pub mod error;
+pub mod ffi;
+pub mod interface;
+pub mod relay;
+
+pub use error::{Result, VmnetError};
+pub use interface::{Vmnet, VmnetConfig, VmnetInterfaceInfo, VmnetMode};
+pub use relay::VmnetRelay;

--- a/virt/arcbox-vmnet/src/lib.rs
+++ b/virt/arcbox-vmnet/src/lib.rs
@@ -32,8 +32,8 @@
 
 pub mod error;
 pub mod ffi;
-pub mod interface;
-pub mod relay;
+mod interface;
+mod relay;
 
 pub use error::{Result, VmnetError};
 pub use interface::{Vmnet, VmnetConfig, VmnetInterfaceInfo, VmnetMode};

--- a/virt/arcbox-vmnet/src/relay.rs
+++ b/virt/arcbox-vmnet/src/relay.rs
@@ -15,7 +15,7 @@ use tokio::io::Interest;
 use tokio::io::unix::AsyncFd;
 use tokio_util::sync::CancellationToken;
 
-use super::vmnet::Vmnet;
+use crate::interface::Vmnet;
 
 /// Maximum Ethernet frame size (jumbo frame capable).
 const MAX_FRAME_SIZE: usize = 9216;

--- a/virt/arcbox-vmnet/tests/api.rs
+++ b/virt/arcbox-vmnet/tests/api.rs
@@ -1,0 +1,154 @@
+//! Integration tests for the `arcbox-vmnet` public API.
+//!
+//! These exercise the surface that consumer crates (`arcbox-net`,
+//! `arcbox-vmm`) actually depend on. Tests that need a live vmnet
+//! interface — and therefore the `com.apple.vm.networking` entitlement
+//! or root — are marked `#[ignore]` and only run via:
+//!
+//! ```sh
+//! sudo cargo test -p arcbox-vmnet --test api -- --ignored
+//! ```
+
+#![cfg(target_os = "macos")]
+
+use std::net::Ipv4Addr;
+
+use arcbox_vmnet::{Vmnet, VmnetConfig, VmnetError, VmnetInterfaceInfo, VmnetMode};
+
+// ---------------------------------------------------------------------------
+// Pure-Rust API tests — no vmnet syscalls, safe to run anywhere on macOS.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn config_default_is_shared_nat() {
+    let config = VmnetConfig::default();
+    assert_eq!(config.mode, VmnetMode::Shared);
+    assert_eq!(config.mtu, 1500);
+    assert!(config.mac.is_none());
+    assert!(config.bridge_interface.is_none());
+    assert!(config.dhcp_start.is_none());
+    assert!(!config.isolated);
+}
+
+#[test]
+fn shared_builder_chain_sets_all_fields() {
+    let mac = [0x02, 0x00, 0x00, 0x12, 0x34, 0x56];
+    let config = VmnetConfig::shared()
+        .with_mac(mac)
+        .with_mtu(9000)
+        .with_dhcp_range(Ipv4Addr::new(10, 0, 0, 2), Ipv4Addr::new(10, 0, 0, 254))
+        .with_subnet_mask(Ipv4Addr::new(255, 255, 255, 0));
+
+    assert_eq!(config.mode, VmnetMode::Shared);
+    assert_eq!(config.mac, Some(mac));
+    assert_eq!(config.mtu, 9000);
+    assert_eq!(config.dhcp_start, Some(Ipv4Addr::new(10, 0, 0, 2)));
+    assert_eq!(config.dhcp_end, Some(Ipv4Addr::new(10, 0, 0, 254)));
+    assert_eq!(config.subnet_mask, Some(Ipv4Addr::new(255, 255, 255, 0)));
+}
+
+#[test]
+fn host_only_with_isolation() {
+    let config = VmnetConfig::host_only().with_isolation(true);
+    assert_eq!(config.mode, VmnetMode::HostOnly);
+    assert!(config.isolated);
+}
+
+#[test]
+fn bridged_carries_interface_name() {
+    let config = VmnetConfig::bridged("en0");
+    assert_eq!(config.mode, VmnetMode::Bridged);
+    assert_eq!(config.bridge_interface.as_deref(), Some("en0"));
+}
+
+#[test]
+fn vmnet_mode_default_is_shared() {
+    assert_eq!(VmnetMode::default(), VmnetMode::Shared);
+}
+
+#[test]
+fn vmnet_is_send_and_sync() {
+    fn assert_send_sync<T: Send + Sync>() {}
+    assert_send_sync::<Vmnet>();
+    assert_send_sync::<VmnetConfig>();
+    assert_send_sync::<VmnetInterfaceInfo>();
+}
+
+#[test]
+fn config_error_carries_message() {
+    let err = VmnetError::config("bad input");
+    let s = err.to_string();
+    assert!(s.contains("bad input"), "display missing message: {s}");
+    assert!(s.contains("vmnet"), "display missing crate prefix: {s}");
+    assert!(matches!(err, VmnetError::Config(_)));
+}
+
+#[test]
+fn io_error_converts_into_vmnet_error() {
+    let io = std::io::Error::new(std::io::ErrorKind::PermissionDenied, "denied");
+    let err: VmnetError = io.into();
+    assert!(matches!(err, VmnetError::Io(_)));
+}
+
+#[test]
+fn interface_info_fields_round_trip() {
+    let info = VmnetInterfaceInfo {
+        mac: [0x02, 0x00, 0x00, 0x00, 0x00, 0x01],
+        mtu: 1500,
+        max_packet_size: 1518,
+    };
+    let cloned = info.clone();
+    assert_eq!(cloned.mac, info.mac);
+    assert_eq!(cloned.mtu, info.mtu);
+    assert_eq!(cloned.max_packet_size, info.max_packet_size);
+}
+
+/// Bridged mode without a bridge interface is rejected before vmnet is
+/// touched, so this path runs without root or entitlement.
+#[test]
+fn bridged_without_interface_fails_with_config_error() {
+    let config = VmnetConfig {
+        mode: VmnetMode::Bridged,
+        bridge_interface: None,
+        ..Default::default()
+    };
+
+    match Vmnet::new(config) {
+        Err(VmnetError::Config(msg)) => {
+            assert!(msg.contains("bridge mode"), "unexpected message: {msg}");
+        }
+        Ok(_) => panic!("bridged mode without interface should fail"),
+        Err(other) => panic!("expected config error, got {other:?}"),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Live tests — require entitlement / root.
+// ---------------------------------------------------------------------------
+
+#[test]
+#[ignore = "requires com.apple.vm.networking entitlement or root"]
+fn shared_interface_starts_and_stops() {
+    let vmnet = Vmnet::new_shared().expect("vmnet start");
+    assert!(vmnet.is_running());
+    assert!(vmnet.max_packet_size() >= 1500);
+    vmnet.stop();
+    assert!(!vmnet.is_running());
+}
+
+#[test]
+#[ignore = "requires com.apple.vm.networking entitlement or root"]
+fn host_only_isolated_interface_starts() {
+    let config = VmnetConfig::host_only().with_isolation(true);
+    let vmnet = Vmnet::new(config).expect("vmnet start");
+    assert!(vmnet.is_running());
+}
+
+#[test]
+#[ignore = "requires com.apple.vm.networking entitlement or root"]
+fn read_with_no_traffic_returns_zero() {
+    let vmnet = Vmnet::new_shared().expect("vmnet start");
+    let mut buf = [0u8; 1500];
+    let n = vmnet.read_packet(&mut buf).expect("read");
+    assert_eq!(n, 0);
+}

--- a/virt/arcbox-vmnet/tests/api.rs
+++ b/virt/arcbox-vmnet/tests/api.rs
@@ -122,6 +122,20 @@ fn bridged_without_interface_fails_with_config_error() {
     }
 }
 
+/// An interface name containing an interior NUL byte must not panic — vmnet
+/// should reject it cleanly with a `Config` error.
+#[test]
+fn bridged_with_nul_in_interface_name_fails_cleanly() {
+    let config = VmnetConfig::bridged("en0\0evil");
+    match Vmnet::new(config) {
+        Err(VmnetError::Config(msg)) => {
+            assert!(msg.contains("NUL"), "unexpected message: {msg}");
+        }
+        Ok(_) => panic!("interface name with NUL should fail"),
+        Err(other) => panic!("expected config error, got {other:?}"),
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Live tests — require entitlement / root.
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Extract the vmnet.framework FFI, the high-level \`Vmnet\` interface, and the vmnet ↔ socketpair \`VmnetRelay\` from \`arcbox-net/darwin/\` into a dedicated \`arcbox-vmnet\` crate (macOS-only, with the proper Objective-C completion-handler ABI behind the same \`vmnet\` feature flag).
- \`arcbox-net\` keeps a thin \`VmnetBackend\` newtype that wraps \`arcbox_vmnet::Vmnet\` and converts errors via a new \`From<VmnetError> for NetError\`; \`arcbox-net::darwin\` re-exports the public types for back-compat.
- \`arcbox-vmm\` imports \`Vmnet\`, \`VmnetConfig\`, \`VmnetRelay\`, and \`VmnetInterfaceInfo\` directly from \`arcbox_vmnet\` instead of reaching through \`arcbox_net::darwin::vmnet::*\`.
- Adds an integration test suite at \`virt/arcbox-vmnet/tests/api.rs\` covering the consumer-facing surface; live-interface tests are gated behind \`#[ignore]\` (need the \`com.apple.vm.networking\` entitlement or root).

## Test plan
- [x] \`cargo check --workspace\` and \`--all-features\` clean
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` clean
- [x] \`cargo fmt --check\` clean
- [x] \`cargo test -p arcbox-vmnet\` — 10 unit + 10 integration pass (6 unit + 3 integration ignored, requiring entitlement)
- [x] \`cargo test -p arcbox-net --lib\` — 212 pass, no regression
- [ ] On a signed build with the vmnet entitlement: \`sudo cargo test -p arcbox-vmnet -- --ignored\`
- [ ] Smoke-boot a VM with \`--features vmnet\` to confirm the bridge NIC still works end-to-end