### PR TITLE
fix(release-please): stop bumping arcbox-hv workspace dep pin

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -191,7 +191,10 @@ arcbox-constants = { version = "0.4.1", path = "common/arcbox-constants", featur
 arcbox-dns = { version = "0.4.1", path = "common/arcbox-dns" } # x-release-please-version
 arcbox-error = { version = "0.4.1", path = "common/arcbox-error" } # x-release-please-version
 arcbox-route = { version = "0.4.1", path = "common/arcbox-route" } # x-release-please-version
-arcbox-hv = { version = "0.3.20", path = "virt/arcbox-hv" } # x-release-please-version
+# arcbox-hv has its own release cadence (Apple Hypervisor.framework
+# bindings), so the workspace dep pin is bumped manually when arcbox-hv
+# itself is bumped — not by release-please.
+arcbox-hv = { version = "0.3.20", path = "virt/arcbox-hv" }
 arcbox-vz = { version = "0.4.1", path = "virt/arcbox-vz" } # x-release-please-version
 arcbox-hypervisor = { version = "0.4.1", path = "virt/arcbox-hypervisor" } # x-release-please-version
 arcbox-vmm = { version = "0.4.1", path = "virt/arcbox-vmm" } # x-release-please-version


### PR DESCRIPTION
## Summary

Release Please on master has been failing since the 0.4.2 release PR was generated. Root cause: `arcbox-hv` is an externally-versioned crate (Apple Hypervisor.framework bindings, currently `0.3.20`) but the workspace dep line in the root \`Cargo.toml\` carried a \`# x-release-please-version\` annotation. release-please dutifully bumped it to \`arcbox-hv = "0.4.2"\` in the release PR, while \`virt/arcbox-hv/Cargo.toml\` (not in the release-please config's \`extra-files\`) stayed at \`0.3.20\`. \`cargo update --workspace\` then failed:

\`\`\`
error: failed to select a version for the requirement \`arcbox-hv = "^0.4.2"\`
candidate versions found which didn't match: 0.3.20
required by package \`arcbox-vmm v0.4.2\`
\`\`\`

Fix: drop the annotation from that single line. release-please now leaves \`arcbox-hv\`'s workspace pin alone; when \`arcbox-hv\` is bumped, both files are updated manually in the same commit (same pattern most workspaces use for external-cadence deps).

## Test plan

- [ ] Wait for next Release Please run on master after merge — workflow should go green and the open release PR (#278) should regenerate with the correct \`arcbox-hv = "0.3.20"\` pin
- [ ] \`cargo check --workspace\` locally passes (verified pre-push)