### PR TITLE
Unify vCPU defaults: single source of truth = host core count

### DIFF
--- a/app/arcbox-api/src/grpc/machine.rs
+++ b/app/arcbox-api/src/grpc/machine.rs
@@ -14,16 +14,6 @@ use tonic::{Request, Response, Status};
 
 use super::{SharedRuntime, SharedRuntimeExt};
 
-/// Resolves a requested CPU count: `0` means "use the daemon default"
-/// (host core count).
-fn resolve_cpus(requested: u32) -> u32 {
-    if requested == 0 {
-        arcbox_core::default_vm_cpu_count()
-    } else {
-        requested
-    }
-}
-
 /// Machine service implementation.
 pub struct MachineServiceImpl {
     runtime: SharedRuntime,
@@ -44,6 +34,7 @@ impl machine_service_server::MachineService for MachineServiceImpl {
         request: Request<CreateMachineRequest>,
     ) -> Result<Response<CreateMachineResponse>, Status> {
         let req = request.into_inner();
+        let runtime = self.runtime.ready()?;
 
         // Convert bytes to MB for internal config.
         let memory_mb = req.memory / (1024 * 1024);
@@ -51,7 +42,12 @@ impl machine_service_server::MachineService for MachineServiceImpl {
 
         let config = arcbox_core::machine::MachineConfig {
             name: req.name.clone(),
-            cpus: resolve_cpus(req.cpus),
+            // 0 on the wire means "use the daemon-configured default".
+            cpus: if req.cpus == 0 {
+                runtime.config().vm.effective_cpus()
+            } else {
+                req.cpus
+            },
             memory_mb,
             disk_gb,
             kernel: if req.kernel.is_empty() {
@@ -79,8 +75,7 @@ impl machine_service_server::MachineService for MachineServiceImpl {
             enable_rosetta: false,
         };
 
-        self.runtime
-            .ready()?
+        runtime
             .machine_manager()
             .create(config)
             .await
@@ -276,20 +271,5 @@ impl machine_service_server::MachineService for MachineServiceImpl {
     ) -> Result<Response<arcbox_protocol::v1::SshInfoResponse>, Status> {
         // TODO: Implement SSH info.
         Err(Status::unimplemented("ssh_info not implemented"))
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::resolve_cpus;
-
-    #[test]
-    fn resolve_cpus_zero_uses_daemon_default() {
-        assert_eq!(resolve_cpus(0), arcbox_core::default_vm_cpu_count());
-    }
-
-    #[test]
-    fn resolve_cpus_explicit_value_passes_through() {
-        assert_eq!(resolve_cpus(3), 3);
     }
 }

--- a/app/arcbox-api/src/grpc/machine.rs
+++ b/app/arcbox-api/src/grpc/machine.rs
@@ -14,6 +14,16 @@ use tonic::{Request, Response, Status};
 
 use super::{SharedRuntime, SharedRuntimeExt};
 
+/// Resolves a requested CPU count: `0` means "use the daemon default"
+/// (host core count).
+fn resolve_cpus(requested: u32) -> u32 {
+    if requested == 0 {
+        arcbox_core::default_vm_cpu_count()
+    } else {
+        requested
+    }
+}
+
 /// Machine service implementation.
 pub struct MachineServiceImpl {
     runtime: SharedRuntime,
@@ -41,7 +51,7 @@ impl machine_service_server::MachineService for MachineServiceImpl {
 
         let config = arcbox_core::machine::MachineConfig {
             name: req.name.clone(),
-            cpus: req.cpus,
+            cpus: resolve_cpus(req.cpus),
             memory_mb,
             disk_gb,
             kernel: if req.kernel.is_empty() {
@@ -266,5 +276,20 @@ impl machine_service_server::MachineService for MachineServiceImpl {
     ) -> Result<Response<arcbox_protocol::v1::SshInfoResponse>, Status> {
         // TODO: Implement SSH info.
         Err(Status::unimplemented("ssh_info not implemented"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::resolve_cpus;
+
+    #[test]
+    fn resolve_cpus_zero_uses_daemon_default() {
+        assert_eq!(resolve_cpus(0), arcbox_core::default_vm_cpu_count());
+    }
+
+    #[test]
+    fn resolve_cpus_explicit_value_passes_through() {
+        assert_eq!(resolve_cpus(3), 3);
     }
 }

--- a/app/arcbox-cli/src/commands/machine.rs
+++ b/app/arcbox-cli/src/commands/machine.rs
@@ -133,7 +133,7 @@ pub struct CreateArgs {
     /// Machine name
     pub name: String,
     /// Number of CPUs (default: host core count, decided by the daemon)
-    #[arg(long)]
+    #[arg(long, value_parser = clap::value_parser!(u32).range(1..))]
     pub cpus: Option<u32>,
     /// Memory in MB
     #[arg(long, default_value = "4096")]

--- a/app/arcbox-cli/src/commands/machine.rs
+++ b/app/arcbox-cli/src/commands/machine.rs
@@ -132,9 +132,9 @@ pub enum MachineCommands {
 pub struct CreateArgs {
     /// Machine name
     pub name: String,
-    /// Number of CPUs
-    #[arg(long, default_value = "4")]
-    pub cpus: u32,
+    /// Number of CPUs (default: host core count, decided by the daemon)
+    #[arg(long)]
+    pub cpus: Option<u32>,
     /// Memory in MB
     #[arg(long, default_value = "4096")]
     pub memory: u64,
@@ -265,7 +265,8 @@ async fn execute_create(args: CreateArgs) -> Result<()> {
     client
         .create(tonic::Request::new(CreateMachineRequest {
             name: args.name.clone(),
-            cpus: args.cpus,
+            // 0 = let the daemon apply its default (host core count).
+            cpus: args.cpus.unwrap_or(0),
             memory: args.memory.saturating_mul(1024_u64 * 1024),
             disk_size: args.disk.saturating_mul(1024_u64 * 1024 * 1024),
             distro: args.distro.clone().unwrap_or_default(),
@@ -280,7 +281,10 @@ async fn execute_create(args: CreateArgs) -> Result<()> {
         .context("Failed to create machine")?;
 
     println!("Machine '{}' created successfully", args.name);
-    println!("  CPUs:   {}", args.cpus);
+    match args.cpus {
+        Some(cpus) => println!("  CPUs:   {cpus}"),
+        None => println!("  CPUs:   default (host core count)"),
+    }
     println!("  Memory: {} MB", args.memory);
     println!("  Disk:   {} GB", args.disk);
     println!();

--- a/app/arcbox-core/src/config.rs
+++ b/app/arcbox-core/src/config.rs
@@ -176,6 +176,23 @@ pub struct VmDefaults {
     pub kernel_path: Option<PathBuf>,
 }
 
+impl VmDefaults {
+    /// Returns the effective CPU count, resolving `0` to the host core
+    /// count default.
+    ///
+    /// `0` means "use the default" both on the wire (gRPC
+    /// `CreateMachineRequest.cpus`) and in `config.toml`, so callers must
+    /// never propagate it into a VM configuration verbatim.
+    #[must_use]
+    pub fn effective_cpus(&self) -> u32 {
+        if self.cpus == 0 {
+            arcbox_hypervisor::default_vm_cpu_count()
+        } else {
+            self.cpus
+        }
+    }
+}
+
 impl Default for VmDefaults {
     fn default() -> Self {
         Self {
@@ -362,6 +379,27 @@ mod tests {
             config.container.guest_docker_vsock_port,
             DOCKER_API_VSOCK_PORT
         );
+    }
+
+    #[test]
+    fn test_effective_cpus_zero_resolves_to_default() {
+        let vm = VmDefaults {
+            cpus: 0,
+            ..VmDefaults::default()
+        };
+        assert_eq!(
+            vm.effective_cpus(),
+            arcbox_hypervisor::default_vm_cpu_count()
+        );
+    }
+
+    #[test]
+    fn test_effective_cpus_explicit_passes_through() {
+        let vm = VmDefaults {
+            cpus: 3,
+            ..VmDefaults::default()
+        };
+        assert_eq!(vm.effective_cpus(), 3);
     }
 
     #[test]

--- a/app/arcbox-core/src/config.rs
+++ b/app/arcbox-core/src/config.rs
@@ -13,7 +13,7 @@
 //! data_dir = "~/.arcbox"
 //!
 //! [vm]
-//! cpus = 4
+//! # cpus = 8         # default: host core count
 //! # memory_mb = 8192  # default: half of host RAM (512–16384)
 //!
 //! [machine]
@@ -168,7 +168,7 @@ impl Config {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default)]
 pub struct VmDefaults {
-    /// Default number of CPUs.
+    /// Default number of CPUs (default: host core count).
     pub cpus: u32,
     /// Default memory in MB.
     pub memory_mb: u64,
@@ -179,7 +179,7 @@ pub struct VmDefaults {
 impl Default for VmDefaults {
     fn default() -> Self {
         Self {
-            cpus: 4,
+            cpus: arcbox_hypervisor::default_vm_cpu_count(),
             memory_mb: arcbox_hypervisor::default_vm_memory_size() / (1024 * 1024),
             kernel_path: None,
         }
@@ -350,7 +350,7 @@ mod tests {
     #[test]
     fn test_default_config() {
         let config = Config::default();
-        assert_eq!(config.vm.cpus, 4);
+        assert_eq!(config.vm.cpus, arcbox_hypervisor::default_vm_cpu_count());
         // Default memory is half of host RAM, clamped to [512, 16384] MB.
         let expected_mb = arcbox_hypervisor::default_vm_memory_size() / (1024 * 1024);
         assert_eq!(config.vm.memory_mb, expected_mb);

--- a/app/arcbox-core/src/lib.rs
+++ b/app/arcbox-core/src/lib.rs
@@ -48,7 +48,6 @@ pub mod vm_lifecycle;
 pub mod workload;
 
 pub use agent_client::AgentClient;
-pub use arcbox_hypervisor::default_vm_cpu_count;
 pub use arcbox_vmm::VmBackend;
 pub use boot_assets::{
     BootAssetConfig, BootAssetManifest, BootAssetProvider, BootAssets, DownloadProgress,

--- a/app/arcbox-core/src/lib.rs
+++ b/app/arcbox-core/src/lib.rs
@@ -48,6 +48,7 @@ pub mod vm_lifecycle;
 pub mod workload;
 
 pub use agent_client::AgentClient;
+pub use arcbox_hypervisor::default_vm_cpu_count;
 pub use arcbox_vmm::VmBackend;
 pub use boot_assets::{
     BootAssetConfig, BootAssetManifest, BootAssetProvider, BootAssets, DownloadProgress,

--- a/app/arcbox-core/src/machine.rs
+++ b/app/arcbox-core/src/machine.rs
@@ -260,7 +260,7 @@ impl Default for MachineConfig {
     fn default() -> Self {
         Self {
             name: "default".to_string(),
-            cpus: 4,
+            cpus: arcbox_hypervisor::default_vm_cpu_count(),
             memory_mb: 4096,
             disk_gb: 50,
             kernel: None,
@@ -1006,7 +1006,7 @@ impl MachineManager {
             state: MachineState::Running,
             vm_id: VmId::new(), // Fake VM ID
             cid: Some(cid),
-            cpus: 4,
+            cpus: arcbox_hypervisor::default_vm_cpu_count(),
             memory_mb: 4096,
             disk_gb: 50,
             kernel: None,

--- a/app/arcbox-core/src/runtime.rs
+++ b/app/arcbox-core/src/runtime.rs
@@ -211,7 +211,7 @@ impl Runtime {
 
         // Propagate config.vm defaults into VM lifecycle so every entry
         // point (daemon, machine, diagnose, API server) uses the same values.
-        vm_lifecycle_config.default_vm.cpus = config.vm.cpus;
+        vm_lifecycle_config.default_vm.cpus = config.vm.effective_cpus();
         vm_lifecycle_config.default_vm.memory_mb = config.vm.memory_mb;
         if let Some(ref kernel) = config.vm.kernel_path {
             vm_lifecycle_config.default_vm.kernel = Some(kernel.clone());

--- a/app/arcbox-core/src/vm.rs
+++ b/app/arcbox-core/src/vm.rs
@@ -161,7 +161,7 @@ pub struct VmConfig {
 impl Default for VmConfig {
     fn default() -> Self {
         Self {
-            cpus: 4,
+            cpus: arcbox_hypervisor::default_vm_cpu_count(),
             memory_mb: 4096,
             kernel: None,
             cmdline: None,

--- a/app/arcbox-core/src/vm_lifecycle/mod.rs
+++ b/app/arcbox-core/src/vm_lifecycle/mod.rs
@@ -221,7 +221,7 @@ impl Default for VmLifecycleConfig {
 /// Default VM configuration.
 #[derive(Debug, Clone)]
 pub struct DefaultVmConfig {
-    /// Number of vCPUs (default: host cores / 2, min: 2).
+    /// Number of vCPUs (default: host core count).
     pub cpus: u32,
     /// Memory in MB (default: half of host RAM, clamped to 512–16384).
     pub memory_mb: u64,
@@ -237,10 +237,8 @@ pub struct DefaultVmConfig {
 
 impl Default for DefaultVmConfig {
     fn default() -> Self {
-        let host_cpus = std::thread::available_parallelism().map_or(4, |n| n.get() as u32);
-
         Self {
-            cpus: (host_cpus / 2).max(2),
+            cpus: arcbox_hypervisor::default_vm_cpu_count(),
             memory_mb: arcbox_hypervisor::default_vm_memory_size() / (1024 * 1024),
             disk_gb: 50,
             kernel: None,
@@ -1230,7 +1228,7 @@ mod tests {
     #[test]
     fn test_default_vm_config() {
         let config = DefaultVmConfig::default();
-        assert!(config.cpus >= 2);
+        assert_eq!(config.cpus, arcbox_hypervisor::default_vm_cpu_count());
         // Default memory is half of host RAM, clamped to [512, 16384] MB.
         let expected_mb = arcbox_hypervisor::default_vm_memory_size() / (1024 * 1024);
         assert_eq!(config.memory_mb, expected_mb);

--- a/app/arcbox-daemon/src/startup/mod.rs
+++ b/app/arcbox-daemon/src/startup/mod.rs
@@ -13,7 +13,7 @@ use std::sync::Arc;
 use anyhow::{Context, Result};
 use arcbox_api::{SetupPhase, SetupState};
 use arcbox_constants::paths::HostLayout;
-use arcbox_core::{Config, Runtime, VmLifecycleConfig};
+use arcbox_core::{Config, Runtime};
 use macos_resolver::to_env_prefix;
 use tokio_util::sync::CancellationToken;
 use tracing::info;
@@ -156,14 +156,10 @@ pub async fn init_runtime(ctx: &DaemonContext) -> Result<Arc<Runtime>> {
     }
     let selected_guest_docker_port = config.container.guest_docker_vsock_port;
 
-    let mut vm_lifecycle_config = VmLifecycleConfig::default();
-    vm_lifecycle_config.default_vm.cpus = config.vm.cpus;
-    vm_lifecycle_config.default_vm.memory_mb = config.vm.memory_mb;
-    if let Some(ref kernel) = config.vm.kernel_path {
-        vm_lifecycle_config.default_vm.kernel = Some(kernel.clone());
-    }
+    // The --kernel CLI flag wins over the config file; Runtime::new
+    // propagates config.vm.* into the VM lifecycle config.
     if let Some(ref kernel) = ctx.vm_args.kernel {
-        vm_lifecycle_config.default_vm.kernel = Some(kernel.clone());
+        config.vm.kernel_path = Some(kernel.clone());
     }
 
     // Seed boot assets from app bundle if available, otherwise download.
@@ -181,10 +177,7 @@ pub async fn init_runtime(ctx: &DaemonContext) -> Result<Arc<Runtime>> {
     ctx.setup_state
         .set_phase(SetupPhase::AssetsReady, "Boot assets ready");
 
-    let runtime = Arc::new(
-        Runtime::with_vm_lifecycle_config(config, vm_lifecycle_config)
-            .context("Failed to create runtime")?,
-    );
+    let runtime = Arc::new(Runtime::new(config).context("Failed to create runtime")?);
     runtime
         .init()
         .await

--- a/app/arcbox-daemon/src/startup/mod.rs
+++ b/app/arcbox-daemon/src/startup/mod.rs
@@ -16,7 +16,7 @@ use arcbox_constants::paths::HostLayout;
 use arcbox_core::{Config, Runtime};
 use macos_resolver::to_env_prefix;
 use tokio_util::sync::CancellationToken;
-use tracing::info;
+use tracing::{info, warn};
 
 use crate::DaemonArgs;
 use crate::context::{DaemonContext, EarlyContext, VmArgs};
@@ -147,10 +147,13 @@ pub async fn wait_for_resources(_ctx: &DaemonContext) -> Result<()> {
 /// can observe DOWNLOADING_ASSETS → ASSETS_READY progression.
 /// Returns the initialized runtime.
 pub async fn init_runtime(ctx: &DaemonContext) -> Result<Arc<Runtime>> {
-    let mut config = Config {
-        data_dir: ctx.layout.data_dir.clone(),
-        ..Default::default()
-    };
+    let mut config = Config::load().unwrap_or_else(|err| {
+        warn!(error = %err, "Failed to load config file; falling back to defaults");
+        Config::default()
+    });
+    // The daemon's layout (sockets, lock file) was already resolved from
+    // --data-dir, so it must win over any data_dir in the config file.
+    config.data_dir = ctx.layout.data_dir.clone();
     if let Some(port) = ctx.vm_args.guest_docker_vsock_port {
         config.container.guest_docker_vsock_port = port;
     }

--- a/rpc/arcbox-protocol/proto/machine.proto
+++ b/rpc/arcbox-protocol/proto/machine.proto
@@ -50,7 +50,7 @@ service MachineService {
 message CreateMachineRequest {
     // Machine name.
     string name = 1;
-    // Number of CPUs.
+    // Number of CPUs (0 = use the daemon default: host core count).
     uint32 cpus = 2;
     // Memory in bytes.
     uint64 memory = 3;

--- a/rpc/arcbox-protocol/proto/machine.proto
+++ b/rpc/arcbox-protocol/proto/machine.proto
@@ -50,7 +50,7 @@ service MachineService {
 message CreateMachineRequest {
     // Machine name.
     string name = 1;
-    // Number of CPUs (0 = use the daemon default: host core count).
+    // Number of CPUs (0 = use the daemon default).
     uint32 cpus = 2;
     // Memory in bytes.
     uint64 memory = 3;

--- a/rpc/arcbox-protocol/src/generated/arcbox.v1.rs
+++ b/rpc/arcbox-protocol/src/generated/arcbox.v1.rs
@@ -94,7 +94,7 @@ pub struct CreateMachineRequest {
     /// Machine name.
     #[prost(string, tag = "1")]
     pub name: ::prost::alloc::string::String,
-    /// Number of CPUs.
+    /// Number of CPUs (0 = use the daemon default: host core count).
     #[prost(uint32, tag = "2")]
     pub cpus: u32,
     /// Memory in bytes.

--- a/rpc/arcbox-protocol/src/generated/arcbox.v1.rs
+++ b/rpc/arcbox-protocol/src/generated/arcbox.v1.rs
@@ -94,7 +94,7 @@ pub struct CreateMachineRequest {
     /// Machine name.
     #[prost(string, tag = "1")]
     pub name: ::prost::alloc::string::String,
-    /// Number of CPUs (0 = use the daemon default: host core count).
+    /// Number of CPUs (0 = use the daemon default).
     #[prost(uint32, tag = "2")]
     pub cpus: u32,
     /// Memory in bytes.

--- a/virt/arcbox-hypervisor/src/config.rs
+++ b/virt/arcbox-hypervisor/src/config.rs
@@ -1,6 +1,6 @@
 //! VM configuration types.
 
-use crate::types::{CpuArch, default_vm_memory_size};
+use crate::types::{CpuArch, default_vm_cpu_count, default_vm_memory_size};
 
 /// Virtual machine configuration.
 #[derive(Debug, Clone)]
@@ -24,7 +24,7 @@ pub struct VmConfig {
 impl Default for VmConfig {
     fn default() -> Self {
         Self {
-            vcpu_count: 1,
+            vcpu_count: default_vm_cpu_count(),
             memory_size: default_vm_memory_size(),
             arch: CpuArch::native(),
             kernel_path: None,

--- a/virt/arcbox-hypervisor/src/lib.rs
+++ b/virt/arcbox-hypervisor/src/lib.rs
@@ -62,7 +62,7 @@ pub use traits::{GuestMemory, Hypervisor, Vcpu, VirtualMachine};
 pub use types::{
     Arm64Registers, BalloonStats, CpuArch, DeviceSnapshot, DirtyPageInfo, MemoryRegionSnapshot,
     PlatformCapabilities, Registers, VcpuExit, VcpuSnapshot, VirtioDeviceConfig, VirtioDeviceType,
-    VmSnapshot, default_vm_memory_size, host_memory_size,
+    VmSnapshot, default_vm_cpu_count, default_vm_memory_size, host_memory_size,
 };
 
 /// Creates the appropriate hypervisor for the current platform.

--- a/virt/arcbox-hypervisor/src/types.rs
+++ b/virt/arcbox-hypervisor/src/types.rs
@@ -161,6 +161,14 @@ pub fn default_vm_memory_size() -> u64 {
     size & !(MIB - 1)
 }
 
+/// Returns a sensible default VM vCPU count: the host's logical core count.
+///
+/// Falls back to 4 if host CPU detection fails.
+#[must_use]
+pub fn default_vm_cpu_count() -> u32 {
+    std::thread::available_parallelism().map_or(4, |n| n.get() as u32)
+}
+
 /// Emits a warning if `memory_size` exceeds 50% of host RAM.
 ///
 /// Shared by Darwin and KVM `validate_config()` to keep the threshold

--- a/virt/arcbox-hypervisor/src/types.rs
+++ b/virt/arcbox-hypervisor/src/types.rs
@@ -166,7 +166,7 @@ pub fn default_vm_memory_size() -> u64 {
 /// Falls back to 4 if host CPU detection fails.
 #[must_use]
 pub fn default_vm_cpu_count() -> u32 {
-    std::thread::available_parallelism().map_or(4, |n| n.get() as u32)
+    std::thread::available_parallelism().map_or(4, |n| u32::try_from(n.get()).unwrap_or(u32::MAX))
 }
 
 /// Emits a warning if `memory_size` exceeds 50% of host RAM.

--- a/virt/arcbox-vmm/src/builder.rs
+++ b/virt/arcbox-vmm/src/builder.rs
@@ -103,7 +103,7 @@ impl VmBuilder {
     pub fn new() -> Self {
         Self {
             name: "arcbox-vm".to_string(),
-            cpus: 1,
+            cpus: arcbox_hypervisor::default_vm_cpu_count(),
             memory_size: arcbox_hypervisor::default_vm_memory_size(),
             kernel_path: None,
             kernel_cmdline: String::new(),
@@ -451,7 +451,7 @@ mod tests {
     #[test]
     fn test_builder_defaults() {
         let builder = VmBuilder::new();
-        assert_eq!(builder.cpus, 1);
+        assert_eq!(builder.cpus, arcbox_hypervisor::default_vm_cpu_count());
         assert_eq!(
             builder.memory_size,
             arcbox_hypervisor::default_vm_memory_size()

--- a/virt/arcbox-vmm/src/vmm/mod.rs
+++ b/virt/arcbox-vmm/src/vmm/mod.rs
@@ -100,7 +100,7 @@ pub struct VmmConfig {
 impl Default for VmmConfig {
     fn default() -> Self {
         Self {
-            vcpu_count: 1,
+            vcpu_count: arcbox_hypervisor::default_vm_cpu_count(),
             memory_size: arcbox_hypervisor::default_vm_memory_size(),
             kernel_path: PathBuf::new(),
             kernel_cmdline: String::new(),


### PR DESCRIPTION
## Problem

The default vCPU-count plumbing was layered and partially broken:

- The effective production default was a hardcoded `cpus: 4` in `VmDefaults::default()`.
- A competing dynamic default `(host_cpus / 2).max(2)` in `DefaultVmConfig::default()` was dead code — unconditionally overwritten by `config.vm.cpus` in two duplicated propagation blocks (daemon startup and `Runtime::new`).
- The CLI hardcoded its own `--cpus` default of 4, and the gRPC create handler trusted `req.cpus` with no 0-guard: a `cpus=0` request from any non-CLI client created a machine that failed at boot with `vcpu_count must be > 0`.
- Further scattered `cpus: 4` / `vcpu_count: 1` Defaults existed in arcbox-core, arcbox-vmm, and arcbox-hypervisor, even though their memory fields already shared `default_vm_memory_size()`.

## Changes

1. **New helper** `default_vm_cpu_count()` in `arcbox-hypervisor` (next to `default_vm_memory_size()`): host logical core count, fallback 4. Re-exported from `arcbox-core`.
2. **Every Default uses it** — `VmDefaults`, `DefaultVmConfig`, `MachineConfig`, `VmConfig` (arcbox-core), plus `VmmConfig`/`VmBuilder`/`VmConfig` in the vmm/hypervisor layer.
3. **Single propagation point** — daemon startup no longer hand-builds `VmLifecycleConfig`; it folds the `--kernel` CLI override into `config.vm.kernel_path` (CLI wins over config file) and calls `Runtime::new`.
4. **Daemon-decided default for `arcbox machine create`** — `--cpus` is optional; omitted sends `0`, proto documents `0 = use daemon default`, handler resolves via `resolve_cpus()`. Fixes the `cpus=0` crash.
5. **Tests** — default-pinning assertions now check against the helper; new tests cover the 0-guard.

## Behavioral notes

- On next daemon startup, existing installs drift (`persisted.cpus = 4` ≠ host cores) and the default machine is recreated; `docker.img` is reattached so container data survives.
- Explicit `vm.cpus` in config.toml still wins everywhere.
- Out of scope: guest Firecracker sandbox defaults (`virt/arcbox-vm`, `guest/arcbox-agent` keep `vcpus: 1`), memory defaults.

## Verification

- `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings`: clean
- `cargo test` for arcbox-hypervisor, arcbox-vmm, arcbox-core, arcbox-daemon, arcbox-api, arcbox-cli: all pass
- Proto regeneration produced a comment-only diff in `arcbox.v1.rs`