### PR TITLE
perf(boot): cut host-side warm-boot overhead

### DIFF
--- a/app/arcbox-core/src/agent_client.rs
+++ b/app/arcbox-core/src/agent_client.rs
@@ -12,8 +12,8 @@ use arcbox_protocol::agent::{
     KubernetesKubeconfigRequest, KubernetesKubeconfigResponse, KubernetesStartRequest,
     KubernetesStartResponse, KubernetesStatusRequest, KubernetesStatusResponse,
     KubernetesStopRequest, KubernetesStopResponse, MmapReadFileRequest, MmapReadFileResponse,
-    PingRequest, PingResponse, RuntimeEnsureRequest, RuntimeEnsureResponse, RuntimeStatusRequest,
-    RuntimeStatusResponse, SystemInfo,
+    PingRequest, PingResponse, ReadinessEvent, RuntimeEnsureRequest, RuntimeEnsureResponse,
+    RuntimeStatusRequest, RuntimeStatusResponse, SystemInfo, WatchReadinessRequest,
 };
 use arcbox_protocol::sandbox_v1::{
     CheckpointRequest, CheckpointResponse, CreateSandboxRequest, CreateSandboxResponse,
@@ -525,6 +525,131 @@ impl AgentClient {
 
         RuntimeStatusResponse::decode(&resp_payload[..])
             .map_err(|e| CoreError::Machine(format!("failed to decode response: {e}")))
+    }
+
+    /// Watches guest readiness until the agent reports a terminal state.
+    ///
+    /// Unlike the older host-side poll loop, this is one request on one
+    /// connection. The guest publishes readiness transitions as soon as it
+    /// observes them, which removes host retry overshoot from warm boot.
+    pub async fn watch_readiness(
+        mut self,
+        start_runtime_if_needed: bool,
+        timeout: Duration,
+    ) -> Result<ReadinessEvent> {
+        if !self.connected {
+            self.connect().await?;
+        }
+
+        let req = WatchReadinessRequest {
+            start_runtime_if_needed,
+            timeout_ms: u32::try_from(timeout.as_millis()).unwrap_or(u32::MAX),
+        };
+        let payload = req.encode_to_vec();
+        let buf = Self::build_message(MessageType::WatchReadinessRequest, "", &payload);
+
+        match &mut self.transport {
+            AgentTransport::Async(t) => {
+                t.send(buf).await.map_err(|e| {
+                    CoreError::Machine(format!("failed to send readiness watch request: {e}"))
+                })?;
+
+                let deadline = tokio::time::Instant::now() + timeout;
+                loop {
+                    let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+                    if remaining.is_zero() {
+                        return Err(CoreError::Machine(
+                            "timeout waiting for guest readiness event".to_string(),
+                        ));
+                    }
+
+                    let raw = tokio::time::timeout(remaining, t.recv())
+                        .await
+                        .map_err(|_| {
+                            CoreError::Machine(
+                                "timeout waiting for guest readiness event".to_string(),
+                            )
+                        })?
+                        .map_err(|e| {
+                            CoreError::Machine(format!("failed to receive readiness event: {e}"))
+                        })?;
+
+                    let event = Self::decode_readiness_event(&raw)?;
+                    if readiness_event_is_terminal(&event) || !start_runtime_if_needed {
+                        return Ok(event);
+                    }
+                }
+            }
+            AgentTransport::Blocking(t) => tokio::task::block_in_place(|| {
+                let deadline = Instant::now() + timeout;
+                t.send(&buf, deadline).map_err(|e| {
+                    CoreError::Machine(format!("failed to send readiness watch request: {e}"))
+                })?;
+
+                loop {
+                    let raw = t.recv(deadline).map_err(|e| {
+                        CoreError::Machine(format!("failed to receive readiness event: {e}"))
+                    })?;
+                    let event = Self::decode_readiness_event(&raw)?;
+                    if readiness_event_is_terminal(&event) || !start_runtime_if_needed {
+                        return Ok(event);
+                    }
+                }
+            }),
+        }
+    }
+
+    /// Blocking readiness watch for the macOS HV socketpair transport.
+    ///
+    /// This is used from startup's blocking probe thread so HV readiness does
+    /// not touch tokio's kqueue reactor while the guest is still booting.
+    pub fn watch_readiness_blocking(
+        mut self,
+        start_runtime_if_needed: bool,
+        timeout: Duration,
+    ) -> Result<ReadinessEvent> {
+        let req = WatchReadinessRequest {
+            start_runtime_if_needed,
+            timeout_ms: u32::try_from(timeout.as_millis()).unwrap_or(u32::MAX),
+        };
+        let payload = req.encode_to_vec();
+        let buf = Self::build_message(MessageType::WatchReadinessRequest, "", &payload);
+
+        let AgentTransport::Blocking(t) = &mut self.transport else {
+            return Err(CoreError::Machine(
+                "blocking readiness watch called on async transport".to_string(),
+            ));
+        };
+
+        let deadline = Instant::now() + timeout;
+        t.send(&buf, deadline).map_err(|e| {
+            CoreError::Machine(format!("failed to send readiness watch request: {e}"))
+        })?;
+
+        loop {
+            let raw = t.recv(deadline).map_err(|e| {
+                CoreError::Machine(format!("failed to receive readiness event: {e}"))
+            })?;
+            let event = Self::decode_readiness_event(&raw)?;
+            if readiness_event_is_terminal(&event) || !start_runtime_if_needed {
+                return Ok(event);
+            }
+        }
+    }
+
+    fn decode_readiness_event(raw: &[u8]) -> Result<ReadinessEvent> {
+        let (resp_type, _, resp_payload) = Self::parse_response(raw)?;
+        if resp_type == MessageType::Error as u32 {
+            let error_msg = parse_error_response(&resp_payload)?;
+            return Err(CoreError::Machine(error_msg));
+        }
+        if resp_type != MessageType::ReadinessEvent as u32 {
+            return Err(CoreError::Machine(format!(
+                "unexpected readiness response type: 0x{resp_type:04x}"
+            )));
+        }
+        ReadinessEvent::decode(&resp_payload[..])
+            .map_err(|e| CoreError::Machine(format!("failed to decode readiness event: {e}")))
     }
 
     /// Starts the native Kubernetes cluster in the guest VM.
@@ -1144,6 +1269,15 @@ fn parse_error_response(payload: &[u8]) -> Result<String> {
 
     String::from_utf8(payload[ERROR_HEADER_SIZE..ERROR_HEADER_SIZE + msg_len].to_vec())
         .map_err(|_| CoreError::Machine("invalid error message encoding".to_string()))
+}
+
+fn readiness_event_is_terminal(event: &ReadinessEvent) -> bool {
+    use arcbox_protocol::agent::readiness_event::Kind;
+
+    matches!(
+        Kind::try_from(event.kind),
+        Ok(Kind::RuntimeReady | Kind::RuntimeFailed)
+    )
 }
 
 #[cfg(test)]

--- a/app/arcbox-core/src/container_backend/guest_docker.rs
+++ b/app/arcbox-core/src/container_backend/guest_docker.rs
@@ -3,9 +3,10 @@ use crate::config::ContainerRuntimeConfig;
 use crate::error::{CoreError, Result};
 use crate::machine::MachineManager;
 use crate::vm_lifecycle::VmLifecycleManager;
+use arcbox_protocol::agent::readiness_event::Kind;
 use async_trait::async_trait;
 use std::sync::Arc;
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
 /// Guest Docker backend (dockerd/containerd/runc inside VM).
 pub struct GuestDockerBackend {
@@ -32,80 +33,23 @@ impl GuestDockerBackend {
     }
 
     async fn wait_guest_endpoint_ready(&self) -> Result<()> {
-        // Each attempt is a handful of ~1ms vsock RPCs, so the backoff cap
-        // (which bounds how late we notice dockerd became ready) matters
-        // far more than the per-attempt cost. dockerd typically comes up a
-        // few hundred ms after the agent; with the old 120→1200ms backoff
-        // the discovery overshoot alone averaged ~200ms per cold boot.
-        const INITIAL_DELAY_MS: u64 = 25;
-        const MAX_DELAY_MS: u64 = 250;
-
         let port = self.config.guest_docker_vsock_port;
         let timeout = Duration::from_millis(self.config.startup_timeout_ms);
-        let deadline = Instant::now() + timeout;
-        let mut delay_ms = INITIAL_DELAY_MS;
-        let mut last_status_detail: Option<String> = None;
+        let agent = self.machine_manager.connect_agent(self.machine_name)?;
 
-        loop {
-            let mut docker_ready = false;
-
-            if let Ok(mut agent) = self.machine_manager.connect_agent(self.machine_name) {
-                match agent.ensure_runtime(true).await {
-                    Ok(resp) => {
-                        last_status_detail = Some(resp.message.clone());
-                        if resp.ready {
-                            validate_reported_vsock_endpoint(&resp.endpoint, port)?;
-                            docker_ready = true;
-                        }
-                        tracing::debug!(
-                            ready = resp.ready,
-                            endpoint = resp.endpoint,
-                            message = resp.message,
-                            status = resp.status,
-                            "requested guest runtime ensure"
-                        );
-                    }
-                    Err(e) => {
-                        tracing::trace!("failed to request guest runtime ensure: {}", e);
-                    }
-                }
-
-                if !docker_ready {
-                    match agent.get_runtime_status().await {
-                        Ok(status) => {
-                            last_status_detail = Some(status.detail.clone());
-                            if status.docker_ready {
-                                validate_reported_vsock_endpoint(&status.endpoint, port)?;
-                                docker_ready = true;
-                            }
-                        }
-                        Err(e) => {
-                            tracing::trace!("failed to get guest runtime status: {}", e);
-                        }
-                    }
-                }
-            }
-
-            if docker_ready {
+        match agent.watch_readiness(true, timeout).await {
+            Ok(event) if Kind::try_from(event.kind) == Ok(Kind::RuntimeReady) => {
+                validate_reported_vsock_endpoint(&event.endpoint, port)?;
                 tracing::debug!(port, "guest docker runtime is ready");
-                return Ok(());
-            } else if Instant::now() >= deadline {
-                return Err(CoreError::Machine(format!(
-                    "guest docker endpoint on vsock port {} not ready within {}ms: {}",
-                    port,
-                    self.config.startup_timeout_ms,
-                    last_status_detail.unwrap_or_else(|| "runtime status unavailable".to_string())
-                )));
-            } else {
-                tracing::trace!(
-                    port,
-                    retry_delay_ms = delay_ms,
-                    "guest runtime not ready yet"
-                );
+                Ok(())
             }
-
-            tokio::time::sleep(Duration::from_millis(delay_ms)).await;
-            delay_ms = (delay_ms * 3 / 2).min(MAX_DELAY_MS);
+            Ok(event) => Err(CoreError::Machine(format!(
+                "guest docker endpoint on vsock port {} not ready within {}ms: {}",
+                port, self.config.startup_timeout_ms, event.detail
+            ))),
+            Err(e) => Err(CoreError::Machine(format!(
+                "guest readiness watch failed: {e}"
+            ))),
         }
     }
 }

--- a/app/arcbox-core/src/container_backend/guest_docker.rs
+++ b/app/arcbox-core/src/container_backend/guest_docker.rs
@@ -32,8 +32,13 @@ impl GuestDockerBackend {
     }
 
     async fn wait_guest_endpoint_ready(&self) -> Result<()> {
-        const INITIAL_DELAY_MS: u64 = 120;
-        const MAX_DELAY_MS: u64 = 1200;
+        // Each attempt is a handful of ~1ms vsock RPCs, so the backoff cap
+        // (which bounds how late we notice dockerd became ready) matters
+        // far more than the per-attempt cost. dockerd typically comes up a
+        // few hundred ms after the agent; with the old 120→1200ms backoff
+        // the discovery overshoot alone averaged ~200ms per cold boot.
+        const INITIAL_DELAY_MS: u64 = 25;
+        const MAX_DELAY_MS: u64 = 250;
 
         let port = self.config.guest_docker_vsock_port;
         let timeout = Duration::from_millis(self.config.startup_timeout_ms);

--- a/app/arcbox-core/src/machine.rs
+++ b/app/arcbox-core/src/machine.rs
@@ -534,22 +534,28 @@ impl MachineManager {
     /// stalls from rapid socketpair fd teardown (same rationale as
     /// `wait_for_agent` in `vm_lifecycle`).
     async fn wait_for_machine_ready(&self, name: &str) -> Result<()> {
-        const MAX_ATTEMPTS: u32 = 20;
-        const INITIAL_DELAY_MS: u64 = 500;
-        const MAX_DELAY_MS: u64 = 3000;
+        const PROBE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(60);
+        const INITIAL_DELAY_MS: u64 = 50;
+        const MAX_DELAY_MS: u64 = 500;
 
         tracing::info!("Waiting for machine '{}' agent to become ready...", name);
 
         // block_in_place is used here (instead of spawn_blocking) because
         // MachineManager is not Clone/Arc at this call site. block_in_place
-        // is acceptable: the total blocking time is bounded by
-        // MAX_ATTEMPTS * MAX_DELAY_MS ≈ 60s, and the blocking RPC uses
+        // is acceptable: the total blocking time is bounded by PROBE_TIMEOUT
+        // (plus one backoff interval), and the blocking RPC uses
         // BlockingVsockTransport (libc::poll) — no tokio reactor interaction.
+        //
+        // Probe before the first sleep: failed probes are ~1ms (vsock RST
+        // via the event-driven RX path), while sleeping first puts a full
+        // backoff interval on every start even when the agent is already up.
         let probe_result: Result<String> = tokio::task::block_in_place(|| {
+            let deadline = std::time::Instant::now() + PROBE_TIMEOUT;
             let mut delay_ms = INITIAL_DELAY_MS;
+            let mut attempt: u32 = 0;
 
-            for attempt in 1..=MAX_ATTEMPTS {
-                std::thread::sleep(std::time::Duration::from_millis(delay_ms));
+            loop {
+                attempt += 1;
 
                 match self.connect_agent(name) {
                     Ok(mut agent) if agent.is_blocking() => match agent.ping_blocking() {
@@ -596,12 +602,14 @@ impl MachineManager {
                     ),
                 }
 
+                if std::time::Instant::now() >= deadline {
+                    return Err(CoreError::Machine(format!(
+                        "Machine '{name}' agent did not report a routable IP within timeout"
+                    )));
+                }
+                std::thread::sleep(std::time::Duration::from_millis(delay_ms));
                 delay_ms = (delay_ms * 3 / 2).min(MAX_DELAY_MS);
             }
-
-            Err(CoreError::Machine(format!(
-                "Machine '{name}' agent did not report a routable IP within timeout"
-            )))
         });
 
         let ip = probe_result?;

--- a/app/arcbox-core/src/vm_lifecycle/mod.rs
+++ b/app/arcbox-core/src/vm_lifecycle/mod.rs
@@ -906,6 +906,11 @@ impl VmLifecycleManager {
     async fn wait_for_agent(&self, timeout: Duration) -> Result<()> {
         tracing::debug!("Waiting for agent to become ready...");
 
+        enum AgentProbe {
+            Ready,
+            Watch(crate::agent_client::AgentClient),
+        }
+
         let mm = Arc::clone(&self.machine_manager);
         let machine_name = self.machine_name.clone();
 
@@ -932,13 +937,24 @@ impl VmLifecycleManager {
                     }
                 }
 
-                // connect_agent → AF_UNIX detected → BlockingVsockTransport.
-                // ping_blocking uses libc::poll with 5s deadline — no tokio.
+                // connect_agent discovers when the guest starts listening on
+                // the agent vsock port. After connection succeeds, use the
+                // agent's readiness event stream. The daemon and guest agent
+                // are bundle-locked, so a readiness-watch failure is a startup
+                // protocol error rather than a compatibility fallback signal.
+                // HV's AF_UNIX transport stays on this blocking thread; async
+                // transports are handed back to tokio below.
                 match mm.connect_agent(&machine_name) {
-                    Ok(mut agent) => match agent.ping_blocking() {
-                        Ok(_) => return Ok(()),
-                        Err(e) => tracing::debug!("Agent ping failed: {e}"),
-                    },
+                    Ok(agent) if agent.is_blocking() => {
+                        let remaining =
+                            deadline.saturating_duration_since(std::time::Instant::now());
+                        if remaining.is_zero() {
+                            return Err(CoreError::Vm("timeout waiting for agent".to_string()));
+                        }
+                        agent.watch_readiness_blocking(false, remaining)?;
+                        return Ok(AgentProbe::Ready);
+                    }
+                    Ok(agent) => return Ok(AgentProbe::Watch(agent)),
                     Err(e) => tracing::debug!("Agent connection failed: {e}"),
                 }
 
@@ -950,7 +966,12 @@ impl VmLifecycleManager {
         .await
         .map_err(|e| CoreError::Vm(format!("probe task panicked: {e}")))?;
 
-        probe_result?;
+        match probe_result? {
+            AgentProbe::Ready => {}
+            AgentProbe::Watch(agent) => {
+                agent.watch_readiness(false, timeout).await?;
+            }
+        }
 
         // Back on async context — do async follow-up work.
         tracing::info!("Agent is ready");

--- a/app/arcbox-core/src/vm_lifecycle/mod.rs
+++ b/app/arcbox-core/src/vm_lifecycle/mod.rs
@@ -917,7 +917,10 @@ impl VmLifecycleManager {
         // probe from the async runtime entirely.
         let probe_result = tokio::task::spawn_blocking(move || {
             let deadline = std::time::Instant::now() + timeout;
-            let poll_interval = Duration::from_millis(100);
+            // Failed probes are ~1ms (vsock RST via the event-driven RX
+            // path), so a tight interval costs little and bounds the
+            // discovery overshoot once the agent starts listening.
+            let poll_interval = Duration::from_millis(25);
 
             while std::time::Instant::now() < deadline {
                 // Console output (best-effort, non-blocking).

--- a/app/arcbox-daemon/src/startup/lock.rs
+++ b/app/arcbox-daemon/src/startup/lock.rs
@@ -14,6 +14,7 @@ use super::cleanup::{is_arcbox_daemon, terminate_stale_daemon};
 /// stores the current PID for diagnostics and signalling.
 pub struct DaemonLock {
     _file: std::fs::File,
+    displaced_stale: bool,
 }
 
 impl DaemonLock {
@@ -36,7 +37,8 @@ impl DaemonLock {
             .context("Failed to open daemon lock")?;
 
         // Try non-blocking lock first.
-        if try_flock_exclusive(&file) {
+        let displaced_stale = !try_flock_exclusive(&file);
+        if !displaced_stale {
             // No stale daemon — we got the lock immediately.
             info!("Daemon lock acquired (no stale daemon)");
         } else {
@@ -69,7 +71,20 @@ impl DaemonLock {
             warn!(%e, "Failed to write PID to daemon.lock");
         }
 
-        Ok(Self { _file: file })
+        Ok(Self {
+            _file: file,
+            displaced_stale,
+        })
+    }
+
+    /// Whether acquisition had to wait for a previous lock holder to exit.
+    ///
+    /// `true` means an old daemon was alive moments ago and its resources
+    /// (e.g. Virtualization.framework XPC helpers holding the disk image)
+    /// may still be releasing.
+    #[must_use]
+    pub const fn displaced_stale_daemon(&self) -> bool {
+        self.displaced_stale
     }
 }
 

--- a/app/arcbox-daemon/src/startup/mod.rs
+++ b/app/arcbox-daemon/src/startup/mod.rs
@@ -97,9 +97,11 @@ async fn acquire_lock(early: EarlyContext) -> Result<DaemonContext> {
 /// Wait for residual resource holders (e.g. docker.img) to release.
 ///
 /// Must complete before [`init_runtime`] — on macOS, orphaned
-/// Virtualization.framework XPC helpers may still hold a previous
-/// daemon's disk images. Reports the `CleaningUp` phase so gRPC clients
-/// can show progress.
+/// Virtualization.framework XPC helpers of a just-displaced daemon may
+/// still hold a previous daemon's disk images. Only runs when lock
+/// acquisition actually displaced a stale daemon; clean starts skip the
+/// (expensive) scan. Reports the `CleaningUp` phase so gRPC clients can
+/// show progress.
 ///
 /// Scans every persistent dockerd image owned by a configured utility
 /// VM role (native `docker.img`, rosetta `docker-rosetta.img`) so a
@@ -116,6 +118,17 @@ async fn wait_for_resources(ctx: &DaemonContext) -> Result<()> {
         .collect();
 
     if docker_imgs.is_empty() {
+        return Ok(());
+    }
+
+    // Residual holders only exist when an old daemon was displaced during
+    // lock acquisition (its XPC helpers may outlive the flock release).
+    // On a clean start, skip the scan: `pids_by_path` walks every
+    // process's fd table and costs ~100ms. A crashed daemon's helpers can
+    // in principle linger past the kernel's flock release, but the scan
+    // was always best-effort (10s cap, then proceed with a warning) and
+    // VM start reports its own error if the image is still held.
+    if !ctx.daemon_lock.displaced_stale_daemon() {
         return Ok(());
     }
 

--- a/app/arcbox-daemon/src/startup/mod.rs
+++ b/app/arcbox-daemon/src/startup/mod.rs
@@ -4,6 +4,7 @@ mod assets;
 mod cleanup;
 mod lock;
 mod pipeline;
+mod resource_cleanup;
 
 pub use assets::find_bundle_contents;
 pub use lock::DaemonLock;
@@ -97,11 +98,11 @@ async fn acquire_lock(early: EarlyContext) -> Result<DaemonContext> {
 /// Wait for residual resource holders (e.g. docker.img) to release.
 ///
 /// Must complete before [`init_runtime`] — on macOS, orphaned
-/// Virtualization.framework XPC helpers of a just-displaced daemon may
-/// still hold a previous daemon's disk images. Only runs when lock
-/// acquisition actually displaced a stale daemon; clean starts skip the
-/// (expensive) scan. Reports the `CleaningUp` phase so gRPC clients can
-/// show progress.
+/// Virtualization.framework XPC helpers of a just-displaced or crashed daemon
+/// may still hold a previous daemon's disk images. Clean starts skip the
+/// expensive scan unless persisted machine state shows the previous daemon was
+/// interrupted while a VM was running. Reports the `CleaningUp` phase so gRPC
+/// clients can show progress.
 ///
 /// Scans every persistent dockerd image owned by a configured utility
 /// VM role (native `docker.img`, rosetta `docker-rosetta.img`) so a
@@ -110,27 +111,27 @@ async fn acquire_lock(early: EarlyContext) -> Result<DaemonContext> {
 /// On non-macOS this is a no-op (no XPC helpers).
 #[cfg(target_os = "macos")]
 async fn wait_for_resources(ctx: &DaemonContext) -> Result<()> {
-    let candidates = ["docker.img", "docker-rosetta.img"];
-    let docker_imgs: Vec<std::path::PathBuf> = candidates
-        .iter()
-        .map(|name| ctx.layout.data_subdir.join(name))
-        .filter(|path| path.exists())
-        .collect();
+    let docker_imgs = resource_cleanup::disk_image_paths(&ctx.layout.data_subdir);
+    let decision = resource_cleanup::decide(
+        ctx.daemon_lock.displaced_stale_daemon(),
+        resource_cleanup::has_interrupted_running_machine(&ctx.layout.data_dir),
+        !docker_imgs.is_empty(),
+    );
 
-    if docker_imgs.is_empty() {
+    let resource_cleanup::ResourceCleanupDecision::ScanDiskImageHolders { reason } = decision
+    else {
+        info!(
+            decision = ?decision,
+            "Skipping startup resource-holder cleanup"
+        );
         return Ok(());
-    }
+    };
 
-    // Residual holders only exist when an old daemon was displaced during
-    // lock acquisition (its XPC helpers may outlive the flock release).
-    // On a clean start, skip the scan: `pids_by_path` walks every
-    // process's fd table and costs ~100ms. A crashed daemon's helpers can
-    // in principle linger past the kernel's flock release, but the scan
-    // was always best-effort (10s cap, then proceed with a warning) and
-    // VM start reports its own error if the image is still held.
-    if !ctx.daemon_lock.displaced_stale_daemon() {
-        return Ok(());
-    }
+    info!(
+        reason = ?reason,
+        image_count = docker_imgs.len(),
+        "Scanning disk-image holders before runtime startup"
+    );
 
     ctx.setup_state
         .set_phase(SetupPhase::CleaningUp, "Waiting for resource release…");

--- a/app/arcbox-daemon/src/startup/pipeline.rs
+++ b/app/arcbox-daemon/src/startup/pipeline.rs
@@ -3,13 +3,15 @@
 //! Each step consumes the previous state and returns the next one, so `main.rs`
 //! can show the startup order directly while Rust types enforce it.
 
+use std::future::Future;
 use std::sync::Arc;
+use std::time::Instant;
 
 use anyhow::Result;
 use arcbox_api::SetupPhase;
 use arcbox_core::Runtime;
 use macos_resolver::FileResolver;
-use tracing::info;
+use tracing::{info, warn};
 
 use crate::context::{DaemonContext, EarlyContext, ServiceHandles};
 use crate::{DaemonArgs, recovery, services};
@@ -35,7 +37,7 @@ impl Startup {
     /// Prepares host directories and pre-lock context.
     pub async fn prepare_host(self) -> Result<HostPrepared> {
         info!("Starting ArcBox daemon...");
-        let early = init_early(self.args).await?;
+        let early = record_startup_phase("prepare_host", init_early(self.args)).await?;
         Ok(HostPrepared { early })
     }
 }
@@ -47,7 +49,7 @@ pub struct HostPrepared {
 impl HostPrepared {
     /// Acquires the exclusive daemon lease.
     pub async fn acquire_daemon_lease(self) -> Result<DaemonLeased> {
-        let ctx = acquire_lock(self.early).await?;
+        let ctx = record_startup_phase("acquire_daemon_lease", acquire_lock(self.early)).await?;
         Ok(DaemonLeased { ctx })
     }
 }
@@ -60,7 +62,11 @@ impl DaemonLeased {
     /// Starts gRPC before slow runtime phases so clients can observe progress.
     pub async fn start_control_plane(self) -> Result<ControlPlaneStarted> {
         let shared_runtime = Arc::clone(&self.ctx.shared_runtime);
-        let grpc = services::start_grpc(&self.ctx, shared_runtime).await?;
+        let grpc = record_startup_phase(
+            "start_control_plane",
+            services::start_grpc(&self.ctx, shared_runtime),
+        )
+        .await?;
         Ok(ControlPlaneStarted {
             ctx: self.ctx,
             grpc,
@@ -76,7 +82,7 @@ pub struct ControlPlaneStarted {
 impl ControlPlaneStarted {
     /// Waits for stale resource holders from a previous daemon to release.
     pub async fn release_stale_resources(self) -> Result<ResourcesReleased> {
-        wait_for_resources(&self.ctx).await?;
+        record_startup_phase("release_stale_resources", wait_for_resources(&self.ctx)).await?;
         Ok(ResourcesReleased {
             ctx: self.ctx,
             grpc: self.grpc,
@@ -92,7 +98,7 @@ pub struct ResourcesReleased {
 impl ResourcesReleased {
     /// Reconciles bundle, downloaded, and staged assets for this app version.
     pub async fn prepare_assets(self) -> Result<AssetsPrepared> {
-        let assets = prepare_assets(&self.ctx).await?;
+        let assets = record_startup_phase("prepare_assets", prepare_assets(&self.ctx)).await?;
         info!(agent = ?assets.agent(), "Startup assets prepared");
         Ok(AssetsPrepared {
             ctx: self.ctx,
@@ -111,7 +117,7 @@ pub struct AssetsPrepared {
 impl AssetsPrepared {
     /// Builds and initializes the ArcBox runtime.
     pub async fn boot_runtime(self) -> Result<RuntimeBooted> {
-        let runtime = init_runtime(&self.ctx).await?;
+        let runtime = record_startup_phase("boot_runtime", init_runtime(&self.ctx)).await?;
         Ok(RuntimeBooted {
             ctx: self.ctx,
             grpc: self.grpc,
@@ -129,8 +135,12 @@ pub struct RuntimeBooted {
 impl RuntimeBooted {
     /// Starts services that require an initialized runtime.
     pub async fn start_runtime_services(self) -> Result<RuntimeServicesStarted> {
-        let handles = services::start_services(&self.ctx, &self.runtime, self.grpc).await?;
-        recovery::run(&self.ctx, &self.runtime).await;
+        let handles = record_startup_phase("start_runtime_services", async {
+            let handles = services::start_services(&self.ctx, &self.runtime, self.grpc).await?;
+            recovery::run(&self.ctx, &self.runtime).await;
+            Ok(handles)
+        })
+        .await?;
         Ok(RuntimeServicesStarted {
             ctx: self.ctx,
             handles,
@@ -146,19 +156,24 @@ pub struct RuntimeServicesStarted {
 impl RuntimeServicesStarted {
     /// Marks startup complete and returns handles for the shutdown loop.
     pub async fn mark_ready(self) -> Result<ReadyDaemon> {
-        check_resolver_installed(&self.ctx.dns_domain);
-        self.ctx
-            .setup_state
-            .set_phase(SetupPhase::Ready, "Daemon ready");
+        record_startup_phase("mark_ready", async {
+            check_resolver_installed(&self.ctx.dns_domain);
+            self.ctx
+                .setup_state
+                .set_phase(SetupPhase::Ready, "Daemon ready");
 
-        println!("ArcBox daemon started");
-        println!("  Docker API: {}", self.ctx.layout.docker_socket.display());
-        println!("  gRPC API:   {}", self.ctx.layout.grpc_socket.display());
-        println!("  DNS:        127.0.0.1:{}", self.ctx.dns_port);
-        println!("  Data:       {}", self.ctx.layout.data_dir.display());
-        println!();
-        println!("Use 'arcbox docker enable' to configure Docker CLI integration.");
-        println!("Press Ctrl+C to stop.");
+            println!("ArcBox daemon started");
+            println!("  Docker API: {}", self.ctx.layout.docker_socket.display());
+            println!("  gRPC API:   {}", self.ctx.layout.grpc_socket.display());
+            println!("  DNS:        127.0.0.1:{}", self.ctx.dns_port);
+            println!("  Data:       {}", self.ctx.layout.data_dir.display());
+            println!();
+            println!("Use 'arcbox docker enable' to configure Docker CLI integration.");
+            println!("Press Ctrl+C to stop.");
+
+            Ok(())
+        })
+        .await?;
 
         Ok(ReadyDaemon {
             ctx: self.ctx,
@@ -172,4 +187,20 @@ fn check_resolver_installed(domain: &str) {
     if !resolver.is_registered(domain) {
         println!("Hint: Run 'sudo arcbox dns install' to enable *.{domain} DNS resolution.");
     }
+}
+
+async fn record_startup_phase<T, F>(phase: &'static str, future: F) -> Result<T>
+where
+    F: Future<Output = Result<T>>,
+{
+    let started = Instant::now();
+    let result = future.await;
+    let elapsed_ms = started.elapsed().as_millis() as u64;
+
+    match &result {
+        Ok(_) => info!(startup_phase = phase, elapsed_ms, "Startup phase complete"),
+        Err(error) => warn!(startup_phase = phase, elapsed_ms, %error, "Startup phase failed"),
+    }
+
+    result
 }

--- a/app/arcbox-daemon/src/startup/resource_cleanup.rs
+++ b/app/arcbox-daemon/src/startup/resource_cleanup.rs
@@ -1,0 +1,178 @@
+//! Startup resource-cleanup policy.
+
+use std::path::{Path, PathBuf};
+
+use arcbox_core::persistence::MachinePersistence;
+
+const DISK_IMAGE_NAMES: [&str; 2] = ["docker.img", "docker-rosetta.img"];
+
+/// Why startup must scan for stale disk-image holders.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum ResourceCleanupReason {
+    /// Lock acquisition displaced a live previous daemon.
+    TookOverLockHolder,
+    /// Persisted state says a previous daemon was interrupted while a VM ran.
+    InterruptedMachineRun,
+}
+
+/// Whether startup should run the expensive disk-image holder scan.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum ResourceCleanupDecision {
+    /// No disk image exists, or this is a true clean start.
+    Skip,
+    /// Scan disk-image holders before VM startup.
+    ScanDiskImageHolders { reason: ResourceCleanupReason },
+}
+
+/// Returns existing persistent Docker disk images that may have stale holders.
+pub(super) fn disk_image_paths(data_subdir: &Path) -> Vec<PathBuf> {
+    DISK_IMAGE_NAMES
+        .iter()
+        .map(|name| data_subdir.join(name))
+        .filter(|path| path.exists())
+        .collect()
+}
+
+/// Detects whether the previous daemon may have crashed while a VM was running.
+pub(super) fn has_interrupted_running_machine(data_dir: &Path) -> bool {
+    let persistence = MachinePersistence::new(data_dir.join("machines"));
+    persistence
+        .load_all()
+        .iter()
+        .any(|machine| machine.state.needs_recovery())
+}
+
+/// Computes the startup cleanup policy from explicit recovery signals.
+pub(super) const fn decide(
+    displaced_lock_holder: bool,
+    interrupted_machine_run: bool,
+    disk_images_exist: bool,
+) -> ResourceCleanupDecision {
+    if !disk_images_exist {
+        return ResourceCleanupDecision::Skip;
+    }
+
+    if displaced_lock_holder {
+        return ResourceCleanupDecision::ScanDiskImageHolders {
+            reason: ResourceCleanupReason::TookOverLockHolder,
+        };
+    }
+
+    if interrupted_machine_run {
+        return ResourceCleanupDecision::ScanDiskImageHolders {
+            reason: ResourceCleanupReason::InterruptedMachineRun,
+        };
+    }
+
+    ResourceCleanupDecision::Skip
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        ResourceCleanupDecision, ResourceCleanupReason, decide, disk_image_paths,
+        has_interrupted_running_machine,
+    };
+
+    fn write_machine_config(data_dir: &Path, name: &str, state: &str) {
+        let machine_dir = data_dir.join("machines").join(name);
+        std::fs::create_dir_all(&machine_dir).unwrap();
+        std::fs::write(
+            machine_dir.join("config.toml"),
+            format!(
+                r#"
+name = "{name}"
+cpus = 2
+memory_mb = 2048
+disk_gb = 10
+state = "{state}"
+vm_id = "vm-{name}"
+"#
+            ),
+        )
+        .unwrap();
+    }
+
+    use std::path::Path;
+
+    #[test]
+    fn clean_start_without_images_skips() {
+        assert_eq!(decide(false, false, false), ResourceCleanupDecision::Skip);
+    }
+
+    #[test]
+    fn clean_start_with_images_skips() {
+        assert_eq!(decide(false, false, true), ResourceCleanupDecision::Skip);
+    }
+
+    #[test]
+    fn takeover_with_images_scans() {
+        assert_eq!(
+            decide(true, false, true),
+            ResourceCleanupDecision::ScanDiskImageHolders {
+                reason: ResourceCleanupReason::TookOverLockHolder
+            }
+        );
+    }
+
+    #[test]
+    fn interrupted_running_machine_with_images_scans() {
+        assert_eq!(
+            decide(false, true, true),
+            ResourceCleanupDecision::ScanDiskImageHolders {
+                reason: ResourceCleanupReason::InterruptedMachineRun
+            }
+        );
+    }
+
+    #[test]
+    fn takeover_and_interrupted_prefers_takeover_reason() {
+        assert_eq!(
+            decide(true, true, true),
+            ResourceCleanupDecision::ScanDiskImageHolders {
+                reason: ResourceCleanupReason::TookOverLockHolder
+            }
+        );
+    }
+
+    #[test]
+    fn interrupted_without_images_skips() {
+        assert_eq!(decide(false, true, false), ResourceCleanupDecision::Skip);
+    }
+
+    #[test]
+    fn disk_image_paths_returns_existing_images() {
+        let temp = tempfile::tempdir().unwrap();
+        let data_subdir = temp.path().join("data");
+        std::fs::create_dir_all(&data_subdir).unwrap();
+        std::fs::write(data_subdir.join("docker.img"), b"").unwrap();
+
+        assert_eq!(
+            disk_image_paths(&data_subdir),
+            vec![data_subdir.join("docker.img")]
+        );
+    }
+
+    #[test]
+    fn interrupted_running_machine_detects_crash_recovery_signal() {
+        let temp = tempfile::tempdir().unwrap();
+        write_machine_config(temp.path(), "arcbox", "running");
+
+        assert!(has_interrupted_running_machine(temp.path()));
+    }
+
+    #[test]
+    fn stopped_machine_does_not_trigger_resource_scan() {
+        let temp = tempfile::tempdir().unwrap();
+        write_machine_config(temp.path(), "arcbox", "stopped");
+
+        assert!(!has_interrupted_running_machine(temp.path()));
+    }
+
+    #[test]
+    fn missing_machine_state_does_not_trigger_resource_scan() {
+        let temp = tempfile::tempdir().unwrap();
+
+        assert!(!has_interrupted_running_machine(temp.path()));
+    }
+}

--- a/common/arcbox-constants/src/wire.rs
+++ b/common/arcbox-constants/src/wire.rs
@@ -32,6 +32,8 @@ pub enum MessageType {
     /// Request the guest to run `fstrim` on data mount points so the host
     /// sparse image reclaims freed blocks.
     DiskTrimRequest = 0x000C,
+    /// Opens a guest-driven readiness event stream.
+    WatchReadinessRequest = 0x000D,
 
     // Sandbox CRUD request types (0x0020 - 0x0024).
     SandboxCreateRequest = 0x0020,
@@ -69,6 +71,8 @@ pub enum MessageType {
     MmapReadFileResponse = 0x100B,
     /// Response to `DiskTrimRequest` with per-mount trim summary.
     DiskTrimResponse = 0x100C,
+    /// Guest-driven readiness event frame.
+    ReadinessEvent = 0x100D,
     PortBindingsChanged = 0x1030,
     PortBindingsRemoved = 0x1031,
 
@@ -112,6 +116,7 @@ impl MessageType {
             0x000A => Some(Self::ShutdownRequest),
             0x000B => Some(Self::MmapReadFileRequest),
             0x000C => Some(Self::DiskTrimRequest),
+            0x000D => Some(Self::WatchReadinessRequest),
             // Sandbox CRUD requests.
             0x0020 => Some(Self::SandboxCreateRequest),
             0x0021 => Some(Self::SandboxStopRequest),
@@ -141,6 +146,7 @@ impl MessageType {
             0x100A => Some(Self::ShutdownResponse),
             0x100B => Some(Self::MmapReadFileResponse),
             0x100C => Some(Self::DiskTrimResponse),
+            0x100D => Some(Self::ReadinessEvent),
             0x1030 => Some(Self::PortBindingsChanged),
             0x1031 => Some(Self::PortBindingsRemoved),
             // Sandbox CRUD responses.
@@ -218,6 +224,7 @@ mod tests {
             (0x000A, MessageType::ShutdownRequest),
             (0x000B, MessageType::MmapReadFileRequest),
             (0x000C, MessageType::DiskTrimRequest),
+            (0x000D, MessageType::WatchReadinessRequest),
             (0x1001, MessageType::PingResponse),
             (0x1002, MessageType::GetSystemInfoResponse),
             (0x1003, MessageType::EnsureRuntimeResponse),
@@ -230,6 +237,7 @@ mod tests {
             (0x100A, MessageType::ShutdownResponse),
             (0x100B, MessageType::MmapReadFileResponse),
             (0x100C, MessageType::DiskTrimResponse),
+            (0x100D, MessageType::ReadinessEvent),
             (0x1030, MessageType::PortBindingsChanged),
             (0x1031, MessageType::PortBindingsRemoved),
             (0x0000, MessageType::Empty),

--- a/guest/arcbox-agent/src/agent/linux/rpc.rs
+++ b/guest/arcbox-agent/src/agent/linux/rpc.rs
@@ -11,10 +11,11 @@ use anyhow::Result;
 use tokio::io::{AsyncRead, AsyncWrite};
 
 use arcbox_protocol::agent::PingResponse;
+use prost::Message as _;
 
 use crate::rpc::{
     AGENT_VERSION, ErrorResponse, RpcRequest, RpcResponse, parse_request, read_message,
-    write_response,
+    write_message, write_response,
 };
 
 use super::disk::handle_disk_trim;
@@ -76,6 +77,10 @@ where
 
         // Parse and handle the request.
         let result = match parse_request(msg_type, &payload) {
+            Ok(RpcRequest::WatchReadiness(req)) => {
+                handle_watch_readiness(&mut stream, req, &trace_id).await?;
+                continue;
+            }
             Ok(request) => handle_request(request).await,
             Err(e) => {
                 tracing::warn!(trace_id = %trace_id, "Failed to parse request: {}", e);
@@ -119,7 +124,135 @@ async fn handle_request(request: RpcRequest) -> RequestResult {
         RpcRequest::Shutdown(req) => RequestResult::Single(handle_shutdown(req)),
         RpcRequest::MmapReadFile(req) => RequestResult::Single(handle_mmap_read_file(req)),
         RpcRequest::DiskTrim(_) => RequestResult::Single(handle_disk_trim().await),
+        RpcRequest::WatchReadiness(_) => unreachable!("watch readiness is streaming"),
     }
+}
+
+async fn handle_watch_readiness<S>(
+    stream: &mut S,
+    req: arcbox_protocol::agent::WatchReadinessRequest,
+    trace_id: &str,
+) -> Result<()>
+where
+    S: AsyncWrite + Unpin,
+{
+    use arcbox_protocol::agent::readiness_event::Kind;
+    use arcbox_protocol::agent::{ReadinessEvent, RuntimeEnsureRequest};
+
+    write_readiness_event(
+        stream,
+        trace_id,
+        ReadinessEvent {
+            kind: Kind::AgentReady as i32,
+            endpoint: String::new(),
+            detail: "agent ready".to_string(),
+            services: Vec::new(),
+        },
+    )
+    .await?;
+
+    if !req.start_runtime_if_needed {
+        return Ok(());
+    }
+
+    write_readiness_event(
+        stream,
+        trace_id,
+        ReadinessEvent {
+            kind: Kind::RuntimeStarting as i32,
+            endpoint: String::new(),
+            detail: "ensuring guest runtime".to_string(),
+            services: Vec::new(),
+        },
+    )
+    .await?;
+
+    let timeout = Duration::from_millis(u64::from(req.timeout_ms).max(1));
+    let deadline = tokio::time::Instant::now() + timeout;
+
+    loop {
+        let response = match super::runtime::handle_ensure_runtime(RuntimeEnsureRequest {
+            start_if_needed: true,
+        })
+        .await
+        {
+            RpcResponse::RuntimeEnsure(response) => response,
+            other => {
+                anyhow::bail!("unexpected ensure runtime response: {:?}", other);
+            }
+        };
+        let response_message = response.message;
+
+        let status = match super::runtime::handle_runtime_status(
+            arcbox_protocol::agent::RuntimeStatusRequest {},
+        )
+        .await
+        {
+            RpcResponse::RuntimeStatus(status) => status,
+            other => {
+                anyhow::bail!("unexpected runtime status response: {:?}", other);
+            }
+        };
+
+        if response.ready || status.docker_ready {
+            return write_readiness_event(
+                stream,
+                trace_id,
+                ReadinessEvent {
+                    kind: Kind::RuntimeReady as i32,
+                    endpoint: if response.endpoint.is_empty() {
+                        status.endpoint
+                    } else {
+                        response.endpoint
+                    },
+                    detail: if response_message.is_empty() {
+                        status.detail
+                    } else {
+                        response_message
+                    },
+                    services: status.services,
+                },
+            )
+            .await;
+        }
+
+        if tokio::time::Instant::now() >= deadline {
+            return write_readiness_event(
+                stream,
+                trace_id,
+                ReadinessEvent {
+                    kind: Kind::RuntimeFailed as i32,
+                    endpoint: status.endpoint,
+                    detail: if response_message.is_empty() {
+                        status.detail
+                    } else {
+                        response_message
+                    },
+                    services: status.services,
+                },
+            )
+            .await;
+        }
+
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+}
+
+async fn write_readiness_event<S>(
+    stream: &mut S,
+    trace_id: &str,
+    event: arcbox_protocol::agent::ReadinessEvent,
+) -> Result<()>
+where
+    S: AsyncWrite + Unpin,
+{
+    write_message(
+        stream,
+        crate::rpc::MessageType::ReadinessEvent,
+        trace_id,
+        &event.encode_to_vec(),
+    )
+    .await
 }
 
 /// Handles a Shutdown request.

--- a/guest/arcbox-agent/src/rpc.rs
+++ b/guest/arcbox-agent/src/rpc.rs
@@ -18,9 +18,9 @@ use arcbox_protocol::agent::{
     KubernetesKubeconfigRequest, KubernetesKubeconfigResponse, KubernetesStartRequest,
     KubernetesStartResponse, KubernetesStatusRequest, KubernetesStatusResponse,
     KubernetesStopRequest, KubernetesStopResponse, MmapReadFileRequest, MmapReadFileResponse,
-    PingRequest, PingResponse, PortBindingsChanged, PortBindingsRemoved, RuntimeEnsureRequest,
-    RuntimeEnsureResponse, RuntimeStatusRequest, RuntimeStatusResponse, ShutdownRequest,
-    ShutdownResponse, SystemInfo,
+    PingRequest, PingResponse, PortBindingsChanged, PortBindingsRemoved, ReadinessEvent,
+    RuntimeEnsureRequest, RuntimeEnsureResponse, RuntimeStatusRequest, RuntimeStatusResponse,
+    ShutdownRequest, ShutdownResponse, SystemInfo, WatchReadinessRequest,
 };
 
 /// Agent version string.
@@ -80,6 +80,7 @@ pub enum RpcRequest {
     Shutdown(ShutdownRequest),
     MmapReadFile(MmapReadFileRequest),
     DiskTrim(DiskTrimRequest),
+    WatchReadiness(WatchReadinessRequest),
 }
 
 /// RPC response envelope.
@@ -99,6 +100,7 @@ pub enum RpcResponse {
     Empty,
     PortBindingsChanged(PortBindingsChanged),
     PortBindingsRemoved(PortBindingsRemoved),
+    ReadinessEvent(ReadinessEvent),
     Error(ErrorResponse),
     MmapReadFile(MmapReadFileResponse),
 }
@@ -121,6 +123,7 @@ impl RpcResponse {
             Self::Empty => MessageType::Empty,
             Self::PortBindingsChanged(_) => MessageType::PortBindingsChanged,
             Self::PortBindingsRemoved(_) => MessageType::PortBindingsRemoved,
+            Self::ReadinessEvent(_) => MessageType::ReadinessEvent,
             Self::Error(_) => MessageType::Error,
             Self::MmapReadFile(_) => MessageType::MmapReadFileResponse,
         }
@@ -143,6 +146,7 @@ impl RpcResponse {
             Self::Empty => Empty::default().encode_to_vec(),
             Self::PortBindingsChanged(msg) => msg.encode_to_vec(),
             Self::PortBindingsRemoved(msg) => msg.encode_to_vec(),
+            Self::ReadinessEvent(msg) => msg.encode_to_vec(),
             Self::Error(err) => err.encode(),
             Self::MmapReadFile(msg) => msg.encode_to_vec(),
         }
@@ -315,6 +319,10 @@ pub fn parse_request(msg_type: MessageType, payload: &[u8]) -> Result<RpcRequest
         MessageType::DiskTrimRequest => {
             let req = DiskTrimRequest::decode(payload)?;
             Ok(RpcRequest::DiskTrim(req))
+        }
+        MessageType::WatchReadinessRequest => {
+            let req = WatchReadinessRequest::decode(payload)?;
+            Ok(RpcRequest::WatchReadiness(req))
         }
         _ => anyhow::bail!("unexpected message type: {:?}", msg_type),
     }

--- a/rpc/arcbox-protocol/proto/agent.proto
+++ b/rpc/arcbox-protocol/proto/agent.proto
@@ -44,6 +44,9 @@ service AgentService {
     // Triggers an immediate fstrim on data mount points to reclaim sparse
     // file space on the host.
     rpc DiskTrim(DiskTrimRequest) returns (DiskTrimResponse);
+
+    // Streams guest readiness events until the requested runtime is ready or failed.
+    rpc WatchReadiness(WatchReadinessRequest) returns (stream ReadinessEvent);
 }
 
 // Ping request.
@@ -108,6 +111,34 @@ message RuntimeEnsureResponse {
 
 // Request for runtime status.
 message RuntimeStatusRequest {}
+
+// Request for guest-driven readiness events.
+message WatchReadinessRequest {
+    // Whether the agent should start the runtime if it is not ready.
+    bool start_runtime_if_needed = 1;
+    // Maximum time to wait for runtime readiness before reporting failure.
+    uint32 timeout_ms = 2;
+}
+
+// Guest readiness event.
+message ReadinessEvent {
+    enum Kind {
+        KIND_UNSPECIFIED = 0;
+        AGENT_READY = 1;
+        RUNTIME_STARTING = 2;
+        RUNTIME_READY = 3;
+        RUNTIME_FAILED = 4;
+    }
+
+    // Event kind.
+    Kind kind = 1;
+    // Runtime endpoint exposed to host proxy when known.
+    string endpoint = 2;
+    // Human-readable detail for diagnostics.
+    string detail = 3;
+    // Per-service status entries for fine-grained observability.
+    repeated ServiceStatus services = 4;
+}
 
 // Runtime status report.
 message RuntimeStatusResponse {

--- a/rpc/arcbox-protocol/src/generated/arcbox.v1.rs
+++ b/rpc/arcbox-protocol/src/generated/arcbox.v1.rs
@@ -1514,6 +1514,76 @@ pub struct RuntimeEnsureResponse {
 #[serde(rename_all = "camelCase")]
 #[derive(Clone, Copy, PartialEq, ::prost::Message)]
 pub struct RuntimeStatusRequest {}
+/// Request for guest-driven readiness events.
+#[derive(serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[derive(Clone, Copy, PartialEq, ::prost::Message)]
+pub struct WatchReadinessRequest {
+    /// Whether the agent should start the runtime if it is not ready.
+    #[prost(bool, tag = "1")]
+    pub start_runtime_if_needed: bool,
+    /// Maximum time to wait for runtime readiness before reporting failure.
+    #[prost(uint32, tag = "2")]
+    pub timeout_ms: u32,
+}
+/// Guest readiness event.
+#[derive(serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ReadinessEvent {
+    /// Event kind.
+    #[prost(enumeration = "readiness_event::Kind", tag = "1")]
+    pub kind: i32,
+    /// Runtime endpoint exposed to host proxy when known.
+    #[prost(string, tag = "2")]
+    pub endpoint: ::prost::alloc::string::String,
+    /// Human-readable detail for diagnostics.
+    #[prost(string, tag = "3")]
+    pub detail: ::prost::alloc::string::String,
+    /// Per-service status entries for fine-grained observability.
+    #[prost(message, repeated, tag = "4")]
+    pub services: ::prost::alloc::vec::Vec<ServiceStatus>,
+}
+/// Nested message and enum types in `ReadinessEvent`.
+pub mod readiness_event {
+    #[derive(serde::Serialize, serde::Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+    #[repr(i32)]
+    pub enum Kind {
+        Unspecified = 0,
+        AgentReady = 1,
+        RuntimeStarting = 2,
+        RuntimeReady = 3,
+        RuntimeFailed = 4,
+    }
+    impl Kind {
+        /// String value of the enum field names used in the ProtoBuf definition.
+        ///
+        /// The values are not transformed in any way and thus are considered stable
+        /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+        pub fn as_str_name(&self) -> &'static str {
+            match self {
+                Self::Unspecified => "KIND_UNSPECIFIED",
+                Self::AgentReady => "AGENT_READY",
+                Self::RuntimeStarting => "RUNTIME_STARTING",
+                Self::RuntimeReady => "RUNTIME_READY",
+                Self::RuntimeFailed => "RUNTIME_FAILED",
+            }
+        }
+        /// Creates an enum from field names used in the ProtoBuf definition.
+        pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+            match value {
+                "KIND_UNSPECIFIED" => Some(Self::Unspecified),
+                "AGENT_READY" => Some(Self::AgentReady),
+                "RUNTIME_STARTING" => Some(Self::RuntimeStarting),
+                "RUNTIME_READY" => Some(Self::RuntimeReady),
+                "RUNTIME_FAILED" => Some(Self::RuntimeFailed),
+                _ => None,
+            }
+        }
+    }
+}
 /// Runtime status report.
 #[derive(serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]

--- a/rpc/arcbox-protocol/src/lib.rs
+++ b/rpc/arcbox-protocol/src/lib.rs
@@ -98,8 +98,9 @@ pub mod agent {
         KubernetesKubeconfigResponse, KubernetesStartRequest, KubernetesStartResponse,
         KubernetesStatusRequest, KubernetesStatusResponse, KubernetesStopRequest,
         KubernetesStopResponse, MmapReadFileRequest, MmapReadFileResponse, PortBindingsChanged,
-        PortBindingsRemoved, RuntimeEnsureRequest, RuntimeEnsureResponse, RuntimeStatusRequest,
-        RuntimeStatusResponse, ServiceStatus, ShutdownRequest, ShutdownResponse, SystemInfo,
+        PortBindingsRemoved, ReadinessEvent, RuntimeEnsureRequest, RuntimeEnsureResponse,
+        RuntimeStatusRequest, RuntimeStatusResponse, ServiceStatus, ShutdownRequest,
+        ShutdownResponse, SystemInfo, WatchReadinessRequest, readiness_event,
     };
 
     // Backward compatibility type aliases (short names without Agent prefix).


### PR DESCRIPTION
Follow-up to #299 — reduce avoidable warm-boot overhead, make cleanup decisions explicit/tested, and move guest runtime readiness from host retry loops to a guest-driven readiness stream.

## Changes

1. **Tighten unavoidable boot discovery polling** — the remaining connect-discovery loops were paced for ~100ms-per-probe vsock; with event-driven RX a failed probe costs ~1ms, so sleep intervals dominated discovery time:
   - `wait_for_agent`: 100ms fixed → 25ms for the only unavoidable phase (discovering when the guest starts listening on the agent vsock port)
   - `wait_for_machine_ready` (`arcbox machine` VMs): probe immediately instead of sleeping 500ms before the first attempt; 50→500ms backoff under a 60s deadline

2. **Replace Docker runtime readiness polling with a guest-driven stream** — host now sends one `WatchReadiness` request and the guest emits readiness transitions on the same RPC connection:
   - new wire types: `WatchReadinessRequest` / `ReadinessEvent`
   - agent emits `AgentReady`, `RuntimeStarting`, then terminal `RuntimeReady` / `RuntimeFailed`
   - `GuestDockerBackend` uses the readiness stream as the only Docker runtime readiness path and validates the reported vsock endpoint before returning
   - no stale-agent compatibility path: daemon and guest agent are bundle-locked, so watch failures are startup protocol errors and fail fast
   - both async vsock and macOS HV blocking socketpair transports are supported without touching the tokio/kqueue reactor from the HV probe loop

3. **Use readiness events for agent handshake after connect** — once `connect_agent` succeeds, startup no longer performs a separate ping-poll loop. The readiness stream is the locked daemon↔agent contract.

4. **Type the resource-cleanup policy** — startup cleanup is now a small explicit policy instead of a compound boolean:
   - `ResourceCleanupDecision::Skip`
   - `ResourceCleanupDecision::ScanDiskImageHolders { reason }`
   - reasons distinguish `TookOverLockHolder` from `InterruptedMachineRun`

5. **Skip the disk-image holder scan only on true clean starts** — `pids_by_path` walks every process's fd table (~117ms measured) to find residual VZ XPC helpers.
   - Takeover path still scans when lock acquisition displaced a live stale daemon (`displaced_stale_daemon()`).
   - Crash/interrupted-run path also scans when persisted machine state contains `running`, covering the case where the kernel released the flock but Virtualization.framework helpers may still be unwinding and holding `docker.img`.
   - Only true clean starts skip the scan: no displaced stale daemon, no interrupted running machine state, or no persistent Docker disk image.

6. **Add startup phase timing logs** — the typed startup pipeline now records structured timing for each host-side phase:
   - `prepare_host`
   - `acquire_daemon_lease`
   - `start_control_plane`
   - `release_stale_resources`
   - `prepare_assets`
   - `boot_runtime`
   - `start_runtime_services`
   - `mark_ready`

## Review follow-up

Addressed the crash-recovery edge case called out by review: immediate flock acquisition no longer automatically means cleanup is unnecessary. The daemon now uses both signals — lock displacement and persisted interrupted machine state — before deciding whether to skip the expensive holder scan.

Also fixed the interrupted-machine signal to read the actual production persistence path (`<data_dir>/machines`), matching `MachineManager`, instead of the persistent data subdirectory.

## Tests

Added cleanup policy tests for:

- clean start with no images skips
- clean start with images skips
- takeover with images scans
- interrupted running machine with images scans
- takeover + interrupted prefers takeover reason
- interrupted signal without images skips
- disk image candidate discovery
- persisted `running` machine triggers the crash-recovery cleanup signal
- persisted `stopped` machine does not
- missing machine state does not

## Measurements (isolated daemon, warm boot, Apple Silicon)

| Phase | before | after |
|---|---|---|
| daemon start → VMM start | 524ms | **4ms**¹ |
| agent ready | 2.63–2.73s | 2.06–2.13s |
| runtime initialized | 2.98–3.10s | **2.43–2.50s** |

¹ the pre-VM phase win includes the companion `arcbox-boot` 0.5.2 change (boot-assets PR: verification cache — stops re-hashing 232MB of runtime binaries on every boot, ~410ms). That dep bump lands separately once 0.5.2 is published; this PR stands alone and accounts for ~170ms of the total.

The latest readiness-stream commit removes host retry overshoot from the Docker runtime phase; the remaining time is mostly guest kernel/runtime startup work rather than host polling cadence.

## Verification

- `cargo fmt --check`
- `cargo test -p arcbox-constants wire`
- `cargo check -p arcbox-core -p arcbox-daemon -p arcbox-agent -p arcbox-protocol -p arcbox-constants`
- `cargo clippy -p arcbox-core -p arcbox-daemon -p arcbox-agent --all-targets -- -D warnings`
- `cargo test -p arcbox-core -p arcbox-daemon -p arcbox-agent`
