### PR TITLE
feat(docker): add utility VM routing seam

### DIFF
--- a/app/arcbox-api/src/grpc/machine.rs
+++ b/app/arcbox-api/src/grpc/machine.rs
@@ -65,6 +65,8 @@ impl machine_service_server::MachineService for MachineServiceImpl {
                 Some(req.version)
             },
             block_devices: Vec::new(),
+            backend: arcbox_core::VmBackend::Hv,
+            enable_rosetta: false,
         };
 
         self.runtime

--- a/app/arcbox-core/src/lib.rs
+++ b/app/arcbox-core/src/lib.rs
@@ -48,6 +48,7 @@ pub mod vm_lifecycle;
 pub mod workload;
 
 pub use agent_client::AgentClient;
+pub use arcbox_vmm::VmBackend;
 pub use boot_assets::{
     BootAssetConfig, BootAssetManifest, BootAssetProvider, BootAssets, DownloadProgress,
     PreparePhase, boot_asset_version,

--- a/app/arcbox-core/src/lib.rs
+++ b/app/arcbox-core/src/lib.rs
@@ -45,6 +45,7 @@ pub mod runtime;
 pub mod trace;
 pub mod vm;
 pub mod vm_lifecycle;
+pub mod workload;
 
 pub use agent_client::AgentClient;
 pub use boot_assets::{
@@ -61,3 +62,4 @@ pub use vm_lifecycle::{
     DEFAULT_MACHINE_NAME, DefaultVmConfig, HealthMonitor, VmLifecycleConfig, VmLifecycleManager,
     VmLifecycleState,
 };
+pub use workload::UtilityVmRole;

--- a/app/arcbox-core/src/machine.rs
+++ b/app/arcbox-core/src/machine.rs
@@ -179,6 +179,20 @@ pub struct MachineConfig {
     pub distro: Option<String>,
     /// Distribution version (e.g., "3.21", "24.04").
     pub distro_version: Option<String>,
+    /// macOS hypervisor backend for this machine.
+    ///
+    /// `Hv` runs ArcBox's custom HV-framework VMM (fast path for
+    /// `linux/arm64` workloads); `Vz` runs Apple's
+    /// Virtualization.framework managed execution (required for Rosetta).
+    /// Defaults to `Hv` so the existing single-VM behavior is preserved.
+    pub backend: arcbox_vmm::VmBackend,
+    /// Whether to expose Apple Rosetta inside the guest for `linux/amd64`
+    /// translation.
+    ///
+    /// Only honored when [`Self::backend`] is `Vz`; the HV path silently
+    /// drops it because Hypervisor.framework does not host the Rosetta
+    /// share. Defaults to `false`.
+    pub enable_rosetta: bool,
 }
 
 impl Default for MachineConfig {
@@ -193,6 +207,8 @@ impl Default for MachineConfig {
             block_devices: Vec::new(),
             distro: None,
             distro_version: None,
+            backend: arcbox_vmm::VmBackend::Hv,
+            enable_rosetta: false,
         }
     }
 }
@@ -358,6 +374,8 @@ impl MachineManager {
             cmdline: config.cmdline.clone(),
             shared_dirs,
             block_devices: config.block_devices.clone(),
+            rosetta: config.enable_rosetta,
+            backend: config.backend,
             ..Default::default()
         };
         let vm_id = self.vm_manager.create(vm_config)?;

--- a/app/arcbox-core/src/runtime.rs
+++ b/app/arcbox-core/src/runtime.rs
@@ -31,10 +31,18 @@ use tokio::sync::RwLock as TokioRwLock;
 #[cfg(not(target_os = "macos"))]
 const DEFAULT_GUEST_IP: Ipv4Addr = Ipv4Addr::new(192, 168, 64, 2);
 
-/// Inbound port-forwarding rules per container: maps container ID to a list of
-/// `(guest_ip, host_port, protocol)` tuples registered for that container.
+/// Inbound port-forwarding rules per container.
+///
+/// Maps the canonical container ID to the machine that holds the rules and
+/// the list of `(host_ip, host_port, protocol)` tuples registered on that
+/// machine. The machine name is needed so teardown reaches the right
+/// inbound listener when both utility VMs are active concurrently.
 #[cfg(target_os = "macos")]
-type InboundRulesMap = Arc<TokioRwLock<HashMap<String, Vec<(Ipv4Addr, u16, InboundProtocol)>>>>;
+type InboundRulesMap =
+    Arc<TokioRwLock<HashMap<String, (String, Vec<(Ipv4Addr, u16, InboundProtocol)>)>>>;
+/// Per-machine inbound listener managers, keyed by machine name.
+#[cfg(target_os = "macos")]
+type InboundListenerMap = Arc<TokioRwLock<HashMap<String, InboundListenerManager>>>;
 const REQUIRED_RUNTIME_ASSETS: [&str; 6] = [
     "dockerd",
     "containerd",
@@ -164,10 +172,14 @@ pub struct Runtime {
     network_manager: Arc<NetworkManager>,
     /// Host-side runtime migration manager.
     migration_manager: Arc<MigrationManager>,
-    /// Inbound listener manager for port forwarding via L2 frame injection (macOS).
+    /// Inbound listener managers keyed by machine name, for port
+    /// forwarding via L2 frame injection (macOS). Each utility VM owns its
+    /// own bridge interface and therefore its own listener.
     #[cfg(target_os = "macos")]
-    inbound_listener: Arc<TokioRwLock<Option<InboundListenerManager>>>,
-    /// Tracks which inbound rules belong to each container for cleanup (macOS).
+    inbound_listeners: InboundListenerMap,
+    /// Tracks which inbound rules belong to each container, plus the
+    /// machine those rules live on, so teardown reaches the right
+    /// listener (macOS).
     #[cfg(target_os = "macos")]
     inbound_rules: InboundRulesMap,
     /// Port forwarders for each container (non-macOS fallback).
@@ -309,7 +321,7 @@ impl Runtime {
             network_manager,
             migration_manager,
             #[cfg(target_os = "macos")]
-            inbound_listener: Arc::new(TokioRwLock::new(None)),
+            inbound_listeners: Arc::new(TokioRwLock::new(HashMap::new())),
             #[cfg(target_os = "macos")]
             inbound_rules: Arc::new(TokioRwLock::new(HashMap::new())),
             #[cfg(not(target_os = "macos"))]
@@ -760,7 +772,7 @@ impl Runtime {
         }
     }
 
-    /// macOS: add inbound rules via `InboundListenerManager`.
+    /// macOS: add inbound rules via the machine's `InboundListenerManager`.
     #[cfg(target_os = "macos")]
     async fn start_port_forwarding_macos(
         &self,
@@ -768,31 +780,34 @@ impl Runtime {
         container_id: &str,
         bindings: &[(String, u16, u16, String)],
     ) -> Result<()> {
-        // Keep the cached manager fresh across VM restarts.
+        // Keep the cached manager for this machine fresh across VM restarts.
         {
-            let mut guard = self.inbound_listener.write().await;
+            let mut guard = self.inbound_listeners.write().await;
             if let Some(manager) = self
                 .machine_manager
                 .take_inbound_listener_manager(machine_name)
             {
-                *guard = Some(manager);
+                guard.insert(machine_name.to_string(), manager);
             }
-            if guard.is_none() {
-                return Err(CoreError::Machine(
-                    "inbound listener manager not available".to_string(),
-                ));
+            if !guard.contains_key(machine_name) {
+                return Err(CoreError::Machine(format!(
+                    "inbound listener manager not available for machine '{machine_name}'",
+                )));
             }
         }
 
         // Remove previously tracked listeners for this container before
-        // applying new bindings, so stale ports do not leak.
-        let previous_rules = {
+        // applying new bindings, so stale ports do not leak. Cleanup
+        // routes to the machine the rules were originally bound to —
+        // which may differ from the requested machine if the container
+        // was previously on a different role.
+        let previous = {
             let mut rules = self.inbound_rules.write().await;
             rules.remove(container_id)
         };
-        if let Some(previous_rules) = previous_rules {
-            let mut guard = self.inbound_listener.write().await;
-            if let Some(manager) = guard.as_mut() {
+        if let Some((prev_machine, previous_rules)) = previous {
+            let mut guard = self.inbound_listeners.write().await;
+            if let Some(manager) = guard.get_mut(&prev_machine) {
                 for (host_ip, host_port, proto) in previous_rules {
                     manager.remove_rule(host_ip, host_port, proto);
                 }
@@ -821,8 +836,10 @@ impl Runtime {
                 continue;
             };
 
-            let mut guard = self.inbound_listener.write().await;
-            let manager = guard.as_mut().expect("checked above");
+            let mut guard = self.inbound_listeners.write().await;
+            let manager = guard
+                .get_mut(machine_name)
+                .expect("checked machine_name presence above");
             if let Err(e) = manager
                 .add_rule(host_ip, *host_port, *container_port, proto)
                 .await
@@ -841,7 +858,10 @@ impl Runtime {
 
         if !added_rules.is_empty() {
             let mut rules = self.inbound_rules.write().await;
-            rules.insert(container_id.to_string(), added_rules);
+            rules.insert(
+                container_id.to_string(),
+                (machine_name.to_string(), added_rules),
+            );
         }
 
         Ok(())
@@ -909,14 +929,18 @@ impl Runtime {
                 let mut guard = self.inbound_rules.write().await;
                 guard.remove(container_id)
             };
-            if let Some(rules) = rules {
-                let mut guard = self.inbound_listener.write().await;
-                if let Some(manager) = guard.as_mut() {
+            if let Some((machine_name, rules)) = rules {
+                let mut guard = self.inbound_listeners.write().await;
+                if let Some(manager) = guard.get_mut(&machine_name) {
                     for (host_ip, host_port, proto) in rules {
                         manager.remove_rule(host_ip, host_port, proto);
                     }
                 }
-                tracing::debug!("Stopped port forwarding for container {}", container_id);
+                tracing::debug!(
+                    machine = %machine_name,
+                    container_id,
+                    "Stopped port forwarding for container",
+                );
             }
         }
 
@@ -973,14 +997,14 @@ impl Runtime {
         tracing::info!(container_id, ?hostnames, "DNS entries deregistered");
     }
 
-    /// Stops all active port forwarders.
+    /// Stops all active port forwarders across every machine.
     pub async fn stop_port_forwarding_all(&self) {
         #[cfg(target_os = "macos")]
         {
-            let mut guard = self.inbound_listener.write().await;
-            // Use take() so that the next start_port_forwarding_macos() call
-            // fetches a fresh manager from the VMM (with a live cmd_tx).
-            if let Some(mut manager) = guard.take() {
+            let mut guard = self.inbound_listeners.write().await;
+            // Drain so the next start_port_forwarding_macos() call fetches
+            // fresh managers from the VMM (with live cmd_tx values).
+            for (_, mut manager) in guard.drain() {
                 manager.stop_all();
             }
             self.inbound_rules.write().await.clear();

--- a/app/arcbox-core/src/runtime.rs
+++ b/app/arcbox-core/src/runtime.rs
@@ -123,6 +123,22 @@ fn rewrite_kubeconfig_server(kubeconfig: &str) -> String {
         .join("\n")
 }
 
+/// Per-role lifecycle + dockerd plumbing owned by a [`Runtime`].
+///
+/// Each enabled [`UtilityVmRole`] gets its own slot so the connector
+/// registry, port-forwarding setup, and ensure-ready paths can address the
+/// VMs independently.
+struct RoleSlot {
+    /// Lifecycle manager that owns this role's VM.
+    lifecycle: Arc<VmLifecycleManager>,
+    /// Container backend that drives ensure-ready on this role.
+    container_backend: DynContainerBackend,
+    /// Machine name this role's VM is registered under.
+    machine_name: String,
+    /// Vsock port the guest dockerd listens on inside this role's VM.
+    guest_docker_vsock_port: u32,
+}
+
 pub struct Runtime {
     /// Configuration.
     config: Config,
@@ -132,10 +148,18 @@ pub struct Runtime {
     vm_manager: Arc<VmManager>,
     /// Machine manager.
     machine_manager: Arc<MachineManager>,
-    /// VM lifecycle manager (automatic VM management).
+    /// VM lifecycle manager for the native (default) machine.
+    ///
+    /// Kept for the daemon-wide lifecycle methods (Kubernetes, shutdown)
+    /// that operate on the primary VM. Role-aware paths should go through
+    /// [`Self::ensure_role_ready`] instead.
     vm_lifecycle: Arc<VmLifecycleManager>,
-    /// Selected container backend implementation.
+    /// Container backend implementation for the native role.
     container_backend: DynContainerBackend,
+    /// Per-role utility VM slots. Always contains
+    /// [`UtilityVmRole::Native`]; [`UtilityVmRole::Rosetta`] is present
+    /// only on platforms where the VZ + Rosetta utility VM is supported.
+    role_slots: HashMap<UtilityVmRole, RoleSlot>,
     /// Network manager.
     network_manager: Arc<NetworkManager>,
     /// Host-side runtime migration manager.
@@ -151,6 +175,17 @@ pub struct Runtime {
     port_forwarders: Arc<TokioRwLock<HashMap<String, PortForwarder>>>,
     /// Tracks DNS registrations: canonical container ID → hostnames.
     dns_entries: Arc<TokioRwLock<HashMap<String, Vec<String>>>>,
+}
+
+/// Machine name used for the rosetta utility VM.
+const ROSETTA_MACHINE_NAME: &str = "rosetta";
+/// Filename of the persistent dockerd data image for the rosetta utility VM.
+const ROSETTA_DATA_IMAGE_NAME: &str = "docker-rosetta.img";
+
+/// Returns `true` on platforms where the VZ + Rosetta utility VM is
+/// supported.
+const fn rosetta_role_supported() -> bool {
+    cfg!(all(target_os = "macos", target_arch = "aarch64"))
 }
 
 impl Runtime {
@@ -201,19 +236,65 @@ impl Runtime {
             shared_dns_table,
         ));
 
-        // Create VM lifecycle manager with the machine manager.
-        let vm_lifecycle = Arc::new(VmLifecycleManager::new(
+        // Build the per-role utility VM slots. The native slot is always
+        // present; the rosetta slot exists only on macOS Apple Silicon
+        // and stays cold until the first amd64 workload triggers it.
+        let mut role_slots: HashMap<UtilityVmRole, RoleSlot> = HashMap::new();
+
+        // Native (HV) slot — the existing default machine.
+        let native_lifecycle = Arc::new(VmLifecycleManager::new(
             machine_manager.clone(),
             event_bus.clone(),
             config.data_dir.clone(),
-            vm_lifecycle_config,
+            vm_lifecycle_config.clone(),
         )?);
-        let container_backend = create_backend(
+        let native_backend = create_backend(
             &config.container,
-            Arc::clone(&vm_lifecycle),
+            Arc::clone(&native_lifecycle),
             Arc::clone(&machine_manager),
             DEFAULT_MACHINE_NAME,
         );
+        role_slots.insert(
+            UtilityVmRole::Native,
+            RoleSlot {
+                lifecycle: Arc::clone(&native_lifecycle),
+                container_backend: native_backend.clone(),
+                machine_name: DEFAULT_MACHINE_NAME.to_string(),
+                guest_docker_vsock_port: config.container.guest_docker_vsock_port,
+            },
+        );
+
+        // Rosetta (VZ) slot — lazy. The lifecycle is constructed now so
+        // its state, persistence and event topic are available, but the
+        // VM only boots when `ensure_role_ready(Rosetta)` is first called.
+        if rosetta_role_supported() {
+            let mut rosetta_config = vm_lifecycle_config;
+            rosetta_config.backend = arcbox_vmm::VmBackend::Vz;
+            rosetta_config.default_vm.rosetta = true;
+            let rosetta_lifecycle = Arc::new(VmLifecycleManager::for_machine(
+                ROSETTA_MACHINE_NAME.to_string(),
+                ROSETTA_DATA_IMAGE_NAME.to_string(),
+                machine_manager.clone(),
+                event_bus.clone(),
+                config.data_dir.clone(),
+                rosetta_config,
+            )?);
+            let rosetta_backend = create_backend(
+                &config.container,
+                Arc::clone(&rosetta_lifecycle),
+                Arc::clone(&machine_manager),
+                ROSETTA_MACHINE_NAME,
+            );
+            role_slots.insert(
+                UtilityVmRole::Rosetta,
+                RoleSlot {
+                    lifecycle: rosetta_lifecycle,
+                    container_backend: rosetta_backend,
+                    machine_name: ROSETTA_MACHINE_NAME.to_string(),
+                    guest_docker_vsock_port: config.container.guest_docker_vsock_port,
+                },
+            );
+        }
 
         let migration_manager = Arc::new(MigrationManager::new(config.docker.socket_path.clone()));
 
@@ -222,8 +303,9 @@ impl Runtime {
             event_bus,
             vm_manager,
             machine_manager,
-            vm_lifecycle,
-            container_backend,
+            vm_lifecycle: native_lifecycle,
+            container_backend: native_backend,
+            role_slots,
             network_manager,
             migration_manager,
             #[cfg(target_os = "macos")]
@@ -307,19 +389,18 @@ impl Runtime {
 
     /// Ensures the utility VM for `role` is running and ready.
     ///
-    /// Today both roles resolve to the single default utility VM; the
-    /// independent VZ Rosetta VM is wired up in a later workstream slice.
-    /// The method exists so callers (the Docker layer's connector
-    /// registry, port forwarding setup, future scheduler decisions) can
-    /// already address VMs by role and have the dual-VM lifecycle plugged
-    /// in beneath them without churning every caller.
+    /// Drives the per-role lifecycle so the native and rosetta VMs are
+    /// reachable independently. If `role` is not configured on this host
+    /// (e.g. rosetta on non-Apple-Silicon) the native slot answers as a
+    /// degradation path — the dockerd connector still works, but the
+    /// workload runs on HV instead of VZ+Rosetta.
     ///
     /// # Errors
     ///
     /// Returns an error if the underlying VM cannot be started or becomes
     /// unhealthy.
-    pub async fn ensure_role_ready(&self, _role: UtilityVmRole) -> Result<u32> {
-        self.ensure_vm_ready().await
+    pub async fn ensure_role_ready(&self, role: UtilityVmRole) -> Result<u32> {
+        self.slot_for(role).container_backend.ensure_ready().await
     }
 
     /// Returns the default machine name used for automatic VM lifecycle.
@@ -330,24 +411,47 @@ impl Runtime {
 
     /// Returns the machine name that hosts `role`.
     ///
-    /// During the routing-seam slice both roles resolve to
-    /// [`DEFAULT_MACHINE_NAME`]; once a dedicated VZ Rosetta machine is
-    /// configured this returns a role-specific name (e.g. `"rosetta"`).
-    /// Callers that proxy or address VMs should consult this rather than
-    /// hard-coding [`Self::default_machine_name`].
+    /// Resolves through the per-role registry. Roles not configured on
+    /// this host fall back to the native machine name so existing callers
+    /// keep working in single-VM deployments.
     #[must_use]
-    pub const fn machine_name_for_role(&self, _role: UtilityVmRole) -> &'static str {
-        DEFAULT_MACHINE_NAME
+    pub fn machine_name_for_role(&self, role: UtilityVmRole) -> &str {
+        self.slot_for(role).machine_name.as_str()
     }
 
     /// Returns the guest dockerd vsock port for `role`.
     ///
-    /// Today every role exposes dockerd on the same port; once the
-    /// secondary VM is wired this returns the rosetta-side port without
-    /// changing the caller signature.
+    /// Both roles currently expose dockerd on the configured global port;
+    /// the seam exists so we can split ports per role later without a
+    /// downstream API churn.
     #[must_use]
-    pub const fn guest_docker_vsock_port_for_role(&self, _role: UtilityVmRole) -> u32 {
-        self.guest_docker_vsock_port()
+    pub fn guest_docker_vsock_port_for_role(&self, role: UtilityVmRole) -> u32 {
+        self.slot_for(role).guest_docker_vsock_port
+    }
+
+    /// Returns the lifecycle manager for `role`, falling back to native.
+    #[must_use]
+    pub fn lifecycle_for_role(&self, role: UtilityVmRole) -> &Arc<VmLifecycleManager> {
+        &self.slot_for(role).lifecycle
+    }
+
+    /// Returns `true` if `role` has a dedicated slot wired in this runtime.
+    /// Used by diagnostics to surface which roles are actually distinct vs
+    /// aliased onto the native fallback.
+    #[must_use]
+    pub fn role_is_distinct(&self, role: UtilityVmRole) -> bool {
+        self.role_slots.contains_key(&role)
+    }
+
+    /// Returns the role slot, falling back to native if `role` is not
+    /// configured on this host.
+    fn slot_for(&self, role: UtilityVmRole) -> &RoleSlot {
+        if let Some(slot) = self.role_slots.get(&role) {
+            return slot;
+        }
+        self.role_slots
+            .get(&UtilityVmRole::Native)
+            .expect("Native role slot must always be present")
     }
 
     /// Gets an agent client for a machine.

--- a/app/arcbox-core/src/runtime.rs
+++ b/app/arcbox-core/src/runtime.rs
@@ -8,6 +8,7 @@ use crate::machine::{MachineManager, MachineState};
 use crate::migration::MigrationManager;
 use crate::vm::VmManager;
 use crate::vm_lifecycle::{DEFAULT_MACHINE_NAME, VmLifecycleConfig, VmLifecycleManager};
+use crate::workload::UtilityVmRole;
 use arcbox_net::NetworkManager;
 #[cfg(target_os = "macos")]
 use arcbox_net::darwin::inbound_relay::{InboundListenerManager, InboundProtocol};
@@ -304,10 +305,49 @@ impl Runtime {
         self.container_backend.ensure_ready().await
     }
 
+    /// Ensures the utility VM for `role` is running and ready.
+    ///
+    /// Today both roles resolve to the single default utility VM; the
+    /// independent VZ Rosetta VM is wired up in a later workstream slice.
+    /// The method exists so callers (the Docker layer's connector
+    /// registry, port forwarding setup, future scheduler decisions) can
+    /// already address VMs by role and have the dual-VM lifecycle plugged
+    /// in beneath them without churning every caller.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the underlying VM cannot be started or becomes
+    /// unhealthy.
+    pub async fn ensure_role_ready(&self, _role: UtilityVmRole) -> Result<u32> {
+        self.ensure_vm_ready().await
+    }
+
     /// Returns the default machine name used for automatic VM lifecycle.
     #[must_use]
     pub const fn default_machine_name(&self) -> &'static str {
         DEFAULT_MACHINE_NAME
+    }
+
+    /// Returns the machine name that hosts `role`.
+    ///
+    /// During the routing-seam slice both roles resolve to
+    /// [`DEFAULT_MACHINE_NAME`]; once a dedicated VZ Rosetta machine is
+    /// configured this returns a role-specific name (e.g. `"rosetta"`).
+    /// Callers that proxy or address VMs should consult this rather than
+    /// hard-coding [`Self::default_machine_name`].
+    #[must_use]
+    pub const fn machine_name_for_role(&self, _role: UtilityVmRole) -> &'static str {
+        DEFAULT_MACHINE_NAME
+    }
+
+    /// Returns the guest dockerd vsock port for `role`.
+    ///
+    /// Today every role exposes dockerd on the same port; once the
+    /// secondary VM is wired this returns the rosetta-side port without
+    /// changing the caller signature.
+    #[must_use]
+    pub const fn guest_docker_vsock_port_for_role(&self, _role: UtilityVmRole) -> u32 {
+        self.guest_docker_vsock_port()
     }
 
     /// Gets an agent client for a machine.

--- a/app/arcbox-core/src/vm.rs
+++ b/app/arcbox-core/src/vm.rs
@@ -150,6 +150,12 @@ pub struct VmConfig {
     /// Rosetta binary and registers it via binfmt_misc in the guest.
     /// This allows near-native execution of x86_64 Linux binaries.
     pub rosetta: bool,
+    /// macOS hypervisor backend selection.
+    ///
+    /// `Hv` (default) drives the custom HV-framework VMM; `Vz` drives
+    /// Apple's Virtualization.framework managed execution and is the only
+    /// backend that can host the Rosetta share.
+    pub backend: arcbox_vmm::VmBackend,
 }
 
 impl Default for VmConfig {
@@ -166,6 +172,7 @@ impl Default for VmConfig {
             guest_cid: None,
             balloon: true, // Enable balloon by default
             rosetta: cfg!(all(target_os = "macos", target_arch = "aarch64")),
+            backend: arcbox_vmm::VmBackend::Hv,
         }
     }
 }
@@ -289,13 +296,11 @@ impl VmManager {
                 })
                 .collect(),
             bridge_nic_mac: Some(bridge_nic_mac_for_vm_id(&entry.info.id)),
-            // HV is the default on this branch — VZ path has separate bugs
-            // around proxy/fake-IP datapath; HV path is the target for the
-            // hv-vz-parity work (ABX-360..363). `VmBackend::default()` is
-            // `Auto`, which still dispatches to VZ when rosetta is enabled
-            // (default on Apple Silicon), so force HV explicitly until the
-            // rosetta default is resolved.
-            backend: arcbox_vmm::VmBackend::Hv,
+            // Backend is now set per-machine on the `VmConfig`. The native
+            // utility VM defaults to `Hv` so behavior matches the previous
+            // hardcoded path; the rosetta utility VM sets `Vz` explicitly
+            // so it can host the Rosetta share.
+            backend: entry.config.backend,
         }
     }
 

--- a/app/arcbox-core/src/vm_lifecycle/mod.rs
+++ b/app/arcbox-core/src/vm_lifecycle/mod.rs
@@ -194,6 +194,12 @@ pub struct VmLifecycleConfig {
     pub skip_vm_check: bool,
     /// Guest docker API vsock port propagated via kernel cmdline.
     pub guest_docker_vsock_port: Option<u32>,
+    /// macOS hypervisor backend this lifecycle's machine will use.
+    ///
+    /// Defaults to `Hv` so the native utility VM keeps running on the
+    /// custom HV-framework path. The rosetta utility VM overrides this
+    /// to `Vz` so it can host the Rosetta share.
+    pub backend: arcbox_vmm::VmBackend,
 }
 
 impl Default for VmLifecycleConfig {
@@ -207,6 +213,7 @@ impl Default for VmLifecycleConfig {
             default_vm: DefaultVmConfig::default(),
             skip_vm_check: false,
             guest_docker_vsock_port: None,
+            backend: arcbox_vmm::VmBackend::Hv,
         }
     }
 }
@@ -799,6 +806,8 @@ impl VmLifecycleManager {
             block_devices,
             distro: None,
             distro_version: None,
+            backend: self.config.backend,
+            enable_rosetta: self.config.default_vm.rosetta,
         };
 
         tracing::info!(

--- a/app/arcbox-core/src/vm_lifecycle/mod.rs
+++ b/app/arcbox-core/src/vm_lifecycle/mod.rs
@@ -265,6 +265,15 @@ pub use recovery::{BackoffStrategy, RecoveryAction, RecoveryPolicy};
 /// agent.create_container(...).await?;
 /// ```
 pub struct VmLifecycleManager {
+    /// Machine name this manager operates on. Set at construction time.
+    /// Defaults to [`DEFAULT_MACHINE_NAME`] for the native utility VM;
+    /// dual-VM setups override it (e.g. `"rosetta"`).
+    machine_name: String,
+    /// Filename used for this machine's persistent dockerd data image,
+    /// relative to `<data_dir>/<DATA>/`. Defaults to `docker.img`; the
+    /// rosetta lifecycle uses `docker-rosetta.img` to keep its image
+    /// strictly separate.
+    data_image_filename: String,
     /// Machine manager for VM operations.
     machine_manager: Arc<MachineManager>,
     /// Event bus.
@@ -396,8 +405,30 @@ impl VmLifecycleManager {
         Ok(())
     }
 
-    /// Creates a new VM lifecycle manager.
+    /// Creates a new VM lifecycle manager for the default native machine.
     pub fn new(
+        machine_manager: Arc<MachineManager>,
+        event_bus: EventBus,
+        data_dir: PathBuf,
+        config: VmLifecycleConfig,
+    ) -> Result<Self> {
+        Self::for_machine(
+            String::from(DEFAULT_MACHINE_NAME),
+            String::from(DOCKER_DATA_IMAGE_NAME),
+            machine_manager,
+            event_bus,
+            data_dir,
+            config,
+        )
+    }
+
+    /// Creates a new VM lifecycle manager bound to a specific machine name
+    /// and persistent data image. Used to build per-role lifecycles (e.g.
+    /// the secondary VZ Rosetta VM) that must not share state with the
+    /// default native machine.
+    pub fn for_machine(
+        machine_name: String,
+        data_image_filename: String,
         machine_manager: Arc<MachineManager>,
         event_bus: EventBus,
         data_dir: PathBuf,
@@ -415,8 +446,7 @@ impl VmLifecycleManager {
 
         let recovery = RecoveryPolicy::new(config.max_retries, BackoffStrategy::default());
 
-        // Check if default machine already exists
-        let initial_state = if let Some(info) = machine_manager.get(DEFAULT_MACHINE_NAME) {
+        let initial_state = if let Some(info) = machine_manager.get(&machine_name) {
             VmLifecycleState::from(info.state)
         } else {
             VmLifecycleState::NotExist
@@ -428,6 +458,8 @@ impl VmLifecycleManager {
             .as_millis() as u64;
 
         Ok(Self {
+            machine_name,
+            data_image_filename,
             machine_manager,
             event_bus,
             state: RwLock::new(initial_state),
@@ -441,6 +473,21 @@ impl VmLifecycleManager {
             balloon_shrunk: std::sync::atomic::AtomicBool::new(false),
             kubernetes_hold: std::sync::atomic::AtomicBool::new(false),
         })
+    }
+
+    /// Returns the machine name this lifecycle manager owns.
+    #[must_use]
+    pub fn machine_name(&self) -> &str {
+        &self.machine_name
+    }
+
+    /// Returns the absolute path of this machine's persistent dockerd
+    /// data image.
+    #[must_use]
+    pub fn data_image_path(&self) -> PathBuf {
+        self.data_dir
+            .join(arcbox_constants::paths::host::DATA)
+            .join(&self.data_image_filename)
     }
 
     /// Returns the current lifecycle state.
@@ -480,7 +527,7 @@ impl VmLifecycleManager {
             // Register a mock machine so that container operations work.
             let mock_cid = 3;
             self.machine_manager
-                .register_mock_machine(DEFAULT_MACHINE_NAME, mock_cid)?;
+                .register_mock_machine(&self.machine_name, mock_cid)?;
             // Return a mock CID for testing.
             return Ok(mock_cid);
         }
@@ -524,14 +571,14 @@ impl VmLifecycleManager {
     /// Gets the CID for the default machine.
     async fn get_cid(&self) -> Result<u32> {
         self.machine_manager
-            .get_cid(DEFAULT_MACHINE_NAME)
+            .get_cid(&self.machine_name)
             .ok_or_else(|| CoreError::Machine("default machine has no CID".to_string()))
     }
 
     /// Starts the default VM.
     async fn start_default_vm(&self, timeout: Duration) -> Result<()> {
         let current_state = *self.state.read().await;
-        let existing_machine = self.machine_manager.get(DEFAULT_MACHINE_NAME);
+        let existing_machine = self.machine_manager.get(&self.machine_name);
         let machine_exists = existing_machine.is_some();
 
         // Detect stale persisted machine whose cpus/memory no longer matches
@@ -556,7 +603,7 @@ impl VmLifecycleManager {
                 boot_version = %boot_version,
                 "default machine config drifted from desired defaults; recreating"
             );
-            let _ = self.machine_manager.remove(DEFAULT_MACHINE_NAME, true);
+            let _ = self.machine_manager.remove(&self.machine_name, true);
         }
 
         // Recreate if state says "not exist", machine record is missing, or
@@ -574,7 +621,7 @@ impl VmLifecycleManager {
                 Ok(()) => {
                     *self.state.write().await = VmLifecycleState::Created;
                     self.event_bus.publish(Event::MachineCreated {
-                        name: DEFAULT_MACHINE_NAME.to_string(),
+                        name: self.machine_name.clone(),
                     });
                 }
                 Err(e) => {
@@ -590,20 +637,19 @@ impl VmLifecycleManager {
         let deadline = tokio::time::Instant::now() + timeout;
 
         loop {
-            match self.machine_manager.start(DEFAULT_MACHINE_NAME).await {
+            match self.machine_manager.start(&self.machine_name).await {
                 Ok(()) => {
                     tracing::info!("Default VM started successfully");
                     *self.state.write().await = VmLifecycleState::Running;
                     self.event_bus.publish(Event::MachineStarted {
-                        name: DEFAULT_MACHINE_NAME.to_string(),
+                        name: self.machine_name.clone(),
                     });
 
                     // Install host route for container subnets via bridge NIC.
                     // Non-blocking: retries transient failures (helper not ready,
                     // bridge FDB not populated) but does not gate VM readiness.
                     #[cfg(all(target_os = "macos", feature = "vmnet"))]
-                    if let Some(bridge) =
-                        self.machine_manager.vmnet_bridge_name(DEFAULT_MACHINE_NAME)
+                    if let Some(bridge) = self.machine_manager.vmnet_bridge_name(&self.machine_name)
                     {
                         // vmnet path: bridge name is known instantly, only need
                         // helper retry (1-2 attempts for XPC readiness).
@@ -617,7 +663,7 @@ impl VmLifecycleManager {
                     }
 
                     #[cfg(all(target_os = "macos", not(feature = "vmnet")))]
-                    if let Some(mac) = self.machine_manager.bridge_mac(DEFAULT_MACHINE_NAME) {
+                    if let Some(mac) = self.machine_manager.bridge_mac(&self.machine_name) {
                         // Non-vmnet path: scan kernel FDB to discover bridge
                         // (retries up to ~10s for FDB learning).
                         drop(tokio::spawn(async move {
@@ -641,7 +687,7 @@ impl VmLifecycleManager {
                             Ok(()) => {
                                 *self.state.write().await = VmLifecycleState::Created;
                                 self.event_bus.publish(Event::MachineCreated {
-                                    name: DEFAULT_MACHINE_NAME.to_string(),
+                                    name: self.machine_name.clone(),
                                 });
                                 continue;
                             }
@@ -731,10 +777,7 @@ impl VmLifecycleManager {
         }];
 
         // Attach persistent Docker data disk.
-        let docker_data_image = self
-            .data_dir
-            .join(arcbox_constants::paths::host::DATA)
-            .join(DOCKER_DATA_IMAGE_NAME);
+        let docker_data_image = self.data_image_path();
         Self::ensure_sparse_block_image(&docker_data_image, DOCKER_DATA_IMAGE_SIZE_BYTES)?;
 
         // Don't inject docker_data_device into cmdline — let the agent
@@ -747,7 +790,7 @@ impl VmLifecycleManager {
         });
 
         let config = MachineConfig {
-            name: DEFAULT_MACHINE_NAME.to_string(),
+            name: self.machine_name.clone(),
             cpus: self.config.default_vm.cpus,
             memory_mb: self.config.default_vm.memory_mb,
             disk_gb: self.config.default_vm.disk_gb,
@@ -776,6 +819,7 @@ impl VmLifecycleManager {
         tracing::debug!("Waiting for agent to become ready...");
 
         let mm = Arc::clone(&self.machine_manager);
+        let machine_name = self.machine_name.clone();
 
         // Run the entire probe loop on a blocking thread. On macOS HV backend,
         // the agent transport is AF_UNIX socketpair → BlockingVsockTransport.
@@ -790,7 +834,7 @@ impl VmLifecycleManager {
             while std::time::Instant::now() < deadline {
                 // Console output (best-effort, non-blocking).
                 #[cfg(target_os = "macos")]
-                if let Ok(output) = mm.read_console_output(DEFAULT_MACHINE_NAME) {
+                if let Ok(output) = mm.read_console_output(&machine_name) {
                     let trimmed = output.trim_matches('\0');
                     if !trimmed.is_empty() {
                         tracing::info!("{}", trimmed.trim_end());
@@ -799,7 +843,7 @@ impl VmLifecycleManager {
 
                 // connect_agent → AF_UNIX detected → BlockingVsockTransport.
                 // ping_blocking uses libc::poll with 5s deadline — no tokio.
-                match mm.connect_agent(DEFAULT_MACHINE_NAME) {
+                match mm.connect_agent(&machine_name) {
                     Ok(mut agent) => match agent.ping_blocking() {
                         Ok(_) => return Ok(()),
                         Err(e) => tracing::debug!("Agent ping failed: {e}"),
@@ -873,7 +917,7 @@ impl VmLifecycleManager {
         }
 
         let target_bytes = IDLE_BALLOON_TARGET_MB * 1024 * 1024;
-        if let Some(info) = self.machine_manager.get(DEFAULT_MACHINE_NAME) {
+        if let Some(info) = self.machine_manager.get(&self.machine_name) {
             match self
                 .machine_manager
                 .vm_manager()
@@ -899,7 +943,7 @@ impl VmLifecycleManager {
             return;
         }
 
-        if let Some(info) = self.machine_manager.get(DEFAULT_MACHINE_NAME) {
+        if let Some(info) = self.machine_manager.get(&self.machine_name) {
             let full_bytes = info.memory_mb * 1024 * 1024;
             match self
                 .machine_manager
@@ -954,7 +998,7 @@ impl VmLifecycleManager {
                     this.shrink_balloon();
                     tracing::info!("VM entered idle state after {}s of inactivity", idle_secs);
                     this.event_bus.publish(Event::MachineIdle {
-                        name: DEFAULT_MACHINE_NAME.to_string(),
+                        name: this.machine_name.clone(),
                     });
                 }
             }
@@ -991,7 +1035,7 @@ impl VmLifecycleManager {
                     "Graceful stop timed out for '{}', falling back to force stop",
                     DEFAULT_MACHINE_NAME
                 );
-                self.machine_manager.stop(DEFAULT_MACHINE_NAME)
+                self.machine_manager.stop(&self.machine_name)
             }
             Err(e) => {
                 tracing::warn!(
@@ -999,7 +1043,7 @@ impl VmLifecycleManager {
                     DEFAULT_MACHINE_NAME,
                     e
                 );
-                self.machine_manager.stop(DEFAULT_MACHINE_NAME)
+                self.machine_manager.stop(&self.machine_name)
             }
         };
 
@@ -1008,7 +1052,7 @@ impl VmLifecycleManager {
                 *self.state.write().await = VmLifecycleState::Stopped;
                 tracing::info!("Default VM stopped");
                 self.event_bus.publish(Event::MachineStopped {
-                    name: DEFAULT_MACHINE_NAME.to_string(),
+                    name: self.machine_name.clone(),
                 });
                 Ok(())
             }
@@ -1029,11 +1073,11 @@ impl VmLifecycleManager {
     pub async fn force_stop(&self) -> Result<()> {
         self.health_monitor.stop();
 
-        let _ = self.machine_manager.remove(DEFAULT_MACHINE_NAME, true);
+        let _ = self.machine_manager.remove(&self.machine_name, true);
 
         *self.state.write().await = VmLifecycleState::NotExist;
         self.event_bus.publish(Event::MachineStopped {
-            name: DEFAULT_MACHINE_NAME.to_string(),
+            name: self.machine_name.clone(),
         });
 
         Ok(())
@@ -1062,7 +1106,7 @@ impl VmLifecycleManager {
 
     /// Returns the machine info for the default machine.
     pub fn default_machine_info(&self) -> Option<MachineInfo> {
-        self.machine_manager.get(DEFAULT_MACHINE_NAME)
+        self.machine_manager.get(&self.machine_name)
     }
 }
 

--- a/app/arcbox-core/src/workload.rs
+++ b/app/arcbox-core/src/workload.rs
@@ -1,0 +1,88 @@
+//! Workload role definitions shared by the daemon, the runtime, and the
+//! Docker compatibility layer.
+//!
+//! ArcBox runs two long-lived utility VM roles on macOS Apple Silicon:
+//!
+//! - [`UtilityVmRole::Native`] — the fast path backed by the custom HV
+//!   hypervisor. Hosts `linux/arm64` workloads.
+//! - [`UtilityVmRole::Rosetta`] — the compatibility path backed by
+//!   `Virtualization.framework` plus Apple Rosetta. Hosts `linux/amd64`
+//!   workloads.
+//!
+//! The role is the unit of routing: every Docker workload (container, exec,
+//! BuildKit session), every guest network endpoint, and every host control
+//! plane interaction is decided per role. Backend choice (HV vs VZ) is an
+//! implementation detail of the role, not part of its public identity.
+
+use std::fmt;
+
+/// One of the long-lived utility VM roles the daemon orchestrates.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum UtilityVmRole {
+    /// Default fast path. Hosts `linux/arm64` workloads on the HV backend.
+    Native,
+    /// Compatibility path that hosts `linux/amd64` workloads on the VZ
+    /// backend via Apple Rosetta. Only available on macOS Apple Silicon.
+    Rosetta,
+}
+
+impl UtilityVmRole {
+    /// Stable diagnostic label, also used as the machine name suffix and as
+    /// the key in role-keyed registries.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Native => "native",
+            Self::Rosetta => "rosetta",
+        }
+    }
+
+    /// Returns every role the daemon may orchestrate, in stable order.
+    /// Suitable for iteration when building per-role state.
+    #[must_use]
+    pub const fn all() -> [Self; 2] {
+        [Self::Native, Self::Rosetta]
+    }
+
+    /// Parses a role from its stable diagnostic label.
+    #[must_use]
+    pub fn from_str_ascii(s: &str) -> Option<Self> {
+        match s {
+            "native" => Some(Self::Native),
+            "rosetta" => Some(Self::Rosetta),
+            _ => None,
+        }
+    }
+}
+
+impl fmt::Display for UtilityVmRole {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn round_trips_through_string() {
+        for role in UtilityVmRole::all() {
+            assert_eq!(UtilityVmRole::from_str_ascii(role.as_str()), Some(role));
+        }
+    }
+
+    #[test]
+    fn from_str_rejects_unknown() {
+        assert!(UtilityVmRole::from_str_ascii("kvm").is_none());
+        assert!(UtilityVmRole::from_str_ascii("").is_none());
+    }
+
+    #[test]
+    fn all_lists_every_variant_once() {
+        let all = UtilityVmRole::all();
+        assert_eq!(all.len(), 2);
+        assert!(all.contains(&UtilityVmRole::Native));
+        assert!(all.contains(&UtilityVmRole::Rosetta));
+    }
+}

--- a/app/arcbox-daemon/src/startup/mod.rs
+++ b/app/arcbox-daemon/src/startup/mod.rs
@@ -95,24 +95,38 @@ pub async fn acquire_lock(early: EarlyContext) -> Result<DaemonContext> {
 /// Wait for residual resource holders (e.g. docker.img) to release.
 ///
 /// Must complete before [`init_runtime`] — on macOS, orphaned
-/// Virtualization.framework XPC helpers may still hold the disk image.
-/// Reports the `CleaningUp` phase so gRPC clients can show progress.
+/// Virtualization.framework XPC helpers may still hold a previous
+/// daemon's disk images. Reports the `CleaningUp` phase so gRPC clients
+/// can show progress.
+///
+/// Scans every persistent dockerd image owned by a configured utility
+/// VM role (native `docker.img`, rosetta `docker-rosetta.img`) so a
+/// stale VZ holder on either side does not block daemon startup.
 ///
 /// On non-macOS this is a no-op (no XPC helpers).
 #[cfg(target_os = "macos")]
 pub async fn wait_for_resources(ctx: &DaemonContext) -> Result<()> {
-    let docker_img = ctx.layout.data_subdir.join("docker.img");
+    let candidates = ["docker.img", "docker-rosetta.img"];
+    let docker_imgs: Vec<std::path::PathBuf> = candidates
+        .iter()
+        .map(|name| ctx.layout.data_subdir.join(name))
+        .filter(|path| path.exists())
+        .collect();
 
-    if !docker_img.exists() {
+    if docker_imgs.is_empty() {
         return Ok(());
     }
 
     ctx.setup_state
         .set_phase(SetupPhase::CleaningUp, "Waiting for resource release…");
 
-    tokio::task::spawn_blocking(move || cleanup::wait_for_docker_img_holders(&docker_img))
-        .await
-        .context("resource wait task panicked")?;
+    tokio::task::spawn_blocking(move || {
+        for path in docker_imgs {
+            cleanup::wait_for_docker_img_holders(&path);
+        }
+    })
+    .await
+    .context("resource wait task panicked")?;
 
     ctx.setup_state.set_phase(
         SetupPhase::Initializing,

--- a/app/arcbox-docker/src/api.rs
+++ b/app/arcbox-docker/src/api.rs
@@ -10,6 +10,7 @@ use crate::handlers;
 use crate::proxy;
 use crate::proxy::GuestConnector;
 use crate::trace::trace_id_middleware;
+use crate::workload::WorkloadRoleRegistry;
 use arcbox_core::Runtime;
 use axum::extract::OriginalUri;
 use axum::{
@@ -25,6 +26,8 @@ pub struct AppState {
     pub runtime: Arc<Runtime>,
     /// Guest connection factory (vsock in production, Unix socket in tests).
     pub connector: Arc<dyn GuestConnector>,
+    /// In-process mapping from container/exec IDs to their utility VM role.
+    pub workload_roles: Arc<WorkloadRoleRegistry>,
 }
 
 /// Creates the Docker API router with all endpoints.
@@ -34,7 +37,11 @@ pub struct AppState {
 /// so that versioned paths (`/v1.51/containers/{id}/start`) are normalised
 /// *before* Axum route matching.
 pub fn create_router(runtime: Arc<Runtime>, connector: Arc<dyn GuestConnector>) -> Router {
-    let state = AppState { runtime, connector };
+    let state = AppState {
+        runtime,
+        connector,
+        workload_roles: WorkloadRoleRegistry::new(),
+    };
 
     api_routes()
         .fallback(proxy::proxy_fallback)

--- a/app/arcbox-docker/src/handlers/build.rs
+++ b/app/arcbox-docker/src/handlers/build.rs
@@ -4,17 +4,37 @@
 ///
 /// All build options (tags, target, build-args, platform, etc.) are passed as
 /// query parameters and forwarded verbatim to guest dockerd's BuildKit.
+///
+/// Also records the BuildKit session UUID (carried by the
+/// `X-Docker-Expose-Session-Uuid` header) so a parallel `/session`
+/// request on the same UUID can be routed to the same utility VM. The
+/// Docker CLI sends the two endpoints concurrently, and `/session` may
+/// arrive first; the UUID binding lets that handler park on
+/// [`WorkloadRoleRegistry::wait_for_role`] until this `/build` declares
+/// the role.
 pub async fn build_image(
     axum::extract::State(state): axum::extract::State<crate::api::AppState>,
     axum::extract::OriginalUri(uri): axum::extract::OriginalUri,
     req: axum::http::Request<axum::body::Body>,
 ) -> crate::error::Result<axum::response::Response> {
     let route = crate::routing::route_build(&uri);
+    let session_uuid = req
+        .headers()
+        .get("x-docker-expose-session-uuid")
+        .and_then(|v| v.to_str().ok())
+        .map(str::to_string);
     tracing::debug!(
         utility_vm = route.utility_vm.as_str(),
         platform = ?route.platform,
+        session_uuid = session_uuid.as_deref().unwrap_or(""),
         "routing Docker build request"
     );
+    if let Some(ref uuid) = session_uuid {
+        state
+            .workload_roles
+            .record(uuid.clone(), route.utility_vm)
+            .await;
+    }
     crate::handlers::proxy_upload_to_role(&state, route.utility_vm, &uri, req).await
 }
 
@@ -27,28 +47,64 @@ crate::handlers::proxy_handler!(build_prune);
 /// for features like build mounts, secrets, and SSH forwarding. The upgrade
 /// proxy handles bidirectional stream bridging between client and guest.
 ///
-/// Routing limitation: the Docker CLI opens `/session` *before* it sends
-/// the matching `/build` that carries platform metadata, so the role
-/// cannot be derived from the session itself. We forward `/session` to
-/// the native (HV) utility VM by default; an amd64 build that needs
-/// Rosetta-side BuildKit features will not see this session and the
-/// build's side channels will fail. Routing both endpoints requires
-/// lazy session forwarding keyed by `X-Docker-Expose-Session-Uuid`,
-/// which is tracked as a follow-up to this PR.
+/// The Docker CLI opens `/session` and the matching `/build` concurrently,
+/// and the session itself carries no platform metadata — the role must
+/// come from `/build`. We resolve the session's role via
+/// [`WorkloadRoleRegistry::wait_for_role`], keyed by the BuildKit
+/// `X-Docker-Expose-Session-Uuid` header:
+///
+/// 1. If `/build` already recorded the UUID, we forward immediately to
+///    that role.
+/// 2. If `/session` arrives first, we wait up to
+///    [`SESSION_ROLE_WAIT_TIMEOUT`] for `/build` to declare the role.
+/// 3. On timeout we forward to native so the session at least completes
+///    its upgrade — the user gets a BuildKit-level error rather than a
+///    hanging request.
 pub async fn session(
     axum::extract::State(state): axum::extract::State<crate::api::AppState>,
     axum::extract::OriginalUri(uri): axum::extract::OriginalUri,
     req: axum::http::Request<axum::body::Body>,
 ) -> crate::error::Result<axum::response::Response> {
-    if let Some(uuid) = req
+    let session_uuid = req
         .headers()
         .get("x-docker-expose-session-uuid")
         .and_then(|v| v.to_str().ok())
-    {
-        tracing::debug!(
-            session_uuid = %uuid,
-            "forwarding BuildKit /session to the native utility VM",
-        );
-    }
-    crate::handlers::proxy_upgrade(&state, &uri, req).await
+        .map(str::to_string);
+    let role = match session_uuid {
+        Some(uuid) => match state
+            .workload_roles
+            .wait_for_role(&uuid, SESSION_ROLE_WAIT_TIMEOUT)
+            .await
+        {
+            Some(role) => {
+                tracing::debug!(
+                    session_uuid = %uuid,
+                    utility_vm = role.as_str(),
+                    "routing BuildKit /session to recorded role",
+                );
+                role
+            }
+            None => {
+                tracing::warn!(
+                    session_uuid = %uuid,
+                    timeout_secs = SESSION_ROLE_WAIT_TIMEOUT.as_secs(),
+                    "no matching /build arrived; routing /session to native",
+                );
+                crate::routing::UtilityVmRole::Native
+            }
+        },
+        None => {
+            tracing::debug!("BuildKit /session without UUID; defaulting to native");
+            crate::routing::UtilityVmRole::Native
+        }
+    };
+    crate::handlers::proxy_upgrade_to_role(&state, role, &uri, req).await
 }
+
+/// Maximum time `/session` parks waiting for `/build` to declare the
+/// role for the same `X-Docker-Expose-Session-Uuid`.
+///
+/// 30 seconds matches BuildKit's own session-handshake timeout and
+/// covers the worst-case CLI scheduling delay between the parallel
+/// `/session` and `/build` connections.
+const SESSION_ROLE_WAIT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);

--- a/app/arcbox-docker/src/handlers/build.rs
+++ b/app/arcbox-docker/src/handlers/build.rs
@@ -26,10 +26,29 @@ crate::handlers::proxy_handler!(build_prune);
 /// BuildKit uses HTTP/1.1 upgrade to establish a gRPC multiplexed session
 /// for features like build mounts, secrets, and SSH forwarding. The upgrade
 /// proxy handles bidirectional stream bridging between client and guest.
+///
+/// Routing limitation: the Docker CLI opens `/session` *before* it sends
+/// the matching `/build` that carries platform metadata, so the role
+/// cannot be derived from the session itself. We forward `/session` to
+/// the native (HV) utility VM by default; an amd64 build that needs
+/// Rosetta-side BuildKit features will not see this session and the
+/// build's side channels will fail. Routing both endpoints requires
+/// lazy session forwarding keyed by `X-Docker-Expose-Session-Uuid`,
+/// which is tracked as a follow-up to this PR.
 pub async fn session(
     axum::extract::State(state): axum::extract::State<crate::api::AppState>,
     axum::extract::OriginalUri(uri): axum::extract::OriginalUri,
     req: axum::http::Request<axum::body::Body>,
 ) -> crate::error::Result<axum::response::Response> {
+    if let Some(uuid) = req
+        .headers()
+        .get("x-docker-expose-session-uuid")
+        .and_then(|v| v.to_str().ok())
+    {
+        tracing::debug!(
+            session_uuid = %uuid,
+            "forwarding BuildKit /session to the native utility VM",
+        );
+    }
     crate::handlers::proxy_upgrade(&state, &uri, req).await
 }

--- a/app/arcbox-docker/src/handlers/build.rs
+++ b/app/arcbox-docker/src/handlers/build.rs
@@ -50,21 +50,27 @@ crate::handlers::proxy_handler!(build_prune);
 /// The Docker CLI opens `/session` and the matching `/build` concurrently,
 /// and the session itself carries no platform metadata — the role must
 /// come from `/build`. We resolve the session's role via
-/// [`WorkloadRoleRegistry::wait_for_role`], keyed by the BuildKit
-/// `X-Docker-Expose-Session-Uuid` header:
+/// [`crate::workload::WorkloadRoleRegistry::wait_for_role`], keyed by the
+/// BuildKit `X-Docker-Expose-Session-Uuid` header:
 ///
 /// 1. If `/build` already recorded the UUID, we forward immediately to
 ///    that role.
 /// 2. If `/session` arrives first, we wait up to
 ///    [`SESSION_ROLE_WAIT_TIMEOUT`] for `/build` to declare the role.
-/// 3. On timeout we forward to native so the session at least completes
-///    its upgrade — the user gets a BuildKit-level error rather than a
-///    hanging request.
+/// 3. On timeout (no matching `/build` arrived) we fail closed with a
+///    400, instead of routing to native: silently forwarding to the
+///    wrong VM would leave the BuildKit gRPC session attached to a guest
+///    that doesn't know about the upcoming amd64 build, producing
+///    hard-to-diagnose secrets/mounts/ssh failures partway through.
+/// 4. An ambiguous binding (multiple roles recorded for the same UUID —
+///    a registry corruption case that should never happen in practice)
+///    is also a 409.
 pub async fn session(
     axum::extract::State(state): axum::extract::State<crate::api::AppState>,
     axum::extract::OriginalUri(uri): axum::extract::OriginalUri,
     req: axum::http::Request<axum::body::Body>,
 ) -> crate::error::Result<axum::response::Response> {
+    use crate::workload::WorkloadRoleLookup;
     let session_uuid = req
         .headers()
         .get("x-docker-expose-session-uuid")
@@ -76,7 +82,7 @@ pub async fn session(
             .wait_for_role(&uuid, SESSION_ROLE_WAIT_TIMEOUT)
             .await
         {
-            Some(role) => {
+            WorkloadRoleLookup::Found(role) => {
                 tracing::debug!(
                     session_uuid = %uuid,
                     utility_vm = role.as_str(),
@@ -84,13 +90,18 @@ pub async fn session(
                 );
                 role
             }
-            None => {
-                tracing::warn!(
-                    session_uuid = %uuid,
-                    timeout_secs = SESSION_ROLE_WAIT_TIMEOUT.as_secs(),
-                    "no matching /build arrived; routing /session to native",
-                );
-                crate::routing::UtilityVmRole::Native
+            WorkloadRoleLookup::Missing => {
+                return Err(crate::error::DockerError::BadRequest(format!(
+                    "BuildKit /session UUID '{uuid}' timed out after {}s waiting \
+                     for the matching /build to declare a utility VM role; \
+                     refusing to forward the session blind",
+                    SESSION_ROLE_WAIT_TIMEOUT.as_secs(),
+                )));
+            }
+            WorkloadRoleLookup::Ambiguous => {
+                return Err(crate::error::DockerError::Conflict(format!(
+                    "BuildKit /session UUID '{uuid}' resolves to multiple utility VMs",
+                )));
             }
         },
         None => {

--- a/app/arcbox-docker/src/handlers/build.rs
+++ b/app/arcbox-docker/src/handlers/build.rs
@@ -9,7 +9,13 @@ pub async fn build_image(
     axum::extract::OriginalUri(uri): axum::extract::OriginalUri,
     req: axum::http::Request<axum::body::Body>,
 ) -> crate::error::Result<axum::response::Response> {
-    crate::handlers::proxy_upload(&state, &uri, req).await
+    let route = crate::routing::route_build(&uri);
+    tracing::debug!(
+        utility_vm = route.utility_vm.as_str(),
+        platform = ?route.platform,
+        "routing Docker build request"
+    );
+    crate::handlers::proxy_upload_to_role(&state, route.utility_vm, &uri, req).await
 }
 
 // Forwards `POST /build/prune` (prune build cache) to guest dockerd.

--- a/app/arcbox-docker/src/handlers/container.rs
+++ b/app/arcbox-docker/src/handlers/container.rs
@@ -49,12 +49,29 @@ pub async fn create_container(
     let requested_name = query_param(&uri, "name").map(str::to_string);
     let compose_project = extract_compose_project(&body_bytes);
 
-    // If the create is part of a Compose project that already has a role
-    // binding, every service in the project must run on that role. If the
-    // requested platform cannot run on the project's role (e.g. an amd64
-    // service joining a native-bound project) the request is rejected
-    // with a clear error rather than silently splitting the project
-    // across utility VMs.
+    // Compose-project scheduling — the honest semantics.
+    //
+    // PLAN.md step 7 asks for "any amd64 service → whole project
+    // rosetta", which requires reading the full compose file before any
+    // service is created. We only see per-service `POST
+    // /containers/create` requests, so true pre-resolution would need a
+    // Compose-aware layer above the Docker API. What we do here instead
+    // is the strongest correctness guarantee achievable from per-service
+    // creates:
+    //
+    // 1. The first service in a project binds the project to the role
+    //    its platform implies (`amd64` → rosetta; otherwise native).
+    // 2. Every subsequent service must be hostable on that role. An
+    //    incompatible service (e.g. an amd64 service joining a
+    //    native-bound project) is rejected with a 400 so the user sees
+    //    the conflict immediately rather than getting a silently
+    //    misrouted container.
+    //
+    // The known consequence: a project whose first service is arm64
+    // followed by an amd64 service will be rejected, even though PLAN's
+    // ideal would have promoted the whole project to rosetta. The fix
+    // is full compose-file inspection and is intentionally out of scope
+    // for the per-API-request routing layer.
     let role = if let Some(ref project) = compose_project {
         match state.workload_roles.project_role(project).await {
             Some(project_role) => {
@@ -139,7 +156,7 @@ pub async fn start_container(
     req: Request<Body>,
 ) -> Result<Response> {
     let container_id = extract_container_id(&uri);
-    let role = resolve_container_role(&state, &uri).await;
+    let role = resolve_container_role(&state, &uri).await?;
 
     // Proxy start request to guest.
     let response = proxy_to_role(&state, role, &uri, req).await?;
@@ -165,7 +182,7 @@ pub async fn stop_container(
     OriginalUri(uri): OriginalUri,
     req: Request<Body>,
 ) -> Result<Response> {
-    let role = resolve_container_role(&state, &uri).await;
+    let role = resolve_container_role(&state, &uri).await?;
     // Resolve canonical ID before proxy — the name/short-id is still valid now
     // but may become stale after stop (e.g. --rm containers).
     let canonical = resolve_or_raw_for_teardown(&state, role, &uri).await;
@@ -195,7 +212,7 @@ pub async fn kill_container(
     OriginalUri(uri): OriginalUri,
     req: Request<Body>,
 ) -> Result<Response> {
-    let role = resolve_container_role(&state, &uri).await;
+    let role = resolve_container_role(&state, &uri).await?;
     // Resolve canonical ID before proxy — kill with --rm triggers auto-remove.
     let canonical = resolve_or_raw_for_teardown(&state, role, &uri).await;
 
@@ -222,7 +239,7 @@ pub async fn restart_container(
     OriginalUri(uri): OriginalUri,
     req: Request<Body>,
 ) -> Result<Response> {
-    let role = resolve_container_role(&state, &uri).await;
+    let role = resolve_container_role(&state, &uri).await?;
     let response = proxy_to_role(&state, role, &uri, req).await?;
 
     // Docker restart returns 204 on success. Refresh DNS (container may get
@@ -253,7 +270,7 @@ pub async fn remove_container(
     OriginalUri(uri): OriginalUri,
     req: Request<Body>,
 ) -> Result<Response> {
-    let role = resolve_container_role(&state, &uri).await;
+    let role = resolve_container_role(&state, &uri).await?;
     // Resolve canonical ID before proxy — the name/short-id is still valid now.
     let canonical = resolve_or_raw_for_teardown(&state, role, &uri).await;
 
@@ -468,7 +485,7 @@ pub async fn rename_container(
     OriginalUri(uri): OriginalUri,
     req: Request<Body>,
 ) -> Result<Response> {
-    let role = resolve_container_role(&state, &uri).await;
+    let role = resolve_container_role(&state, &uri).await?;
     // Resolve canonical ID BEFORE proxy — the old name/short-id is still valid
     // now but will be invalid after a successful rename.
     let canonical = resolve_canonical_from_uri(&state, role, &uri).await;
@@ -514,7 +531,7 @@ pub async fn attach_container(
     OriginalUri(uri): OriginalUri,
     req: Request<Body>,
 ) -> Result<Response> {
-    let role = resolve_container_role(&state, &uri).await;
+    let role = resolve_container_role(&state, &uri).await?;
     proxy_upgrade_to_role(&state, role, &uri, req).await
 }
 

--- a/app/arcbox-docker/src/handlers/container.rs
+++ b/app/arcbox-docker/src/handlers/container.rs
@@ -108,7 +108,8 @@ pub async fn start_container(
     // Proxy start request to guest.
     let response = proxy_to_role(&state, role, &uri, req).await?;
 
-    // On success, inspect the container and set up port forwarding + DNS.
+    // On success, inspect the container and set up port forwarding + DNS
+    // against the role's utility VM so host ports land on the right bridge.
     if response.status().is_success() {
         if let Some(ref id) = container_id {
             setup_container_networking(&state, role, id).await;
@@ -254,8 +255,8 @@ async fn setup_container_networking(state: &AppState, role: UtilityVmRole, conta
     // may be a name or short ID) so that stop/remove can reliably match the key.
     let canonical_id = canonical_id_or_fallback(container_id, &body_bytes);
 
-    // Port forwarding.
-    setup_port_forwarding_from_inspect(state, &canonical_id, &body_bytes).await;
+    // Port forwarding (against this role's utility VM).
+    setup_port_forwarding_from_inspect(state, role, &canonical_id, &body_bytes).await;
 
     // DNS registration.
     if let Some((aliases, ip)) = extract_container_dns_info(&body_bytes) {
@@ -308,9 +309,12 @@ async fn inspect_container_body(
     }
 }
 
-/// Configures port forwarding from pre-fetched inspect JSON.
+/// Configures port forwarding from pre-fetched inspect JSON. The `role`
+/// selects which utility VM's bridge (and inbound listener manager) owns
+/// the resulting host port bindings.
 async fn setup_port_forwarding_from_inspect(
     state: &AppState,
+    role: UtilityVmRole,
     canonical_id: &str,
     body_bytes: &[u8],
 ) {
@@ -347,16 +351,17 @@ async fn setup_port_forwarding_from_inspect(
         })
         .collect();
 
-    let machine_name = state.runtime.default_machine_name();
+    let machine_name = state.runtime.machine_name_for_role(role);
     if let Err(e) = state
         .runtime
         .start_port_forwarding_for(machine_name, canonical_id, &rules)
         .await
     {
         tracing::warn!(
+            utility_vm = role.as_str(),
             "Failed to start port forwarding for {}: {}",
             canonical_id,
-            e
+            e,
         );
     }
 }

--- a/app/arcbox-docker/src/handlers/container.rs
+++ b/app/arcbox-docker/src/handlers/container.rs
@@ -2,7 +2,9 @@ use super::{extract_container_id, proxy_to_role, proxy_upgrade_to_role, resolve_
 use crate::api::AppState;
 use crate::error::{DockerError, Result};
 use crate::proxy::{parse_port_bindings, proxy_to_guest_for_role};
-use crate::routing::{UtilityVmRole, query_param, route_container_create};
+use crate::routing::{
+    UtilityVmRole, UtilityVmRoleExt, extract_compose_project, query_param, route_container_create,
+};
 use axum::body::Body;
 use axum::extract::{OriginalUri, State};
 use axum::http::{HeaderMap, Method, Request, Uri};
@@ -44,11 +46,45 @@ pub async fn create_container(
 
     let body_bytes = crate::host_path::rewrite_create_body(body_bytes);
     let route = route_container_create(&uri, &body_bytes);
-    let role = route.utility_vm;
     let requested_name = query_param(&uri, "name").map(str::to_string);
+    let compose_project = extract_compose_project(&body_bytes);
+
+    // If the create is part of a Compose project that already has a role
+    // binding, every service in the project must run on that role. If the
+    // requested platform cannot run on the project's role (e.g. an amd64
+    // service joining a native-bound project) the request is rejected
+    // with a clear error rather than silently splitting the project
+    // across utility VMs.
+    let role = if let Some(ref project) = compose_project {
+        match state.workload_roles.project_role(project).await {
+            Some(project_role) => {
+                if !project_role.can_host(route.platform) {
+                    return Err(DockerError::BadRequest(format!(
+                        "compose project '{project}' is bound to the {} utility VM but \
+                         this service requires {:?}; mixed-backend compose projects \
+                         are not supported",
+                        project_role.as_str(),
+                        route.platform,
+                    )));
+                }
+                project_role
+            }
+            None => {
+                state
+                    .workload_roles
+                    .record_project(project.clone(), route.utility_vm)
+                    .await;
+                route.utility_vm
+            }
+        }
+    } else {
+        route.utility_vm
+    };
+
     tracing::debug!(
         utility_vm = role.as_str(),
         platform = ?route.platform,
+        compose_project = compose_project.as_deref().unwrap_or(""),
         name = requested_name.as_deref().unwrap_or(""),
         "routing Docker container create request"
     );

--- a/app/arcbox-docker/src/handlers/container.rs
+++ b/app/arcbox-docker/src/handlers/container.rs
@@ -2,7 +2,7 @@ use super::{extract_container_id, proxy_to_role, proxy_upgrade_to_role, resolve_
 use crate::api::AppState;
 use crate::error::{DockerError, Result};
 use crate::proxy::{parse_port_bindings, proxy_to_guest_for_role};
-use crate::routing::{UtilityVmRole, route_container_create};
+use crate::routing::{UtilityVmRole, query_param, route_container_create};
 use axum::body::Body;
 use axum::extract::{OriginalUri, State};
 use axum::http::{HeaderMap, Method, Request, Uri};
@@ -45,9 +45,11 @@ pub async fn create_container(
     let body_bytes = crate::host_path::rewrite_create_body(body_bytes);
     let route = route_container_create(&uri, &body_bytes);
     let role = route.utility_vm;
+    let requested_name = query_param(&uri, "name").map(str::to_string);
     tracing::debug!(
         utility_vm = role.as_str(),
         platform = ?route.platform,
+        name = requested_name.as_deref().unwrap_or(""),
         "routing Docker container create request"
     );
     let mut req = Request::from_parts(parts, Body::from(body_bytes));
@@ -73,9 +75,13 @@ pub async fn create_container(
         tracing::debug!(
             utility_vm = role.as_str(),
             container_id = %id,
+            name = requested_name.as_deref().unwrap_or(""),
             "recorded container role binding",
         );
-        state.workload_roles.record(id, role).await;
+        state.workload_roles.record(id.clone(), role).await;
+        if let Some(name) = requested_name {
+            state.workload_roles.add_alias(&id, name).await;
+        }
     } else {
         tracing::warn!(
             utility_vm = role.as_str(),
@@ -425,6 +431,7 @@ pub async fn rename_container(
     // Resolve canonical ID BEFORE proxy — the old name/short-id is still valid
     // now but will be invalid after a successful rename.
     let canonical = resolve_canonical_from_uri(&state, role, &uri).await;
+    let new_name = query_param(&uri, "name").map(str::to_string);
 
     // Proxy rename to guest.
     let response = proxy_to_role(&state, role, &uri, req).await?;
@@ -434,7 +441,16 @@ pub async fn rename_container(
             // 1. Remove old DNS entry.
             state.runtime.deregister_dns_by_id(canonical).await;
 
-            // 2. Inspect (using canonical ID which survives rename) to get
+            // 2. Update the registry alias so future lookups by the new name
+            //    keep landing on the same role.
+            if let Some(ref new_name) = new_name {
+                state
+                    .workload_roles
+                    .rename_alias(canonical, new_name.clone())
+                    .await;
+            }
+
+            // 3. Inspect (using canonical ID which survives rename) to get
             //    new name + IP, then register.
             if let Some(body_bytes) = inspect_container_body(&state, role, canonical).await
                 && let Some((aliases, ip)) = extract_container_dns_info(&body_bytes)

--- a/app/arcbox-docker/src/handlers/container.rs
+++ b/app/arcbox-docker/src/handlers/container.rs
@@ -1,8 +1,8 @@
-use super::{proxy, proxy_upgrade};
+use super::{extract_container_id, proxy_to_role, proxy_upgrade_to_role, resolve_container_role};
 use crate::api::AppState;
-use crate::error::Result;
-use crate::proxy::{parse_port_bindings, proxy_to_guest};
-use crate::routing::route_container_create;
+use crate::error::{DockerError, Result};
+use crate::proxy::{parse_port_bindings, proxy_to_guest_for_role};
+use crate::routing::{UtilityVmRole, route_container_create};
 use axum::body::Body;
 use axum::extract::{OriginalUri, State};
 use axum::http::{HeaderMap, Method, Request, Uri};
@@ -11,15 +11,15 @@ use bytes::Bytes;
 use std::net::IpAddr;
 
 crate::handlers::proxy_handler!(list_containers);
-crate::handlers::proxy_handler!(inspect_container);
-crate::handlers::proxy_handler!(container_logs);
-crate::handlers::proxy_handler!(wait_container);
-crate::handlers::proxy_handler!(pause_container);
-crate::handlers::proxy_handler!(unpause_container);
-crate::handlers::proxy_handler!(container_top);
-crate::handlers::proxy_handler!(container_stats);
-crate::handlers::proxy_handler!(container_changes);
 crate::handlers::proxy_handler!(prune_containers);
+crate::handlers::container_proxy_handler!(inspect_container);
+crate::handlers::container_proxy_handler!(container_logs);
+crate::handlers::container_proxy_handler!(wait_container);
+crate::handlers::container_proxy_handler!(pause_container);
+crate::handlers::container_proxy_handler!(unpause_container);
+crate::handlers::container_proxy_handler!(container_top);
+crate::handlers::container_proxy_handler!(container_stats);
+crate::handlers::container_proxy_handler!(container_changes);
 
 /// Create a container, resolving macOS symlinks in bind-mount source paths.
 ///
@@ -27,6 +27,10 @@ crate::handlers::proxy_handler!(prune_containers);
 /// mounts host `/private` via VirtioFS while its `/tmp` and `/var` are
 /// isolated tmpfs. This handler resolves the top-level symlink so
 /// bind-mount paths land on the VirtioFS share.
+///
+/// On a successful response, the canonical container ID is recorded against
+/// the chosen utility VM role so every follow-up lifecycle call is routed
+/// to the same role.
 pub async fn create_container(
     State(state): State<AppState>,
     OriginalUri(uri): OriginalUri,
@@ -35,13 +39,14 @@ pub async fn create_container(
     let (parts, body) = req.into_parts();
     let body_bytes = http_body_util::BodyExt::collect(body)
         .await
-        .map_err(|e| crate::error::DockerError::Server(format!("failed to read body: {e}")))?
+        .map_err(|e| DockerError::Server(format!("failed to read body: {e}")))?
         .to_bytes();
 
     let body_bytes = crate::host_path::rewrite_create_body(body_bytes);
     let route = route_container_create(&uri, &body_bytes);
+    let role = route.utility_vm;
     tracing::debug!(
-        utility_vm = route.utility_vm.as_str(),
+        utility_vm = role.as_str(),
         platform = ?route.platform,
         "routing Docker container create request"
     );
@@ -49,25 +54,36 @@ pub async fn create_container(
     // Body may have changed size; remove Content-Length so the proxy
     // recomputes framing from the actual body.
     req.headers_mut().remove(axum::http::header::CONTENT_LENGTH);
-    super::proxy_to_role(&state, route.utility_vm, &uri, req).await
-}
 
-/// Extract container ID from URI path.
-///
-/// Matches patterns like `/containers/{id}/start`, `/v1.43/containers/{id}/stop`,
-/// or `/containers/{id}` (for DELETE).
-fn extract_container_id(uri: &Uri) -> Option<String> {
-    let segments: Vec<&str> = uri.path().split('/').filter(|s| !s.is_empty()).collect();
-    for (i, seg) in segments.iter().enumerate() {
-        if *seg == "containers" && i + 1 < segments.len() {
-            let id = segments[i + 1];
-            // Skip collection endpoints (no container ID).
-            if !matches!(id, "json" | "create" | "prune") {
-                return Some(id.to_string());
-            }
-        }
+    let response = proxy_to_role(&state, role, &uri, req).await?;
+    if !response.status().is_success() {
+        return Ok(response);
     }
-    None
+
+    // Buffer the create response so the canonical container ID can be
+    // recorded. Create responses are small JSON (just `Id` + `Warnings`),
+    // so this does not affect streaming or memory behavior.
+    let (parts, body) = response.into_parts();
+    let body_bytes = http_body_util::BodyExt::collect(body)
+        .await
+        .map_err(|e| DockerError::Server(format!("failed to read create response: {e}")))?
+        .to_bytes();
+
+    if let Some(id) = parse_create_response_id(&body_bytes) {
+        tracing::debug!(
+            utility_vm = role.as_str(),
+            container_id = %id,
+            "recorded container role binding",
+        );
+        state.workload_roles.record(id, role).await;
+    } else {
+        tracing::warn!(
+            utility_vm = role.as_str(),
+            "create response missing container ID; lifecycle ops will fall back to native"
+        );
+    }
+
+    Ok(Response::from_parts(parts, Body::from(body_bytes)))
 }
 
 /// Start a container, then set up host-side port forwarding and DNS.
@@ -81,14 +97,15 @@ pub async fn start_container(
     req: Request<Body>,
 ) -> Result<Response> {
     let container_id = extract_container_id(&uri);
+    let role = resolve_container_role(&state, &uri).await;
 
     // Proxy start request to guest.
-    let response = proxy(&state, &uri, req).await?;
+    let response = proxy_to_role(&state, role, &uri, req).await?;
 
     // On success, inspect the container and set up port forwarding + DNS.
     if response.status().is_success() {
         if let Some(ref id) = container_id {
-            setup_container_networking(&state, id).await;
+            setup_container_networking(&state, role, id).await;
         }
     }
 
@@ -105,11 +122,12 @@ pub async fn stop_container(
     OriginalUri(uri): OriginalUri,
     req: Request<Body>,
 ) -> Result<Response> {
+    let role = resolve_container_role(&state, &uri).await;
     // Resolve canonical ID before proxy — the name/short-id is still valid now
     // but may become stale after stop (e.g. --rm containers).
-    let canonical = resolve_or_raw_for_teardown(&state, &uri).await;
+    let canonical = resolve_or_raw_for_teardown(&state, role, &uri).await;
 
-    let response = proxy(&state, &uri, req).await?;
+    let response = proxy_to_role(&state, role, &uri, req).await?;
 
     // Tear down networking after a terminal stop response.
     // Docker returns 204 on success and 304 when already stopped.
@@ -134,10 +152,11 @@ pub async fn kill_container(
     OriginalUri(uri): OriginalUri,
     req: Request<Body>,
 ) -> Result<Response> {
+    let role = resolve_container_role(&state, &uri).await;
     // Resolve canonical ID before proxy — kill with --rm triggers auto-remove.
-    let canonical = resolve_or_raw_for_teardown(&state, &uri).await;
+    let canonical = resolve_or_raw_for_teardown(&state, role, &uri).await;
 
-    let response = proxy(&state, &uri, req).await?;
+    let response = proxy_to_role(&state, role, &uri, req).await?;
 
     // Docker kill returns 204 on success.
     if response.status().as_u16() == 204 {
@@ -160,7 +179,8 @@ pub async fn restart_container(
     OriginalUri(uri): OriginalUri,
     req: Request<Body>,
 ) -> Result<Response> {
-    let response = proxy(&state, &uri, req).await?;
+    let role = resolve_container_role(&state, &uri).await;
+    let response = proxy_to_role(&state, role, &uri, req).await?;
 
     // Docker restart returns 204 on success. Refresh DNS (container may get
     // a new IP) with a single inspect call for both canonical ID and DNS info.
@@ -168,7 +188,7 @@ pub async fn restart_container(
     if response.status().as_u16() == 204 {
         if let Some(id) = extract_container_id(&uri) {
             let _ = state.runtime.ensure_vm_ready().await;
-            if let Some(body_bytes) = inspect_container_body(&state, &id).await {
+            if let Some(body_bytes) = inspect_container_body(&state, role, &id).await {
                 let canonical = canonical_id_or_fallback(&id, &body_bytes);
                 if let Some((aliases, ip)) = extract_container_dns_info(&body_bytes) {
                     state.runtime.register_dns(&canonical, &aliases, ip).await;
@@ -190,16 +210,19 @@ pub async fn remove_container(
     OriginalUri(uri): OriginalUri,
     req: Request<Body>,
 ) -> Result<Response> {
+    let role = resolve_container_role(&state, &uri).await;
     // Resolve canonical ID before proxy — the name/short-id is still valid now.
-    let canonical = resolve_or_raw_for_teardown(&state, &uri).await;
+    let canonical = resolve_or_raw_for_teardown(&state, role, &uri).await;
 
-    let response = proxy(&state, &uri, req).await?;
+    let response = proxy_to_role(&state, role, &uri, req).await?;
 
     // Only tear down networking after a successful remove.
     if response.status().is_success() {
         if let Some(canonical) = canonical {
             state.runtime.stop_port_forwarding_by_id(&canonical).await;
             state.runtime.deregister_dns_by_id(&canonical).await;
+            // Drop the workload→role binding once the container is gone.
+            state.workload_roles.forget(&canonical).await;
         }
     }
 
@@ -208,9 +231,11 @@ pub async fn remove_container(
 
 /// Inspect a started container and configure port forwarding + DNS registration.
 ///
-/// Shares a single inspect call for both port forwarding and DNS setup.
-async fn setup_container_networking(state: &AppState, container_id: &str) {
-    let Some(body_bytes) = inspect_container_body(state, container_id).await else {
+/// Shares a single inspect call for both port forwarding and DNS setup. The
+/// `role` selects which utility VM hosts the container so the inspect lands
+/// on the right guest dockerd.
+async fn setup_container_networking(state: &AppState, role: UtilityVmRole, container_id: &str) {
+    let Some(body_bytes) = inspect_container_body(state, role, container_id).await else {
         tracing::warn!(
             container_id,
             "Failed to inspect container for networking setup; \
@@ -235,11 +260,17 @@ async fn setup_container_networking(state: &AppState, container_id: &str) {
     }
 }
 
-/// Fetches the inspect JSON body for a container from guest dockerd.
-async fn inspect_container_body(state: &AppState, container_id: &str) -> Option<Bytes> {
+/// Fetches the inspect JSON body for a container from the selected role's
+/// guest dockerd.
+async fn inspect_container_body(
+    state: &AppState,
+    role: UtilityVmRole,
+    container_id: &str,
+) -> Option<Bytes> {
     let inspect_path = format!("/containers/{container_id}/json");
-    let inspect_resp = match proxy_to_guest(
+    let inspect_resp = match proxy_to_guest_for_role(
         state.connector.as_ref(),
+        role,
         Method::GET,
         &inspect_path,
         &HeaderMap::new(),
@@ -390,12 +421,13 @@ pub async fn rename_container(
     OriginalUri(uri): OriginalUri,
     req: Request<Body>,
 ) -> Result<Response> {
+    let role = resolve_container_role(&state, &uri).await;
     // Resolve canonical ID BEFORE proxy — the old name/short-id is still valid
     // now but will be invalid after a successful rename.
-    let canonical = resolve_canonical_from_uri(&state, &uri).await;
+    let canonical = resolve_canonical_from_uri(&state, role, &uri).await;
 
     // Proxy rename to guest.
-    let response = proxy(&state, &uri, req).await?;
+    let response = proxy_to_role(&state, role, &uri, req).await?;
 
     if response.status().is_success() {
         if let Some(ref canonical) = canonical {
@@ -404,10 +436,10 @@ pub async fn rename_container(
 
             // 2. Inspect (using canonical ID which survives rename) to get
             //    new name + IP, then register.
-            if let Some(body_bytes) = inspect_container_body(&state, canonical).await {
-                if let Some((aliases, ip)) = extract_container_dns_info(&body_bytes) {
-                    state.runtime.register_dns(canonical, &aliases, ip).await;
-                }
+            if let Some(body_bytes) = inspect_container_body(&state, role, canonical).await
+                && let Some((aliases, ip)) = extract_container_dns_info(&body_bytes)
+            {
+                state.runtime.register_dns(canonical, &aliases, ip).await;
             }
         }
     }
@@ -425,7 +457,8 @@ pub async fn attach_container(
     OriginalUri(uri): OriginalUri,
     req: Request<Body>,
 ) -> Result<Response> {
-    proxy_upgrade(&state, &uri, req).await
+    let role = resolve_container_role(&state, &uri).await;
+    proxy_upgrade_to_role(&state, role, &uri, req).await
 }
 
 /// Extracts the canonical full container ID from a Docker inspect JSON response.
@@ -441,8 +474,8 @@ fn canonical_id_or_fallback(container_id: &str, inspect_json: &[u8]) -> String {
 }
 
 /// Extracts a container identifier from the URI and resolves it to the
-/// canonical full ID. Returns `None` (with a warning) when canonical
-/// resolution fails.
+/// canonical full ID via an inspect against the selected utility VM.
+/// Returns `None` (with a warning) when canonical resolution fails.
 ///
 /// Teardown handlers (stop/kill/remove) layer a raw-ID fallback on top
 /// of this via [`resolve_or_raw_for_teardown`] so transient inspect
@@ -452,18 +485,23 @@ fn canonical_id_or_fallback(container_id: &str, inspect_json: &[u8]) -> String {
 /// rename, which would break DNS re-registration.
 ///
 /// Best-effort wakes the VM before inspecting, since
-/// [`resolve_canonical_id`] uses `proxy_to_guest` directly and does not
-/// call `ensure_vm_ready` itself. Readiness failures are not fatal — the
-/// subsequent inspect will surface them as a `None` resolution.
-async fn resolve_canonical_from_uri(state: &AppState, uri: &Uri) -> Option<String> {
+/// [`resolve_canonical_id`] uses `proxy_to_guest_for_role` directly and
+/// does not call `ensure_vm_ready` itself. Readiness failures are not
+/// fatal — the subsequent inspect will surface them as a `None` resolution.
+async fn resolve_canonical_from_uri(
+    state: &AppState,
+    role: UtilityVmRole,
+    uri: &Uri,
+) -> Option<String> {
     let id = extract_container_id(uri)?;
     // Best-effort wake; if it fails, the inspect call below will too.
     let _ = state.runtime.ensure_vm_ready().await;
-    match resolve_canonical_id(state, &id).await {
+    match resolve_canonical_id(state, role, &id).await {
         Some(canonical) => Some(canonical),
         None => {
             tracing::warn!(
                 container_id = %id,
+                utility_vm = role.as_str(),
                 "Failed to resolve canonical container ID"
             );
             None
@@ -476,24 +514,30 @@ async fn resolve_canonical_from_uri(state: &AppState, uri: &Uri) -> Option<Strin
 /// the raw URI-extracted ID so cleanup of port forwarding + DNS still
 /// runs. A non-matching key is a no-op against the canonical-keyed maps
 /// — strictly better than skipping teardown entirely.
-async fn resolve_or_raw_for_teardown(state: &AppState, uri: &Uri) -> Option<String> {
-    if let Some(canonical) = resolve_canonical_from_uri(state, uri).await {
+async fn resolve_or_raw_for_teardown(
+    state: &AppState,
+    role: UtilityVmRole,
+    uri: &Uri,
+) -> Option<String> {
+    if let Some(canonical) = resolve_canonical_from_uri(state, role, uri).await {
         return Some(canonical);
     }
     let raw = extract_container_id(uri)?;
     tracing::warn!(
         container_id = %raw,
+        utility_vm = role.as_str(),
         "Using raw URI-extracted ID for networking teardown"
     );
     Some(raw)
 }
 
 /// Resolves a container name, short ID, or full ID to the canonical full ID
-/// by inspecting the container on the guest.
-async fn resolve_canonical_id(state: &AppState, id: &str) -> Option<String> {
+/// by inspecting the container on the selected utility VM.
+async fn resolve_canonical_id(state: &AppState, role: UtilityVmRole, id: &str) -> Option<String> {
     let inspect_path = format!("/containers/{id}/json");
-    let resp = proxy_to_guest(
+    let resp = proxy_to_guest_for_role(
         state.connector.as_ref(),
+        role,
         Method::GET,
         &inspect_path,
         &HeaderMap::new(),
@@ -512,6 +556,12 @@ async fn resolve_canonical_id(state: &AppState, id: &str) -> Option<String> {
         .to_bytes();
 
     extract_canonical_id_from_inspect(&body_bytes)
+}
+
+/// Parses the `Id` field from a `POST /containers/create` JSON response.
+fn parse_create_response_id(body: &[u8]) -> Option<String> {
+    let value: serde_json::Value = serde_json::from_slice(body).ok()?;
+    value.get("Id")?.as_str().map(String::from)
 }
 
 #[cfg(test)]
@@ -570,6 +620,21 @@ mod tests {
     #[test]
     fn extract_canonical_id_invalid_json() {
         assert_eq!(extract_canonical_id_from_inspect(b"not json"), None);
+    }
+
+    #[test]
+    fn parses_id_from_create_response() {
+        let json = br#"{"Id":"abc123def456","Warnings":null}"#;
+        assert_eq!(
+            parse_create_response_id(json).as_deref(),
+            Some("abc123def456"),
+        );
+    }
+
+    #[test]
+    fn returns_none_when_create_response_missing_id() {
+        assert_eq!(parse_create_response_id(b"{}"), None);
+        assert_eq!(parse_create_response_id(b"not json"), None);
     }
 
     #[test]

--- a/app/arcbox-docker/src/handlers/container.rs
+++ b/app/arcbox-docker/src/handlers/container.rs
@@ -2,6 +2,7 @@ use super::{proxy, proxy_upgrade};
 use crate::api::AppState;
 use crate::error::Result;
 use crate::proxy::{parse_port_bindings, proxy_to_guest};
+use crate::routing::route_container_create;
 use axum::body::Body;
 use axum::extract::{OriginalUri, State};
 use axum::http::{HeaderMap, Method, Request, Uri};
@@ -38,11 +39,17 @@ pub async fn create_container(
         .to_bytes();
 
     let body_bytes = crate::host_path::rewrite_create_body(body_bytes);
+    let route = route_container_create(&uri, &body_bytes);
+    tracing::debug!(
+        utility_vm = route.utility_vm.as_str(),
+        platform = ?route.platform,
+        "routing Docker container create request"
+    );
     let mut req = Request::from_parts(parts, Body::from(body_bytes));
     // Body may have changed size; remove Content-Length so the proxy
     // recomputes framing from the actual body.
     req.headers_mut().remove(axum::http::header::CONTENT_LENGTH);
-    proxy(&state, &uri, req).await
+    super::proxy_to_role(&state, route.utility_vm, &uri, req).await
 }
 
 /// Extract container ID from URI path.

--- a/app/arcbox-docker/src/handlers/exec.rs
+++ b/app/arcbox-docker/src/handlers/exec.rs
@@ -1,14 +1,56 @@
-use super::{proxy as proxy_request, proxy_upgrade};
+use super::{proxy_to_role, proxy_upgrade_to_role, resolve_container_role, resolve_exec_role};
 use crate::api::AppState;
-use crate::error::Result;
+use crate::error::{DockerError, Result};
 use axum::body::Body;
 use axum::extract::{OriginalUri, State};
 use axum::http::{Request, header};
 use axum::response::Response;
 
-crate::handlers::proxy_handler!(exec_create);
-crate::handlers::proxy_handler!(exec_resize);
-crate::handlers::proxy_handler!(exec_inspect);
+crate::handlers::exec_proxy_handler!(exec_resize);
+crate::handlers::exec_proxy_handler!(exec_inspect);
+
+/// Create an exec instance on a container, recording the resulting exec ID
+/// against the container's utility VM role so follow-up
+/// `start`/`resize`/`inspect` calls land on the same VM.
+///
+/// # Errors
+///
+/// Returns an error if VM readiness fails or proxying to guest dockerd fails.
+pub async fn exec_create(
+    State(state): State<AppState>,
+    OriginalUri(uri): OriginalUri,
+    req: Request<Body>,
+) -> Result<Response> {
+    let role = resolve_container_role(&state, &uri).await;
+    let response = proxy_to_role(&state, role, &uri, req).await?;
+    if !response.status().is_success() {
+        return Ok(response);
+    }
+
+    // Buffer the create response so the exec ID can be recorded. Exec create
+    // responses are small JSON (just `Id`).
+    let (parts, body) = response.into_parts();
+    let body_bytes = http_body_util::BodyExt::collect(body)
+        .await
+        .map_err(|e| DockerError::Server(format!("failed to read exec create response: {e}")))?
+        .to_bytes();
+
+    if let Some(exec_id) = parse_exec_create_response_id(&body_bytes) {
+        tracing::debug!(
+            utility_vm = role.as_str(),
+            exec_id = %exec_id,
+            "recorded exec role binding",
+        );
+        state.workload_roles.record(exec_id, role).await;
+    } else {
+        tracing::warn!(
+            utility_vm = role.as_str(),
+            "exec create response missing exec ID; follow-up calls will fall back to native"
+        );
+    }
+
+    Ok(Response::from_parts(parts, Body::from(body_bytes)))
+}
 
 /// Start exec instance (proxy + upgrade for interactive mode).
 ///
@@ -20,6 +62,7 @@ pub async fn exec_start(
     OriginalUri(uri): OriginalUri,
     req: Request<Body>,
 ) -> Result<Response> {
+    let role = resolve_exec_role(&state, &uri).await;
     let wants_upgrade = req.headers().get(header::UPGRADE).is_some()
         || req
             .headers()
@@ -28,8 +71,34 @@ pub async fn exec_start(
             .is_some_and(|v| v.to_ascii_lowercase().contains("upgrade"));
 
     if wants_upgrade {
-        proxy_upgrade(&state, &uri, req).await
+        proxy_upgrade_to_role(&state, role, &uri, req).await
     } else {
-        proxy_request(&state, &uri, req).await
+        proxy_to_role(&state, role, &uri, req).await
+    }
+}
+
+/// Parses the `Id` field from a `POST /containers/{id}/exec` JSON response.
+fn parse_exec_create_response_id(body: &[u8]) -> Option<String> {
+    let value: serde_json::Value = serde_json::from_slice(body).ok()?;
+    value.get("Id")?.as_str().map(String::from)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_exec_id_from_create_response() {
+        let json = br#"{"Id":"exec-abc123"}"#;
+        assert_eq!(
+            parse_exec_create_response_id(json).as_deref(),
+            Some("exec-abc123"),
+        );
+    }
+
+    #[test]
+    fn returns_none_when_exec_create_response_missing_id() {
+        assert_eq!(parse_exec_create_response_id(b"{}"), None);
+        assert_eq!(parse_exec_create_response_id(b"not json"), None);
     }
 }

--- a/app/arcbox-docker/src/handlers/exec.rs
+++ b/app/arcbox-docker/src/handlers/exec.rs
@@ -21,7 +21,7 @@ pub async fn exec_create(
     OriginalUri(uri): OriginalUri,
     req: Request<Body>,
 ) -> Result<Response> {
-    let role = resolve_container_role(&state, &uri).await;
+    let role = resolve_container_role(&state, &uri).await?;
     let response = proxy_to_role(&state, role, &uri, req).await?;
     if !response.status().is_success() {
         return Ok(response);
@@ -62,7 +62,7 @@ pub async fn exec_start(
     OriginalUri(uri): OriginalUri,
     req: Request<Body>,
 ) -> Result<Response> {
-    let role = resolve_exec_role(&state, &uri).await;
+    let role = resolve_exec_role(&state, &uri).await?;
     let wants_upgrade = req.headers().get(header::UPGRADE).is_some()
         || req
             .headers()

--- a/app/arcbox-docker/src/handlers/mod.rs
+++ b/app/arcbox-docker/src/handlers/mod.rs
@@ -151,7 +151,21 @@ pub(crate) async fn resolve_role_from_uri(state: &AppState, uri: &Uri) -> Utilit
 /// Ensures the utility VM hosting `role` is up before any request reaches
 /// the connector. Surfaces the role in the error message so a Rosetta-VM
 /// failure can't be confused with a native-VM failure.
+///
+/// Refuses requests for a role that is not configured on this host
+/// (e.g. `Rosetta` on non-Apple-Silicon) with a clear platform-specific
+/// error rather than silently routing to native — silently degrading
+/// would land an `amd64` container on the HV native VM that cannot
+/// translate x86.
 pub(crate) async fn ensure_role_ready(state: &AppState, role: UtilityVmRole) -> Result<()> {
+    if !state.runtime.role_is_distinct(role) && role != UtilityVmRole::Native {
+        return Err(DockerError::Server(format!(
+            "{} utility VM is not available on this host; \
+             {} workloads require macOS Apple Silicon",
+            role.as_str(),
+            role.as_str(),
+        )));
+    }
     state
         .runtime
         .ensure_role_ready(role)

--- a/app/arcbox-docker/src/handlers/mod.rs
+++ b/app/arcbox-docker/src/handlers/mod.rs
@@ -7,6 +7,7 @@
 use crate::api::AppState;
 use crate::error::{DockerError, Result};
 use crate::proxy;
+use crate::routing::UtilityVmRole;
 use axum::body::Body;
 use axum::http::{Request, Uri};
 use axum::response::Response;
@@ -32,17 +33,13 @@ pub(crate) use proxy_handler;
 
 /// Forward a request to guest dockerd, ensuring the VM is running first.
 pub(crate) async fn proxy(state: &AppState, uri: &Uri, req: Request<Body>) -> Result<Response> {
-    state
-        .runtime
-        .ensure_vm_ready()
-        .await
-        .map_err(|e| DockerError::Server(format!("failed to ensure VM is ready: {e}")))?;
-    proxy::proxy_to_guest_stream(state.connector.as_ref(), uri, req).await
+    proxy_to_role(state, UtilityVmRole::Native, uri, req).await
 }
 
-/// Forward an upload request to guest dockerd, ensuring the VM is running first.
-pub(crate) async fn proxy_upload(
+/// Forward a request to a selected utility VM's guest dockerd.
+pub(crate) async fn proxy_to_role(
     state: &AppState,
+    role: UtilityVmRole,
     uri: &Uri,
     req: Request<Body>,
 ) -> Result<Response> {
@@ -51,7 +48,31 @@ pub(crate) async fn proxy_upload(
         .ensure_vm_ready()
         .await
         .map_err(|e| DockerError::Server(format!("failed to ensure VM is ready: {e}")))?;
-    proxy::proxy_streaming_upload(state.connector.as_ref(), uri, req).await
+    proxy::proxy_to_guest_stream_for_role(state.connector.as_ref(), role, uri, req).await
+}
+
+/// Forward an upload request to guest dockerd, ensuring the VM is running first.
+pub(crate) async fn proxy_upload(
+    state: &AppState,
+    uri: &Uri,
+    req: Request<Body>,
+) -> Result<Response> {
+    proxy_upload_to_role(state, UtilityVmRole::Native, uri, req).await
+}
+
+/// Forward an upload request to a selected utility VM's guest dockerd.
+pub(crate) async fn proxy_upload_to_role(
+    state: &AppState,
+    role: UtilityVmRole,
+    uri: &Uri,
+    req: Request<Body>,
+) -> Result<Response> {
+    state
+        .runtime
+        .ensure_vm_ready()
+        .await
+        .map_err(|e| DockerError::Server(format!("failed to ensure VM is ready: {e}")))?;
+    proxy::proxy_streaming_upload_for_role(state.connector.as_ref(), role, uri, req).await
 }
 
 /// Forward an upgraded request to guest dockerd, ensuring the VM is running first.

--- a/app/arcbox-docker/src/handlers/mod.rs
+++ b/app/arcbox-docker/src/handlers/mod.rs
@@ -8,6 +8,7 @@ use crate::api::AppState;
 use crate::error::{DockerError, Result};
 use crate::proxy;
 use crate::routing::UtilityVmRole;
+use crate::workload::WorkloadRoleLookup;
 use axum::body::Body;
 use axum::http::{Request, Uri};
 use axum::response::Response;
@@ -33,41 +34,45 @@ macro_rules! proxy_handler {
 }
 
 /// Forwards a `/containers/{id}/...` request to the utility VM role
-/// recorded for that container, falling back to `native` when no record
-/// exists (pre-existing or post-restart workloads).
+/// recorded for that container. Returns a 409 Conflict if the URI
+/// resolves to multiple utility VMs (ambiguous short ID); falls back to
+/// native only when no role can be determined at all.
 macro_rules! container_proxy_handler {
     ($name:ident) => {
         /// Forwards the request to the container's utility VM.
         ///
         /// # Errors
         ///
-        /// Returns an error if VM readiness fails or proxying to guest dockerd fails.
+        /// Returns an error if the URI is ambiguous across utility VMs,
+        /// if VM readiness fails, or if proxying to guest dockerd fails.
         pub async fn $name(
             axum::extract::State(state): axum::extract::State<crate::api::AppState>,
             axum::extract::OriginalUri(uri): axum::extract::OriginalUri,
             req: axum::http::Request<axum::body::Body>,
         ) -> crate::error::Result<axum::response::Response> {
-            let role = $crate::handlers::resolve_container_role(&state, &uri).await;
+            let role = $crate::handlers::resolve_container_role(&state, &uri).await?;
             $crate::handlers::proxy_to_role(&state, role, &uri, req).await
         }
     };
 }
 
 /// Forwards an `/exec/{id}/...` request to the utility VM role recorded for
-/// the originating container, falling back to `native` when no record exists.
+/// the originating container. Returns a 409 Conflict if the URI resolves
+/// to multiple utility VMs.
 macro_rules! exec_proxy_handler {
     ($name:ident) => {
         /// Forwards the request to the exec instance's utility VM.
         ///
         /// # Errors
         ///
-        /// Returns an error if VM readiness fails or proxying to guest dockerd fails.
+        /// Returns an error if the URI is ambiguous across utility VMs,
+        /// if VM readiness fails, or if proxying to guest dockerd fails.
         pub async fn $name(
             axum::extract::State(state): axum::extract::State<crate::api::AppState>,
             axum::extract::OriginalUri(uri): axum::extract::OriginalUri,
             req: axum::http::Request<axum::body::Body>,
         ) -> crate::error::Result<axum::response::Response> {
-            let role = $crate::handlers::resolve_exec_role(&state, &uri).await;
+            let role = $crate::handlers::resolve_exec_role(&state, &uri).await?;
             $crate::handlers::proxy_to_role(&state, role, &uri, req).await
         }
     };
@@ -103,41 +108,54 @@ fn extract_id_after_segment(uri: &Uri, segment: &str, skip_tokens: &[&str]) -> O
 
 /// Resolves the utility VM role for a `/containers/{id}/...` URI.
 ///
-/// First consults the in-process [`WorkloadRoleRegistry`]. On a miss
-/// (e.g. an `arcbox-daemon` restart between create and the follow-up
-/// call), probes each configured role's guest dockerd to find which one
-/// owns the container, caches the result, and returns it. Falls back to
-/// `native` when no probe succeeds.
-pub(crate) async fn resolve_container_role(state: &AppState, uri: &Uri) -> UtilityVmRole {
+/// Lookup order:
+///
+/// 1. Consult the in-process [`WorkloadRoleRegistry`]. A
+///    [`WorkloadRoleLookup::Found`] returns the role directly. A
+///    [`WorkloadRoleLookup::Ambiguous`] short ID surfaces as a 409
+///    Conflict so we never silently pick a VM.
+/// 2. On [`WorkloadRoleLookup::Missing`] (e.g. after a daemon restart),
+///    probe every configured role's guest dockerd. Exactly one match is
+///    recorded and returned; multiple matches surface as a 409 Conflict.
+///    Zero matches falls back to `native` so the request still reaches a
+///    guest that can return the appropriate `404 No such container`.
+pub(crate) async fn resolve_container_role(state: &AppState, uri: &Uri) -> Result<UtilityVmRole> {
     let Some(id) = extract_container_id(uri) else {
-        return UtilityVmRole::Native;
+        return Ok(UtilityVmRole::Native);
     };
-    if let Some(role) = state.workload_roles.lookup(&id).await {
-        return role;
+    match state.workload_roles.lookup(&id).await {
+        WorkloadRoleLookup::Found(role) => Ok(role),
+        WorkloadRoleLookup::Ambiguous => Err(ambiguous_workload_error(&id)),
+        WorkloadRoleLookup::Missing => match rebuild_container_role_from_guests(state, &id).await {
+            WorkloadRoleLookup::Found(role) => {
+                state.workload_roles.record(id.clone(), role).await;
+                tracing::debug!(
+                    container_id = %id,
+                    utility_vm = role.as_str(),
+                    "rebuilt workload role from guest dockerd",
+                );
+                Ok(role)
+            }
+            WorkloadRoleLookup::Ambiguous => Err(ambiguous_workload_error(&id)),
+            WorkloadRoleLookup::Missing => Ok(UtilityVmRole::Native),
+        },
     }
-    if let Some(role) = rebuild_container_role_from_guests(state, &id).await {
-        state.workload_roles.record(id.clone(), role).await;
-        tracing::debug!(
-            container_id = %id,
-            utility_vm = role.as_str(),
-            "rebuilt workload role from guest dockerd",
-        );
-        return role;
-    }
-    UtilityVmRole::Native
 }
 
-/// Resolves the utility VM role for an `/exec/{id}/...` URI from the
-/// in-process workload registry, falling back to `native`.
-pub(crate) async fn resolve_exec_role(state: &AppState, uri: &Uri) -> UtilityVmRole {
+/// Resolves the utility VM role for an `/exec/{id}/...` URI.
+///
+/// Returns the recorded role on hit, fails closed with 409 on an
+/// ambiguous short ID, and falls back to `native` only when no role is
+/// known at all.
+pub(crate) async fn resolve_exec_role(state: &AppState, uri: &Uri) -> Result<UtilityVmRole> {
     let Some(id) = extract_exec_id(uri) else {
-        return UtilityVmRole::Native;
+        return Ok(UtilityVmRole::Native);
     };
-    state
-        .workload_roles
-        .lookup(&id)
-        .await
-        .unwrap_or(UtilityVmRole::Native)
+    match state.workload_roles.lookup(&id).await {
+        WorkloadRoleLookup::Found(role) => Ok(role),
+        WorkloadRoleLookup::Ambiguous => Err(ambiguous_workload_error(&id)),
+        WorkloadRoleLookup::Missing => Ok(UtilityVmRole::Native),
+    }
 }
 
 /// Resolves the utility VM role for any Docker request URI that may carry a
@@ -145,52 +163,83 @@ pub(crate) async fn resolve_exec_role(state: &AppState, uri: &Uri) -> UtilityVmR
 /// fallback so unrouted endpoints like `/containers/{id}/archive` still
 /// land on the role that owns the container.
 ///
-/// Falls back to a guest-probe rebuild on registry miss for container
-/// URIs so unrouted endpoints survive an `arcbox-daemon` restart.
-pub(crate) async fn resolve_role_from_uri(state: &AppState, uri: &Uri) -> UtilityVmRole {
+/// Surfaces ambiguity as a 409 the same way the per-handler resolvers do;
+/// rebuilds from guest dockerds on registry miss for container URIs.
+pub(crate) async fn resolve_role_from_uri(state: &AppState, uri: &Uri) -> Result<UtilityVmRole> {
     if let Some(id) = extract_container_id(uri) {
-        if let Some(role) = state.workload_roles.lookup(&id).await {
-            return role;
+        match state.workload_roles.lookup(&id).await {
+            WorkloadRoleLookup::Found(role) => return Ok(role),
+            WorkloadRoleLookup::Ambiguous => return Err(ambiguous_workload_error(&id)),
+            WorkloadRoleLookup::Missing => {}
         }
-        if let Some(role) = rebuild_container_role_from_guests(state, &id).await {
-            state.workload_roles.record(id.clone(), role).await;
-            return role;
+        match rebuild_container_role_from_guests(state, &id).await {
+            WorkloadRoleLookup::Found(role) => {
+                state.workload_roles.record(id.clone(), role).await;
+                return Ok(role);
+            }
+            WorkloadRoleLookup::Ambiguous => return Err(ambiguous_workload_error(&id)),
+            WorkloadRoleLookup::Missing => {}
         }
     }
-    if let Some(id) = extract_exec_id(uri)
-        && let Some(role) = state.workload_roles.lookup(&id).await
-    {
-        return role;
+    if let Some(id) = extract_exec_id(uri) {
+        match state.workload_roles.lookup(&id).await {
+            WorkloadRoleLookup::Found(role) => return Ok(role),
+            WorkloadRoleLookup::Ambiguous => return Err(ambiguous_workload_error(&id)),
+            WorkloadRoleLookup::Missing => {}
+        }
     }
-    UtilityVmRole::Native
+    Ok(UtilityVmRole::Native)
 }
 
-/// Probes each configured utility VM's guest dockerd for a container
-/// matching `container_id`. Returns the role whose dockerd accepts the
-/// inspect, or `None` if no guest knows the container.
+/// Probes **every** configured utility VM's guest dockerd for a container
+/// matching `container_id` and reports whether zero, one, or multiple
+/// guests claim it.
 ///
-/// Only runs in roles that have a distinct slot configured for this
-/// host. The Native probe is essentially free (the VM is already up);
-/// the Rosetta probe will trigger lazy startup if the VM is not yet
-/// running — that's exactly the recovery behavior we want when a
-/// rosetta workload survives a daemon restart.
+/// Returning on the first match would re-introduce the silent-misroute
+/// bug for cross-VM short-ID collisions: a 12-char prefix might match
+/// canonical IDs on both VMs. We always probe both and treat a
+/// double-hit as ambiguous so the caller fails closed.
+///
+/// The Native probe is essentially free (its VM is already up); the
+/// Rosetta probe triggers lazy VZ startup on first miss, which is the
+/// recovery behavior we want when a rosetta workload survives an
+/// `arcbox-daemon` restart.
 async fn rebuild_container_role_from_guests(
     state: &AppState,
     container_id: &str,
-) -> Option<UtilityVmRole> {
-    use arcbox_core::workload::UtilityVmRole as Role;
-
-    for role in [Role::Native, Role::Rosetta] {
-        // Skip roles that have no distinct slot on this host — there is
-        // nothing to recover from, and probing would just retest Native.
-        if role != Role::Native && !state.runtime.role_is_distinct(role) {
+) -> WorkloadRoleLookup {
+    let mut hits: Vec<UtilityVmRole> = Vec::new();
+    for role in [UtilityVmRole::Native, UtilityVmRole::Rosetta] {
+        if role != UtilityVmRole::Native && !state.runtime.role_is_distinct(role) {
             continue;
         }
         if probe_container_exists(state, role, container_id).await {
-            return Some(role);
+            hits.push(role);
         }
     }
-    None
+    match hits.as_slice() {
+        [] => WorkloadRoleLookup::Missing,
+        [only] => WorkloadRoleLookup::Found(*only),
+        _ => {
+            tracing::warn!(
+                container_id,
+                ?hits,
+                "container identifier resolves on multiple utility VMs",
+            );
+            WorkloadRoleLookup::Ambiguous
+        }
+    }
+}
+
+/// Returns a 409 Conflict describing an ambiguous workload identifier.
+///
+/// Used both for in-registry prefix collisions and for guest-probe
+/// rebuilds that find the same name/short-ID on more than one VM.
+fn ambiguous_workload_error(id: &str) -> DockerError {
+    DockerError::Conflict(format!(
+        "workload identifier '{id}' is ambiguous: it matches workloads on \
+         multiple utility VMs. Use the full canonical container ID."
+    ))
 }
 
 /// Returns `true` if `container_id` exists on `role`'s guest dockerd.

--- a/app/arcbox-docker/src/handlers/mod.rs
+++ b/app/arcbox-docker/src/handlers/mod.rs
@@ -148,6 +148,23 @@ pub(crate) async fn resolve_role_from_uri(state: &AppState, uri: &Uri) -> Utilit
     UtilityVmRole::Native
 }
 
+/// Ensures the utility VM hosting `role` is up before any request reaches
+/// the connector. Surfaces the role in the error message so a Rosetta-VM
+/// failure can't be confused with a native-VM failure.
+pub(crate) async fn ensure_role_ready(state: &AppState, role: UtilityVmRole) -> Result<()> {
+    state
+        .runtime
+        .ensure_role_ready(role)
+        .await
+        .map(|_| ())
+        .map_err(|e| {
+            DockerError::Server(format!(
+                "failed to ensure {} utility VM is ready: {e}",
+                role.as_str(),
+            ))
+        })
+}
+
 /// Forward a request to guest dockerd, ensuring the VM is running first.
 pub(crate) async fn proxy(state: &AppState, uri: &Uri, req: Request<Body>) -> Result<Response> {
     proxy_to_role(state, UtilityVmRole::Native, uri, req).await
@@ -160,11 +177,7 @@ pub(crate) async fn proxy_to_role(
     uri: &Uri,
     req: Request<Body>,
 ) -> Result<Response> {
-    state
-        .runtime
-        .ensure_vm_ready()
-        .await
-        .map_err(|e| DockerError::Server(format!("failed to ensure VM is ready: {e}")))?;
+    ensure_role_ready(state, role).await?;
     proxy::proxy_to_guest_stream_for_role(state.connector.as_ref(), role, uri, req).await
 }
 
@@ -184,11 +197,7 @@ pub(crate) async fn proxy_upload_to_role(
     uri: &Uri,
     req: Request<Body>,
 ) -> Result<Response> {
-    state
-        .runtime
-        .ensure_vm_ready()
-        .await
-        .map_err(|e| DockerError::Server(format!("failed to ensure VM is ready: {e}")))?;
+    ensure_role_ready(state, role).await?;
     proxy::proxy_streaming_upload_for_role(state.connector.as_ref(), role, uri, req).await
 }
 
@@ -208,11 +217,7 @@ pub(crate) async fn proxy_upgrade_to_role(
     uri: &Uri,
     req: Request<Body>,
 ) -> Result<Response> {
-    state
-        .runtime
-        .ensure_vm_ready()
-        .await
-        .map_err(|e| DockerError::Server(format!("failed to ensure VM is ready: {e}")))?;
+    ensure_role_ready(state, role).await?;
     proxy::proxy_with_upgrade_for_role(state.connector.as_ref(), role, req, uri).await
 }
 

--- a/app/arcbox-docker/src/handlers/mod.rs
+++ b/app/arcbox-docker/src/handlers/mod.rs
@@ -127,6 +127,27 @@ pub(crate) async fn resolve_exec_role(state: &AppState, uri: &Uri) -> UtilityVmR
         .unwrap_or(UtilityVmRole::Native)
 }
 
+/// Resolves the utility VM role for any Docker request URI that may carry a
+/// workload identity (container or exec). Used by the catch-all proxy
+/// fallback so unrouted endpoints like `/containers/{id}/archive` still
+/// land on the role that owns the container.
+///
+/// Returns `Native` only when neither a container nor an exec ID is found
+/// in the URI, or when neither lookup hits the registry.
+pub(crate) async fn resolve_role_from_uri(state: &AppState, uri: &Uri) -> UtilityVmRole {
+    if let Some(id) = extract_container_id(uri)
+        && let Some(role) = state.workload_roles.lookup(&id).await
+    {
+        return role;
+    }
+    if let Some(id) = extract_exec_id(uri)
+        && let Some(role) = state.workload_roles.lookup(&id).await
+    {
+        return role;
+    }
+    UtilityVmRole::Native
+}
+
 /// Forward a request to guest dockerd, ensuring the VM is running first.
 pub(crate) async fn proxy(state: &AppState, uri: &Uri, req: Request<Body>) -> Result<Response> {
     proxy_to_role(state, UtilityVmRole::Native, uri, req).await

--- a/app/arcbox-docker/src/handlers/mod.rs
+++ b/app/arcbox-docker/src/handlers/mod.rs
@@ -12,6 +12,9 @@ use axum::body::Body;
 use axum::http::{Request, Uri};
 use axum::response::Response;
 
+/// Forwards a request that has no per-workload identity (e.g. `/_ping`,
+/// `/containers/json`, `/images/json`). These hit the native default role
+/// while the connector still resolves both roles to the same VM.
 macro_rules! proxy_handler {
     ($name:ident) => {
         /// Forwards the request to guest dockerd.
@@ -29,7 +32,100 @@ macro_rules! proxy_handler {
     };
 }
 
-pub(crate) use proxy_handler;
+/// Forwards a `/containers/{id}/...` request to the utility VM role
+/// recorded for that container, falling back to `native` when no record
+/// exists (pre-existing or post-restart workloads).
+macro_rules! container_proxy_handler {
+    ($name:ident) => {
+        /// Forwards the request to the container's utility VM.
+        ///
+        /// # Errors
+        ///
+        /// Returns an error if VM readiness fails or proxying to guest dockerd fails.
+        pub async fn $name(
+            axum::extract::State(state): axum::extract::State<crate::api::AppState>,
+            axum::extract::OriginalUri(uri): axum::extract::OriginalUri,
+            req: axum::http::Request<axum::body::Body>,
+        ) -> crate::error::Result<axum::response::Response> {
+            let role = $crate::handlers::resolve_container_role(&state, &uri).await;
+            $crate::handlers::proxy_to_role(&state, role, &uri, req).await
+        }
+    };
+}
+
+/// Forwards an `/exec/{id}/...` request to the utility VM role recorded for
+/// the originating container, falling back to `native` when no record exists.
+macro_rules! exec_proxy_handler {
+    ($name:ident) => {
+        /// Forwards the request to the exec instance's utility VM.
+        ///
+        /// # Errors
+        ///
+        /// Returns an error if VM readiness fails or proxying to guest dockerd fails.
+        pub async fn $name(
+            axum::extract::State(state): axum::extract::State<crate::api::AppState>,
+            axum::extract::OriginalUri(uri): axum::extract::OriginalUri,
+            req: axum::http::Request<axum::body::Body>,
+        ) -> crate::error::Result<axum::response::Response> {
+            let role = $crate::handlers::resolve_exec_role(&state, &uri).await;
+            $crate::handlers::proxy_to_role(&state, role, &uri, req).await
+        }
+    };
+}
+
+pub(crate) use {container_proxy_handler, exec_proxy_handler, proxy_handler};
+
+/// Extracts the `{id}` token from a `/containers/{id}/...` URI, ignoring
+/// collection endpoints (`/containers/json|create|prune`).
+#[must_use]
+pub(crate) fn extract_container_id(uri: &Uri) -> Option<String> {
+    extract_id_after_segment(uri, "containers", &["json", "create", "prune"])
+}
+
+/// Extracts the `{id}` token from an `/exec/{id}/...` URI.
+#[must_use]
+pub(crate) fn extract_exec_id(uri: &Uri) -> Option<String> {
+    extract_id_after_segment(uri, "exec", &[])
+}
+
+fn extract_id_after_segment(uri: &Uri, segment: &str, skip_tokens: &[&str]) -> Option<String> {
+    let segments: Vec<&str> = uri.path().split('/').filter(|s| !s.is_empty()).collect();
+    for (i, seg) in segments.iter().enumerate() {
+        if *seg == segment && i + 1 < segments.len() {
+            let id = segments[i + 1];
+            if !skip_tokens.contains(&id) {
+                return Some(id.to_string());
+            }
+        }
+    }
+    None
+}
+
+/// Resolves the utility VM role for a `/containers/{id}/...` URI from the
+/// in-process workload registry, falling back to `native`.
+pub(crate) async fn resolve_container_role(state: &AppState, uri: &Uri) -> UtilityVmRole {
+    let Some(id) = extract_container_id(uri) else {
+        return UtilityVmRole::Native;
+    };
+    state
+        .workload_roles
+        .lookup(&id)
+        .await
+        .unwrap_or(UtilityVmRole::Native)
+}
+
+/// Resolves the utility VM role for an `/exec/{id}/...` URI from the
+/// in-process workload registry, falling back to `native`.
+pub(crate) async fn resolve_exec_role(state: &AppState, uri: &Uri) -> UtilityVmRole {
+    let Some(id) = extract_exec_id(uri) else {
+        return UtilityVmRole::Native;
+    };
+    state
+        .workload_roles
+        .lookup(&id)
+        .await
+        .unwrap_or(UtilityVmRole::Native)
+}
 
 /// Forward a request to guest dockerd, ensuring the VM is running first.
 pub(crate) async fn proxy(state: &AppState, uri: &Uri, req: Request<Body>) -> Result<Response> {
@@ -81,12 +177,22 @@ pub(crate) async fn proxy_upgrade(
     uri: &Uri,
     req: Request<Body>,
 ) -> Result<Response> {
+    proxy_upgrade_to_role(state, UtilityVmRole::Native, uri, req).await
+}
+
+/// Forward an upgraded request to a selected utility VM's guest dockerd.
+pub(crate) async fn proxy_upgrade_to_role(
+    state: &AppState,
+    role: UtilityVmRole,
+    uri: &Uri,
+    req: Request<Body>,
+) -> Result<Response> {
     state
         .runtime
         .ensure_vm_ready()
         .await
         .map_err(|e| DockerError::Server(format!("failed to ensure VM is ready: {e}")))?;
-    proxy::proxy_with_upgrade(state.connector.as_ref(), req, uri).await
+    proxy::proxy_with_upgrade_for_role(state.connector.as_ref(), role, req, uri).await
 }
 
 mod build;
@@ -111,3 +217,41 @@ pub use image::{inspect_image, list_images, load_image, pull_image, remove_image
 pub use network::{create_network, inspect_network, list_networks, remove_network};
 pub use system::{get_info, get_version, ping};
 pub use volume::{create_volume, inspect_volume, list_volumes, prune_volumes, remove_volume};
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn uri(s: &str) -> Uri {
+        s.parse().unwrap()
+    }
+
+    #[test]
+    fn extract_exec_id_from_simple_path() {
+        assert_eq!(
+            extract_exec_id(&uri("/exec/exec-abc/start")).as_deref(),
+            Some("exec-abc"),
+        );
+    }
+
+    #[test]
+    fn extract_exec_id_from_versioned_path() {
+        assert_eq!(
+            extract_exec_id(&uri("/v1.51/exec/exec-xyz/resize?w=80&h=24")).as_deref(),
+            Some("exec-xyz"),
+        );
+    }
+
+    #[test]
+    fn extract_exec_id_ignores_non_exec_paths() {
+        assert_eq!(extract_exec_id(&uri("/containers/abc/start")), None);
+    }
+
+    #[test]
+    fn extract_container_id_from_exec_subpath() {
+        assert_eq!(
+            extract_container_id(&uri("/containers/abc/exec")).as_deref(),
+            Some("abc"),
+        );
+    }
+}

--- a/app/arcbox-docker/src/handlers/mod.rs
+++ b/app/arcbox-docker/src/handlers/mod.rs
@@ -101,17 +101,30 @@ fn extract_id_after_segment(uri: &Uri, segment: &str, skip_tokens: &[&str]) -> O
     None
 }
 
-/// Resolves the utility VM role for a `/containers/{id}/...` URI from the
-/// in-process workload registry, falling back to `native`.
+/// Resolves the utility VM role for a `/containers/{id}/...` URI.
+///
+/// First consults the in-process [`WorkloadRoleRegistry`]. On a miss
+/// (e.g. an `arcbox-daemon` restart between create and the follow-up
+/// call), probes each configured role's guest dockerd to find which one
+/// owns the container, caches the result, and returns it. Falls back to
+/// `native` when no probe succeeds.
 pub(crate) async fn resolve_container_role(state: &AppState, uri: &Uri) -> UtilityVmRole {
     let Some(id) = extract_container_id(uri) else {
         return UtilityVmRole::Native;
     };
-    state
-        .workload_roles
-        .lookup(&id)
-        .await
-        .unwrap_or(UtilityVmRole::Native)
+    if let Some(role) = state.workload_roles.lookup(&id).await {
+        return role;
+    }
+    if let Some(role) = rebuild_container_role_from_guests(state, &id).await {
+        state.workload_roles.record(id.clone(), role).await;
+        tracing::debug!(
+            container_id = %id,
+            utility_vm = role.as_str(),
+            "rebuilt workload role from guest dockerd",
+        );
+        return role;
+    }
+    UtilityVmRole::Native
 }
 
 /// Resolves the utility VM role for an `/exec/{id}/...` URI from the
@@ -132,13 +145,17 @@ pub(crate) async fn resolve_exec_role(state: &AppState, uri: &Uri) -> UtilityVmR
 /// fallback so unrouted endpoints like `/containers/{id}/archive` still
 /// land on the role that owns the container.
 ///
-/// Returns `Native` only when neither a container nor an exec ID is found
-/// in the URI, or when neither lookup hits the registry.
+/// Falls back to a guest-probe rebuild on registry miss for container
+/// URIs so unrouted endpoints survive an `arcbox-daemon` restart.
 pub(crate) async fn resolve_role_from_uri(state: &AppState, uri: &Uri) -> UtilityVmRole {
-    if let Some(id) = extract_container_id(uri)
-        && let Some(role) = state.workload_roles.lookup(&id).await
-    {
-        return role;
+    if let Some(id) = extract_container_id(uri) {
+        if let Some(role) = state.workload_roles.lookup(&id).await {
+            return role;
+        }
+        if let Some(role) = rebuild_container_role_from_guests(state, &id).await {
+            state.workload_roles.record(id.clone(), role).await;
+            return role;
+        }
     }
     if let Some(id) = extract_exec_id(uri)
         && let Some(role) = state.workload_roles.lookup(&id).await
@@ -146,6 +163,62 @@ pub(crate) async fn resolve_role_from_uri(state: &AppState, uri: &Uri) -> Utilit
         return role;
     }
     UtilityVmRole::Native
+}
+
+/// Probes each configured utility VM's guest dockerd for a container
+/// matching `container_id`. Returns the role whose dockerd accepts the
+/// inspect, or `None` if no guest knows the container.
+///
+/// Only runs in roles that have a distinct slot configured for this
+/// host. The Native probe is essentially free (the VM is already up);
+/// the Rosetta probe will trigger lazy startup if the VM is not yet
+/// running — that's exactly the recovery behavior we want when a
+/// rosetta workload survives a daemon restart.
+async fn rebuild_container_role_from_guests(
+    state: &AppState,
+    container_id: &str,
+) -> Option<UtilityVmRole> {
+    use arcbox_core::workload::UtilityVmRole as Role;
+
+    for role in [Role::Native, Role::Rosetta] {
+        // Skip roles that have no distinct slot on this host — there is
+        // nothing to recover from, and probing would just retest Native.
+        if role != Role::Native && !state.runtime.role_is_distinct(role) {
+            continue;
+        }
+        if probe_container_exists(state, role, container_id).await {
+            return Some(role);
+        }
+    }
+    None
+}
+
+/// Returns `true` if `container_id` exists on `role`'s guest dockerd.
+///
+/// Uses the same vsock connector + buffered HTTP/1.1 client as the rest
+/// of the proxy stack, so a probe failure surfaces the same way as any
+/// other guest-side error.
+async fn probe_container_exists(state: &AppState, role: UtilityVmRole, container_id: &str) -> bool {
+    use axum::http::{HeaderMap, Method};
+    use bytes::Bytes;
+
+    if ensure_role_ready(state, role).await.is_err() {
+        return false;
+    }
+    let path = format!("/containers/{container_id}/json");
+    match crate::proxy::proxy_to_guest_for_role(
+        state.connector.as_ref(),
+        role,
+        Method::GET,
+        &path,
+        &HeaderMap::new(),
+        Bytes::new(),
+    )
+    .await
+    {
+        Ok(resp) => resp.status().is_success(),
+        Err(_) => false,
+    }
 }
 
 /// Ensures the utility VM hosting `role` is up before any request reaches
@@ -213,15 +286,6 @@ pub(crate) async fn proxy_upload_to_role(
 ) -> Result<Response> {
     ensure_role_ready(state, role).await?;
     proxy::proxy_streaming_upload_for_role(state.connector.as_ref(), role, uri, req).await
-}
-
-/// Forward an upgraded request to guest dockerd, ensuring the VM is running first.
-pub(crate) async fn proxy_upgrade(
-    state: &AppState,
-    uri: &Uri,
-    req: Request<Body>,
-) -> Result<Response> {
-    proxy_upgrade_to_role(state, UtilityVmRole::Native, uri, req).await
 }
 
 /// Forward an upgraded request to a selected utility VM's guest dockerd.

--- a/app/arcbox-docker/src/lib.rs
+++ b/app/arcbox-docker/src/lib.rs
@@ -50,6 +50,7 @@ pub mod proxy;
 pub mod routing;
 pub mod server;
 pub mod trace;
+pub mod workload;
 // Docker API compatibility layer contains many spec fields only serialized/deserialized.
 #[allow(dead_code)]
 pub mod types;

--- a/app/arcbox-docker/src/lib.rs
+++ b/app/arcbox-docker/src/lib.rs
@@ -47,6 +47,7 @@ pub mod error;
 pub mod handlers;
 pub(crate) mod host_path;
 pub mod proxy;
+pub mod routing;
 pub mod server;
 pub mod trace;
 // Docker API compatibility layer contains many spec fields only serialized/deserialized.

--- a/app/arcbox-docker/src/proxy/connector.rs
+++ b/app/arcbox-docker/src/proxy/connector.rs
@@ -3,6 +3,7 @@
 use super::GuestConnector;
 use super::stream::RawFdStream;
 use crate::error::{DockerError, Result};
+use crate::routing::UtilityVmRole;
 use arcbox_core::Runtime;
 use arcbox_error::CommonError;
 use hyper_util::rt::TokioIo;
@@ -39,6 +40,13 @@ impl VsockConnector {
 
 impl GuestConnector for VsockConnector {
     fn connect(&self) -> Pin<Box<dyn Future<Output = Result<TokioIo<RawFdStream>>> + Send + '_>> {
+        self.connect_for(UtilityVmRole::Native)
+    }
+
+    fn connect_for(
+        &self,
+        role: UtilityVmRole,
+    ) -> Pin<Box<dyn Future<Output = Result<TokioIo<RawFdStream>>> + Send + '_>> {
         Box::pin(async move {
             let _permit = CONNECT_SEMAPHORE
                 .acquire()
@@ -49,6 +57,12 @@ impl GuestConnector for VsockConnector {
             let machine_name = self.runtime.default_machine_name();
             let manager = self.runtime.machine_manager().clone();
             let name = machine_name.to_string();
+            tracing::debug!(
+                utility_vm = role.as_str(),
+                machine = %name,
+                port,
+                "connecting to guest dockerd"
+            );
 
             let handle = tokio::task::spawn_blocking(move || {
                 let fd = manager.connect_vsock_port(&name, port)?;

--- a/app/arcbox-docker/src/proxy/connector.rs
+++ b/app/arcbox-docker/src/proxy/connector.rs
@@ -53,8 +53,12 @@ impl GuestConnector for VsockConnector {
                 .await
                 .map_err(|_| DockerError::Server("connect semaphore closed".into()))?;
 
-            let port = self.runtime.guest_docker_vsock_port();
-            let machine_name = self.runtime.default_machine_name();
+            // Resolve role → machine/port via the runtime. Today both
+            // roles still alias to the default machine; once the dual VM
+            // lifecycle lands the rosetta branch returns its own machine
+            // name and dockerd port without any change here.
+            let port = self.runtime.guest_docker_vsock_port_for_role(role);
+            let machine_name = self.runtime.machine_name_for_role(role);
             let manager = self.runtime.machine_manager().clone();
             let name = machine_name.to_string();
             tracing::debug!(

--- a/app/arcbox-docker/src/proxy/fallback.rs
+++ b/app/arcbox-docker/src/proxy/fallback.rs
@@ -2,8 +2,8 @@
 
 use super::{forward, upgrade, upload};
 use crate::api::AppState;
-use crate::error::{DockerError, Result};
-use crate::handlers::resolve_role_from_uri;
+use crate::error::Result;
+use crate::handlers::{ensure_role_ready, resolve_role_from_uri};
 use axum::body::Body;
 use axum::extract::{OriginalUri, State};
 use axum::http::{Response, header};
@@ -31,11 +31,7 @@ pub async fn proxy_fallback(
         utility_vm = role.as_str(),
         "proxy_fallback dispatch",
     );
-    state
-        .runtime
-        .ensure_vm_ready()
-        .await
-        .map_err(|e| DockerError::Server(format!("failed to ensure VM is ready: {e}")))?;
+    ensure_role_ready(&state, role).await?;
 
     // Detect upgrade requests (attach, exec, BuildKit gRPC/session).
     let wants_upgrade = req.headers().get(header::UPGRADE).is_some()

--- a/app/arcbox-docker/src/proxy/fallback.rs
+++ b/app/arcbox-docker/src/proxy/fallback.rs
@@ -3,14 +3,18 @@
 use super::{forward, upgrade, upload};
 use crate::api::AppState;
 use crate::error::{DockerError, Result};
+use crate::handlers::resolve_role_from_uri;
 use axum::body::Body;
 use axum::extract::{OriginalUri, State};
 use axum::http::{Response, header};
 
 /// Catch-all handler that proxies unmatched requests to guest dockerd.
 ///
-/// Ensures forward compatibility with newer Docker API versions — any endpoint
-/// we don't explicitly handle gets forwarded transparently.
+/// Ensures forward compatibility with newer Docker API versions — any
+/// endpoint we don't explicitly handle gets forwarded transparently. When
+/// the URI carries a known container or exec ID, the request is routed to
+/// that workload's utility VM role so endpoints like
+/// `/containers/{id}/archive` follow the same VM as their lifecycle calls.
 ///
 /// # Errors
 ///
@@ -20,7 +24,13 @@ pub async fn proxy_fallback(
     OriginalUri(uri): OriginalUri,
     req: axum::http::Request<Body>,
 ) -> Result<Response<Body>> {
-    tracing::debug!("proxy_fallback: method={} uri={}", req.method(), uri);
+    let role = resolve_role_from_uri(&state, &uri).await;
+    tracing::debug!(
+        method = %req.method(),
+        uri = %uri,
+        utility_vm = role.as_str(),
+        "proxy_fallback dispatch",
+    );
     state
         .runtime
         .ensure_vm_ready()
@@ -36,12 +46,14 @@ pub async fn proxy_fallback(
             .is_some_and(|v| v.to_ascii_lowercase().contains("upgrade"));
 
     if wants_upgrade {
-        return upgrade::proxy_with_upgrade(state.connector.as_ref(), req, &uri).await;
+        return upgrade::proxy_with_upgrade_for_role(state.connector.as_ref(), role, req, &uri)
+            .await;
     }
 
     if upload::is_streaming_upload_request(req.method(), &uri) {
-        return upload::proxy_streaming_upload(state.connector.as_ref(), &uri, req).await;
+        return upload::proxy_streaming_upload_for_role(state.connector.as_ref(), role, &uri, req)
+            .await;
     }
 
-    forward::proxy_to_guest_stream(state.connector.as_ref(), &uri, req).await
+    forward::proxy_to_guest_stream_for_role(state.connector.as_ref(), role, &uri, req).await
 }

--- a/app/arcbox-docker/src/proxy/fallback.rs
+++ b/app/arcbox-docker/src/proxy/fallback.rs
@@ -24,7 +24,7 @@ pub async fn proxy_fallback(
     OriginalUri(uri): OriginalUri,
     req: axum::http::Request<Body>,
 ) -> Result<Response<Body>> {
-    let role = resolve_role_from_uri(&state, &uri).await;
+    let role = resolve_role_from_uri(&state, &uri).await?;
     tracing::debug!(
         method = %req.method(),
         uri = %uri,

--- a/app/arcbox-docker/src/proxy/forward.rs
+++ b/app/arcbox-docker/src/proxy/forward.rs
@@ -5,6 +5,7 @@
 
 use super::{GuestConnector, HANDSHAKE_TIMEOUT};
 use crate::error::{DockerError, Result};
+use crate::routing::UtilityVmRole;
 use arcbox_error::CommonError;
 use axum::body::Body;
 use axum::http::{HeaderMap, HeaderName, HeaderValue, Method, Request, Response, Uri, header};
@@ -134,7 +135,22 @@ pub async fn proxy_to_guest_stream(
     original_uri: &Uri,
     req: Request<Body>,
 ) -> Result<Response<Body>> {
-    let io = connector.connect().await?;
+    proxy_to_guest_stream_for_role(connector, UtilityVmRole::Native, original_uri, req).await
+}
+
+/// Forward an HTTP request to a selected utility VM's guest dockerd without buffering.
+///
+/// # Errors
+///
+/// Returns an error if guest connection, handshake, request forwarding,
+/// or response mapping fails.
+pub async fn proxy_to_guest_stream_for_role(
+    connector: &dyn GuestConnector,
+    role: UtilityVmRole,
+    original_uri: &Uri,
+    req: Request<Body>,
+) -> Result<Response<Body>> {
+    let io = connector.connect_for(role).await?;
 
     let (mut sender, conn) =
         tokio::time::timeout(HANDSHAKE_TIMEOUT, http1::Builder::new().handshake(io))

--- a/app/arcbox-docker/src/proxy/forward.rs
+++ b/app/arcbox-docker/src/proxy/forward.rs
@@ -82,7 +82,36 @@ pub async fn proxy_to_guest(
     headers: &HeaderMap,
     body: Bytes,
 ) -> Result<Response<Body>> {
-    let io = connector.connect().await?;
+    proxy_to_guest_for_role(
+        connector,
+        UtilityVmRole::Native,
+        method,
+        path_and_query,
+        headers,
+        body,
+    )
+    .await
+}
+
+/// Forward an HTTP request to a selected utility VM's guest dockerd.
+///
+/// Mirrors [`proxy_to_guest`] but lets the caller pick the role for
+/// programmatic internal lookups (e.g. canonical-ID resolution during
+/// lifecycle teardown).
+///
+/// # Errors
+///
+/// Returns an error if guest connection, handshake, request forwarding,
+/// or response mapping fails.
+pub async fn proxy_to_guest_for_role(
+    connector: &dyn GuestConnector,
+    role: UtilityVmRole,
+    method: Method,
+    path_and_query: &str,
+    headers: &HeaderMap,
+    body: Bytes,
+) -> Result<Response<Body>> {
+    let io = connector.connect_for(role).await?;
 
     let (mut sender, conn) =
         tokio::time::timeout(HANDSHAKE_TIMEOUT, http1::Builder::new().handshake(io))

--- a/app/arcbox-docker/src/proxy/mod.rs
+++ b/app/arcbox-docker/src/proxy/mod.rs
@@ -13,10 +13,12 @@ mod upload;
 
 pub use connector::VsockConnector;
 pub use fallback::proxy_fallback;
-pub use forward::{proxy_to_guest, proxy_to_guest_stream, proxy_to_guest_stream_for_role};
+pub use forward::{
+    proxy_to_guest, proxy_to_guest_for_role, proxy_to_guest_stream, proxy_to_guest_stream_for_role,
+};
 pub use port_bindings::{PortBindingInfo, parse_port_bindings};
 pub use stream::RawFdStream;
-pub use upgrade::proxy_with_upgrade;
+pub use upgrade::{proxy_with_upgrade, proxy_with_upgrade_for_role};
 pub use upload::{proxy_streaming_upload, proxy_streaming_upload_for_role};
 
 use crate::error::Result;

--- a/app/arcbox-docker/src/proxy/mod.rs
+++ b/app/arcbox-docker/src/proxy/mod.rs
@@ -13,13 +13,14 @@ mod upload;
 
 pub use connector::VsockConnector;
 pub use fallback::proxy_fallback;
-pub use forward::{proxy_to_guest, proxy_to_guest_stream};
+pub use forward::{proxy_to_guest, proxy_to_guest_stream, proxy_to_guest_stream_for_role};
 pub use port_bindings::{PortBindingInfo, parse_port_bindings};
 pub use stream::RawFdStream;
 pub use upgrade::proxy_with_upgrade;
-pub use upload::proxy_streaming_upload;
+pub use upload::{proxy_streaming_upload, proxy_streaming_upload_for_role};
 
 use crate::error::Result;
+use crate::routing::UtilityVmRole;
 use hyper_util::rt::TokioIo;
 use std::future::Future;
 use std::pin::Pin;
@@ -36,4 +37,16 @@ const HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(5);
 pub trait GuestConnector: Send + Sync + 'static {
     /// Opens a new connection to guest dockerd.
     fn connect(&self) -> Pin<Box<dyn Future<Output = Result<TokioIo<RawFdStream>>> + Send + '_>>;
+
+    /// Opens a new connection to guest dockerd for a utility VM role.
+    ///
+    /// Single-VM connectors can ignore the role by using the default
+    /// implementation. Dual-stack connectors should route `Native` to the HV
+    /// utility VM and `Rosetta` to the VZ/Rosetta utility VM.
+    fn connect_for(
+        &self,
+        _role: UtilityVmRole,
+    ) -> Pin<Box<dyn Future<Output = Result<TokioIo<RawFdStream>>> + Send + '_>> {
+        self.connect()
+    }
 }

--- a/app/arcbox-docker/src/proxy/upgrade.rs
+++ b/app/arcbox-docker/src/proxy/upgrade.rs
@@ -10,6 +10,7 @@
 use super::stream::RawFdStream;
 use super::{GuestConnector, HANDSHAKE_TIMEOUT};
 use crate::error::{DockerError, Result};
+use crate::routing::UtilityVmRole;
 use arcbox_error::CommonError;
 use axum::body::Body;
 use axum::http::{HeaderMap, HeaderValue, Method, Response, StatusCode, Uri, header};
@@ -123,10 +124,30 @@ async fn send_raw_upgrade(
 /// construction fails.
 pub async fn proxy_with_upgrade(
     connector: &dyn GuestConnector,
+    client_req: axum::http::Request<Body>,
+    original_uri: &Uri,
+) -> Result<Response<Body>> {
+    proxy_with_upgrade_for_role(connector, UtilityVmRole::Native, client_req, original_uri).await
+}
+
+/// Forward an HTTP request with upgrade support to a selected utility VM's
+/// guest dockerd.
+///
+/// Mirrors [`proxy_with_upgrade`] but lets the caller pick the role for
+/// per-workload upgrade endpoints (`/containers/{id}/attach`,
+/// `/exec/{id}/start` interactive, BuildKit session).
+///
+/// # Errors
+///
+/// Returns an error if guest connection, upgrade handshake, or response
+/// construction fails.
+pub async fn proxy_with_upgrade_for_role(
+    connector: &dyn GuestConnector,
+    role: UtilityVmRole,
     mut client_req: axum::http::Request<Body>,
     original_uri: &Uri,
 ) -> Result<Response<Body>> {
-    let io = connector.connect().await?;
+    let io = connector.connect_for(role).await?;
     // Unwrap TokioIo to get the raw vsock stream — we drive the guest
     // side manually so the fd stays alive throughout the bridge.
     let mut guest_stream = io.into_inner();

--- a/app/arcbox-docker/src/proxy/upload.rs
+++ b/app/arcbox-docker/src/proxy/upload.rs
@@ -6,6 +6,7 @@
 use super::forward::forwarded_request_headers;
 use super::{GuestConnector, HANDSHAKE_TIMEOUT};
 use crate::error::{DockerError, Result};
+use crate::routing::UtilityVmRole;
 use arcbox_error::CommonError;
 use axum::body::{Body, BodyDataStream};
 use axum::http::{HeaderValue, Method, Uri, header};
@@ -34,7 +35,22 @@ pub async fn proxy_streaming_upload(
     original_uri: &Uri,
     req: axum::http::Request<Body>,
 ) -> Result<axum::http::Response<Body>> {
-    let io = connector.connect().await?;
+    proxy_streaming_upload_for_role(connector, UtilityVmRole::Native, original_uri, req).await
+}
+
+/// Forward a large upload request to a selected utility VM's guest dockerd.
+///
+/// # Errors
+///
+/// Returns an error if guest connection, handshake, request forwarding,
+/// or response mapping fails.
+pub async fn proxy_streaming_upload_for_role(
+    connector: &dyn GuestConnector,
+    role: UtilityVmRole,
+    original_uri: &Uri,
+    req: axum::http::Request<Body>,
+) -> Result<axum::http::Response<Body>> {
+    let io = connector.connect_for(role).await?;
 
     let had_expect = req.headers().contains_key(header::EXPECT);
     let had_content_length = req.headers().contains_key(header::CONTENT_LENGTH);

--- a/app/arcbox-docker/src/routing.rs
+++ b/app/arcbox-docker/src/routing.rs
@@ -101,14 +101,17 @@ pub fn route_build(uri: &Uri) -> RoutingDecision {
 }
 
 fn platform_from_query(uri: &Uri) -> Option<WorkloadPlatform> {
-    uri.query()
-        .and_then(|query| query.split('&').find_map(platform_pair_value))
-        .map(WorkloadPlatform::parse)
+    query_param(uri, "platform").map(WorkloadPlatform::parse)
 }
 
-fn platform_pair_value(pair: &str) -> Option<&str> {
-    let (key, value) = pair.split_once('=')?;
-    (key.eq_ignore_ascii_case("platform") && !value.is_empty()).then_some(value)
+/// Returns the value of the first non-empty `key` parameter in `uri`'s
+/// query string, matched case-insensitively.
+#[must_use]
+pub fn query_param<'a>(uri: &'a Uri, key: &str) -> Option<&'a str> {
+    uri.query()?.split('&').find_map(|pair| {
+        let (k, v) = pair.split_once('=')?;
+        (k.eq_ignore_ascii_case(key) && !v.is_empty()).then_some(v)
+    })
 }
 
 fn platform_from_create_body(body: &Bytes) -> Option<WorkloadPlatform> {

--- a/app/arcbox-docker/src/routing.rs
+++ b/app/arcbox-docker/src/routing.rs
@@ -6,6 +6,25 @@ use serde_json::Value;
 
 pub use arcbox_core::UtilityVmRole;
 
+/// Extension methods on [`UtilityVmRole`] specific to Docker routing.
+pub trait UtilityVmRoleExt {
+    /// Returns `true` if the utility VM for this role is capable of
+    /// hosting workloads of `platform`.
+    fn can_host(self, platform: WorkloadPlatform) -> bool;
+}
+
+impl UtilityVmRoleExt for UtilityVmRole {
+    fn can_host(self, platform: WorkloadPlatform) -> bool {
+        match self {
+            // VZ + Rosetta hosts both arm64 and amd64.
+            Self::Rosetta => true,
+            // HV runs native ARM64 only; amd64 needs translation only
+            // available via VZ + Rosetta.
+            Self::Native => !matches!(platform, WorkloadPlatform::LinuxAmd64),
+        }
+    }
+}
+
 /// Parsed workload platform from Docker API request metadata.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum WorkloadPlatform {
@@ -107,6 +126,23 @@ fn platform_from_create_body(body: &Bytes) -> Option<WorkloadPlatform> {
     Some(WorkloadPlatform::parse(platform))
 }
 
+/// Extracts the `com.docker.compose.project` label from a
+/// container-create body.
+///
+/// Compose-managed containers carry this label so all services in a
+/// project can be scheduled onto a single utility VM role.
+#[must_use]
+pub fn extract_compose_project(body: &Bytes) -> Option<String> {
+    let value: Value = serde_json::from_slice(body).ok()?;
+    let project = value
+        .pointer("/Labels/com.docker.compose.project")?
+        .as_str()?;
+    if project.is_empty() {
+        return None;
+    }
+    Some(project.to_string())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -184,5 +220,42 @@ mod tests {
         let route = route_build(&uri);
         assert_eq!(route.platform, WorkloadPlatform::LinuxAmd64);
         assert_eq!(route.utility_vm, UtilityVmRole::Rosetta);
+    }
+
+    #[test]
+    fn extracts_compose_project_from_labels() {
+        let body = Bytes::from_static(
+            br#"{"Image":"alpine","Labels":{"com.docker.compose.project":"myproj"}}"#,
+        );
+        assert_eq!(extract_compose_project(&body).as_deref(), Some("myproj"));
+    }
+
+    #[test]
+    fn returns_none_when_no_compose_project_label() {
+        let body = Bytes::from_static(br#"{"Image":"alpine"}"#);
+        assert!(extract_compose_project(&body).is_none());
+        let body = Bytes::from_static(br#"{"Image":"alpine","Labels":{"foo":"bar"}}"#);
+        assert!(extract_compose_project(&body).is_none());
+    }
+
+    #[test]
+    fn returns_none_when_compose_project_is_empty() {
+        let body =
+            Bytes::from_static(br#"{"Image":"alpine","Labels":{"com.docker.compose.project":""}}"#);
+        assert!(extract_compose_project(&body).is_none());
+    }
+
+    #[test]
+    fn native_can_host_arm64_and_unspecified_only() {
+        assert!(UtilityVmRole::Native.can_host(WorkloadPlatform::LinuxArm64));
+        assert!(UtilityVmRole::Native.can_host(WorkloadPlatform::Unspecified));
+        assert!(!UtilityVmRole::Native.can_host(WorkloadPlatform::LinuxAmd64));
+    }
+
+    #[test]
+    fn rosetta_can_host_every_platform() {
+        assert!(UtilityVmRole::Rosetta.can_host(WorkloadPlatform::LinuxAmd64));
+        assert!(UtilityVmRole::Rosetta.can_host(WorkloadPlatform::LinuxArm64));
+        assert!(UtilityVmRole::Rosetta.can_host(WorkloadPlatform::Unspecified));
     }
 }

--- a/app/arcbox-docker/src/routing.rs
+++ b/app/arcbox-docker/src/routing.rs
@@ -106,6 +106,11 @@ fn platform_from_query(uri: &Uri) -> Option<WorkloadPlatform> {
 
 /// Returns the value of the first non-empty `key` parameter in `uri`'s
 /// query string, matched case-insensitively.
+///
+/// The value is returned **raw** — percent-encoding is not decoded. Current
+/// callers only use this for ASCII-safe identifiers (`platform`, `name`),
+/// so this is acceptable; introducing values that could plausibly carry
+/// percent-encoded bytes would require decoding first.
 #[must_use]
 pub fn query_param<'a>(uri: &'a Uri, key: &str) -> Option<&'a str> {
     uri.query()?.split('&').find_map(|pair| {

--- a/app/arcbox-docker/src/routing.rs
+++ b/app/arcbox-docker/src/routing.rs
@@ -4,25 +4,7 @@ use axum::http::Uri;
 use bytes::Bytes;
 use serde_json::Value;
 
-/// Guest utility VM role selected for a Docker workload.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum UtilityVmRole {
-    /// Native fast path backed by the HV utility VM.
-    Native,
-    /// Rosetta compatibility path backed by the VZ utility VM.
-    Rosetta,
-}
-
-impl UtilityVmRole {
-    /// Stable diagnostic label for this utility VM role.
-    #[must_use]
-    pub const fn as_str(self) -> &'static str {
-        match self {
-            Self::Native => "native",
-            Self::Rosetta => "rosetta",
-        }
-    }
-}
+pub use arcbox_core::UtilityVmRole;
 
 /// Parsed workload platform from Docker API request metadata.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/app/arcbox-docker/src/routing.rs
+++ b/app/arcbox-docker/src/routing.rs
@@ -1,0 +1,198 @@
+//! Docker workload routing decisions for ArcBox utility VMs.
+
+use axum::http::Uri;
+use bytes::Bytes;
+use serde_json::Value;
+
+/// Guest utility VM role selected for a Docker workload.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum UtilityVmRole {
+    /// Native fast path backed by the HV utility VM.
+    Native,
+    /// Rosetta compatibility path backed by the VZ utility VM.
+    Rosetta,
+}
+
+impl UtilityVmRole {
+    /// Stable diagnostic label for this utility VM role.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Native => "native",
+            Self::Rosetta => "rosetta",
+        }
+    }
+}
+
+/// Parsed workload platform from Docker API request metadata.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WorkloadPlatform {
+    /// Linux ARM64 / AArch64 userspace.
+    LinuxArm64,
+    /// Linux AMD64 / x86_64 userspace.
+    LinuxAmd64,
+    /// No explicit or recognized platform was requested.
+    Unspecified,
+}
+
+impl WorkloadPlatform {
+    /// Parses Docker platform strings such as `linux/amd64` and `linux/arm64`.
+    #[must_use]
+    pub fn parse(platform: &str) -> Self {
+        let normalized = platform.trim().to_ascii_lowercase().replace("%2f", "/");
+        match normalized.as_str() {
+            "linux/amd64" | "linux/x86_64" | "amd64" | "x86_64" => Self::LinuxAmd64,
+            "linux/arm64" | "linux/aarch64" | "arm64" | "aarch64" => Self::LinuxArm64,
+            _ => Self::Unspecified,
+        }
+    }
+
+    /// Returns the default utility VM role for this platform.
+    #[must_use]
+    pub const fn utility_vm_role(self) -> UtilityVmRole {
+        match self {
+            Self::LinuxAmd64 => UtilityVmRole::Rosetta,
+            Self::LinuxArm64 | Self::Unspecified => UtilityVmRole::Native,
+        }
+    }
+}
+
+/// Routing decision for a Docker workload.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RoutingDecision {
+    /// Requested or inferred platform.
+    pub platform: WorkloadPlatform,
+    /// Selected utility VM role.
+    pub utility_vm: UtilityVmRole,
+}
+
+impl RoutingDecision {
+    /// Creates a routing decision from a parsed workload platform.
+    #[must_use]
+    pub const fn from_platform(platform: WorkloadPlatform) -> Self {
+        Self {
+            platform,
+            utility_vm: platform.utility_vm_role(),
+        }
+    }
+
+    /// Returns the native/HV default routing decision.
+    #[must_use]
+    pub const fn native_default() -> Self {
+        Self::from_platform(WorkloadPlatform::Unspecified)
+    }
+}
+
+/// Computes the route for `POST /containers/create`.
+#[must_use]
+pub fn route_container_create(uri: &Uri, body: &Bytes) -> RoutingDecision {
+    let platform = platform_from_query(uri)
+        .or_else(|| platform_from_create_body(body))
+        .unwrap_or(WorkloadPlatform::Unspecified);
+    RoutingDecision::from_platform(platform)
+}
+
+/// Computes the route for `POST /build`.
+#[must_use]
+pub fn route_build(uri: &Uri) -> RoutingDecision {
+    RoutingDecision::from_platform(
+        platform_from_query(uri).unwrap_or(WorkloadPlatform::Unspecified),
+    )
+}
+
+fn platform_from_query(uri: &Uri) -> Option<WorkloadPlatform> {
+    uri.query()
+        .and_then(|query| query.split('&').find_map(platform_pair_value))
+        .map(WorkloadPlatform::parse)
+}
+
+fn platform_pair_value(pair: &str) -> Option<&str> {
+    let (key, value) = pair.split_once('=')?;
+    (key.eq_ignore_ascii_case("platform") && !value.is_empty()).then_some(value)
+}
+
+fn platform_from_create_body(body: &Bytes) -> Option<WorkloadPlatform> {
+    let value: Value = serde_json::from_slice(body).ok()?;
+    let platform = value.get("Platform")?.as_str()?;
+    Some(WorkloadPlatform::parse(platform))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_amd64_platform_aliases() {
+        assert_eq!(
+            WorkloadPlatform::parse("linux/amd64"),
+            WorkloadPlatform::LinuxAmd64
+        );
+        assert_eq!(
+            WorkloadPlatform::parse("linux/x86_64"),
+            WorkloadPlatform::LinuxAmd64
+        );
+        assert_eq!(
+            WorkloadPlatform::parse("amd64"),
+            WorkloadPlatform::LinuxAmd64
+        );
+    }
+
+    #[test]
+    fn parses_arm64_platform_aliases() {
+        assert_eq!(
+            WorkloadPlatform::parse("linux/arm64"),
+            WorkloadPlatform::LinuxArm64
+        );
+        assert_eq!(
+            WorkloadPlatform::parse("linux/aarch64"),
+            WorkloadPlatform::LinuxArm64
+        );
+        assert_eq!(
+            WorkloadPlatform::parse("aarch64"),
+            WorkloadPlatform::LinuxArm64
+        );
+    }
+
+    #[test]
+    fn routes_amd64_to_rosetta_role() {
+        let route = RoutingDecision::from_platform(WorkloadPlatform::LinuxAmd64);
+        assert_eq!(route.utility_vm, UtilityVmRole::Rosetta);
+    }
+
+    #[test]
+    fn routes_arm64_and_unspecified_to_native_role() {
+        assert_eq!(
+            RoutingDecision::from_platform(WorkloadPlatform::LinuxArm64).utility_vm,
+            UtilityVmRole::Native
+        );
+        assert_eq!(
+            RoutingDecision::native_default().utility_vm,
+            UtilityVmRole::Native
+        );
+    }
+
+    #[test]
+    fn container_create_prefers_query_platform_over_body() {
+        let uri = "/containers/create?platform=linux/amd64".parse().unwrap();
+        let body = Bytes::from_static(br#"{"Image":"alpine","Platform":"linux/arm64"}"#);
+        let route = route_container_create(&uri, &body);
+        assert_eq!(route.platform, WorkloadPlatform::LinuxAmd64);
+        assert_eq!(route.utility_vm, UtilityVmRole::Rosetta);
+    }
+
+    #[test]
+    fn container_create_uses_body_platform_when_query_absent() {
+        let uri = "/containers/create".parse().unwrap();
+        let body = Bytes::from_static(br#"{"Image":"alpine","Platform":"linux/amd64"}"#);
+        let route = route_container_create(&uri, &body);
+        assert_eq!(route.utility_vm, UtilityVmRole::Rosetta);
+    }
+
+    #[test]
+    fn build_uses_query_platform() {
+        let uri = "/build?t=image&platform=linux%2Famd64".parse().unwrap();
+        let route = route_build(&uri);
+        assert_eq!(route.platform, WorkloadPlatform::LinuxAmd64);
+        assert_eq!(route.utility_vm, UtilityVmRole::Rosetta);
+    }
+}

--- a/app/arcbox-docker/src/workload.rs
+++ b/app/arcbox-docker/src/workload.rs
@@ -42,6 +42,10 @@ struct RegistryInner {
     /// Canonical ID → aliases registered for it, so a single `forget` or
     /// `rename_alias` call can update every binding atomically.
     aliases: HashMap<String, Vec<String>>,
+    /// Alias key → the canonical it currently belongs to. Required so that
+    /// reassigning an alias (or forgetting the previous owner) cannot leave
+    /// the alias list and the role binding out of sync.
+    alias_owner: HashMap<String, String>,
 }
 
 impl WorkloadRoleRegistry {
@@ -77,6 +81,12 @@ impl WorkloadRoleRegistry {
     /// shares the role binding of `canonical`. The alias is tracked so that
     /// [`Self::forget`] or [`Self::rename_alias`] can drop it cleanly.
     ///
+    /// If the alias is currently owned by a different canonical (e.g. a
+    /// previous container with the same name that has not yet been
+    /// forgotten), the alias is detached from the previous owner first so
+    /// the old owner's alias list never points to a key that now resolves
+    /// to a different role.
+    ///
     /// Does nothing if `canonical` has no recorded role yet — callers should
     /// always [`Self::record`] the canonical first.
     pub async fn add_alias(&self, canonical: &str, alias: impl Into<String>) {
@@ -93,12 +103,15 @@ impl WorkloadRoleRegistry {
             );
             return;
         };
+        detach_alias_from_previous_owner(&mut guard, &alias);
         guard.roles.insert(alias.clone(), role);
         guard
-            .aliases
-            .entry(canonical.to_string())
-            .or_default()
-            .push(alias);
+            .alias_owner
+            .insert(alias.clone(), canonical.to_string());
+        let entry = guard.aliases.entry(canonical.to_string()).or_default();
+        if !entry.iter().any(|existing| existing == &alias) {
+            entry.push(alias);
+        }
     }
 
     /// Replaces every alias previously registered against `canonical` with a
@@ -113,17 +126,28 @@ impl WorkloadRoleRegistry {
         if let Some(old_aliases) = guard.aliases.remove(canonical) {
             for old in old_aliases {
                 guard.roles.remove(&old);
+                guard.alias_owner.remove(&old);
             }
         }
         if new_alias.is_empty() || new_alias == canonical {
             return;
         }
+        detach_alias_from_previous_owner(&mut guard, &new_alias);
         guard.roles.insert(new_alias.clone(), role);
+        guard
+            .alias_owner
+            .insert(new_alias.clone(), canonical.to_string());
         guard.aliases.insert(canonical.to_string(), vec![new_alias]);
     }
 
-    /// Returns the recorded role for `id`, considering exact matches and
-    /// hex short-ID prefix matches against canonical entries.
+    /// Returns the recorded role for `id`. Considers, in order:
+    ///
+    /// 1. Direct hits in the canonical/alias map.
+    /// 2. Hex short-ID prefix matches against canonical entries: if every
+    ///    match agrees on a single role that role is returned; if matches
+    ///    disagree on role (cross-VM ambiguity) `None` is returned so the
+    ///    caller falls back to the native default rather than silently
+    ///    picking the wrong VM.
     pub async fn lookup(&self, id: &str) -> Option<UtilityVmRole> {
         let guard = self.inner.read().await;
         if let Some(role) = guard.roles.get(id).copied() {
@@ -132,25 +156,65 @@ impl WorkloadRoleRegistry {
         if !is_hex_short_id(id) {
             return None;
         }
-        guard
-            .roles
-            .iter()
-            .find(|(key, _)| is_canonical_id(key) && key.starts_with(id))
-            .map(|(_, role)| *role)
+        let mut resolved: Option<UtilityVmRole> = None;
+        for (key, role) in &guard.roles {
+            if !is_canonical_id(key) || !key.starts_with(id) {
+                continue;
+            }
+            match resolved {
+                None => resolved = Some(*role),
+                Some(existing) if existing != *role => {
+                    tracing::warn!(
+                        prefix = %id,
+                        "short ID prefix matches workloads on multiple roles; refusing to guess",
+                    );
+                    return None;
+                }
+                _ => {}
+            }
+        }
+        resolved
     }
 
-    /// Removes the record for `id`. If `id` is a canonical with tracked
-    /// aliases, the aliases are dropped as well. Returns the role that was
-    /// associated with `id`, if any.
+    /// Removes the record for `id` and keeps the alias bookkeeping
+    /// consistent. Returns the role that was associated with `id`, if any.
+    ///
+    /// - If `id` is a canonical with tracked aliases, every alias still
+    ///   owned by this canonical is dropped from `roles` and `alias_owner`.
+    ///   Aliases that have since been reassigned to another canonical are
+    ///   left intact.
+    /// - If `id` is itself an alias, it is removed from its owner's alias
+    ///   list and from `alias_owner`.
     pub async fn forget(&self, id: &str) -> Option<UtilityVmRole> {
         let mut guard = self.inner.write().await;
         let role = guard.roles.remove(id);
-        if let Some(aliases) = guard.aliases.remove(id) {
-            for alias in aliases {
-                guard.roles.remove(&alias);
+        if let Some(alias_list) = guard.aliases.remove(id) {
+            for alias in alias_list {
+                if guard.alias_owner.get(&alias).map(String::as_str) == Some(id) {
+                    guard.roles.remove(&alias);
+                    guard.alias_owner.remove(&alias);
+                }
             }
         }
+        if let Some(owner) = guard.alias_owner.remove(id)
+            && let Some(owner_aliases) = guard.aliases.get_mut(&owner)
+        {
+            owner_aliases.retain(|a| a != id);
+        }
         role
+    }
+}
+
+/// If `alias` currently belongs to a different canonical, drop it from that
+/// canonical's alias list so a later `forget`/`rename_alias` against the old
+/// owner can't accidentally remove the binding that now points to the new
+/// owner.
+fn detach_alias_from_previous_owner(inner: &mut RegistryInner, alias: &str) {
+    let Some(previous_owner) = inner.alias_owner.remove(alias) else {
+        return;
+    };
+    if let Some(previous_list) = inner.aliases.get_mut(&previous_owner) {
+        previous_list.retain(|existing| existing != alias);
     }
 }
 
@@ -295,5 +359,104 @@ mod tests {
         registry.record(CANONICAL_A, UtilityVmRole::Rosetta).await;
         // `alpine` contains non-hex characters; prefix scan must not fire.
         assert!(registry.lookup("alpine").await.is_none());
+    }
+
+    /// Two canonicals share the same hex prefix but live on different VMs.
+    /// Returning either role would be a silent misroute, so the registry
+    /// must refuse to resolve the prefix.
+    #[tokio::test]
+    async fn cross_role_prefix_collision_returns_none() {
+        let prefix = "abcd";
+        let canonical_x = format!("{prefix}{}", "1".repeat(60));
+        let canonical_y = format!("{prefix}{}", "2".repeat(60));
+        let registry = WorkloadRoleRegistry::new();
+        registry.record(canonical_x, UtilityVmRole::Native).await;
+        registry.record(canonical_y, UtilityVmRole::Rosetta).await;
+        assert!(registry.lookup(prefix).await.is_none());
+    }
+
+    /// Two canonicals share the same hex prefix but are on the same role.
+    /// The user's prefix is ambiguous for *which container* but unambiguous
+    /// for routing, so the registry returns the agreed role.
+    #[tokio::test]
+    async fn same_role_prefix_collision_resolves() {
+        let prefix = "deed";
+        let canonical_x = format!("{prefix}{}", "1".repeat(60));
+        let canonical_y = format!("{prefix}{}", "2".repeat(60));
+        let registry = WorkloadRoleRegistry::new();
+        registry.record(canonical_x, UtilityVmRole::Rosetta).await;
+        registry.record(canonical_y, UtilityVmRole::Rosetta).await;
+        assert_eq!(registry.lookup(prefix).await, Some(UtilityVmRole::Rosetta),);
+    }
+
+    /// Reassigning the same alias from canonical A to canonical B must:
+    ///   (a) make the alias resolve to B's role,
+    ///   (b) survive a subsequent `forget(A)` — A's alias list should no
+    ///       longer claim ownership of the alias.
+    #[tokio::test]
+    async fn alias_reassignment_survives_old_owner_forget() {
+        let registry = WorkloadRoleRegistry::new();
+        registry.record(CANONICAL_A, UtilityVmRole::Native).await;
+        registry.add_alias(CANONICAL_A, "web").await;
+        registry.record(CANONICAL_B, UtilityVmRole::Rosetta).await;
+        registry.add_alias(CANONICAL_B, "web").await;
+        assert_eq!(registry.lookup("web").await, Some(UtilityVmRole::Rosetta));
+
+        // Forgetting A must not drop the binding now owned by B.
+        registry.forget(CANONICAL_A).await;
+        assert_eq!(registry.lookup("web").await, Some(UtilityVmRole::Rosetta));
+    }
+
+    /// Renaming canonical A's alias to one currently owned by B steals the
+    /// alias from B's bookkeeping rather than leaving a dangling entry that
+    /// a later `forget(B)` would drop incorrectly.
+    #[tokio::test]
+    async fn rename_alias_steals_from_previous_owner() {
+        let registry = WorkloadRoleRegistry::new();
+        registry.record(CANONICAL_A, UtilityVmRole::Native).await;
+        registry.record(CANONICAL_B, UtilityVmRole::Rosetta).await;
+        registry.add_alias(CANONICAL_B, "web").await;
+
+        // A is renamed to "web", stealing the alias from B.
+        registry.rename_alias(CANONICAL_A, "web").await;
+        assert_eq!(registry.lookup("web").await, Some(UtilityVmRole::Native));
+
+        // forget(B) must not undo A's claim on "web".
+        registry.forget(CANONICAL_B).await;
+        assert_eq!(registry.lookup("web").await, Some(UtilityVmRole::Native));
+    }
+
+    /// Adding the same alias to the same canonical twice should not produce
+    /// duplicate entries in the canonical's alias list — otherwise the next
+    /// `forget` would attempt redundant cleanup and any future reassignment
+    /// would mis-account.
+    #[tokio::test]
+    async fn duplicate_alias_for_same_canonical_is_deduped() {
+        let registry = WorkloadRoleRegistry::new();
+        registry.record(CANONICAL_A, UtilityVmRole::Native).await;
+        registry.add_alias(CANONICAL_A, "web").await;
+        registry.add_alias(CANONICAL_A, "web").await;
+        // A single forget must clear the alias cleanly.
+        registry.forget(CANONICAL_A).await;
+        assert!(registry.lookup("web").await.is_none());
+        assert!(registry.lookup(CANONICAL_A).await.is_none());
+    }
+
+    /// Forgetting an alias key should leave the canonical untouched but
+    /// remove the alias from `roles` and `alias_owner` so a later
+    /// `forget(canonical)` does not try to scrub it twice.
+    #[tokio::test]
+    async fn forget_alias_only_removes_alias() {
+        let registry = WorkloadRoleRegistry::new();
+        registry.record(CANONICAL_A, UtilityVmRole::Native).await;
+        registry.add_alias(CANONICAL_A, "web").await;
+        assert_eq!(registry.forget("web").await, Some(UtilityVmRole::Native));
+        assert!(registry.lookup("web").await.is_none());
+        assert_eq!(
+            registry.lookup(CANONICAL_A).await,
+            Some(UtilityVmRole::Native),
+        );
+        // forget(canonical) still succeeds after the alias was already gone.
+        registry.forget(CANONICAL_A).await;
     }
 }

--- a/app/arcbox-docker/src/workload.rs
+++ b/app/arcbox-docker/src/workload.rs
@@ -9,27 +9,64 @@
 //!
 //! Scope:
 //!
+//! - Lookups return [`WorkloadRoleLookup`], a tri-state of
+//!   `Found(role)` / `Missing` / `Ambiguous`. Ambiguity (a short ID that
+//!   matches canonical workloads on more than one utility VM) is a
+//!   first-class outcome so the handler layer can fail closed with a 409
+//!   instead of silently picking native.
 //! - The registry itself is **in-process**. After an `arcbox-daemon`
 //!   restart it starts empty; durability across restarts is recovered
-//!   *lazily*: the docker handler probes each role's guest dockerd on a
-//!   lookup miss and re-records the role for the affected workload.
-//!   See `rebuild_container_role_from_guests` in `handlers/mod.rs`.
+//!   *lazily*: the docker handler probes every configured role's guest
+//!   dockerd on a `Missing` lookup, accepts exactly one match, and
+//!   re-records the binding. Multiple matches across guests are
+//!   reported as `Ambiguous`. See `rebuild_container_role_from_guests`
+//!   in `handlers/mod.rs`.
 //! - Container and exec IDs share the same key namespace because Docker's
 //!   ID generator makes them globally distinct.
 //! - For containers, the canonical 64-char ID, the user-supplied name (e.g.
 //!   `--name web`), and any subsequent rename are all registered. Lookup by
 //!   short hex prefix (≥ 4 chars) is also supported so `docker logs ab12c3`
-//!   resolves to the same role as the canonical entry.
+//!   resolves to the same role as the canonical entry, except when the
+//!   prefix is ambiguous across roles (handled per above).
 //! - For BuildKit, [`WorkloadRoleRegistry::wait_for_role`] lets `/session`
 //!   block until the matching `/build` declares its role under the same
 //!   `X-Docker-Expose-Session-Uuid`, so the upgraded gRPC stream and the
-//!   build land on the same utility VM.
+//!   build land on the same utility VM. On timeout `/session` fails
+//!   closed at the handler layer rather than forwarding blind.
 
 use crate::routing::UtilityVmRole;
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 use tokio::sync::{Notify, RwLock};
+
+/// Result of a registry lookup. Distinguishes "no role known" from
+/// "multiple roles could claim this identifier" so the caller can fail
+/// closed on ambiguity rather than silently defaulting to native.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WorkloadRoleLookup {
+    /// Exactly one role is associated with the identifier.
+    Found(UtilityVmRole),
+    /// No role binding exists. The caller decides whether to rebuild,
+    /// fall back to a default, or surface an error.
+    Missing,
+    /// Multiple distinct roles claim this identifier — typically a short
+    /// hex prefix that matches canonical container IDs on more than one
+    /// utility VM. Routing must refuse to pick one without explicit
+    /// disambiguation by the user.
+    Ambiguous,
+}
+
+impl WorkloadRoleLookup {
+    /// Returns the role for a [`Self::Found`] result, otherwise `None`.
+    #[must_use]
+    pub const fn role(self) -> Option<UtilityVmRole> {
+        match self {
+            Self::Found(role) => Some(role),
+            _ => None,
+        }
+    }
+}
 
 /// Tracks Docker workload IDs (container, exec, BuildKit session) and the
 /// utility VM role they were created on. See module docs for scope and
@@ -99,18 +136,23 @@ impl WorkloadRoleRegistry {
     /// Waits until `key` has a recorded role binding, or `max_wait`
     /// elapses, whichever comes first.
     ///
-    /// Returns the role once recorded; returns `None` on timeout.
-    /// Designed for BuildKit `/session` requests that arrive before the
-    /// matching `/build` declares the session's utility VM role.
-    pub async fn wait_for_role(&self, key: &str, max_wait: Duration) -> Option<UtilityVmRole> {
+    /// Returns [`WorkloadRoleLookup::Found`] once recorded,
+    /// [`WorkloadRoleLookup::Missing`] on timeout, or
+    /// [`WorkloadRoleLookup::Ambiguous`] in the (pathological) case where
+    /// the key resolves to multiple roles. Designed for BuildKit
+    /// `/session` requests that arrive before the matching `/build`
+    /// declares the session's utility VM role.
+    pub async fn wait_for_role(&self, key: &str, max_wait: Duration) -> WorkloadRoleLookup {
         let deadline = Instant::now() + max_wait;
         loop {
-            if let Some(role) = self.lookup(key).await {
-                return Some(role);
+            match self.lookup(key).await {
+                WorkloadRoleLookup::Found(role) => return WorkloadRoleLookup::Found(role),
+                WorkloadRoleLookup::Ambiguous => return WorkloadRoleLookup::Ambiguous,
+                WorkloadRoleLookup::Missing => {}
             }
             let now = Instant::now();
             if now >= deadline {
-                return None;
+                return WorkloadRoleLookup::Missing;
             }
             // Subscribe to the next signal *before* re-checking so we
             // can't lose a concurrent `record` that fires between the
@@ -118,13 +160,15 @@ impl WorkloadRoleRegistry {
             let notified = self.role_recorded.notified();
             tokio::pin!(notified);
             notified.as_mut().enable();
-            if let Some(role) = self.lookup(key).await {
-                return Some(role);
+            match self.lookup(key).await {
+                WorkloadRoleLookup::Found(role) => return WorkloadRoleLookup::Found(role),
+                WorkloadRoleLookup::Ambiguous => return WorkloadRoleLookup::Ambiguous,
+                WorkloadRoleLookup::Missing => {}
             }
             let remaining = deadline.saturating_duration_since(now);
             tokio::select! {
                 () = notified => {}
-                () = tokio::time::sleep(remaining) => return None,
+                () = tokio::time::sleep(remaining) => return WorkloadRoleLookup::Missing,
             }
         }
     }
@@ -197,16 +241,16 @@ impl WorkloadRoleRegistry {
     /// 1. Direct hits in the canonical/alias map.
     /// 2. Hex short-ID prefix matches against canonical entries: if every
     ///    match agrees on a single role that role is returned; if matches
-    ///    disagree on role (cross-VM ambiguity) `None` is returned so the
-    ///    caller falls back to the native default rather than silently
-    ///    picking the wrong VM.
-    pub async fn lookup(&self, id: &str) -> Option<UtilityVmRole> {
+    ///    disagree on role the result is
+    ///    [`WorkloadRoleLookup::Ambiguous`] so the caller fails closed
+    ///    instead of guessing.
+    pub async fn lookup(&self, id: &str) -> WorkloadRoleLookup {
         let guard = self.inner.read().await;
         if let Some(role) = guard.roles.get(id).copied() {
-            return Some(role);
+            return WorkloadRoleLookup::Found(role);
         }
         if !is_hex_short_id(id) {
-            return None;
+            return WorkloadRoleLookup::Missing;
         }
         let mut resolved: Option<UtilityVmRole> = None;
         for (key, role) in &guard.roles {
@@ -220,12 +264,15 @@ impl WorkloadRoleRegistry {
                         prefix = %id,
                         "short ID prefix matches workloads on multiple roles; refusing to guess",
                     );
-                    return None;
+                    return WorkloadRoleLookup::Ambiguous;
                 }
                 _ => {}
             }
         }
-        resolved
+        match resolved {
+            Some(role) => WorkloadRoleLookup::Found(role),
+            None => WorkloadRoleLookup::Missing,
+        }
     }
 
     /// Returns the utility VM role recorded for a Compose project, if any.
@@ -326,14 +373,20 @@ mod tests {
     #[tokio::test]
     async fn lookup_returns_none_for_unknown_id() {
         let registry = WorkloadRoleRegistry::new();
-        assert!(registry.lookup("missing").await.is_none());
+        assert_eq!(
+            registry.lookup("missing").await,
+            WorkloadRoleLookup::Missing
+        );
     }
 
     #[tokio::test]
     async fn record_then_lookup_returns_stored_role() {
         let registry = WorkloadRoleRegistry::new();
         registry.record("abc", UtilityVmRole::Rosetta).await;
-        assert_eq!(registry.lookup("abc").await, Some(UtilityVmRole::Rosetta));
+        assert_eq!(
+            registry.lookup("abc").await,
+            WorkloadRoleLookup::Found(UtilityVmRole::Rosetta)
+        );
     }
 
     #[tokio::test]
@@ -341,7 +394,7 @@ mod tests {
         let registry = WorkloadRoleRegistry::new();
         registry.record("abc", UtilityVmRole::Native).await;
         assert_eq!(registry.forget("abc").await, Some(UtilityVmRole::Native));
-        assert!(registry.lookup("abc").await.is_none());
+        assert_eq!(registry.lookup("abc").await, WorkloadRoleLookup::Missing);
     }
 
     #[tokio::test]
@@ -349,7 +402,10 @@ mod tests {
         let registry = WorkloadRoleRegistry::new();
         registry.record("abc", UtilityVmRole::Native).await;
         registry.record("abc", UtilityVmRole::Rosetta).await;
-        assert_eq!(registry.lookup("abc").await, Some(UtilityVmRole::Rosetta));
+        assert_eq!(
+            registry.lookup("abc").await,
+            WorkloadRoleLookup::Found(UtilityVmRole::Rosetta)
+        );
     }
 
     #[tokio::test]
@@ -357,14 +413,17 @@ mod tests {
         let registry = WorkloadRoleRegistry::new();
         registry.record(CANONICAL_A, UtilityVmRole::Rosetta).await;
         registry.add_alias(CANONICAL_A, "web").await;
-        assert_eq!(registry.lookup("web").await, Some(UtilityVmRole::Rosetta));
+        assert_eq!(
+            registry.lookup("web").await,
+            WorkloadRoleLookup::Found(UtilityVmRole::Rosetta)
+        );
     }
 
     #[tokio::test]
     async fn add_alias_is_noop_without_canonical_record() {
         let registry = WorkloadRoleRegistry::new();
         registry.add_alias(CANONICAL_A, "ghost").await;
-        assert!(registry.lookup("ghost").await.is_none());
+        assert_eq!(registry.lookup("ghost").await, WorkloadRoleLookup::Missing);
     }
 
     #[tokio::test]
@@ -377,8 +436,11 @@ mod tests {
             registry.forget(CANONICAL_A).await,
             Some(UtilityVmRole::Rosetta)
         );
-        assert!(registry.lookup("web").await.is_none());
-        assert!(registry.lookup("frontend").await.is_none());
+        assert_eq!(registry.lookup("web").await, WorkloadRoleLookup::Missing);
+        assert_eq!(
+            registry.lookup("frontend").await,
+            WorkloadRoleLookup::Missing
+        );
     }
 
     #[tokio::test]
@@ -387,14 +449,17 @@ mod tests {
         registry.record(CANONICAL_A, UtilityVmRole::Native).await;
         registry.add_alias(CANONICAL_A, "old-name").await;
         registry.rename_alias(CANONICAL_A, "new-name").await;
-        assert!(registry.lookup("old-name").await.is_none());
+        assert_eq!(
+            registry.lookup("old-name").await,
+            WorkloadRoleLookup::Missing
+        );
         assert_eq!(
             registry.lookup("new-name").await,
-            Some(UtilityVmRole::Native)
+            WorkloadRoleLookup::Found(UtilityVmRole::Native)
         );
         assert_eq!(
             registry.lookup(CANONICAL_A).await,
-            Some(UtilityVmRole::Native)
+            WorkloadRoleLookup::Found(UtilityVmRole::Native)
         );
     }
 
@@ -405,12 +470,12 @@ mod tests {
         // 12-char Docker short ID.
         assert_eq!(
             registry.lookup(&CANONICAL_A[..12]).await,
-            Some(UtilityVmRole::Rosetta),
+            WorkloadRoleLookup::Found(UtilityVmRole::Rosetta)
         );
         // 4-char minimum.
         assert_eq!(
             registry.lookup(&CANONICAL_A[..4]).await,
-            Some(UtilityVmRole::Rosetta),
+            WorkloadRoleLookup::Found(UtilityVmRole::Rosetta)
         );
     }
 
@@ -419,7 +484,7 @@ mod tests {
         let registry = WorkloadRoleRegistry::new();
         // 4-char hex string that isn't a canonical 64-char ID — must not match.
         registry.record("abcd", UtilityVmRole::Rosetta).await;
-        assert!(registry.lookup("abc").await.is_none());
+        assert_eq!(registry.lookup("abc").await, WorkloadRoleLookup::Missing);
     }
 
     #[tokio::test]
@@ -429,11 +494,11 @@ mod tests {
         registry.record(CANONICAL_B, UtilityVmRole::Rosetta).await;
         assert_eq!(
             registry.lookup(&CANONICAL_B[..8]).await,
-            Some(UtilityVmRole::Rosetta),
+            WorkloadRoleLookup::Found(UtilityVmRole::Rosetta)
         );
         assert_eq!(
             registry.lookup(&CANONICAL_A[..8]).await,
-            Some(UtilityVmRole::Native),
+            WorkloadRoleLookup::Found(UtilityVmRole::Native)
         );
     }
 
@@ -442,21 +507,21 @@ mod tests {
         let registry = WorkloadRoleRegistry::new();
         registry.record(CANONICAL_A, UtilityVmRole::Rosetta).await;
         // `alpine` contains non-hex characters; prefix scan must not fire.
-        assert!(registry.lookup("alpine").await.is_none());
+        assert_eq!(registry.lookup("alpine").await, WorkloadRoleLookup::Missing);
     }
 
     /// Two canonicals share the same hex prefix but live on different VMs.
     /// Returning either role would be a silent misroute, so the registry
-    /// must refuse to resolve the prefix.
+    /// reports the prefix as ambiguous and the caller must fail closed.
     #[tokio::test]
-    async fn cross_role_prefix_collision_returns_none() {
+    async fn cross_role_prefix_collision_is_ambiguous() {
         let prefix = "abcd";
         let canonical_x = format!("{prefix}{}", "1".repeat(60));
         let canonical_y = format!("{prefix}{}", "2".repeat(60));
         let registry = WorkloadRoleRegistry::new();
         registry.record(canonical_x, UtilityVmRole::Native).await;
         registry.record(canonical_y, UtilityVmRole::Rosetta).await;
-        assert!(registry.lookup(prefix).await.is_none());
+        assert_eq!(registry.lookup(prefix).await, WorkloadRoleLookup::Ambiguous);
     }
 
     /// Two canonicals share the same hex prefix but are on the same role.
@@ -470,7 +535,10 @@ mod tests {
         let registry = WorkloadRoleRegistry::new();
         registry.record(canonical_x, UtilityVmRole::Rosetta).await;
         registry.record(canonical_y, UtilityVmRole::Rosetta).await;
-        assert_eq!(registry.lookup(prefix).await, Some(UtilityVmRole::Rosetta),);
+        assert_eq!(
+            registry.lookup(prefix).await,
+            WorkloadRoleLookup::Found(UtilityVmRole::Rosetta)
+        );
     }
 
     /// Reassigning the same alias from canonical A to canonical B must:
@@ -484,11 +552,17 @@ mod tests {
         registry.add_alias(CANONICAL_A, "web").await;
         registry.record(CANONICAL_B, UtilityVmRole::Rosetta).await;
         registry.add_alias(CANONICAL_B, "web").await;
-        assert_eq!(registry.lookup("web").await, Some(UtilityVmRole::Rosetta));
+        assert_eq!(
+            registry.lookup("web").await,
+            WorkloadRoleLookup::Found(UtilityVmRole::Rosetta)
+        );
 
         // Forgetting A must not drop the binding now owned by B.
         registry.forget(CANONICAL_A).await;
-        assert_eq!(registry.lookup("web").await, Some(UtilityVmRole::Rosetta));
+        assert_eq!(
+            registry.lookup("web").await,
+            WorkloadRoleLookup::Found(UtilityVmRole::Rosetta)
+        );
     }
 
     /// Renaming canonical A's alias to one currently owned by B steals the
@@ -503,11 +577,17 @@ mod tests {
 
         // A is renamed to "web", stealing the alias from B.
         registry.rename_alias(CANONICAL_A, "web").await;
-        assert_eq!(registry.lookup("web").await, Some(UtilityVmRole::Native));
+        assert_eq!(
+            registry.lookup("web").await,
+            WorkloadRoleLookup::Found(UtilityVmRole::Native)
+        );
 
         // forget(B) must not undo A's claim on "web".
         registry.forget(CANONICAL_B).await;
-        assert_eq!(registry.lookup("web").await, Some(UtilityVmRole::Native));
+        assert_eq!(
+            registry.lookup("web").await,
+            WorkloadRoleLookup::Found(UtilityVmRole::Native)
+        );
     }
 
     /// Adding the same alias to the same canonical twice should not produce
@@ -522,8 +602,11 @@ mod tests {
         registry.add_alias(CANONICAL_A, "web").await;
         // A single forget must clear the alias cleanly.
         registry.forget(CANONICAL_A).await;
-        assert!(registry.lookup("web").await.is_none());
-        assert!(registry.lookup(CANONICAL_A).await.is_none());
+        assert_eq!(registry.lookup("web").await, WorkloadRoleLookup::Missing);
+        assert_eq!(
+            registry.lookup(CANONICAL_A).await,
+            WorkloadRoleLookup::Missing
+        );
     }
 
     /// Forgetting an alias key should leave the canonical untouched but
@@ -535,10 +618,10 @@ mod tests {
         registry.record(CANONICAL_A, UtilityVmRole::Native).await;
         registry.add_alias(CANONICAL_A, "web").await;
         assert_eq!(registry.forget("web").await, Some(UtilityVmRole::Native));
-        assert!(registry.lookup("web").await.is_none());
+        assert_eq!(registry.lookup("web").await, WorkloadRoleLookup::Missing);
         assert_eq!(
             registry.lookup(CANONICAL_A).await,
-            Some(UtilityVmRole::Native),
+            WorkloadRoleLookup::Found(UtilityVmRole::Native)
         );
         // forget(canonical) still succeeds after the alias was already gone.
         registry.forget(CANONICAL_A).await;
@@ -566,7 +649,7 @@ mod tests {
         let role = registry
             .wait_for_role("session-uuid", Duration::from_secs(1))
             .await;
-        assert_eq!(role, Some(UtilityVmRole::Rosetta));
+        assert_eq!(role, WorkloadRoleLookup::Found(UtilityVmRole::Rosetta));
     }
 
     #[tokio::test]
@@ -582,16 +665,16 @@ mod tests {
             .wait_for_role("late-uuid", Duration::from_secs(2))
             .await;
         writer.await.unwrap();
-        assert_eq!(role, Some(UtilityVmRole::Rosetta));
+        assert_eq!(role, WorkloadRoleLookup::Found(UtilityVmRole::Rosetta));
     }
 
     #[tokio::test]
-    async fn wait_for_role_returns_none_after_timeout() {
+    async fn wait_for_role_returns_missing_after_timeout() {
         let registry = WorkloadRoleRegistry::new();
         let role = registry
             .wait_for_role("never-recorded", Duration::from_millis(50))
             .await;
-        assert!(role.is_none());
+        assert_eq!(role, WorkloadRoleLookup::Missing);
     }
 
     #[tokio::test]

--- a/app/arcbox-docker/src/workload.rs
+++ b/app/arcbox-docker/src/workload.rs
@@ -9,23 +9,27 @@
 //!
 //! Scope:
 //!
-//! - The registry is **in-process** and not durable. After an `arcbox-daemon`
-//!   restart, lookups for pre-existing workloads return `None` and callers
-//!   fall back to the native default. Surviving role bindings across daemon
-//!   restarts will require either persistent storage or rebuilding the map by
-//!   inspecting each role's guest dockerd at startup, and is part of a later
-//!   workstream.
+//! - The registry itself is **in-process**. After an `arcbox-daemon`
+//!   restart it starts empty; durability across restarts is recovered
+//!   *lazily*: the docker handler probes each role's guest dockerd on a
+//!   lookup miss and re-records the role for the affected workload.
+//!   See `rebuild_container_role_from_guests` in `handlers/mod.rs`.
 //! - Container and exec IDs share the same key namespace because Docker's
 //!   ID generator makes them globally distinct.
 //! - For containers, the canonical 64-char ID, the user-supplied name (e.g.
 //!   `--name web`), and any subsequent rename are all registered. Lookup by
 //!   short hex prefix (≥ 4 chars) is also supported so `docker logs ab12c3`
 //!   resolves to the same role as the canonical entry.
+//! - For BuildKit, [`WorkloadRoleRegistry::wait_for_role`] lets `/session`
+//!   block until the matching `/build` declares its role under the same
+//!   `X-Docker-Expose-Session-Uuid`, so the upgraded gRPC stream and the
+//!   build land on the same utility VM.
 
 use crate::routing::UtilityVmRole;
 use std::collections::HashMap;
 use std::sync::Arc;
-use tokio::sync::RwLock;
+use std::time::{Duration, Instant};
+use tokio::sync::{Notify, RwLock};
 
 /// Tracks Docker workload IDs (container, exec, BuildKit session) and the
 /// utility VM role they were created on. See module docs for scope and
@@ -33,6 +37,10 @@ use tokio::sync::RwLock;
 #[derive(Debug, Default)]
 pub struct WorkloadRoleRegistry {
     inner: RwLock<RegistryInner>,
+    /// Broadcast signal fired whenever a new role binding is recorded.
+    /// Used by [`Self::wait_for_role`] so a BuildKit `/session` request
+    /// can block until the matching `/build` declares the role.
+    role_recorded: Notify,
 }
 
 #[derive(Debug, Default)]
@@ -81,6 +89,43 @@ impl WorkloadRoleRegistry {
                 new = role.as_str(),
                 "workload role record replaced with a different role",
             );
+        }
+        // Wake any `wait_for_role` callers (e.g. BuildKit `/session`
+        // handlers parked waiting for the matching `/build` to declare
+        // the role). False wake-ups are filtered by the re-check loop.
+        self.role_recorded.notify_waiters();
+    }
+
+    /// Waits until `key` has a recorded role binding, or `max_wait`
+    /// elapses, whichever comes first.
+    ///
+    /// Returns the role once recorded; returns `None` on timeout.
+    /// Designed for BuildKit `/session` requests that arrive before the
+    /// matching `/build` declares the session's utility VM role.
+    pub async fn wait_for_role(&self, key: &str, max_wait: Duration) -> Option<UtilityVmRole> {
+        let deadline = Instant::now() + max_wait;
+        loop {
+            if let Some(role) = self.lookup(key).await {
+                return Some(role);
+            }
+            let now = Instant::now();
+            if now >= deadline {
+                return None;
+            }
+            // Subscribe to the next signal *before* re-checking so we
+            // can't lose a concurrent `record` that fires between the
+            // miss above and the await below.
+            let notified = self.role_recorded.notified();
+            tokio::pin!(notified);
+            notified.as_mut().enable();
+            if let Some(role) = self.lookup(key).await {
+                return Some(role);
+            }
+            let remaining = deadline.saturating_duration_since(now);
+            tokio::select! {
+                () = notified => {}
+                () = tokio::time::sleep(remaining) => return None,
+            }
         }
     }
 
@@ -510,6 +555,43 @@ mod tests {
             registry.project_role("proj").await,
             Some(UtilityVmRole::Rosetta),
         );
+    }
+
+    #[tokio::test]
+    async fn wait_for_role_returns_existing_binding_immediately() {
+        let registry = WorkloadRoleRegistry::new();
+        registry
+            .record("session-uuid", UtilityVmRole::Rosetta)
+            .await;
+        let role = registry
+            .wait_for_role("session-uuid", Duration::from_secs(1))
+            .await;
+        assert_eq!(role, Some(UtilityVmRole::Rosetta));
+    }
+
+    #[tokio::test]
+    async fn wait_for_role_wakes_when_record_arrives_later() {
+        let registry = WorkloadRoleRegistry::new();
+        let registry2 = Arc::clone(&registry);
+        let writer = tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_millis(20)).await;
+            registry2.record("late-uuid", UtilityVmRole::Rosetta).await;
+        });
+
+        let role = registry
+            .wait_for_role("late-uuid", Duration::from_secs(2))
+            .await;
+        writer.await.unwrap();
+        assert_eq!(role, Some(UtilityVmRole::Rosetta));
+    }
+
+    #[tokio::test]
+    async fn wait_for_role_returns_none_after_timeout() {
+        let registry = WorkloadRoleRegistry::new();
+        let role = registry
+            .wait_for_role("never-recorded", Duration::from_millis(50))
+            .await;
+        assert!(role.is_none());
     }
 
     #[tokio::test]

--- a/app/arcbox-docker/src/workload.rs
+++ b/app/arcbox-docker/src/workload.rs
@@ -46,6 +46,13 @@ struct RegistryInner {
     /// reassigning an alias (or forgetting the previous owner) cannot leave
     /// the alias list and the role binding out of sync.
     alias_owner: HashMap<String, String>,
+    /// Compose project name → the utility VM role that owns the project.
+    ///
+    /// Recorded on the first container created for a project so every
+    /// subsequent service in the same project lands on the same role.
+    /// Entries persist for the daemon's lifetime to keep group routing
+    /// coherent across `docker-compose down`/`up` cycles.
+    projects: HashMap<String, UtilityVmRole>,
 }
 
 impl WorkloadRoleRegistry {
@@ -174,6 +181,38 @@ impl WorkloadRoleRegistry {
             }
         }
         resolved
+    }
+
+    /// Returns the utility VM role recorded for a Compose project, if any.
+    pub async fn project_role(&self, project: &str) -> Option<UtilityVmRole> {
+        self.inner.read().await.projects.get(project).copied()
+    }
+
+    /// Records that `project` is bound to `role`. Subsequent services in
+    /// the same project must match (or be compatible with) this role.
+    ///
+    /// Replacing an existing binding with a different role logs a warning
+    /// and the new value wins; callers should normally consult
+    /// [`Self::project_role`] first and reject incompatible services
+    /// rather than silently re-pinning the project.
+    pub async fn record_project(&self, project: impl Into<String>, role: UtilityVmRole) {
+        let project = project.into();
+        let previous = self
+            .inner
+            .write()
+            .await
+            .projects
+            .insert(project.clone(), role);
+        if let Some(previous) = previous
+            && previous != role
+        {
+            tracing::warn!(
+                project = %project,
+                previous = previous.as_str(),
+                new = role.as_str(),
+                "compose project role binding replaced with a different role",
+            );
+        }
     }
 
     /// Removes the record for `id` and keeps the alias bookkeeping
@@ -458,5 +497,33 @@ mod tests {
         );
         // forget(canonical) still succeeds after the alias was already gone.
         registry.forget(CANONICAL_A).await;
+    }
+
+    #[tokio::test]
+    async fn project_role_returns_none_until_recorded() {
+        let registry = WorkloadRoleRegistry::new();
+        assert!(registry.project_role("proj").await.is_none());
+        registry
+            .record_project("proj", UtilityVmRole::Rosetta)
+            .await;
+        assert_eq!(
+            registry.project_role("proj").await,
+            Some(UtilityVmRole::Rosetta),
+        );
+    }
+
+    #[tokio::test]
+    async fn project_roles_are_independent_of_container_aliases() {
+        let registry = WorkloadRoleRegistry::new();
+        registry.record(CANONICAL_A, UtilityVmRole::Native).await;
+        registry.add_alias(CANONICAL_A, "web").await;
+        registry.record_project("proj", UtilityVmRole::Native).await;
+        // Forgetting the only container of a project does not invalidate
+        // the project binding (we keep it sticky across compose up/down).
+        registry.forget(CANONICAL_A).await;
+        assert_eq!(
+            registry.project_role("proj").await,
+            Some(UtilityVmRole::Native),
+        );
     }
 }

--- a/app/arcbox-docker/src/workload.rs
+++ b/app/arcbox-docker/src/workload.rs
@@ -1,32 +1,47 @@
-//! Tracks which utility VM role each Docker workload is bound to.
+//! Tracks the utility VM role for each Docker workload during the daemon's
+//! lifetime.
 //!
-//! After `POST /containers/create` or `POST /containers/{id}/exec` selects a
-//! role for a new workload, lifecycle handlers consult this registry to keep
-//! follow-up operations on the same role. Without it, an `amd64` container
-//! created on the `rosetta` utility VM would have its `start`/`logs`/`stop`
-//! calls silently re-routed to `native`.
+//! Whenever a workload is created (`POST /containers/create`,
+//! `POST /containers/{id}/exec`, or a BuildKit session), lifecycle handlers
+//! consult this registry so follow-up operations land on the same role.
+//! Without it an `amd64` container created on the `rosetta` utility VM would
+//! have its `start`/`logs`/`stop` calls silently re-routed to `native`.
 //!
 //! Scope:
 //!
-//! - Process-local. After an `arcbox-daemon` restart, lookups for pre-existing
-//!   workloads return `None` and callers fall back to the native default
-//!   routing. Durable persistence is part of a later workstream once the
-//!   connector layer actually resolves each role to a distinct VM.
-//! - Tracks both container and exec IDs in a single namespace because Docker's
+//! - The registry is **in-process** and not durable. After an `arcbox-daemon`
+//!   restart, lookups for pre-existing workloads return `None` and callers
+//!   fall back to the native default. Surviving role bindings across daemon
+//!   restarts will require either persistent storage or rebuilding the map by
+//!   inspecting each role's guest dockerd at startup, and is part of a later
+//!   workstream.
+//! - Container and exec IDs share the same key namespace because Docker's
 //!   ID generator makes them globally distinct.
-//! - Build sessions are out of scope; their routing is decided per call from
-//!   query parameters.
+//! - For containers, the canonical 64-char ID, the user-supplied name (e.g.
+//!   `--name web`), and any subsequent rename are all registered. Lookup by
+//!   short hex prefix (≥ 4 chars) is also supported so `docker logs ab12c3`
+//!   resolves to the same role as the canonical entry.
 
 use crate::routing::UtilityVmRole;
 use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::sync::RwLock;
 
-/// Maps Docker workload IDs (container or exec) to the utility VM role they
-/// were created on.
+/// Tracks Docker workload IDs (container, exec, BuildKit session) and the
+/// utility VM role they were created on. See module docs for scope and
+/// guarantees.
 #[derive(Debug, Default)]
 pub struct WorkloadRoleRegistry {
-    inner: RwLock<HashMap<String, UtilityVmRole>>,
+    inner: RwLock<RegistryInner>,
+}
+
+#[derive(Debug, Default)]
+struct RegistryInner {
+    /// Direct key → role bindings (canonical IDs, aliases, exec IDs, etc.).
+    roles: HashMap<String, UtilityVmRole>,
+    /// Canonical ID → aliases registered for it, so a single `forget` or
+    /// `rename_alias` call can update every binding atomically.
+    aliases: HashMap<String, Vec<String>>,
 }
 
 impl WorkloadRoleRegistry {
@@ -36,15 +51,16 @@ impl WorkloadRoleRegistry {
         Arc::new(Self::default())
     }
 
-    /// Records the role for `workload_id` (a canonical container or exec ID).
+    /// Records a role binding for `id` (a canonical container ID, exec ID,
+    /// or BuildKit session UUID).
     ///
-    /// Replacing an existing record with a different role indicates the
+    /// Replacing an existing binding with a different role indicates the
     /// caller is mixing roles for the same ID, which would corrupt routing
     /// for in-flight follow-up calls. Such a replacement is logged as a
     /// warning and the new value wins.
-    pub async fn record(&self, workload_id: impl Into<String>, role: UtilityVmRole) {
-        let id = workload_id.into();
-        let previous = self.inner.write().await.insert(id.clone(), role);
+    pub async fn record(&self, id: impl Into<String>, role: UtilityVmRole) {
+        let id = id.into();
+        let previous = self.inner.write().await.roles.insert(id.clone(), role);
         if let Some(previous) = previous
             && previous != role
         {
@@ -57,20 +73,107 @@ impl WorkloadRoleRegistry {
         }
     }
 
-    /// Returns the recorded role, or `None` when no record exists.
-    pub async fn lookup(&self, workload_id: &str) -> Option<UtilityVmRole> {
-        self.inner.read().await.get(workload_id).copied()
+    /// Registers an additional lookup key (e.g. a container `--name`) that
+    /// shares the role binding of `canonical`. The alias is tracked so that
+    /// [`Self::forget`] or [`Self::rename_alias`] can drop it cleanly.
+    ///
+    /// Does nothing if `canonical` has no recorded role yet — callers should
+    /// always [`Self::record`] the canonical first.
+    pub async fn add_alias(&self, canonical: &str, alias: impl Into<String>) {
+        let alias = alias.into();
+        if alias.is_empty() || alias == canonical {
+            return;
+        }
+        let mut guard = self.inner.write().await;
+        let Some(role) = guard.roles.get(canonical).copied() else {
+            tracing::debug!(
+                canonical,
+                alias = %alias,
+                "skipping alias registration: canonical ID has no role binding",
+            );
+            return;
+        };
+        guard.roles.insert(alias.clone(), role);
+        guard
+            .aliases
+            .entry(canonical.to_string())
+            .or_default()
+            .push(alias);
     }
 
-    /// Removes the record for `workload_id` and returns its previous value.
-    pub async fn forget(&self, workload_id: &str) -> Option<UtilityVmRole> {
-        self.inner.write().await.remove(workload_id)
+    /// Replaces every alias previously registered against `canonical` with a
+    /// single new alias. Used by `docker rename`, which preserves the
+    /// container ID but invalidates the old name.
+    pub async fn rename_alias(&self, canonical: &str, new_alias: impl Into<String>) {
+        let new_alias = new_alias.into();
+        let mut guard = self.inner.write().await;
+        let Some(role) = guard.roles.get(canonical).copied() else {
+            return;
+        };
+        if let Some(old_aliases) = guard.aliases.remove(canonical) {
+            for old in old_aliases {
+                guard.roles.remove(&old);
+            }
+        }
+        if new_alias.is_empty() || new_alias == canonical {
+            return;
+        }
+        guard.roles.insert(new_alias.clone(), role);
+        guard.aliases.insert(canonical.to_string(), vec![new_alias]);
     }
+
+    /// Returns the recorded role for `id`, considering exact matches and
+    /// hex short-ID prefix matches against canonical entries.
+    pub async fn lookup(&self, id: &str) -> Option<UtilityVmRole> {
+        let guard = self.inner.read().await;
+        if let Some(role) = guard.roles.get(id).copied() {
+            return Some(role);
+        }
+        if !is_hex_short_id(id) {
+            return None;
+        }
+        guard
+            .roles
+            .iter()
+            .find(|(key, _)| is_canonical_id(key) && key.starts_with(id))
+            .map(|(_, role)| *role)
+    }
+
+    /// Removes the record for `id`. If `id` is a canonical with tracked
+    /// aliases, the aliases are dropped as well. Returns the role that was
+    /// associated with `id`, if any.
+    pub async fn forget(&self, id: &str) -> Option<UtilityVmRole> {
+        let mut guard = self.inner.write().await;
+        let role = guard.roles.remove(id);
+        if let Some(aliases) = guard.aliases.remove(id) {
+            for alias in aliases {
+                guard.roles.remove(&alias);
+            }
+        }
+        role
+    }
+}
+
+/// A short hex ID is at least 4 hex characters and shorter than a full
+/// canonical ID. We use this as the trigger for prefix scans so non-hex
+/// names like `alpine` don't pay the cost of a scan and arbitrary strings
+/// can't accidentally prefix-match a canonical ID.
+fn is_hex_short_id(id: &str) -> bool {
+    let len = id.len();
+    (4..64).contains(&len) && id.bytes().all(|b| b.is_ascii_hexdigit())
+}
+
+/// Docker container/exec canonical IDs are 64 lowercase hex characters.
+fn is_canonical_id(id: &str) -> bool {
+    id.len() == 64 && id.bytes().all(|b| b.is_ascii_hexdigit())
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    const CANONICAL_A: &str = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+    const CANONICAL_B: &str = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
 
     #[tokio::test]
     async fn lookup_returns_none_for_unknown_id() {
@@ -99,5 +202,98 @@ mod tests {
         registry.record("abc", UtilityVmRole::Native).await;
         registry.record("abc", UtilityVmRole::Rosetta).await;
         assert_eq!(registry.lookup("abc").await, Some(UtilityVmRole::Rosetta));
+    }
+
+    #[tokio::test]
+    async fn alias_lookup_returns_canonical_role() {
+        let registry = WorkloadRoleRegistry::new();
+        registry.record(CANONICAL_A, UtilityVmRole::Rosetta).await;
+        registry.add_alias(CANONICAL_A, "web").await;
+        assert_eq!(registry.lookup("web").await, Some(UtilityVmRole::Rosetta));
+    }
+
+    #[tokio::test]
+    async fn add_alias_is_noop_without_canonical_record() {
+        let registry = WorkloadRoleRegistry::new();
+        registry.add_alias(CANONICAL_A, "ghost").await;
+        assert!(registry.lookup("ghost").await.is_none());
+    }
+
+    #[tokio::test]
+    async fn forget_canonical_drops_aliases() {
+        let registry = WorkloadRoleRegistry::new();
+        registry.record(CANONICAL_A, UtilityVmRole::Rosetta).await;
+        registry.add_alias(CANONICAL_A, "web").await;
+        registry.add_alias(CANONICAL_A, "frontend").await;
+        assert_eq!(
+            registry.forget(CANONICAL_A).await,
+            Some(UtilityVmRole::Rosetta)
+        );
+        assert!(registry.lookup("web").await.is_none());
+        assert!(registry.lookup("frontend").await.is_none());
+    }
+
+    #[tokio::test]
+    async fn rename_alias_drops_old_and_adds_new() {
+        let registry = WorkloadRoleRegistry::new();
+        registry.record(CANONICAL_A, UtilityVmRole::Native).await;
+        registry.add_alias(CANONICAL_A, "old-name").await;
+        registry.rename_alias(CANONICAL_A, "new-name").await;
+        assert!(registry.lookup("old-name").await.is_none());
+        assert_eq!(
+            registry.lookup("new-name").await,
+            Some(UtilityVmRole::Native)
+        );
+        assert_eq!(
+            registry.lookup(CANONICAL_A).await,
+            Some(UtilityVmRole::Native)
+        );
+    }
+
+    #[tokio::test]
+    async fn short_hex_prefix_resolves_to_canonical_role() {
+        let registry = WorkloadRoleRegistry::new();
+        registry.record(CANONICAL_A, UtilityVmRole::Rosetta).await;
+        // 12-char Docker short ID.
+        assert_eq!(
+            registry.lookup(&CANONICAL_A[..12]).await,
+            Some(UtilityVmRole::Rosetta),
+        );
+        // 4-char minimum.
+        assert_eq!(
+            registry.lookup(&CANONICAL_A[..4]).await,
+            Some(UtilityVmRole::Rosetta),
+        );
+    }
+
+    #[tokio::test]
+    async fn short_prefix_does_not_match_non_canonical_keys() {
+        let registry = WorkloadRoleRegistry::new();
+        // 4-char hex string that isn't a canonical 64-char ID — must not match.
+        registry.record("abcd", UtilityVmRole::Rosetta).await;
+        assert!(registry.lookup("abc").await.is_none());
+    }
+
+    #[tokio::test]
+    async fn prefix_picks_correct_canonical_among_many() {
+        let registry = WorkloadRoleRegistry::new();
+        registry.record(CANONICAL_A, UtilityVmRole::Native).await;
+        registry.record(CANONICAL_B, UtilityVmRole::Rosetta).await;
+        assert_eq!(
+            registry.lookup(&CANONICAL_B[..8]).await,
+            Some(UtilityVmRole::Rosetta),
+        );
+        assert_eq!(
+            registry.lookup(&CANONICAL_A[..8]).await,
+            Some(UtilityVmRole::Native),
+        );
+    }
+
+    #[tokio::test]
+    async fn non_hex_strings_skip_prefix_scan() {
+        let registry = WorkloadRoleRegistry::new();
+        registry.record(CANONICAL_A, UtilityVmRole::Rosetta).await;
+        // `alpine` contains non-hex characters; prefix scan must not fire.
+        assert!(registry.lookup("alpine").await.is_none());
     }
 }

--- a/app/arcbox-docker/src/workload.rs
+++ b/app/arcbox-docker/src/workload.rs
@@ -1,0 +1,103 @@
+//! Tracks which utility VM role each Docker workload is bound to.
+//!
+//! After `POST /containers/create` or `POST /containers/{id}/exec` selects a
+//! role for a new workload, lifecycle handlers consult this registry to keep
+//! follow-up operations on the same role. Without it, an `amd64` container
+//! created on the `rosetta` utility VM would have its `start`/`logs`/`stop`
+//! calls silently re-routed to `native`.
+//!
+//! Scope:
+//!
+//! - Process-local. After an `arcbox-daemon` restart, lookups for pre-existing
+//!   workloads return `None` and callers fall back to the native default
+//!   routing. Durable persistence is part of a later workstream once the
+//!   connector layer actually resolves each role to a distinct VM.
+//! - Tracks both container and exec IDs in a single namespace because Docker's
+//!   ID generator makes them globally distinct.
+//! - Build sessions are out of scope; their routing is decided per call from
+//!   query parameters.
+
+use crate::routing::UtilityVmRole;
+use std::collections::HashMap;
+use std::sync::Arc;
+use tokio::sync::RwLock;
+
+/// Maps Docker workload IDs (container or exec) to the utility VM role they
+/// were created on.
+#[derive(Debug, Default)]
+pub struct WorkloadRoleRegistry {
+    inner: RwLock<HashMap<String, UtilityVmRole>>,
+}
+
+impl WorkloadRoleRegistry {
+    /// Returns a new shared, empty registry.
+    #[must_use]
+    pub fn new() -> Arc<Self> {
+        Arc::new(Self::default())
+    }
+
+    /// Records the role for `workload_id` (a canonical container or exec ID).
+    ///
+    /// Replacing an existing record with a different role indicates the
+    /// caller is mixing roles for the same ID, which would corrupt routing
+    /// for in-flight follow-up calls. Such a replacement is logged as a
+    /// warning and the new value wins.
+    pub async fn record(&self, workload_id: impl Into<String>, role: UtilityVmRole) {
+        let id = workload_id.into();
+        let previous = self.inner.write().await.insert(id.clone(), role);
+        if let Some(previous) = previous
+            && previous != role
+        {
+            tracing::warn!(
+                workload_id = %id,
+                previous = previous.as_str(),
+                new = role.as_str(),
+                "workload role record replaced with a different role",
+            );
+        }
+    }
+
+    /// Returns the recorded role, or `None` when no record exists.
+    pub async fn lookup(&self, workload_id: &str) -> Option<UtilityVmRole> {
+        self.inner.read().await.get(workload_id).copied()
+    }
+
+    /// Removes the record for `workload_id` and returns its previous value.
+    pub async fn forget(&self, workload_id: &str) -> Option<UtilityVmRole> {
+        self.inner.write().await.remove(workload_id)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn lookup_returns_none_for_unknown_id() {
+        let registry = WorkloadRoleRegistry::new();
+        assert!(registry.lookup("missing").await.is_none());
+    }
+
+    #[tokio::test]
+    async fn record_then_lookup_returns_stored_role() {
+        let registry = WorkloadRoleRegistry::new();
+        registry.record("abc", UtilityVmRole::Rosetta).await;
+        assert_eq!(registry.lookup("abc").await, Some(UtilityVmRole::Rosetta));
+    }
+
+    #[tokio::test]
+    async fn forget_removes_record_and_returns_previous() {
+        let registry = WorkloadRoleRegistry::new();
+        registry.record("abc", UtilityVmRole::Native).await;
+        assert_eq!(registry.forget("abc").await, Some(UtilityVmRole::Native));
+        assert!(registry.lookup("abc").await.is_none());
+    }
+
+    #[tokio::test]
+    async fn record_overwrites_existing_role() {
+        let registry = WorkloadRoleRegistry::new();
+        registry.record("abc", UtilityVmRole::Native).await;
+        registry.record("abc", UtilityVmRole::Rosetta).await;
+        assert_eq!(registry.lookup("abc").await, Some(UtilityVmRole::Rosetta));
+    }
+}


### PR DESCRIPTION
## Summary

Starts ABX-374 by adding the Docker-side routing seam for the dual utility VM architecture:

- adds platform parsing and routing decisions for `native` vs `rosetta` utility VM roles
- routes `POST /containers/create` and `POST /build` based on Docker `platform` metadata
- threads the selected utility VM role through the guest dockerd connector interface
- keeps current single-VM behavior as the default connector implementation while making the future HV/VZ split explicit

This is intentionally the first incremental slice: it does not start the second utility VM yet, but establishes the API boundary needed for a dual connector/runtime implementation.

## Validation

- `cargo fmt --check`
- `cargo test -p arcbox-docker --lib`
- `cargo clippy -p arcbox-docker --all-targets -- -D warnings`

Linear: ABX-374
