### PR TITLE
ci(release): pass release-please PR JSON via env, not inline interpolation

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -34,8 +34,11 @@ jobs:
         if: steps.release.outputs.pr
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          # Passed via env, not inline interpolation: the JSON contains the
+          # changelog body, whose quotes would break the shell script.
+          RELEASE_PR: ${{ steps.release.outputs.pr }}
         run: |
-          PR_BRANCH=$(echo '${{ steps.release.outputs.pr }}' | jq -r '.headBranchName')
+          PR_BRANCH=$(jq -r '.headBranchName' <<< "$RELEASE_PR")
           git clone --depth 1 --branch "$PR_BRANCH" \
             "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git" /tmp/release-pr
           cd /tmp/release-pr


### PR DESCRIPTION
Fixes the [Release Please run failure](https://github.com/arcboxlabs/arcbox/actions/runs/27282592782/job/80580908909) on master.

## Problem

The `Update Cargo.lock on release PR` step interpolated `${{ steps.release.outputs.pr }}` directly into the bash script, inside single quotes:

```bash
PR_BRANCH=$(echo '${{ steps.release.outputs.pr }}' | jq -r '.headBranchName')
```

The PR JSON embeds the full changelog body. The 0.4.5 changelog contains an apostrophe ("…so FEX amd64 **doesn't** SIGILL…"), which terminated the single-quoted string, and bash failed with `syntax error near unexpected token '('` before any step logic ran. As a result, release PR #288 never got its `Cargo.lock` refresh.

## Fix

Pass the JSON through `env` instead. Environment variables reach the shell via the process environment rather than script text, so arbitrary changelog content (quotes, parens, backticks) can't alter the script. This is also GitHub's recommended hardening against script injection from expression interpolation.

Verified locally by running the new snippet with a JSON payload containing apostrophes, parens, and `$(…)` text — the branch name parses correctly.

I checked the other `${{ }}` uses inside `run:` blocks across the workflows; the rest interpolate constrained values (repo name, tag names, versions, run id), not free text.