### PR TITLE
fix: ship vmnet bridge NIC by default and keep route_installed in sync

### DIFF
--- a/app/arcbox-api/src/system.rs
+++ b/app/arcbox-api/src/system.rs
@@ -74,7 +74,7 @@ impl SetupState {
     }
 
     /// Returns the current status snapshot.
-    fn current(&self) -> SetupStatus {
+    pub fn current(&self) -> SetupStatus {
         self.tx.borrow().clone()
     }
 }

--- a/app/arcbox-core/src/event.rs
+++ b/app/arcbox-core/src/event.rs
@@ -17,6 +17,8 @@ pub enum Event {
     MachineIdle { name: String },
     /// Machine stopped.
     MachineStopped { name: String },
+    /// Container subnet route installed on the host for a machine's bridge NIC.
+    ContainerRouteInstalled { name: String },
 }
 
 /// Event bus for system-wide event distribution.

--- a/app/arcbox-core/src/vm_lifecycle/mod.rs
+++ b/app/arcbox-core/src/vm_lifecycle/mod.rs
@@ -707,11 +707,16 @@ impl VmLifecycleManager {
                     {
                         // vmnet path: bridge name is known instantly, only need
                         // helper retry (1-2 attempts for XPC readiness).
+                        let event_bus = self.event_bus.clone();
+                        let name = self.machine_name.clone();
                         drop(tokio::spawn(async move {
-                            if let Err(e) =
-                                crate::route_reconciler::ensure_route_for_bridge(&bridge).await
-                            {
-                                tracing::warn!(error = %e, "failed to install container route (vmnet)");
+                            match crate::route_reconciler::ensure_route_for_bridge(&bridge).await {
+                                Ok(()) => {
+                                    event_bus.publish(Event::ContainerRouteInstalled { name });
+                                }
+                                Err(e) => {
+                                    tracing::warn!(error = %e, "failed to install container route (vmnet)");
+                                }
                             }
                         }));
                     }
@@ -720,11 +725,16 @@ impl VmLifecycleManager {
                     if let Some(mac) = self.machine_manager.bridge_mac(&self.machine_name) {
                         // Non-vmnet path: scan kernel FDB to discover bridge
                         // (retries up to ~10s for FDB learning).
+                        let event_bus = self.event_bus.clone();
+                        let name = self.machine_name.clone();
                         drop(tokio::spawn(async move {
-                            if let Err(e) =
-                                crate::route_reconciler::ensure_route_with_retry(&mac).await
-                            {
-                                tracing::warn!(error = %e, "failed to install container route");
+                            match crate::route_reconciler::ensure_route_with_retry(&mac).await {
+                                Ok(()) => {
+                                    event_bus.publish(Event::ContainerRouteInstalled { name });
+                                }
+                                Err(e) => {
+                                    tracing::warn!(error = %e, "failed to install container route");
+                                }
                             }
                         }));
                     }

--- a/app/arcbox-daemon/Cargo.toml
+++ b/app/arcbox-daemon/Cargo.toml
@@ -44,7 +44,13 @@ macos-resolver = { workspace = true }
 libproc = { workspace = true }
 
 [features]
-default = ["gic"]
+# `vmnet` is on by default: the bridge NIC (NIC2) for host→container L3
+# routing only compiles behind it, and no build pipeline passes
+# `--features` — without it release daemons ship without container
+# routing, `route_installed` stays false, and the desktop app falls back
+# to localhost instead of *.arcbox.local domains. Failure to create the
+# vmnet interface at runtime (e.g. unsigned dev builds) is non-fatal.
+default = ["gic", "vmnet"]
 vmnet = ["arcbox-core/vmnet"]
 gic = ["arcbox-core/gic"]
 

--- a/app/arcbox-daemon/src/services.rs
+++ b/app/arcbox-daemon/src/services.rs
@@ -134,6 +134,17 @@ pub async fn start_services(
     // Kubernetes API proxy (TCP 127.0.0.1:16443 → guest vsock).
     let kubernetes_proxy = crate::kubernetes_proxy::start(Arc::clone(runtime)).await;
 
+    // Mirror route-install events into SetupStatus. VM (re)starts install
+    // the container route from vm_lifecycle, outside the cold-start
+    // recovery path that sets the flag directly — without this bridge,
+    // route_installed would stay stale until the next daemon restart.
+    let route_events = runtime.event_bus().subscribe();
+    let route_state = Arc::clone(&ctx.setup_state);
+    let route_shutdown = ctx.shutdown.clone();
+    drop(tokio::spawn(async move {
+        route_status_loop(route_events, route_state, route_shutdown).await;
+    }));
+
     Ok(ServiceHandles {
         dns,
         docker,
@@ -145,6 +156,38 @@ pub async fn start_services(
 // =============================================================================
 // Helpers
 // =============================================================================
+
+/// Mirrors VM lifecycle events into `SetupState.route_installed`.
+///
+/// `ContainerRouteInstalled` sets the flag; `MachineStopped` clears it
+/// (the bridge interface — and with it the host route — dies with the VM).
+async fn route_status_loop(
+    mut events: tokio::sync::broadcast::Receiver<arcbox_core::event::Event>,
+    setup_state: Arc<arcbox_api::SetupState>,
+    shutdown: tokio_util::sync::CancellationToken,
+) {
+    use arcbox_core::event::Event;
+    use tokio::sync::broadcast::error::RecvError;
+
+    loop {
+        tokio::select! {
+            () = shutdown.cancelled() => break,
+            event = events.recv() => match event {
+                Ok(Event::ContainerRouteInstalled { .. }) => {
+                    setup_state.set_route_installed(true);
+                }
+                Ok(Event::MachineStopped { .. }) => {
+                    setup_state.set_route_installed(false);
+                }
+                Ok(_) => {}
+                // Missed events under load; state converges on the next
+                // route-install or stop event.
+                Err(RecvError::Lagged(_)) => {}
+                Err(RecvError::Closed) => break,
+            },
+        }
+    }
+}
 
 fn register_host_dns(runtime: &Arc<Runtime>) {
     let network_cfg = &runtime.config().network;
@@ -180,5 +223,65 @@ fn first_address_in_subnet(subnet: &str) -> Option<Ipv4Addr> {
         None
     } else {
         Some(Ipv4Addr::from(first))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use arcbox_api::SetupState;
+    use arcbox_core::event::{Event, EventBus};
+
+    use super::*;
+
+    /// Polls until `route_installed` matches `want` or times out.
+    async fn wait_for_route_installed(state: &SetupState, want: bool) -> bool {
+        for _ in 0..200 {
+            if state.current().route_installed == want {
+                return true;
+            }
+            tokio::time::sleep(Duration::from_millis(5)).await;
+        }
+        false
+    }
+
+    #[tokio::test]
+    async fn route_status_loop_mirrors_events_into_setup_state() {
+        let bus = EventBus::new();
+        let setup_state = Arc::new(SetupState::new());
+        let shutdown = tokio_util::sync::CancellationToken::new();
+
+        let task = tokio::spawn(route_status_loop(
+            bus.subscribe(),
+            Arc::clone(&setup_state),
+            shutdown.clone(),
+        ));
+
+        assert!(!setup_state.current().route_installed);
+
+        bus.publish(Event::ContainerRouteInstalled {
+            name: "default".into(),
+        });
+        assert!(wait_for_route_installed(&setup_state, true).await);
+
+        // Unrelated events leave the flag untouched.
+        bus.publish(Event::MachineIdle {
+            name: "default".into(),
+        });
+        tokio::time::sleep(Duration::from_millis(20)).await;
+        assert!(setup_state.current().route_installed);
+
+        // The bridge dies with the VM, so MachineStopped clears the flag.
+        bus.publish(Event::MachineStopped {
+            name: "default".into(),
+        });
+        assert!(wait_for_route_installed(&setup_state, false).await);
+
+        shutdown.cancel();
+        tokio::time::timeout(Duration::from_secs(1), task)
+            .await
+            .expect("loop exits on shutdown")
+            .expect("loop task panicked");
     }
 }


### PR DESCRIPTION
## Problem

The desktop app never shows `*.arcbox.local` container domains — it always falls back to `localhost`. The app gates domain display on `SetupStatus.dns_resolver_installed && route_installed`, and `route_installed` is permanently `false` on released builds. Every daemon start logs:

```
WARN route install failed after all attempts: bridge not found in kernel FDB   (arcbox_core::route_reconciler)
WARN failed to install container route on cold start                          (arcbox_daemon::recovery)
```

## Root causes

**1. The `vmnet` feature was never enabled by any build pipeline.** `release.yml`, the Makefile, and CI all build with default features, and `vmnet` was not a default. The NIC2 vmnet bridge (`create_hv_bridge_nic`) only compiles behind `#[cfg(feature = "vmnet")]`, so released daemons have no bridge interface at all — bridge discovery scans the kernel FDB for an interface that cannot exist, and the container subnet route can never be installed. The `com.apple.vm.networking` entitlement was already present in `bundle/arcbox.entitlements`; only the feature flag was missing.

**2. `route_installed` was only set on the cold-start recovery path.** `vm_lifecycle` installs the route on every VM (re)start but never updated `SetupState`, so even with vmnet fixed, the flag would go stale across VM stop/start cycles.

## Changes

- `arcbox-daemon`: `default = ["gic"]` → `default = ["gic", "vmnet"]`. Runtime failure to create the vmnet interface (e.g. unsigned dev builds) stays non-fatal: VM boot continues without container routing.
- `arcbox-core`: `vm_lifecycle` publishes a new `Event::ContainerRouteInstalled` after a successful route install (both the vmnet and FDB-discovery paths).
- `arcbox-daemon`: `start_services` spawns a small loop mirroring lifecycle events into `SetupState` — `ContainerRouteInstalled` sets `route_installed`, `MachineStopped` clears it (the bridge interface, and with it the host route, dies with the VM). The cold-start recovery path keeps setting the flag directly.
- `arcbox-api`: `SetupState::current()` is now public (observability + tests).

## Verification

- `cargo clippy -p arcbox-daemon -p arcbox-core -p arcbox-api --all-targets -- -D warnings` clean
- `cargo fmt --check` clean
- `cargo test -p arcbox-daemon -p arcbox-api` passes, including a new test driving the event loop end to end (`route_status_loop_mirrors_events_into_setup_state`)
- `cargo tree -p arcbox-daemon -e features` confirms the `vmnet` cascade (daemon → core → vmm → net/vmnet)
- Caveat: final binary linking could not be verified on my machine (Xcode CLT SDK 14.4 lacks the macOS 15+ `hv_gic_*` symbols; master fails identically, pre-existing). CI's macos-26 runners are unaffected.

## Impact

Next release ships a daemon whose VMs get the NIC2 bridge; the 172.16.0.0/12 route installs, `route_installed` flips true, and the desktop app shows `*.arcbox.local` domains instead of `localhost`.

Note for reviewers: `route::add` replaces an existing conflicting route via RTM_CHANGE. On hosts whose LAN/VPN actually uses 172.16/12 (mine pushes such a route via the default gateway), installing the container route shadows that traffic — pre-existing behavior, but it becomes reachable once vmnet ships. Worth a follow-up (conflict detection or a narrower subnet).