### PR TITLE
fix(vsock): event-driven host-to-guest injection to eliminate 1-2s docker stalls

### DIFF
--- a/virt/arcbox-virtio-vsock/src/manager.rs
+++ b/virt/arcbox-virtio-vsock/src/manager.rs
@@ -15,9 +15,18 @@ use std::num::Wrapping;
 #[cfg(test)]
 use std::os::unix::io::FromRawFd;
 use std::os::unix::io::{AsRawFd, OwnedFd, RawFd};
+use std::sync::Arc;
 use std::sync::atomic::{AtomicU32, Ordering};
 
 use crate::VsockHostConnections;
+
+/// Wakeup hook invoked when host→guest RX work appears from outside the
+/// injection driver (new connection, handshake completion, credit grants).
+///
+/// The VMM installs a callback that wakes its vsock-io worker so injection
+/// runs immediately instead of waiting for the next natural vCPU exit —
+/// without it, an idle guest adds ~100 ms per host→guest leg.
+pub type VsockDoorbell = Arc<dyn Fn() + Send + Sync>;
 
 // ============================================================================
 // RxOps: Per-connection pending RX operation bitmask
@@ -304,6 +313,12 @@ pub struct VsockConnectionManager {
     pub backend_rxq: VecDeque<VsockConnectionId>,
     /// Monotonically increasing counter for ephemeral host port allocation.
     next_host_port: AtomicU32,
+    /// Rung when RX work appears from producer paths (allocate, handshake
+    /// completion, credit grants). NOT rung from the injection driver's own
+    /// enqueues (`enqueue_rw`/`enqueue_reset` and in-loop re-pushes) — the
+    /// driver is already awake there, and ringing on its re-pushes would
+    /// spin it while the guest catches up.
+    doorbell: Option<VsockDoorbell>,
 }
 
 impl VsockConnectionManager {
@@ -316,6 +331,18 @@ impl VsockConnectionManager {
             connections: HashMap::new(),
             backend_rxq: VecDeque::new(),
             next_host_port: AtomicU32::new(Self::EPHEMERAL_PORT_BASE),
+            doorbell: None,
+        }
+    }
+
+    /// Installs the doorbell rung when new host→guest RX work appears.
+    pub fn set_doorbell(&mut self, doorbell: VsockDoorbell) {
+        self.doorbell = Some(doorbell);
+    }
+
+    fn ring_doorbell(&self) {
+        if let Some(doorbell) = &self.doorbell {
+            doorbell();
         }
     }
 
@@ -351,6 +378,7 @@ impl VsockConnectionManager {
         self.connections.insert(id, conn);
         // Signal that this connection has a pending RX op (OP_REQUEST).
         self.backend_rxq.push_back(id);
+        self.ring_doorbell();
         tracing::info!(
             "VsockConnectionManager: allocated connection guest_port={} host_port={} — \
              OP_REQUEST enqueued",
@@ -461,6 +489,10 @@ impl VsockHostConnections for VsockConnectionManager {
         };
         if let Some(conn) = self.connections.get_mut(&id) {
             conn.connect = true;
+            // The daemon may already have written request data into the
+            // socketpair while the handshake was in flight; wake the
+            // injection driver so it starts watching this fd now.
+            self.ring_doorbell();
             tracing::info!("VsockConnectionManager: connection {:?} now Connected", id,);
         } else {
             tracing::warn!(
@@ -505,6 +537,7 @@ impl VsockHostConnections for VsockConnectionManager {
             conn.advance_fwd_cnt(bytes);
             if conn.rx_queue.pending() {
                 self.backend_rxq.push_back(id);
+                self.ring_doorbell();
                 return true;
             }
         }
@@ -519,6 +552,7 @@ impl VsockHostConnections for VsockConnectionManager {
         if let Some(conn) = self.connections.get_mut(&id) {
             conn.rx_queue.enqueue(RxOps::CREDIT_UPDATE);
             self.backend_rxq.push_back(id);
+            self.ring_doorbell();
         }
     }
 
@@ -892,6 +926,69 @@ mod tests {
         daemon_stream
             .write_all(b"still-alive")
             .expect("daemon→internal write should still succeed");
+    }
+
+    #[test]
+    fn doorbell_rings_on_producer_paths() {
+        use std::sync::atomic::AtomicUsize;
+
+        let rings = Arc::new(AtomicUsize::new(0));
+        let mut mgr = VsockConnectionManager::new();
+        let rings_cb = Arc::clone(&rings);
+        mgr.set_doorbell(Arc::new(move || {
+            rings_cb.fetch_add(1, Ordering::SeqCst);
+        }));
+
+        let (_, internal) = make_socketpair();
+        let (id, _rx) = mgr.allocate(1024, 3, internal);
+        assert_eq!(rings.load(Ordering::SeqCst), 1, "allocate rings");
+
+        mgr.mark_connected(id.guest_port, id.host_port);
+        assert_eq!(rings.load(Ordering::SeqCst), 2, "mark_connected rings");
+
+        mgr.enqueue_credit_update(id.guest_port, id.host_port);
+        assert_eq!(
+            rings.load(Ordering::SeqCst),
+            3,
+            "enqueue_credit_update rings"
+        );
+
+        // advance_fwd_cnt rings only when it actually enqueues RX work.
+        assert!(mgr.advance_fwd_cnt(id.guest_port, id.host_port, CREDIT_UPDATE_THRESHOLD));
+        assert_eq!(
+            rings.load(Ordering::SeqCst),
+            4,
+            "advance_fwd_cnt rings on push"
+        );
+    }
+
+    #[test]
+    fn doorbell_silent_on_injection_driver_paths() {
+        use std::sync::atomic::AtomicUsize;
+
+        let rings = Arc::new(AtomicUsize::new(0));
+        let mut mgr = VsockConnectionManager::new();
+
+        let (_, internal) = make_socketpair();
+        let (id, _rx) = mgr.allocate(1024, 3, internal);
+        // Drain the initial REQUEST so rx_queue is empty for the checks below.
+        mgr.get_mut(&id).unwrap().rx_queue.dequeue();
+
+        // Install the doorbell after allocate so only the calls below count.
+        let rings_cb = Arc::clone(&rings);
+        mgr.set_doorbell(Arc::new(move || {
+            rings_cb.fetch_add(1, Ordering::SeqCst);
+        }));
+
+        // Sub-threshold fwd_cnt advance enqueues nothing → no ring.
+        assert!(!mgr.advance_fwd_cnt(id.guest_port, id.host_port, 1));
+        assert_eq!(rings.load(Ordering::SeqCst), 0);
+
+        // Phase-1 enqueues come from the injection driver itself — it is
+        // already awake, so these must not self-wake it.
+        mgr.enqueue_rw(id);
+        mgr.enqueue_reset(id);
+        assert_eq!(rings.load(Ordering::SeqCst), 0);
     }
 
     #[test]

--- a/virt/arcbox-vmm/src/lib.rs
+++ b/virt/arcbox-vmm/src/lib.rs
@@ -77,6 +77,8 @@ pub mod snapshot;
 pub mod vcpu;
 pub(crate) mod virtqueue_util;
 pub mod vmm;
+#[cfg(target_os = "macos")]
+pub(crate) mod vsock_rx_worker;
 /// Back-compat re-export of `arcbox_virtio::vsock_manager`.
 ///
 /// The module moved to `arcbox-virtio` so that

--- a/virt/arcbox-vmm/src/vmm/darwin_hv/mod.rs
+++ b/virt/arcbox-vmm/src/vmm/darwin_hv/mod.rs
@@ -160,6 +160,36 @@ fn fdt_err(e: vm_fdt::Error) -> VmmError {
     VmmError::Memory(format!("FDT error: {e}"))
 }
 
+/// Builds a thread-safe closure that force-exits every registered vCPU out
+/// of `hv_vcpu_run`, used by io-worker threads (net-rx, vsock-io) to wake a
+/// guest that is idle in WFI for interrupt delivery.
+///
+/// On arm64 `hv_vcpus_exit` requires a concrete list of vCPU IDs; NULL/0 is
+/// a silent no-op. The registry is snapshotted on each invocation so
+/// late-arriving secondaries (PSCI CPU_ON) are picked up. Safe to call from
+/// any thread. See ABX-367.
+fn make_exit_vcpus_fn(ids: HvVcpuIds) -> Arc<dyn Fn() + Send + Sync> {
+    Arc::new(move || {
+        let ids_snapshot: Vec<u64> = ids
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .clone();
+        if ids_snapshot.is_empty() {
+            return;
+        }
+        // SAFETY: `ids_snapshot` is a live Vec owned by this closure for
+        // the duration of the FFI call; the pointer and length are
+        // consistent.
+        #[allow(clippy::cast_possible_truncation)]
+        let ret = unsafe {
+            arcbox_hv::ffi::hv_vcpus_exit(ids_snapshot.as_ptr(), ids_snapshot.len() as u32)
+        };
+        if let Err(e) = arcbox_hv::check(ret) {
+            tracing::warn!("exit_vcpus: hv_vcpus_exit failed: {e}");
+        }
+    })
+}
+
 impl Vmm {
     /// Duplicates a daemon-facing socketpair fd into a monotonically increasing
     /// descriptor range derived from the connection's host port.
@@ -1021,38 +1051,13 @@ impl Vmm {
                         }
                         Ok(())
                     });
-                // Force-exit all vCPUs closure used by the net-rx worker to
-                // wake a guest that is idle in WFI for interrupt delivery.
-                // On arm64 `hv_vcpus_exit` requires a concrete list of vCPU
-                // IDs; NULL/0 is a silent no-op. Snapshot `hv_vcpu_ids` each
-                // invocation so late-arriving secondaries (PSCI CPU_ON) are
-                // picked up. Safe to call from any thread. See ABX-367.
-                let exit_ids = self
-                    .hv_vcpu_ids
-                    .clone()
-                    .expect("hv_vcpu_ids asserted Some above");
-                let exit_fn: Arc<dyn Fn() + Send + Sync> = Arc::new(move || {
-                    let ids_snapshot: Vec<u64> = exit_ids
-                        .lock()
-                        .unwrap_or_else(std::sync::PoisonError::into_inner)
-                        .clone();
-                    if ids_snapshot.is_empty() {
-                        return;
-                    }
-                    // SAFETY: `ids_snapshot` is a live Vec owned by this
-                    // closure for the duration of the FFI call; the pointer
-                    // and length are consistent.
-                    #[allow(clippy::cast_possible_truncation)]
-                    let ret = unsafe {
-                        arcbox_hv::ffi::hv_vcpus_exit(
-                            ids_snapshot.as_ptr(),
-                            ids_snapshot.len() as u32,
-                        )
-                    };
-                    if let Err(e) = arcbox_hv::check(ret) {
-                        tracing::warn!("net-rx exit_fn: hv_vcpus_exit failed: {e}");
-                    }
-                });
+                // Force-exit closure used by the net-rx worker to wake a
+                // guest that is idle in WFI for interrupt delivery (ABX-367).
+                let exit_fn = make_exit_vcpus_fn(
+                    self.hv_vcpu_ids
+                        .clone()
+                        .expect("hv_vcpu_ids asserted Some above"),
+                );
                 dm.set_net_rx_hooks(net_irq_cb, exit_fn);
             }
 
@@ -1061,6 +1066,14 @@ impl Vmm {
 
         // Store a shared reference for connect_vsock_hv to use after start.
         self.hv_device_manager = Some(Arc::clone(&device_manager));
+
+        // --- vsock-io worker: event-driven host→guest injection ---
+        // Without it, packets enqueued by the daemon wait for the BSP's
+        // next natural VM exit (~100 ms on an idle guest). The doorbell
+        // pipe is rung by the connection manager on new RX work; the
+        // worker also watches every connected socketpair fd for data.
+        self.spawn_vsock_rx_worker(&device_manager)?;
+
         let running = self.running.clone();
         let paused = self.hv_paused.clone();
         // Ensure a fresh start always begins unpaused, even if a prior
@@ -1295,6 +1308,15 @@ impl Vmm {
             }
         }
 
+        // Join the vsock-io worker for the same reason: it injects into
+        // guest memory via the DeviceManager. It observes `running=false`
+        // within its kevent backstop timeout (10 ms).
+        if let Some(t) = self.hv_vsock_worker.take() {
+            if let Err(e) = t.join() {
+                tracing::warn!("vsock-io worker thread join failed: {e:?}");
+            }
+        }
+
         // Cleanup in correct order: DAX → GIC → VM → guest memory.
         //
         // DAX mappers must be drained first because `hv_vm_unmap` must be
@@ -1387,6 +1409,88 @@ impl Vmm {
         Ok(())
     }
 
+    /// Creates the vsock doorbell pipe, installs the ring callback into the
+    /// connection manager, and spawns the vsock-io worker thread.
+    ///
+    /// The worker owns host→guest vsock injection from here on; the vCPU
+    /// loop no longer polls vsock. Joined in `stop_darwin_hv` before guest
+    /// memory is released.
+    fn spawn_vsock_rx_worker(&mut self, device_manager: &Arc<DeviceManager>) -> Result<()> {
+        let mut pipe_fds: [libc::c_int; 2] = [0; 2];
+        // SAFETY: `pipe_fds` is a valid 2-element array; pipe writes two
+        // fds into it on success.
+        let ret = unsafe { libc::pipe(pipe_fds.as_mut_ptr()) };
+        if ret != 0 {
+            return Err(VmmError::Device(format!(
+                "vsock doorbell pipe failed: {}",
+                std::io::Error::last_os_error()
+            )));
+        }
+        // SAFETY: both fds are fresh from pipe above with sole ownership.
+        let doorbell_rd = unsafe { OwnedFd::from_raw_fd(pipe_fds[0]) };
+        // SAFETY: same as above for the write end.
+        let doorbell_wr = unsafe { OwnedFd::from_raw_fd(pipe_fds[1]) };
+
+        // Both ends non-blocking + cloexec. The write end must never block
+        // a producer (a full pipe already guarantees a pending wakeup); the
+        // worker drains the read end with a non-blocking loop.
+        for fd in [doorbell_rd.as_raw_fd(), doorbell_wr.as_raw_fd()] {
+            // SAFETY: `fd` is a live fd owned by the OwnedFds above.
+            let flags = unsafe { libc::fcntl(fd, libc::F_GETFL) };
+            // SAFETY: same fd; setting O_NONBLOCK is side-effect-only.
+            if flags == -1
+                || unsafe { libc::fcntl(fd, libc::F_SETFL, flags | libc::O_NONBLOCK) } == -1
+            {
+                return Err(VmmError::Device(format!(
+                    "vsock doorbell O_NONBLOCK failed: {}",
+                    std::io::Error::last_os_error()
+                )));
+            }
+            // SAFETY: same fd; FD_CLOEXEC is side-effect-only.
+            let fd_flags = unsafe { libc::fcntl(fd, libc::F_GETFD) };
+            if fd_flags != -1 {
+                // SAFETY: same fd as above.
+                let _ = unsafe { libc::fcntl(fd, libc::F_SETFD, fd_flags | libc::FD_CLOEXEC) };
+            }
+        }
+
+        let doorbell: crate::vsock_manager::VsockDoorbell = Arc::new(move || {
+            let byte = [1u8];
+            // SAFETY: the write end is owned by this closure and stays open
+            // for its lifetime. EAGAIN on a full pipe is fine — a wakeup is
+            // already pending.
+            let _ = unsafe {
+                libc::write(
+                    doorbell_wr.as_raw_fd(),
+                    byte.as_ptr().cast::<libc::c_void>(),
+                    1,
+                )
+            };
+        });
+        device_manager
+            .vsock_connections()
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .set_doorbell(doorbell);
+
+        let ctx = crate::vsock_rx_worker::VsockRxWorkerContext {
+            device_manager: Arc::clone(device_manager),
+            doorbell_rd,
+            running: self.running.clone(),
+            exit_vcpus: make_exit_vcpus_fn(
+                self.hv_vcpu_ids
+                    .clone()
+                    .expect("hv_vcpu_ids asserted Some above"),
+            ),
+        };
+        let handle = std::thread::Builder::new()
+            .name("vsock-io".to_string())
+            .spawn(move || crate::vsock_rx_worker::vsock_rx_worker_loop(ctx))
+            .map_err(|e| VmmError::Device(format!("spawn vsock-io worker: {e}")))?;
+        self.hv_vsock_worker = Some(handle);
+        Ok(())
+    }
+
     /// Connects to a vsock port on the guest VM (HV backend).
     ///
     /// Creates a Unix `SOCK_STREAM` socketpair; one end is returned to the
@@ -1395,10 +1499,10 @@ impl Vmm {
     /// between the socketpair and the guest's RX/TX queues.
     ///
     /// Returns immediately after allocating and enqueueing the connection —
-    /// OP_REQUEST injection into the guest RX queue is deferred to
-    /// `poll_vsock_rx` running on the vCPU thread. The returned fd is
-    /// usable right away; the guest responds with OP_RESPONSE or OP_RST
-    /// within one vCPU cycle of injection.
+    /// `allocate` rings the vsock-io worker's doorbell, which injects the
+    /// OP_REQUEST into the guest RX queue right away. The returned fd is
+    /// usable immediately; the guest responds with OP_RESPONSE or OP_RST
+    /// as soon as it services the interrupt.
     #[allow(clippy::unnecessary_wraps)]
     pub(super) fn connect_vsock_hv(&self, port: u32) -> Result<std::os::unix::io::RawFd> {
         // Create a Unix SOCK_STREAM socketpair for bidirectional data.
@@ -1521,9 +1625,9 @@ impl Vmm {
             host_fd.as_raw_fd(),
         );
 
-        // OP_REQUEST is in backend_rxq. The vCPU BSP thread's poll_vsock_rx
-        // will inject it and fire injected_notify. We do NOT block here —
-        // the daemon's ping().await handles the timing:
+        // OP_REQUEST is in backend_rxq and the vsock-io worker's doorbell
+        // has been rung; it injects and fires injected_notify. We do NOT
+        // block here — the daemon's ping().await handles the timing:
         // - If REQUEST not yet injected: ping timeout (2s) → retry
         // - If injected + RST: read returns EOF → retry
         // - If injected + RESPONSE: read returns data → success

--- a/virt/arcbox-vmm/src/vmm/darwin_hv/mod.rs
+++ b/virt/arcbox-vmm/src/vmm/darwin_hv/mod.rs
@@ -918,6 +918,13 @@ impl Vmm {
             ));
         }
 
+        // `running` gates every thread spawned below (vsock-io worker, vCPU
+        // loops, blk/net workers). The generic `Vmm::start` only stores it
+        // after this function returns, which is too late: a freshly spawned
+        // thread that checks the flag before then exits immediately.
+        self.running
+            .store(true, std::sync::atomic::Ordering::SeqCst);
+
         let mut device_manager = Arc::new(
             self.device_manager
                 .take()
@@ -1416,6 +1423,11 @@ impl Vmm {
     /// loop no longer polls vsock. Joined in `stop_darwin_hv` before guest
     /// memory is released.
     fn spawn_vsock_rx_worker(&mut self, device_manager: &Arc<DeviceManager>) -> Result<()> {
+        // Spawn once per VMM lifecycle; `stop_darwin_hv` joins and clears.
+        if self.hv_vsock_worker.is_some() {
+            return Ok(());
+        }
+
         let mut pipe_fds: [libc::c_int; 2] = [0; 2];
         // SAFETY: `pipe_fds` is a valid 2-element array; pipe writes two
         // fds into it on success.

--- a/virt/arcbox-vmm/src/vmm/darwin_hv/vcpu_loop.rs
+++ b/virt/arcbox-vmm/src/vmm/darwin_hv/vcpu_loop.rs
@@ -200,19 +200,12 @@ pub(super) fn vcpu_run_loop(vcpu_id: u32, entry_addr: u64, x0_value: u64, ctx: V
             break;
         }
 
-        // BSP (vCPU 0) handles all device polling to avoid lock contention.
-        if vcpu_id == 0 {
-            if device_manager.poll_vsock_rx() {
-                device_manager.raise_interrupt_for(
-                    crate::device::DeviceType::VirtioVsock,
-                    1, // INT_VRING
-                );
-            }
-            // poll_net_rx removed — handled by net-io worker thread.
-            if device_manager.poll_bridge_rx() {
-                if let Some(bid) = device_manager.bridge_device_id() {
-                    device_manager.raise_interrupt_for_device(bid, 1);
-                }
+        // BSP (vCPU 0) handles bridge polling to avoid lock contention.
+        // poll_net_rx removed — handled by net-io worker thread.
+        // poll_vsock_rx removed — handled by vsock-io worker thread.
+        if vcpu_id == 0 && device_manager.poll_bridge_rx() {
+            if let Some(bid) = device_manager.bridge_device_id() {
+                device_manager.raise_interrupt_for_device(bid, 1);
             }
         }
 
@@ -337,24 +330,13 @@ pub(super) fn vcpu_run_loop(vcpu_id: u32, entry_addr: u64, x0_value: u64, ctx: V
                 ..
             } => {
                 // Guest executed WFI — it is idle and waiting for an interrupt.
-                // Before parking, poll vsock host fds for incoming data.
-                // If data arrives, inject into RX queue and trigger interrupt
-                // so the guest wakes up to process it.
-                let wfi_has_vsock = device_manager.poll_vsock_rx();
-                if wfi_has_vsock {
-                    device_manager.raise_interrupt_for(crate::device::DeviceType::VirtioVsock, 1);
-                }
-
-                // poll_net_rx removed — handled by net-io worker thread.
-
+                // Before parking, poll the bridge for incoming data. vsock and
+                // net injection are handled by their dedicated worker threads.
                 let wfi_has_bridge = device_manager.poll_bridge_rx();
                 if wfi_has_bridge {
                     if let Some(bid) = device_manager.bridge_device_id() {
                         device_manager.raise_interrupt_for_device(bid, 1);
                     }
-                }
-
-                if wfi_has_vsock || wfi_has_bridge {
                     continue; // Re-enter run loop immediately.
                 }
                 // No pending data — park with timeout.

--- a/virt/arcbox-vmm/src/vmm/mod.rs
+++ b/virt/arcbox-vmm/src/vmm/mod.rs
@@ -291,6 +291,10 @@ pub struct Vmm {
     /// `hv_vm_unmap` on drop. Those must complete before `hv_vm_destroy`.
     #[cfg(target_os = "macos")]
     hv_device_manager: Option<std::sync::Arc<DeviceManager>>,
+    /// vsock-io worker thread handle (custom HV). Owns host→guest vsock
+    /// injection; joined in `stop_darwin_hv` before guest memory drops.
+    #[cfg(target_os = "macos")]
+    hv_vsock_worker: Option<std::thread::JoinHandle<()>>,
     /// HV-side network fd (NIC1). Paired with the NetworkDatapath fd.
     /// Kept alive so the socketpair stays open while the VM runs.
     #[cfg(target_os = "macos")]
@@ -462,6 +466,8 @@ impl Vmm {
             resolved_backend: None,
             #[cfg(target_os = "macos")]
             hv_device_manager: None,
+            #[cfg(target_os = "macos")]
+            hv_vsock_worker: None,
             #[cfg(target_os = "macos")]
             hv_net_fd: None,
             hv_bridge_net_fd: None,

--- a/virt/arcbox-vmm/src/vsock_rx_worker.rs
+++ b/virt/arcbox-vmm/src/vsock_rx_worker.rs
@@ -1,0 +1,185 @@
+//! Dedicated vsock-io worker thread for VirtIO-vsock RX injection.
+//!
+//! Decouples host→guest vsock delivery from the BSP vCPU run loop. The BSP
+//! previously drove `poll_vsock_rx` only when it took a VM exit; with an
+//! idle guest parked inside `hv_vcpu_run`, exits are ~100 ms apart, so every
+//! host→guest leg (OP_REQUEST, request data, credit grants) stalled for that
+//! long. Three sequential connects per proxied Docker request turned into a
+//! 0.5–1.5 s command stall.
+//!
+//! The worker blocks in `kevent` on two wakeup sources:
+//! - the doorbell pipe, rung by `VsockConnectionManager` when producer paths
+//!   enqueue RX work (new connection, handshake completion, credit grants);
+//! - readability of every connected socketpair fd (daemon→guest data).
+//!
+//! On wakeup it runs the existing injection path (`poll_vsock_rx`), raises
+//! `INT_VRING`, and force-exits vCPUs via `hv_vcpus_exit` so a WFI-idle
+//! guest services the interrupt immediately — the same delivery scheme the
+//! net-rx worker uses (ABX-367).
+
+use std::os::fd::{AsRawFd, OwnedFd, RawFd};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::Duration;
+
+use crate::device::{DeviceManager, DeviceType};
+
+/// kevent backstop timeout — bounds shutdown detection and recovers wakeups
+/// lost to connection-set races (snapshot vs. concurrent close).
+const BACKSTOP_TIMEOUT: Duration = Duration::from_millis(10);
+
+/// Backoff when fds are readable but injection made no progress (guest RX
+/// descriptors exhausted or peer credit depleted). Level-triggered kevent
+/// would otherwise return immediately and spin until the guest catches up.
+const NO_PROGRESS_BACKOFF: Duration = Duration::from_millis(1);
+
+/// VirtIO MMIO interrupt status bit for "used ring updated".
+const INT_VRING: u32 = 1;
+
+/// Resources for the vsock-io worker thread.
+pub struct VsockRxWorkerContext {
+    /// Device manager owning the vsock device and connection manager.
+    pub device_manager: Arc<DeviceManager>,
+    /// Non-blocking read end of the doorbell pipe.
+    pub doorbell_rd: OwnedFd,
+    /// VM shutdown flag.
+    pub running: Arc<AtomicBool>,
+    /// Force-exit all vCPUs from `hv_vcpu_run` (thread-safe).
+    pub exit_vcpus: Arc<dyn Fn() + Send + Sync>,
+}
+
+/// Main loop for the vsock-io worker thread.
+pub fn vsock_rx_worker_loop(ctx: VsockRxWorkerContext) {
+    // SAFETY: kqueue() takes no arguments and returns a new fd or -1.
+    let kq = unsafe { libc::kqueue() };
+    if kq < 0 {
+        tracing::error!(
+            "vsock-io: kqueue creation failed: {}",
+            std::io::Error::last_os_error()
+        );
+        return;
+    }
+
+    tracing::info!(
+        "vsock-io worker started (doorbell fd={})",
+        ctx.doorbell_rd.as_raw_fd()
+    );
+
+    let doorbell_fd = ctx.doorbell_rd.as_raw_fd();
+    let conns = ctx.device_manager.vsock_connections();
+
+    let timeout = libc::timespec {
+        tv_sec: 0,
+        #[allow(clippy::cast_possible_truncation)]
+        tv_nsec: BACKSTOP_TIMEOUT.as_nanos() as i64,
+    };
+
+    loop {
+        if !ctx.running.load(Ordering::Relaxed) {
+            break;
+        }
+
+        // Register the doorbell plus a snapshot of every connected fd.
+        // EV_ADD is an idempotent upsert and closed fds auto-deregister, so
+        // re-submitting the snapshot each iteration is self-healing against
+        // connection churn (including fd-number reuse).
+        let mut changes: Vec<libc::kevent> = Vec::with_capacity(8);
+        changes.push(read_event(doorbell_fd));
+        {
+            let snapshot = conns
+                .lock()
+                .map(|mgr| mgr.connected_fds())
+                .unwrap_or_default();
+            for (_, fd) in snapshot {
+                changes.push(read_event(fd));
+            }
+        }
+
+        // One syscall: submit registrations and wait for events. Stale fds
+        // in the changelist surface as EV_ERROR entries, not call failures.
+        let mut events: Vec<libc::kevent> = Vec::with_capacity(changes.len() + 8);
+        let nchanges =
+            libc::c_int::try_from(changes.len()).expect("change list bounded by open fd count");
+        let nevents =
+            libc::c_int::try_from(events.capacity()).expect("event list bounded by open fd count");
+        // SAFETY: `changes` and `events` are live Vecs; lengths passed match
+        // their allocated capacities; `timeout` outlives the call.
+        let nev = unsafe {
+            libc::kevent(
+                kq,
+                changes.as_ptr(),
+                nchanges,
+                events.as_mut_ptr(),
+                nevents,
+                &raw const timeout,
+            )
+        };
+        if nev < 0 {
+            let err = std::io::Error::last_os_error();
+            if err.kind() == std::io::ErrorKind::Interrupted {
+                continue;
+            }
+            tracing::error!("vsock-io: kevent wait failed: {err}");
+            break;
+        }
+        // SAFETY: kevent wrote `nev` initialized entries into `events`.
+        unsafe { events.set_len(nev as usize) };
+
+        if !ctx.running.load(Ordering::Relaxed) {
+            break;
+        }
+
+        // Classify events: drain the doorbell, note real fd readability.
+        let mut had_fd_data = false;
+        for ev in &events {
+            if ev.flags & libc::EV_ERROR != 0 {
+                continue; // Stale fd from a racing close — snapshot heals.
+            }
+            if ev.ident == doorbell_fd as usize {
+                drain_doorbell(doorbell_fd);
+            } else {
+                had_fd_data = true;
+            }
+        }
+
+        let injected = ctx.device_manager.poll_vsock_rx();
+        if injected {
+            ctx.device_manager
+                .raise_interrupt_for(DeviceType::VirtioVsock, INT_VRING);
+            (ctx.exit_vcpus)();
+        } else if had_fd_data {
+            // Data is buffered but the guest must free descriptors or grant
+            // credit first; back off so level-triggered kevent doesn't spin.
+            std::thread::sleep(NO_PROGRESS_BACKOFF);
+        }
+    }
+
+    // SAFETY: `kq` is a live fd owned exclusively by this function.
+    unsafe { libc::close(kq) };
+    tracing::info!("vsock-io worker stopped");
+}
+
+/// Builds an `EV_ADD` read-filter registration for `fd`.
+fn read_event(fd: RawFd) -> libc::kevent {
+    libc::kevent {
+        ident: fd as usize,
+        filter: libc::EVFILT_READ,
+        flags: libc::EV_ADD | libc::EV_ENABLE,
+        fflags: 0,
+        data: 0,
+        udata: std::ptr::null_mut(),
+    }
+}
+
+/// Drains all pending doorbell bytes (non-blocking read until EAGAIN).
+fn drain_doorbell(fd: RawFd) {
+    let mut buf = [0u8; 64];
+    loop {
+        // SAFETY: `fd` is the worker-owned non-blocking doorbell read end;
+        // `buf` is a valid mutable buffer of the stated length.
+        let n = unsafe { libc::read(fd, buf.as_mut_ptr().cast::<libc::c_void>(), buf.len()) };
+        if n <= 0 {
+            break;
+        }
+    }
+}


### PR DESCRIPTION
## Problem

Every docker command (`pull`, `image ls`, even `/_ping`) stalled 0.5–1.5s before doing anything, worst after the guest had been idle a few seconds.

## Root cause

Host→guest vsock delivery on the custom HV backend was poll-driven: `poll_vsock_rx` ran only when the BSP vCPU took a VM exit. An idle guest parked inside `hv_vcpu_run()` exits ~100ms apart (vtimer/NOHZ), so every host→guest leg — OP_REQUEST, request data, credit grants — stalled 90–150ms. Each proxied docker request pays ~3 sequential vsock connects (agent RPC, readiness probe, proxy connect) and the docker CLI sends ping + the actual request, multiplying the per-leg stall into seconds.

## Fix

Mirror the net-rx worker scheme (ABX-367):

- **`VsockConnectionManager` doorbell** — producer paths that enqueue host→guest work (new connection, handshake completion, credit grants) ring a callback. Injection-driver paths stay silent to avoid self-wake spins.
- **Dedicated `vsock-io` worker thread** — blocks in `kevent` on the doorbell pipe plus every connected socketpair fd; on wakeup runs the existing injection path (`poll_vsock_rx`), raises `INT_VRING`, and force-exits vCPUs via `hv_vcpus_exit` so a WFI-idle guest services the interrupt immediately. EV_ADD upsert per iteration self-heals against connection churn; 10ms backstop bounds shutdown; 1ms backoff prevents level-triggered spin when the guest lacks descriptors/credit.
- **BSP vCPU loop no longer polls vsock**; guest→host TX remains inline on QUEUE_NOTIFY exits (already fast). Worker and MMIO TX serialize on the existing device mutex.
- **`running` flag ordering fix** — `Vmm::start` stored it only after `start_darwin_hv` returned, so threads spawned inside (including the new worker) could observe `false` and exit immediately.

## Measurements

Isolated daemon instance, same binary, Apple Silicon:

| Operation | Before | After |
|---|---|---|
| `/_ping` (rapid) | 250–760ms | 2–19ms |
| `/_ping` (after 8s idle) | ~590ms | 5–11ms |
| `docker image ls` (after idle) | 1.62s | 38ms |
| `docker version` | ~1s | 47ms |

`docker pull alpine` (network-bound, no stall) and `docker run --rm alpine echo` (620ms end-to-end) verified — sustained streaming and credit updates healthy through the worker. Clean worker join confirmed on the orderly stop path.

## Notes

- Pre-existing, not addressed here: on SIGTERM the HV backend always takes `force_stop_without_hypervisor` (graceful stop is VZ-only — "no DarwinVm"), which drops the Vmm without joining vCPU/worker threads (`hv_vm_destroy` → "resource is busy"). Harmless today since the process exits immediately after, but the HV backend deserves its own orderly stop path.
- Smaller follow-up wins not in scope: cache guest readiness instead of per-request agent RPC + probe, answer `/_ping` natively, pool connections to guest dockerd.