### PR TITLE
chore(devenv): add devenv-based reproducible dev shell

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+eval "$(devenv direnvrc)"
+
+use devenv

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,14 @@ tests/resources/boot-assets-arm64-*
 # Scratch notes
 perf-issue.md
 issues.net.md
+
+# Devenv
+.devenv*
+devenv.local.nix
+devenv.local.yaml
+
+# direnv
+.direnv
+
+# pre-commit
+.pre-commit-config.yaml

--- a/devenv.lock
+++ b/devenv.lock
@@ -1,0 +1,86 @@
+{
+  "nodes": {
+    "devenv": {
+      "locked": {
+        "dir": "src/modules",
+        "lastModified": 1779636362,
+        "narHash": "sha256-Q/hy/ybvbe91fjA1MbulUwPjJH9yKaFZnSaTkwLE8S0=",
+        "owner": "cachix",
+        "repo": "devenv",
+        "rev": "9d6e68dac81fab1f7f2ec6784220151b4fba4b59",
+        "type": "github"
+      },
+      "original": {
+        "dir": "src/modules",
+        "owner": "cachix",
+        "repo": "devenv",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "inputs": {
+        "nixpkgs-src": "nixpkgs-src"
+      },
+      "locked": {
+        "lastModified": 1778507786,
+        "narHash": "sha256-HzSQCKMsMr8r55LwM1JuzIOB+8bzk0FEv6sItKvsfoY=",
+        "owner": "cachix",
+        "repo": "devenv-nixpkgs",
+        "rev": "8f24a228a782e24576b155d1e39f0d914b380691",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "ref": "rolling",
+        "repo": "devenv-nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1778274207,
+        "narHash": "sha256-I4puXmX1iovcCHZlRmztO3vW0mAbbRvq4F8wgIMQ1MM=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b3da656039dc7a6240f27b2ef8cc6a3ef3bccae7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "devenv": "devenv",
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1779679233,
+        "narHash": "sha256-qSIAAfK66X6waos6alIYxVze1ZU3C/WPp7NlN4ooP54=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "47ab6c7b3c6a68beac60067490240efa32ae344c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/devenv.nix
+++ b/devenv.nix
@@ -1,0 +1,27 @@
+{ pkgs, lib, ... }:
+
+{
+  # Host build deps. The C cross-compiler for the aarch64-musl guest agent
+  # still comes from `brew install FiloSottile/musl-cross/musl-cross` —
+  # pkgsCross on darwin is not cached and would force a multi-hour rebuild.
+  packages = with pkgs; [
+    protobuf
+    pkg-config
+    cargo-nextest
+    cargo-watch
+    cargo-about
+  ] ++ lib.optionals pkgs.stdenv.isDarwin [
+    pkgs.libiconv
+  ];
+
+  languages.rust = {
+    enable = true;
+    channel = "stable";
+    targets = [
+      "aarch64-unknown-linux-musl"
+      "x86_64-unknown-linux-musl"
+    ];
+  };
+
+  env.PROTOC = "${pkgs.protobuf}/bin/protoc";
+}

--- a/devenv.yaml
+++ b/devenv.yaml
@@ -1,0 +1,9 @@
+# yaml-language-server: $schema=https://devenv.sh/devenv.schema.json
+inputs:
+  nixpkgs:
+    url: github:cachix/devenv-nixpkgs/rolling
+  rust-overlay:
+    url: github:oxalica/rust-overlay
+    inputs:
+      nixpkgs:
+        follows: nixpkgs


### PR DESCRIPTION
## Summary

- Add a [devenv](https://devenv.sh) / Nix-based dev environment as an alternative to the per-tool Brew/rustup setup.
- Pin every host build dep in `devenv.lock` so the env reproduces deterministically across machines and over time.
- Opt-in only: nothing in the Makefile, CI, or product code references devenv. Existing workflows are unaffected.

The shell provides:
- `protobuf`, `pkg-config`
- `cargo-nextest`, `cargo-watch`, `cargo-about`
- Rust stable with `aarch64-unknown-linux-musl` / `x86_64-unknown-linux-musl` targets
- `libiconv` on Darwin (common Rust link requirement)

`musl-cross` (the C cross-compiler for the guest agent) is intentionally **not** included — Nix's `pkgsCross` is not in the official cache on darwin and would force a multi-hour rebuild on first entry. The existing `brew install FiloSottile/musl-cross/musl-cross` step in CONTRIBUTING.md still applies.

`.gitignore` is updated to ignore devenv per-user state (`.devenv*`, `devenv.local.*`, `.direnv`) and the auto-generated `.pre-commit-config.yaml`.

## Test plan

- [x] `direnv allow` in repo root enters the shell on macOS Apple Silicon
- [x] `cargo build -p arcbox-cli -p arcbox-daemon` succeeds inside the shell
- [x] `protoc --version` and `cargo nextest --version` resolve to the pinned versions
- [ ] Drive-by: existing contributors confirm no Brew/rustup flow regression (no behavioral change expected — devenv files are inert without direnv)