### PR TITLE
chore(workspace): promote internal path deps to workspace.dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -190,6 +190,8 @@ fc-sdk = "0.2.3"
 arcbox-constants = { version = "0.4.1", path = "common/arcbox-constants", features = ["std"] } # x-release-please-version
 arcbox-dns = { version = "0.4.1", path = "common/arcbox-dns" } # x-release-please-version
 arcbox-error = { version = "0.4.1", path = "common/arcbox-error" } # x-release-please-version
+arcbox-route = { version = "0.4.1", path = "common/arcbox-route" } # x-release-please-version
+arcbox-hv = { version = "0.3.20", path = "virt/arcbox-hv" } # x-release-please-version
 arcbox-vz = { version = "0.4.1", path = "virt/arcbox-vz" } # x-release-please-version
 arcbox-hypervisor = { version = "0.4.1", path = "virt/arcbox-hypervisor" } # x-release-please-version
 arcbox-vmm = { version = "0.4.1", path = "virt/arcbox-vmm" } # x-release-please-version
@@ -206,8 +208,10 @@ arcbox-vm = { version = "0.4.1", path = "virt/arcbox-vm" } # x-release-please-ve
 arcbox-fs = { version = "0.4.1", path = "virt/arcbox-fs" } # x-release-please-version
 arcbox-net = { version = "0.4.1", path = "virt/arcbox-net" } # x-release-please-version
 arcbox-vmnet = { version = "0.4.1", path = "virt/arcbox-vmnet" } # x-release-please-version
+arcbox-net-inject = { version = "0.4.1", path = "virt/arcbox-net-inject" } # x-release-please-version
 arcbox-dhcp = { version = "0.4.1", path = "virt/arcbox-dhcp" } # x-release-please-version
 arcbox-container = { version = "0.4.1", path = "runtime/arcbox-container" } # x-release-please-version
+arcbox-oci = { version = "0.4.1", path = "runtime/arcbox-oci" } # x-release-please-version
 arcbox-protocol = { version = "0.4.1", path = "rpc/arcbox-protocol" } # x-release-please-version
 arcbox-grpc = { version = "0.4.1", path = "rpc/arcbox-grpc" } # x-release-please-version
 arcbox-transport = { version = "0.4.1", path = "rpc/arcbox-transport" } # x-release-please-version
@@ -215,6 +219,7 @@ arcbox-docker = { version = "0.4.1", path = "app/arcbox-docker" } # x-release-pl
 arcbox-helper = { version = "0.4.1", path = "app/arcbox-helper" } # x-release-please-version
 arcbox-core = { version = "0.4.1", path = "app/arcbox-core" } # x-release-please-version
 arcbox-api = { version = "0.4.1", path = "app/arcbox-api" } # x-release-please-version
+arcbox-migration = { version = "0.4.1", path = "app/arcbox-migration" } # x-release-please-version
 arcbox-logging = { version = "0.4.1", path = "common/arcbox-logging", default-features = false } # x-release-please-version
 
 # Test infrastructure

--- a/app/arcbox-core/Cargo.toml
+++ b/app/arcbox-core/Cargo.toml
@@ -39,7 +39,7 @@ sha2 = { workspace = true }
 reqwest = { version = "0.12.28", default-features = false, features = ["rustls-tls", "json"] }
 arcbox-dns = { workspace = true }
 arcbox-helper = { workspace = true }
-arcbox-migration = { path = "../arcbox-migration" }
+arcbox-migration = { workspace = true }
 libc = { workspace = true }
 tempfile = "3"
 

--- a/app/arcbox-helper/Cargo.toml
+++ b/app/arcbox-helper/Cargo.toml
@@ -26,7 +26,7 @@ thiserror = { workspace = true }
 libc = { workspace = true }
 arcbox-constants.workspace = true
 arcbox-logging.workspace = true
-arcbox-route = { path = "../../common/arcbox-route" }
+arcbox-route = { workspace = true }
 tracing = { workspace = true }
 tokio-util = "0.7"
 ipnetwork = "0.21.1"

--- a/virt/arcbox-vmm/Cargo.toml
+++ b/virt/arcbox-vmm/Cargo.toml
@@ -26,13 +26,13 @@ tokio-util = "0.7"
 lz4_flex = "0.11"
 libc.workspace = true
 arcbox-dns = { workspace = true }
-arcbox-hv = { version = "0.3.20", path = "../arcbox-hv" }
+arcbox-hv = { workspace = true }
 vm-memory = { version = "0.17", features = ["backend-mmap"] }
 linux-loader = { version = "0.13", features = ["elf", "pe"] }
 vm-fdt = "0.3"
 vm-superio = "0.8"
-arcbox-fs = { version = "0.4.0", path = "../arcbox-fs" }
-arcbox-net-inject = { version = "0.4.0", path = "../arcbox-net-inject" }
+arcbox-fs = { workspace = true }
+arcbox-net-inject = { workspace = true }
 crossbeam-channel = "0.5"
 
 [target.'cfg(target_os = "macos")'.dependencies]


### PR DESCRIPTION
## Summary
- Five workspace members were consumed by other members but path-deped manually instead of going through \`[workspace.dependencies]\`. As a result \`arcbox-net-inject\` and \`arcbox-fs\` were still pinned to \`0.4.0\` in \`arcbox-vmm\` while the workspace had moved to \`0.4.1\`, and future bumps had to be hand-edited per consumer.
- Promote each one so every cross-member dep flows through the workspace, and fix the stale \`arcbox-fs\` pin while moving it to \`workspace = true\`.

| Crate | Consumer | Notes |
|---|---|---|
| \`arcbox-route\` | \`arcbox-helper\` | |
| \`arcbox-hv\` | \`arcbox-vmm\` | kept on its independent \`0.3.20\` release line |
| \`arcbox-net-inject\` | \`arcbox-vmm\` | drift fix \`0.4.0\` → \`0.4.1\` |
| \`arcbox-migration\` | \`arcbox-core\` | |
| \`arcbox-oci\` | _(none yet)_ | promoted preemptively for consistency |

Also fixes \`arcbox-fs\` in \`arcbox-vmm\`: was \`{ version = "0.4.0", path = ".." }\`, now \`{ workspace = true }\`.

## Test plan
- [x] \`cargo check --workspace\` clean
- [x] \`cargo check --workspace --all-features\` clean
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` clean
- [x] \`cargo fmt --check\` clean