### PR TITLE
test(core): concurrent MachineManager::create regression test

### DIFF
--- a/app/arcbox-core/src/machine.rs
+++ b/app/arcbox-core/src/machine.rs
@@ -119,6 +119,56 @@ mod tests {
         ];
         assert_eq!(select_routable_ip(&ips), Some("2001:db8::42".to_string()));
     }
+
+    /// Two concurrent `create` calls with the same name must not both succeed.
+    /// One wins, the other returns `AlreadyExists`, and only one machine is
+    /// registered.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_create_concurrent_same_name_no_duplicate() {
+        let temp_dir = tempdir().unwrap();
+        let machine_manager = Arc::new(test_machine_manager(temp_dir.path()));
+
+        let name = "race-test";
+        let mm1 = machine_manager.clone();
+        let mm2 = machine_manager.clone();
+
+        let t1 = tokio::spawn(async move {
+            mm1.create(MachineConfig {
+                name: name.to_string(),
+                ..Default::default()
+            })
+            .await
+        });
+        let t2 = tokio::spawn(async move {
+            mm2.create(MachineConfig {
+                name: name.to_string(),
+                ..Default::default()
+            })
+            .await
+        });
+
+        let r1 = t1.await.unwrap();
+        let r2 = t2.await.unwrap();
+
+        let (winner, loser) = match (r1, r2) {
+            (Ok(n), Err(e)) | (Err(e), Ok(n)) => (n, e),
+            (Ok(_), Ok(_)) => panic!("both creates succeeded — TOCTOU regression"),
+            (Err(e1), Err(e2)) => panic!("both creates failed: {e1:?} / {e2:?}"),
+        };
+        assert_eq!(winner, name);
+        match loser {
+            CoreError::Common(ref c) if c.is_already_exists() => {}
+            other => panic!("loser should be AlreadyExists, got {other:?}"),
+        }
+
+        let machines = machine_manager.list();
+        assert_eq!(
+            machines.len(),
+            1,
+            "exactly one machine should be registered"
+        );
+        assert_eq!(machines[0].name, name);
+    }
 }
 
 /// Machine information.

--- a/app/arcbox-core/src/machine.rs
+++ b/app/arcbox-core/src/machine.rs
@@ -132,7 +132,17 @@ mod tests {
         let mm1 = machine_manager.clone();
         let mm2 = machine_manager.clone();
 
+        // `create` has no `.await` points, so without a barrier the
+        // first-polled task can run to completion before the second is even
+        // scheduled — defeating the contention scenario we want to cover.
+        // The barrier guarantees both tasks reach the `create` call before
+        // either acquires the write lock.
+        let barrier = Arc::new(tokio::sync::Barrier::new(2));
+        let b1 = barrier.clone();
+        let b2 = barrier.clone();
+
         let t1 = tokio::spawn(async move {
+            b1.wait().await;
             mm1.create(MachineConfig {
                 name: name.to_string(),
                 ..Default::default()
@@ -140,6 +150,7 @@ mod tests {
             .await
         });
         let t2 = tokio::spawn(async move {
+            b2.wait().await;
             mm2.create(MachineConfig {
                 name: name.to_string(),
                 ..Default::default()


### PR DESCRIPTION
## Summary
- Adds a multi-thread tokio test that races two `MachineManager::create` calls with the same name.
- Asserts exactly one succeeds, the other returns `AlreadyExists`, and only one machine is registered.
- Locks in the behavior of the TOCTOU fix from 42f3e3f (originally proposed in #151).

## Why
Addresses the second Copilot review comment on #151 — that PR's code change already landed via 42f3e3f, but no regression test was added at the time.

## Test plan
- [ ] CI green on `cargo test --workspace --exclude arcbox-agent` (macos-26 has the needed Hypervisor.framework SDK; the local Nix-pinned 14.4 SDK cannot link binaries that pull in `arcbox-vmm`'s `gic` default feature).
- [ ] Re-run the new test 5x to confirm it does not flake.