### PR TITLE
fix(docker): bundle docker-init so buildx can boot its buildkit container

### DIFF
--- a/app/arcbox-core/src/boot_assets.rs
+++ b/app/arcbox-core/src/boot_assets.rs
@@ -246,7 +246,8 @@ impl BootAssetProvider {
         })
     }
 
-    /// Prepare host-side binaries (dockerd, containerd, shim, runc, k3s) into `dest_dir`.
+    /// Prepare host-side binaries (dockerd, containerd, shim, runc, docker-init, k3s)
+    /// into `dest_dir`.
     pub async fn prepare_binaries(
         &self,
         dest_dir: &Path,

--- a/app/arcbox-core/src/runtime.rs
+++ b/app/arcbox-core/src/runtime.rs
@@ -34,11 +34,12 @@ const DEFAULT_GUEST_IP: Ipv4Addr = Ipv4Addr::new(192, 168, 64, 2);
 /// `(guest_ip, host_port, protocol)` tuples registered for that container.
 #[cfg(target_os = "macos")]
 type InboundRulesMap = Arc<TokioRwLock<HashMap<String, Vec<(Ipv4Addr, u16, InboundProtocol)>>>>;
-const REQUIRED_RUNTIME_ASSETS: [&str; 5] = [
+const REQUIRED_RUNTIME_ASSETS: [&str; 6] = [
     "dockerd",
     "containerd",
     "containerd-shim-runc-v2",
     "runc",
+    "docker-init",
     "k3s",
 ];
 const KUBERNETES_HOST_ENDPOINT: &str = "https://127.0.0.1:16443";
@@ -441,7 +442,8 @@ impl Runtime {
         tokio::fs::create_dir_all(self.config.data_dir.join("vms")).await?;
         tokio::fs::create_dir_all(self.config.data_dir.join("machines")).await?;
 
-        // Download runtime binaries (dockerd, containerd, shim, runc, k3s) if not cached.
+        // Download runtime binaries (dockerd, containerd, shim, runc, docker-init, k3s)
+        // if not cached.
         let runtime_bin_dir = self.config.data_dir.join("runtime/bin");
         tokio::fs::create_dir_all(&runtime_bin_dir).await?;
         self.vm_lifecycle
@@ -874,6 +876,7 @@ mod tests {
             "runtime/bin/containerd",
             "runtime/bin/containerd-shim-runc-v2",
             "runtime/bin/runc",
+            "runtime/bin/docker-init",
             "runtime/bin/k3s",
         ] {
             let path = data_dir.join(name);

--- a/assets.lock
+++ b/assets.lock
@@ -11,9 +11,9 @@
 # skew to worry about when upgrading.
 
 [boot]
-version = "0.5.5"
+version = "0.5.7"
 cdn = "https://boot.arcboxcdn.com"
-manifest_sha256 = "7b9f8355f3ca2fe0b1aa143579216adc006580b9b0c0f843156ab29d50e8813e"
+manifest_sha256 = "66c0113b9f8537da22b3ecf53d6c3cdd0d89383b7a2294758285cdd44b0a069d"
 
 [[tools]]
 name = "docker"

--- a/guest/arcbox-agent/src/agent/linux/runtime.rs
+++ b/guest/arcbox-agent/src/agent/linux/runtime.rs
@@ -33,8 +33,13 @@ use crate::rpc::RpcResponse;
 pub(super) const CONTAINERD_SOCKET_CANDIDATES: [&str; 2] =
     [CONTAINERD_SOCKET, "/var/run/containerd/containerd.sock"];
 
-const REQUIRED_RUNTIME_BINARIES: &[&str] =
-    &["dockerd", "containerd", "containerd-shim-runc-v2", "runc"];
+const REQUIRED_RUNTIME_BINARIES: &[&str] = &[
+    "dockerd",
+    "containerd",
+    "containerd-shim-runc-v2",
+    "runc",
+    "docker-init",
+];
 
 /// Minimum "sane" UNIX timestamp for TLS certificate validation.
 ///
@@ -225,12 +230,14 @@ async fn ensure_dockerd_ready(runtime_bin_dir: &Path, notes: &mut Vec<String>) {
 
     let path_env = runtime_path_env(runtime_bin_dir);
     let dockerd_bin = runtime_bin_dir.join("dockerd");
+    let init_bin = runtime_bin_dir.join("docker-init");
     let mut cmd = Command::new(&dockerd_bin);
     cmd.arg(format!("--host=unix://{DOCKER_API_UNIX_SOCKET}"))
         .arg(format!("--containerd={CONTAINERD_SOCKET}"))
         .arg("--exec-root=/var/run/docker")
         .arg(format!("--data-root={DOCKER_DATA_MOUNT_POINT}"))
         .arg("--userland-proxy=false")
+        .arg(format!("--init-path={}", init_bin.display()))
         .env("PATH", &path_env)
         .stdin(Stdio::null())
         .stdout(daemon_log_file("dockerd"))


### PR DESCRIPTION
## Summary

- Add `docker-init` (tini) to the guest runtime binaries and pass `--init-path` to dockerd, so `docker run --init` and `docker buildx build` stop failing with `exec: "docker-init": executable file not found in $PATH`.
- Bump `assets.lock` to `boot-assets v0.5.7`, which is the first release that ships `docker-init` in the manifest (see `arcboxlabs/boot-assets@v0.5.7`).

Fixes [ABX-373](https://linear.app/arcbox/issue/ABX-373/guest-dockerd-missing-docker-init-docker-buildx-fails-to-create).

## Root cause

`docker buildx create` defaults to `--init`, so dockerd is asked to inject `docker-init` as PID 1 of the buildkit container. arcbox forwards `HostConfig.Init=true` verbatim to the guest dockerd (the `/containers/create` handler is a pure proxy), but the guest never had `docker-init` — only `dockerd / containerd / containerd-shim-runc-v2 / runc / k3s`. Same root cause would also bite plain `docker run --init`.

## Changes

**boot-assets (separately merged on master + tagged v0.5.7):**
- `upstream.toml`: extract `docker/docker-init` from the existing `docker-27.5.1.tgz` — same tarball as dockerd/containerd/runc, so versions stay locked.

**This PR:**
- `app/arcbox-core/src/runtime.rs`: add `docker-init` to `REQUIRED_RUNTIME_ASSETS`, update the test fixture list.
- `app/arcbox-core/src/boot_assets.rs`: docstring tweak.
- `guest/arcbox-agent/src/agent/linux/runtime.rs`: add `docker-init` to `REQUIRED_RUNTIME_BINARIES`; pass `--init-path={runtime_bin_dir}/docker-init` to dockerd at spawn so it resolves the explicit path instead of relying on `$PATH`.
- `assets.lock`: bump to `boot-assets 0.5.7` + new manifest sha256.

## Test plan

- [ ] `arcbox boot prefetch` pulls v0.5.7, including `docker-init` in `~/.arcbox/runtime/bin/`.
- [ ] `arcbox daemon start` reaches Ready (host-side `ensure_guest_binaries` and guest-side `REQUIRED_RUNTIME_BINARIES` both pass with docker-init present).
- [ ] `docker buildx create --name test --use && docker buildx inspect --bootstrap` creates and starts the buildkit container.
- [ ] `docker run --rm --init alpine echo ok` prints `ok`.
- [ ] The original wrangler / `docker buildx build` repro (`wrangler` building `artalk-artalk`) completes.
- [ ] Extend `e2e_docker_buildx_build` with a default-builder cold-start subcase. *(follow-up — current test doesn't trigger the path that auto-creates the builder.)*