### PR TITLE
fix(docker): cache guest HTTP readiness in proxy

### DIFF
--- a/app/arcbox-core/src/container_backend/guest_docker.rs
+++ b/app/arcbox-core/src/container_backend/guest_docker.rs
@@ -6,6 +6,7 @@ use crate::vm_lifecycle::VmLifecycleManager;
 use async_trait::async_trait;
 use std::os::fd::FromRawFd;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::{Duration, Instant};
 
 /// Guest Docker backend (dockerd/containerd/runc inside VM).
@@ -14,6 +15,9 @@ pub struct GuestDockerBackend {
     machine_manager: Arc<MachineManager>,
     machine_name: &'static str,
     config: ContainerRuntimeConfig,
+    /// Set once the guest endpoint has been verified; collapses the
+    /// per-request readiness check to a single vsock connect probe.
+    endpoint_verified: AtomicBool,
 }
 
 impl GuestDockerBackend {
@@ -29,10 +33,38 @@ impl GuestDockerBackend {
             machine_manager,
             machine_name,
             config,
+            endpoint_verified: AtomicBool::new(false),
         }
     }
 
+    /// Probes the guest dockerd endpoint with one vsock connect.
+    fn probe_guest_endpoint(&self) -> Result<()> {
+        let fd = self
+            .machine_manager
+            .connect_vsock_port(self.machine_name, self.config.guest_docker_vsock_port)?;
+        // SAFETY: connect_vsock_port returns a freshly created fd owned by
+        // the caller; wrapping it transfers that ownership so it closes.
+        let _owned = unsafe { std::os::fd::OwnedFd::from_raw_fd(fd) };
+        Ok(())
+    }
+
     async fn wait_guest_endpoint_ready(&self) -> Result<()> {
+        // Fast path: the endpoint was verified earlier in this VM's
+        // lifetime. One connect probe replaces the agent RPC round trips;
+        // if dockerd died (or the VM restarted underneath us), the probe
+        // fails and we fall through to the full ensure-runtime loop,
+        // which restarts dockerd via the agent.
+        if self.endpoint_verified.load(Ordering::Relaxed) {
+            match self.probe_guest_endpoint() {
+                Ok(()) => return Ok(()),
+                Err(e) => {
+                    self.endpoint_verified.store(false, Ordering::Relaxed);
+                    tracing::debug!(
+                        "guest endpoint failed cached probe ({e}); re-running full readiness"
+                    );
+                }
+            }
+        }
         const INITIAL_DELAY_MS: u64 = 120;
         const MAX_DELAY_MS: u64 = 1200;
 
@@ -88,7 +120,11 @@ impl GuestDockerBackend {
                     .connect_vsock_port(self.machine_name, port)
                 {
                     Ok(fd) => {
+                        // SAFETY: connect_vsock_port returns a freshly
+                        // created fd owned by the caller; wrapping it
+                        // transfers that ownership so it closes.
                         let _owned = unsafe { std::os::fd::OwnedFd::from_raw_fd(fd) };
+                        self.endpoint_verified.store(true, Ordering::Relaxed);
                         tracing::debug!(port, "guest docker endpoint is ready");
                         return Ok(());
                     }

--- a/app/arcbox-core/src/container_backend/guest_docker.rs
+++ b/app/arcbox-core/src/container_backend/guest_docker.rs
@@ -4,10 +4,13 @@ use crate::error::{CoreError, Result};
 use crate::machine::MachineManager;
 use crate::vm_lifecycle::VmLifecycleManager;
 use async_trait::async_trait;
-use std::os::fd::FromRawFd;
+use std::os::fd::{AsRawFd, FromRawFd, OwnedFd, RawFd};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::{Duration, Instant};
+
+const ENDPOINT_PROBE_TIMEOUT: Duration = Duration::from_secs(2);
+const DOCKER_PING_REQUEST: &[u8] = b"GET /_ping HTTP/1.0\r\nHost: docker\r\n\r\n";
 
 /// Guest Docker backend (dockerd/containerd/runc inside VM).
 pub struct GuestDockerBackend {
@@ -37,25 +40,40 @@ impl GuestDockerBackend {
         }
     }
 
-    /// Probes the guest dockerd endpoint with one vsock connect.
-    fn probe_guest_endpoint(&self) -> Result<()> {
-        let fd = self
-            .machine_manager
-            .connect_vsock_port(self.machine_name, self.config.guest_docker_vsock_port)?;
-        // SAFETY: connect_vsock_port returns a freshly created fd owned by
-        // the caller; wrapping it transfers that ownership so it closes.
-        let _owned = unsafe { std::os::fd::OwnedFd::from_raw_fd(fd) };
-        Ok(())
+    /// Probes the guest dockerd endpoint with a real Docker `_ping` request.
+    async fn probe_guest_endpoint(&self) -> Result<()> {
+        let manager = Arc::clone(&self.machine_manager);
+        let machine_name = self.machine_name;
+        let port = self.config.guest_docker_vsock_port;
+
+        let task = tokio::task::spawn_blocking(move || {
+            let fd = manager.connect_vsock_port(machine_name, port)?;
+            probe_docker_ping(fd)
+        });
+
+        match tokio::time::timeout(ENDPOINT_PROBE_TIMEOUT, task).await {
+            Ok(join_result) => join_result.map_err(|e| {
+                CoreError::Machine(format!("guest endpoint probe task failed: {e}"))
+            })?,
+            Err(_) => Err(CoreError::Machine(format!(
+                "guest docker endpoint probe timed out after {}ms",
+                ENDPOINT_PROBE_TIMEOUT.as_millis()
+            ))),
+        }
     }
 
     async fn wait_guest_endpoint_ready(&self) -> Result<()> {
         // Fast path: the endpoint was verified earlier in this VM's
-        // lifetime. One connect probe replaces the agent RPC round trips;
-        // if dockerd died (or the VM restarted underneath us), the probe
-        // fails and we fall through to the full ensure-runtime loop,
+        // lifetime. One blocking `_ping` probe replaces the agent RPC round
+        // trips; if dockerd died (or the VM restarted underneath us), the
+        // probe fails and we fall through to the full ensure-runtime loop,
         // which restarts dockerd via the agent.
+        //
+        // Relaxed is intentional: this flag is a pure optimization hint with
+        // no associated data to synchronize. A stale read in either direction
+        // is safe — we either take an unnecessary slow path or retry the probe.
         if self.endpoint_verified.load(Ordering::Relaxed) {
-            match self.probe_guest_endpoint() {
+            match self.probe_guest_endpoint().await {
                 Ok(()) => return Ok(()),
                 Err(e) => {
                     self.endpoint_verified.store(false, Ordering::Relaxed);
@@ -115,15 +133,8 @@ impl GuestDockerBackend {
             }
 
             if docker_ready {
-                match self
-                    .machine_manager
-                    .connect_vsock_port(self.machine_name, port)
-                {
-                    Ok(fd) => {
-                        // SAFETY: connect_vsock_port returns a freshly
-                        // created fd owned by the caller; wrapping it
-                        // transfers that ownership so it closes.
-                        let _owned = unsafe { std::os::fd::OwnedFd::from_raw_fd(fd) };
+                match self.probe_guest_endpoint().await {
+                    Ok(()) => {
                         self.endpoint_verified.store(true, Ordering::Relaxed);
                         tracing::debug!(port, "guest docker endpoint is ready");
                         return Ok(());
@@ -166,6 +177,116 @@ impl GuestDockerBackend {
     }
 }
 
+fn probe_docker_ping(fd: RawFd) -> Result<()> {
+    // SAFETY: connect_vsock_port returns a freshly created fd owned by the
+    // caller; wrapping it transfers that ownership so it closes.
+    let owned = unsafe { OwnedFd::from_raw_fd(fd) };
+    write_all_with_poll(
+        owned.as_raw_fd(),
+        DOCKER_PING_REQUEST,
+        ENDPOINT_PROBE_TIMEOUT,
+    )?;
+
+    let mut response = [0u8; 512];
+    let n = read_with_poll(owned.as_raw_fd(), &mut response, ENDPOINT_PROBE_TIMEOUT)?;
+    validate_docker_ping_response(&response[..n])
+}
+
+fn write_all_with_poll(fd: RawFd, mut buf: &[u8], timeout: Duration) -> Result<()> {
+    while !buf.is_empty() {
+        poll_fd(fd, libc::POLLOUT, timeout)?;
+        // SAFETY: fd is live for the duration of the call, and buf points to
+        // readable memory of length buf.len().
+        let written = unsafe { libc::write(fd, buf.as_ptr().cast(), buf.len()) };
+        if written > 0 {
+            buf = &buf[written as usize..];
+            continue;
+        }
+        if written == 0 {
+            return Err(CoreError::from(std::io::Error::new(
+                std::io::ErrorKind::WriteZero,
+                "guest docker endpoint accepted zero bytes",
+            )));
+        }
+
+        let err = std::io::Error::last_os_error();
+        if matches!(
+            err.kind(),
+            std::io::ErrorKind::Interrupted | std::io::ErrorKind::WouldBlock
+        ) {
+            continue;
+        }
+        return Err(CoreError::from(err));
+    }
+    Ok(())
+}
+
+fn read_with_poll(fd: RawFd, buf: &mut [u8], timeout: Duration) -> Result<usize> {
+    poll_fd(fd, libc::POLLIN, timeout)?;
+    // SAFETY: fd is live for the duration of the call, and buf points to
+    // writable memory of length buf.len().
+    let read = unsafe { libc::read(fd, buf.as_mut_ptr().cast(), buf.len()) };
+    if read > 0 {
+        return Ok(read as usize);
+    }
+    if read == 0 {
+        return Err(CoreError::from(std::io::Error::new(
+            std::io::ErrorKind::UnexpectedEof,
+            "guest docker endpoint closed before responding to _ping",
+        )));
+    }
+
+    Err(CoreError::from(std::io::Error::last_os_error()))
+}
+
+fn poll_fd(fd: RawFd, events: libc::c_short, timeout: Duration) -> Result<()> {
+    let timeout_ms = i32::try_from(timeout.as_millis()).unwrap_or(i32::MAX);
+    loop {
+        let mut pollfd = libc::pollfd {
+            fd,
+            events,
+            revents: 0,
+        };
+        // SAFETY: pollfd points to one valid pollfd for the duration of poll.
+        let result = unsafe { libc::poll(&raw mut pollfd, 1, timeout_ms) };
+        if result > 0 {
+            if pollfd.revents & events != 0 {
+                return Ok(());
+            }
+            return Err(CoreError::from(std::io::Error::new(
+                std::io::ErrorKind::ConnectionAborted,
+                format!(
+                    "guest docker endpoint poll failed: revents={}",
+                    pollfd.revents
+                ),
+            )));
+        }
+        if result == 0 {
+            return Err(CoreError::from(std::io::Error::new(
+                std::io::ErrorKind::TimedOut,
+                "guest docker endpoint probe timed out",
+            )));
+        }
+
+        let err = std::io::Error::last_os_error();
+        if err.kind() == std::io::ErrorKind::Interrupted {
+            continue;
+        }
+        return Err(CoreError::from(err));
+    }
+}
+
+fn validate_docker_ping_response(response: &[u8]) -> Result<()> {
+    if response.starts_with(b"HTTP/1.0 200") || response.starts_with(b"HTTP/1.1 200") {
+        return Ok(());
+    }
+
+    Err(CoreError::Machine(format!(
+        "guest docker endpoint returned unexpected _ping response: {}",
+        String::from_utf8_lossy(response).trim_end()
+    )))
+}
+
 fn parse_vsock_endpoint_port(endpoint: &str) -> Option<u32> {
     endpoint.strip_prefix("vsock:")?.parse::<u32>().ok()
 }
@@ -201,7 +322,9 @@ impl ContainerBackend for GuestDockerBackend {
 
 #[cfg(test)]
 mod tests {
-    use super::{parse_vsock_endpoint_port, validate_reported_vsock_endpoint};
+    use super::{
+        parse_vsock_endpoint_port, validate_docker_ping_response, validate_reported_vsock_endpoint,
+    };
 
     #[test]
     fn test_parse_vsock_endpoint_port_ok() {
@@ -234,5 +357,17 @@ mod tests {
         let err =
             validate_reported_vsock_endpoint("unix:///var/run/docker.sock", 2375).unwrap_err();
         assert!(err.to_string().contains("format invalid"));
+    }
+
+    #[test]
+    fn test_validate_docker_ping_response_accepts_http_200() {
+        assert!(validate_docker_ping_response(b"HTTP/1.0 200 OK\r\n\r\nOK").is_ok());
+        assert!(validate_docker_ping_response(b"HTTP/1.1 200 OK\r\n\r\nOK").is_ok());
+    }
+
+    #[test]
+    fn test_validate_docker_ping_response_rejects_non_200() {
+        assert!(validate_docker_ping_response(b"HTTP/1.1 503 Service Unavailable\r\n").is_err());
+        assert!(validate_docker_ping_response(b"").is_err());
     }
 }

--- a/app/arcbox-core/src/container_backend/guest_docker.rs
+++ b/app/arcbox-core/src/container_backend/guest_docker.rs
@@ -4,13 +4,8 @@ use crate::error::{CoreError, Result};
 use crate::machine::MachineManager;
 use crate::vm_lifecycle::VmLifecycleManager;
 use async_trait::async_trait;
-use std::os::fd::{AsRawFd, FromRawFd, OwnedFd, RawFd};
 use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::{Duration, Instant};
-
-const ENDPOINT_PROBE_TIMEOUT: Duration = Duration::from_secs(2);
-const DOCKER_PING_REQUEST: &[u8] = b"GET /_ping HTTP/1.0\r\nHost: docker\r\n\r\n";
 
 /// Guest Docker backend (dockerd/containerd/runc inside VM).
 pub struct GuestDockerBackend {
@@ -18,9 +13,6 @@ pub struct GuestDockerBackend {
     machine_manager: Arc<MachineManager>,
     machine_name: &'static str,
     config: ContainerRuntimeConfig,
-    /// Set once the guest endpoint has been verified; collapses the
-    /// per-request readiness check to a single vsock connect probe.
-    endpoint_verified: AtomicBool,
 }
 
 impl GuestDockerBackend {
@@ -36,53 +28,10 @@ impl GuestDockerBackend {
             machine_manager,
             machine_name,
             config,
-            endpoint_verified: AtomicBool::new(false),
-        }
-    }
-
-    /// Probes the guest dockerd endpoint with a real Docker `_ping` request.
-    async fn probe_guest_endpoint(&self) -> Result<()> {
-        let manager = Arc::clone(&self.machine_manager);
-        let machine_name = self.machine_name;
-        let port = self.config.guest_docker_vsock_port;
-
-        let task = tokio::task::spawn_blocking(move || {
-            let fd = manager.connect_vsock_port(machine_name, port)?;
-            probe_docker_ping(fd)
-        });
-
-        match tokio::time::timeout(ENDPOINT_PROBE_TIMEOUT, task).await {
-            Ok(join_result) => join_result.map_err(|e| {
-                CoreError::Machine(format!("guest endpoint probe task failed: {e}"))
-            })?,
-            Err(_) => Err(CoreError::Machine(format!(
-                "guest docker endpoint probe timed out after {}ms",
-                ENDPOINT_PROBE_TIMEOUT.as_millis()
-            ))),
         }
     }
 
     async fn wait_guest_endpoint_ready(&self) -> Result<()> {
-        // Fast path: the endpoint was verified earlier in this VM's
-        // lifetime. One blocking `_ping` probe replaces the agent RPC round
-        // trips; if dockerd died (or the VM restarted underneath us), the
-        // probe fails and we fall through to the full ensure-runtime loop,
-        // which restarts dockerd via the agent.
-        //
-        // Relaxed is intentional: this flag is a pure optimization hint with
-        // no associated data to synchronize. A stale read in either direction
-        // is safe — we either take an unnecessary slow path or retry the probe.
-        if self.endpoint_verified.load(Ordering::Relaxed) {
-            match self.probe_guest_endpoint().await {
-                Ok(()) => return Ok(()),
-                Err(e) => {
-                    self.endpoint_verified.store(false, Ordering::Relaxed);
-                    tracing::debug!(
-                        "guest endpoint failed cached probe ({e}); re-running full readiness"
-                    );
-                }
-            }
-        }
         const INITIAL_DELAY_MS: u64 = 120;
         const MAX_DELAY_MS: u64 = 1200;
 
@@ -133,29 +82,8 @@ impl GuestDockerBackend {
             }
 
             if docker_ready {
-                match self.probe_guest_endpoint().await {
-                    Ok(()) => {
-                        self.endpoint_verified.store(true, Ordering::Relaxed);
-                        tracing::debug!(port, "guest docker endpoint is ready");
-                        return Ok(());
-                    }
-                    Err(e) => {
-                        if Instant::now() >= deadline {
-                            return Err(CoreError::Machine(format!(
-                                "guest docker endpoint on vsock port {} not ready within {}ms: {}",
-                                port,
-                                self.config.startup_timeout_ms,
-                                last_status_detail.unwrap_or_else(|| e.to_string())
-                            )));
-                        }
-                        tracing::trace!(
-                            port,
-                            retry_delay_ms = delay_ms,
-                            "guest docker endpoint not reachable yet: {}",
-                            e
-                        );
-                    }
-                }
+                tracing::debug!(port, "guest docker runtime is ready");
+                return Ok(());
             } else if Instant::now() >= deadline {
                 return Err(CoreError::Machine(format!(
                     "guest docker endpoint on vsock port {} not ready within {}ms: {}",
@@ -175,116 +103,6 @@ impl GuestDockerBackend {
             delay_ms = (delay_ms * 3 / 2).min(MAX_DELAY_MS);
         }
     }
-}
-
-fn probe_docker_ping(fd: RawFd) -> Result<()> {
-    // SAFETY: connect_vsock_port returns a freshly created fd owned by the
-    // caller; wrapping it transfers that ownership so it closes.
-    let owned = unsafe { OwnedFd::from_raw_fd(fd) };
-    write_all_with_poll(
-        owned.as_raw_fd(),
-        DOCKER_PING_REQUEST,
-        ENDPOINT_PROBE_TIMEOUT,
-    )?;
-
-    let mut response = [0u8; 512];
-    let n = read_with_poll(owned.as_raw_fd(), &mut response, ENDPOINT_PROBE_TIMEOUT)?;
-    validate_docker_ping_response(&response[..n])
-}
-
-fn write_all_with_poll(fd: RawFd, mut buf: &[u8], timeout: Duration) -> Result<()> {
-    while !buf.is_empty() {
-        poll_fd(fd, libc::POLLOUT, timeout)?;
-        // SAFETY: fd is live for the duration of the call, and buf points to
-        // readable memory of length buf.len().
-        let written = unsafe { libc::write(fd, buf.as_ptr().cast(), buf.len()) };
-        if written > 0 {
-            buf = &buf[written as usize..];
-            continue;
-        }
-        if written == 0 {
-            return Err(CoreError::from(std::io::Error::new(
-                std::io::ErrorKind::WriteZero,
-                "guest docker endpoint accepted zero bytes",
-            )));
-        }
-
-        let err = std::io::Error::last_os_error();
-        if matches!(
-            err.kind(),
-            std::io::ErrorKind::Interrupted | std::io::ErrorKind::WouldBlock
-        ) {
-            continue;
-        }
-        return Err(CoreError::from(err));
-    }
-    Ok(())
-}
-
-fn read_with_poll(fd: RawFd, buf: &mut [u8], timeout: Duration) -> Result<usize> {
-    poll_fd(fd, libc::POLLIN, timeout)?;
-    // SAFETY: fd is live for the duration of the call, and buf points to
-    // writable memory of length buf.len().
-    let read = unsafe { libc::read(fd, buf.as_mut_ptr().cast(), buf.len()) };
-    if read > 0 {
-        return Ok(read as usize);
-    }
-    if read == 0 {
-        return Err(CoreError::from(std::io::Error::new(
-            std::io::ErrorKind::UnexpectedEof,
-            "guest docker endpoint closed before responding to _ping",
-        )));
-    }
-
-    Err(CoreError::from(std::io::Error::last_os_error()))
-}
-
-fn poll_fd(fd: RawFd, events: libc::c_short, timeout: Duration) -> Result<()> {
-    let timeout_ms = i32::try_from(timeout.as_millis()).unwrap_or(i32::MAX);
-    loop {
-        let mut pollfd = libc::pollfd {
-            fd,
-            events,
-            revents: 0,
-        };
-        // SAFETY: pollfd points to one valid pollfd for the duration of poll.
-        let result = unsafe { libc::poll(&raw mut pollfd, 1, timeout_ms) };
-        if result > 0 {
-            if pollfd.revents & events != 0 {
-                return Ok(());
-            }
-            return Err(CoreError::from(std::io::Error::new(
-                std::io::ErrorKind::ConnectionAborted,
-                format!(
-                    "guest docker endpoint poll failed: revents={}",
-                    pollfd.revents
-                ),
-            )));
-        }
-        if result == 0 {
-            return Err(CoreError::from(std::io::Error::new(
-                std::io::ErrorKind::TimedOut,
-                "guest docker endpoint probe timed out",
-            )));
-        }
-
-        let err = std::io::Error::last_os_error();
-        if err.kind() == std::io::ErrorKind::Interrupted {
-            continue;
-        }
-        return Err(CoreError::from(err));
-    }
-}
-
-fn validate_docker_ping_response(response: &[u8]) -> Result<()> {
-    if response.starts_with(b"HTTP/1.0 200") || response.starts_with(b"HTTP/1.1 200") {
-        return Ok(());
-    }
-
-    Err(CoreError::Machine(format!(
-        "guest docker endpoint returned unexpected _ping response: {}",
-        String::from_utf8_lossy(response).trim_end()
-    )))
 }
 
 fn parse_vsock_endpoint_port(endpoint: &str) -> Option<u32> {
@@ -322,9 +140,7 @@ impl ContainerBackend for GuestDockerBackend {
 
 #[cfg(test)]
 mod tests {
-    use super::{
-        parse_vsock_endpoint_port, validate_docker_ping_response, validate_reported_vsock_endpoint,
-    };
+    use super::{parse_vsock_endpoint_port, validate_reported_vsock_endpoint};
 
     #[test]
     fn test_parse_vsock_endpoint_port_ok() {
@@ -357,17 +173,5 @@ mod tests {
         let err =
             validate_reported_vsock_endpoint("unix:///var/run/docker.sock", 2375).unwrap_err();
         assert!(err.to_string().contains("format invalid"));
-    }
-
-    #[test]
-    fn test_validate_docker_ping_response_accepts_http_200() {
-        assert!(validate_docker_ping_response(b"HTTP/1.0 200 OK\r\n\r\nOK").is_ok());
-        assert!(validate_docker_ping_response(b"HTTP/1.1 200 OK\r\n\r\nOK").is_ok());
-    }
-
-    #[test]
-    fn test_validate_docker_ping_response_rejects_non_200() {
-        assert!(validate_docker_ping_response(b"HTTP/1.1 503 Service Unavailable\r\n").is_err());
-        assert!(validate_docker_ping_response(b"").is_err());
     }
 }

--- a/app/arcbox-docker/README.md
+++ b/app/arcbox-docker/README.md
@@ -169,6 +169,38 @@ file descriptor is wrapped by `arcbox_transport::vsock::VsockStream`, giving
 the proxy one async stream abstraction for both production vsock and Unix-socket
 integration tests.
 
+### Guest Docker readiness
+
+`arcbox-core` owns the slow readiness path: starting the utility VM, asking the
+guest agent to ensure the container runtime, and validating the reported vsock
+endpoint. `arcbox-docker` owns Docker HTTP readiness because only the proxy can
+prove that guest `dockerd` accepted and answered a real Docker request.
+
+Before a request is forwarded, `ProxyState` asks `GuestDockerReadiness` to
+verify the selected `UtilityVmRole`. Readiness is tracked per role with an
+explicit state machine:
+
+```mermaid
+stateDiagram-v2
+    [*] --> Unverified
+    Unverified --> Verifying: prepare runtime + GET /_ping
+    Verifying --> Verified: success
+    Verifying --> Unverified: prepare or _ping failed
+    Verified --> Unverified: transport/proxy failure
+```
+
+Only one caller performs the runtime preparation and `_ping` while a role is in
+`Verifying`; concurrent callers wait for the state change and then reuse the
+result. Any forwarding, upload, or upgrade transport error invalidates that
+role's readiness so the next request re-runs the slow readiness path and then
+verifies guest `dockerd` with another `_ping`.
+
+This keeps the ownership boundary clear:
+
+- `arcbox-core`: VM lifecycle, guest agent runtime readiness, endpoint shape.
+- `arcbox-docker`: HTTP verification, readiness caching, transport-failure
+  invalidation.
+
 ## API Version
 
 - **Host route compatibility:** `/v1.24` through `/v1.43` plus unversioned routes
@@ -181,12 +213,14 @@ Focused proxy checks:
 ```bash
 cargo test -p arcbox-docker proxy::
 cargo test -p arcbox-docker --test proxy_integration
+cargo test -p arcbox-docker api::tests::readiness
 ```
 
 The integration tests run against a mock guest `dockerd` over a Unix socket, so
 they do not require a VM. They cover ordinary forwarding, pooled session reuse,
 early body-drop discard behavior, streaming forwarding, and HTTP upgrade
-handling.
+handling. The readiness unit tests cover the explicit state transitions,
+per-role isolation, invalidation, and concurrent verification serialization.
 
 ## License
 

--- a/app/arcbox-docker/src/api.rs
+++ b/app/arcbox-docker/src/api.rs
@@ -10,15 +10,22 @@ use crate::handlers;
 use crate::proxy;
 use crate::proxy::{GuestConnector, GuestHttpClient};
 use crate::request_context::proxy_request_context_middleware;
+use crate::routing::UtilityVmRole;
 use crate::trace::trace_id_middleware;
 use crate::workload::WorkloadRoleRegistry;
 use arcbox_core::Runtime;
 use axum::extract::OriginalUri;
+use axum::http::{HeaderMap, Method, StatusCode};
 use axum::{
     Router, middleware,
     routing::{delete, post},
 };
+use bytes::Bytes;
+use http_body_util::BodyExt;
+use std::future::Future;
 use std::sync::Arc;
+use std::sync::Mutex;
+use tokio::sync::Notify;
 
 /// Application state shared with handlers.
 #[derive(Clone)]
@@ -35,6 +42,7 @@ pub struct AppState {
 pub struct ProxyState {
     connector: Arc<dyn GuestConnector>,
     guest_http_client: GuestHttpClient,
+    endpoint_readiness: GuestDockerReadiness,
 }
 
 impl ProxyState {
@@ -42,6 +50,7 @@ impl ProxyState {
         Self {
             guest_http_client: GuestHttpClient::new(Arc::clone(&connector)),
             connector,
+            endpoint_readiness: GuestDockerReadiness::new(),
         }
     }
 
@@ -51,6 +60,179 @@ impl ProxyState {
 
     pub(crate) fn client(&self) -> &GuestHttpClient {
         &self.guest_http_client
+    }
+
+    /// Ensures guest dockerd is reachable at the Docker HTTP layer for `role`.
+    ///
+    /// The supplied `prepare_runtime` future owns the slow VM/agent/runtime
+    /// readiness path. This proxy state owns the cheaper HTTP `_ping`
+    /// verification and caches it until a transport failure invalidates it.
+    pub(crate) async fn ensure_endpoint_verified<F>(
+        &self,
+        role: UtilityVmRole,
+        prepare_runtime: F,
+    ) -> crate::error::Result<()>
+    where
+        F: Future<Output = crate::error::Result<()>>,
+    {
+        self.endpoint_readiness
+            .ensure_verified(role, prepare_runtime, || self.ping_guest(role))
+            .await
+    }
+
+    pub(crate) fn invalidate_endpoint(&self, role: UtilityVmRole) {
+        self.endpoint_readiness.invalidate(role);
+    }
+
+    async fn ping_guest(&self, role: UtilityVmRole) -> crate::error::Result<()> {
+        let response = proxy::proxy_to_guest_for_role_pooled(
+            &self.guest_http_client,
+            role,
+            Method::GET,
+            "/_ping",
+            &HeaderMap::new(),
+            Bytes::new(),
+        )
+        .await?;
+
+        let status = response.status();
+        let body = BodyExt::collect(response.into_body())
+            .await
+            .map_err(|e| {
+                crate::error::DockerError::Server(format!(
+                    "failed to read guest docker _ping response: {e}"
+                ))
+            })?
+            .to_bytes();
+
+        if status == StatusCode::OK {
+            return Ok(());
+        }
+
+        Err(crate::error::DockerError::Server(format!(
+            "guest docker _ping returned {status}: {}",
+            String::from_utf8_lossy(&body).trim_end()
+        )))
+    }
+}
+
+struct GuestDockerReadiness {
+    native: RoleEndpointReadiness,
+    rosetta: RoleEndpointReadiness,
+}
+
+impl GuestDockerReadiness {
+    fn new() -> Self {
+        Self {
+            native: RoleEndpointReadiness::new(),
+            rosetta: RoleEndpointReadiness::new(),
+        }
+    }
+
+    async fn ensure_verified<Prepare, Verify, VerifyFuture>(
+        &self,
+        role: UtilityVmRole,
+        prepare_runtime: Prepare,
+        verify_endpoint: Verify,
+    ) -> crate::error::Result<()>
+    where
+        Prepare: Future<Output = crate::error::Result<()>>,
+        Verify: FnOnce() -> VerifyFuture,
+        VerifyFuture: Future<Output = crate::error::Result<()>>,
+    {
+        self.for_role(role)
+            .ensure_verified(prepare_runtime, verify_endpoint)
+            .await
+    }
+
+    fn invalidate(&self, role: UtilityVmRole) {
+        self.for_role(role).invalidate();
+    }
+
+    const fn for_role(&self, role: UtilityVmRole) -> &RoleEndpointReadiness {
+        match role {
+            UtilityVmRole::Native => &self.native,
+            UtilityVmRole::Rosetta => &self.rosetta,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum EndpointReadinessState {
+    Unverified,
+    Verifying,
+    Verified,
+}
+
+struct RoleEndpointReadiness {
+    state: Mutex<EndpointReadinessState>,
+    changed: Notify,
+}
+
+impl RoleEndpointReadiness {
+    fn new() -> Self {
+        Self {
+            state: Mutex::new(EndpointReadinessState::Unverified),
+            changed: Notify::new(),
+        }
+    }
+
+    async fn ensure_verified<Prepare, Verify, VerifyFuture>(
+        &self,
+        prepare_runtime: Prepare,
+        verify_endpoint: Verify,
+    ) -> crate::error::Result<()>
+    where
+        Prepare: Future<Output = crate::error::Result<()>>,
+        Verify: FnOnce() -> VerifyFuture,
+        VerifyFuture: Future<Output = crate::error::Result<()>>,
+    {
+        loop {
+            let wait_for_change = {
+                let mut state = self.state.lock().unwrap_or_else(|e| e.into_inner());
+                match *state {
+                    EndpointReadinessState::Verified => return Ok(()),
+                    EndpointReadinessState::Unverified => {
+                        *state = EndpointReadinessState::Verifying;
+                        None
+                    }
+                    EndpointReadinessState::Verifying => Some(self.changed.notified()),
+                }
+            };
+
+            if let Some(wait_for_change) = wait_for_change {
+                wait_for_change.await;
+                continue;
+            }
+
+            let result = async {
+                prepare_runtime.await?;
+                verify_endpoint().await
+            }
+            .await;
+
+            let mut state = self.state.lock().unwrap_or_else(|e| e.into_inner());
+            *state = if result.is_ok() {
+                EndpointReadinessState::Verified
+            } else {
+                EndpointReadinessState::Unverified
+            };
+            self.changed.notify_waiters();
+            return result;
+        }
+    }
+
+    fn invalidate(&self) {
+        let mut state = self.state.lock().unwrap_or_else(|e| e.into_inner());
+        if *state != EndpointReadinessState::Unverified {
+            *state = EndpointReadinessState::Unverified;
+            self.changed.notify_waiters();
+        }
+    }
+
+    #[cfg(test)]
+    fn state(&self) -> EndpointReadinessState {
+        *self.state.lock().unwrap_or_else(|e| e.into_inner())
     }
 }
 
@@ -179,6 +361,9 @@ fn volume_routes() -> Router<AppState> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::error::DockerError;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use tokio::time::{Duration, sleep};
 
     #[test]
     fn strip_standard_version_prefix() {
@@ -248,5 +433,230 @@ mod tests {
         let req = strip_api_version_prefix(req);
         assert_eq!(req.uri().path(), "/containers/abc/start");
         assert!(req.extensions().get::<OriginalUri>().is_none());
+    }
+
+    #[tokio::test]
+    async fn readiness_transitions_unverified_to_verified_after_success() {
+        let readiness = GuestDockerReadiness::new();
+        let prepared = Arc::new(AtomicUsize::new(0));
+        let verified = Arc::new(AtomicUsize::new(0));
+
+        assert_eq!(
+            readiness.for_role(UtilityVmRole::Native).state(),
+            EndpointReadinessState::Unverified
+        );
+
+        let prepared_current = Arc::clone(&prepared);
+        let verified_current = Arc::clone(&verified);
+        readiness
+            .ensure_verified(
+                UtilityVmRole::Native,
+                async move {
+                    prepared_current.fetch_add(1, Ordering::Relaxed);
+                    Ok::<(), DockerError>(())
+                },
+                || async move {
+                    verified_current.fetch_add(1, Ordering::Relaxed);
+                    Ok::<(), DockerError>(())
+                },
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(
+            readiness.for_role(UtilityVmRole::Native).state(),
+            EndpointReadinessState::Verified
+        );
+        assert_eq!(prepared.load(Ordering::Relaxed), 1);
+        assert_eq!(verified.load(Ordering::Relaxed), 1);
+    }
+
+    #[tokio::test]
+    async fn readiness_keeps_verified_state_on_cache_hit() {
+        let readiness = GuestDockerReadiness::new();
+        let prepared = Arc::new(AtomicUsize::new(0));
+        let verified = Arc::new(AtomicUsize::new(0));
+
+        let prepared_first = Arc::clone(&prepared);
+        let verified_first = Arc::clone(&verified);
+        readiness
+            .ensure_verified(
+                UtilityVmRole::Native,
+                async move {
+                    prepared_first.fetch_add(1, Ordering::Relaxed);
+                    Ok::<(), DockerError>(())
+                },
+                || async move {
+                    verified_first.fetch_add(1, Ordering::Relaxed);
+                    Ok::<(), DockerError>(())
+                },
+            )
+            .await
+            .unwrap();
+
+        let prepared_second = Arc::clone(&prepared);
+        let verified_second = Arc::clone(&verified);
+        readiness
+            .ensure_verified(
+                UtilityVmRole::Native,
+                async move {
+                    prepared_second.fetch_add(1, Ordering::Relaxed);
+                    Ok::<(), DockerError>(())
+                },
+                || async move {
+                    verified_second.fetch_add(1, Ordering::Relaxed);
+                    Ok::<(), DockerError>(())
+                },
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(prepared.load(Ordering::Relaxed), 1);
+        assert_eq!(verified.load(Ordering::Relaxed), 1);
+    }
+
+    #[tokio::test]
+    async fn readiness_transitions_back_to_unverified_after_failure() {
+        let readiness = GuestDockerReadiness::new();
+        let prepared = Arc::new(AtomicUsize::new(0));
+        let verified = Arc::new(AtomicUsize::new(0));
+
+        let prepared_current = Arc::clone(&prepared);
+        let verified_current = Arc::clone(&verified);
+        let err = readiness
+            .ensure_verified(
+                UtilityVmRole::Native,
+                async move {
+                    prepared_current.fetch_add(1, Ordering::Relaxed);
+                    Ok::<(), DockerError>(())
+                },
+                || async move {
+                    verified_current.fetch_add(1, Ordering::Relaxed);
+                    Err::<(), DockerError>(DockerError::Server("ping failed".into()))
+                },
+            )
+            .await
+            .unwrap_err();
+
+        assert!(err.to_string().contains("ping failed"));
+        assert_eq!(
+            readiness.for_role(UtilityVmRole::Native).state(),
+            EndpointReadinessState::Unverified
+        );
+        assert_eq!(prepared.load(Ordering::Relaxed), 1);
+        assert_eq!(verified.load(Ordering::Relaxed), 1);
+    }
+
+    #[tokio::test]
+    async fn readiness_invalidation_transitions_verified_to_unverified() {
+        let readiness = GuestDockerReadiness::new();
+        let verified = Arc::new(AtomicUsize::new(0));
+
+        for _ in 0..2 {
+            let verified_current = Arc::clone(&verified);
+            readiness
+                .ensure_verified(
+                    UtilityVmRole::Native,
+                    async { Ok::<(), DockerError>(()) },
+                    || async move {
+                        verified_current.fetch_add(1, Ordering::Relaxed);
+                        Ok::<(), DockerError>(())
+                    },
+                )
+                .await
+                .unwrap();
+            readiness.invalidate(UtilityVmRole::Native);
+        }
+
+        assert_eq!(verified.load(Ordering::Relaxed), 2);
+        assert_eq!(
+            readiness.for_role(UtilityVmRole::Native).state(),
+            EndpointReadinessState::Unverified
+        );
+    }
+
+    #[tokio::test]
+    async fn readiness_is_isolated_per_utility_vm_role() {
+        let readiness = GuestDockerReadiness::new();
+
+        readiness
+            .ensure_verified(
+                UtilityVmRole::Native,
+                async { Ok::<(), DockerError>(()) },
+                || async { Ok::<(), DockerError>(()) },
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(
+            readiness.for_role(UtilityVmRole::Native).state(),
+            EndpointReadinessState::Verified
+        );
+        assert_eq!(
+            readiness.for_role(UtilityVmRole::Rosetta).state(),
+            EndpointReadinessState::Unverified
+        );
+    }
+
+    #[tokio::test]
+    async fn readiness_serializes_concurrent_verification() {
+        let readiness = Arc::new(GuestDockerReadiness::new());
+        let prepared = Arc::new(AtomicUsize::new(0));
+        let verified = Arc::new(AtomicUsize::new(0));
+
+        let first_readiness = Arc::clone(&readiness);
+        let first_prepared = Arc::clone(&prepared);
+        let first_verified = Arc::clone(&verified);
+        let first = tokio::spawn(async move {
+            first_readiness
+                .ensure_verified(
+                    UtilityVmRole::Native,
+                    async move {
+                        first_prepared.fetch_add(1, Ordering::Relaxed);
+                        sleep(Duration::from_millis(20)).await;
+                        Ok::<(), DockerError>(())
+                    },
+                    || async move {
+                        first_verified.fetch_add(1, Ordering::Relaxed);
+                        sleep(Duration::from_millis(20)).await;
+                        Ok::<(), DockerError>(())
+                    },
+                )
+                .await
+        });
+
+        while readiness.for_role(UtilityVmRole::Native).state() != EndpointReadinessState::Verifying
+        {
+            sleep(Duration::from_millis(1)).await;
+        }
+
+        let second_readiness = Arc::clone(&readiness);
+        let second_prepared = Arc::clone(&prepared);
+        let second_verified = Arc::clone(&verified);
+        let second = tokio::spawn(async move {
+            second_readiness
+                .ensure_verified(
+                    UtilityVmRole::Native,
+                    async move {
+                        second_prepared.fetch_add(1, Ordering::Relaxed);
+                        Ok::<(), DockerError>(())
+                    },
+                    || async move {
+                        second_verified.fetch_add(1, Ordering::Relaxed);
+                        Ok::<(), DockerError>(())
+                    },
+                )
+                .await
+        });
+
+        first.await.unwrap().unwrap();
+        second.await.unwrap().unwrap();
+
+        assert_eq!(
+            readiness.for_role(UtilityVmRole::Native).state(),
+            EndpointReadinessState::Verified
+        );
+        assert_eq!(prepared.load(Ordering::Relaxed), 1);
+        assert_eq!(verified.load(Ordering::Relaxed), 1);
     }
 }

--- a/app/arcbox-docker/src/handlers/proxying.rs
+++ b/app/arcbox-docker/src/handlers/proxying.rs
@@ -7,10 +7,12 @@ use crate::routing::UtilityVmRole;
 use axum::body::Body;
 use axum::http::{Request, Uri};
 use axum::response::Response;
+use std::sync::Arc;
 
 /// Ensures the utility VM hosting `role` is up before any request reaches
-/// the connector. Surfaces the role in the error message so a Rosetta-VM
-/// failure can't be confused with a native-VM failure.
+/// the connector, then verifies guest dockerd with a real Docker `_ping`.
+/// Surfaces the role in the error message so a Rosetta-VM failure can't be
+/// confused with a native-VM failure.
 ///
 /// Refuses requests for a role that is not configured on this host
 /// (e.g. `Rosetta` on non-Apple-Silicon) with a clear platform-specific
@@ -26,17 +28,23 @@ pub async fn ensure_role_ready(state: &AppState, role: UtilityVmRole) -> Result<
             role.as_str(),
         )));
     }
+
+    let runtime = Arc::clone(&state.runtime);
     state
-        .runtime
-        .ensure_role_ready(role)
-        .await
-        .map(|_| ())
-        .map_err(|e| {
-            DockerError::Server(format!(
-                "failed to ensure {} utility VM is ready: {e}",
-                role.as_str(),
-            ))
+        .proxy
+        .ensure_endpoint_verified(role, async move {
+            runtime
+                .ensure_role_ready(role)
+                .await
+                .map(|_| ())
+                .map_err(|e| {
+                    DockerError::Server(format!(
+                        "failed to ensure {} utility VM is ready: {e}",
+                        role.as_str(),
+                    ))
+                })
         })
+        .await
 }
 
 /// Forward a request to a selected utility VM's guest dockerd.
@@ -47,7 +55,13 @@ pub async fn proxy_to_role(
     req: Request<Body>,
 ) -> Result<Response> {
     ensure_role_ready(state, role).await?;
-    proxy::proxy_to_guest_stream_for_role_pooled(state.proxy.client(), role, uri, req).await
+    match proxy::proxy_to_guest_stream_for_role_pooled(state.proxy.client(), role, uri, req).await {
+        Ok(response) => Ok(response),
+        Err(e) => {
+            state.proxy.invalidate_endpoint(role);
+            Err(e)
+        }
+    }
 }
 
 /// Forward an upload request to a selected utility VM's guest dockerd.
@@ -58,5 +72,11 @@ pub async fn proxy_upload_to_role(
     req: Request<Body>,
 ) -> Result<Response> {
     ensure_role_ready(state, role).await?;
-    proxy::proxy_streaming_upload_for_role(state.proxy.connector(), role, uri, req).await
+    match proxy::proxy_streaming_upload_for_role(state.proxy.connector(), role, uri, req).await {
+        Ok(response) => Ok(response),
+        Err(e) => {
+            state.proxy.invalidate_endpoint(role);
+            Err(e)
+        }
+    }
 }

--- a/app/arcbox-docker/src/proxy/fallback.rs
+++ b/app/arcbox-docker/src/proxy/fallback.rs
@@ -46,16 +46,43 @@ pub async fn proxy_fallback(
 
     if req.headers().wants_upgrade() {
         tracing::Span::current().record("protocol", "upgrade");
-        return upgrade::proxy_with_upgrade_for_role(state.proxy.connector(), role, req, &uri)
-            .await;
+        return match upgrade::proxy_with_upgrade_for_role(state.proxy.connector(), role, req, &uri)
+            .await
+        {
+            Ok(response) => Ok(response),
+            Err(e) => {
+                state.proxy.invalidate_endpoint(role);
+                Err(e)
+            }
+        };
     }
 
     if upload::is_streaming_upload_request(req.method(), &uri) {
         tracing::Span::current().record("protocol", "upload");
-        return upload::proxy_streaming_upload_for_role(state.proxy.connector(), role, &uri, req)
-            .await;
+        return match upload::proxy_streaming_upload_for_role(
+            state.proxy.connector(),
+            role,
+            &uri,
+            req,
+        )
+        .await
+        {
+            Ok(response) => Ok(response),
+            Err(e) => {
+                state.proxy.invalidate_endpoint(role);
+                Err(e)
+            }
+        };
     }
 
     tracing::Span::current().record("protocol", "http");
-    forward::proxy_to_guest_stream_for_role_pooled(state.proxy.client(), role, &uri, req).await
+    match forward::proxy_to_guest_stream_for_role_pooled(state.proxy.client(), role, &uri, req)
+        .await
+    {
+        Ok(response) => Ok(response),
+        Err(e) => {
+            state.proxy.invalidate_endpoint(role);
+            Err(e)
+        }
+    }
 }


### PR DESCRIPTION
Follow-up to #299/#301 on the Docker request path.

## Problem

Every proxied Docker API request re-ran the slow guest readiness path: VM lifecycle readiness, guest-agent `ensure_runtime`, status fallback, and a throwaway endpoint probe. That made warm Docker requests pay agent/vsock round trips even after guest `dockerd` was already known to be serving traffic.

The earlier approach cached readiness inside `arcbox-core`, but that put Docker HTTP semantics in the wrong layer and could only prove transport/connectivity. The proxy layer is the component that can prove guest `dockerd` accepted and answered a real Docker request.

## Change

Move Docker HTTP readiness ownership into `arcbox-docker`:

- `arcbox-core` now owns only the slow readiness path: VM lifecycle, guest-agent runtime readiness, and reported vsock endpoint validation.
- `arcbox-docker::ProxyState` owns HTTP verification and invalidation.
- Guest dockerd readiness is tracked per `UtilityVmRole` with an explicit state machine:
  - `Unverified`
  - `Verifying`
  - `Verified`
- First request for a role runs the slow readiness path, then verifies guest dockerd with a real `GET /_ping` through the pooled proxy client.
- Concurrent callers that observe `Verifying` wait for the state change instead of starting duplicate probes.
- Forwarding, upload, or upgrade transport failures invalidate that role's readiness so the next request re-runs slow readiness + HTTP verification.

## Why this shape

This keeps the ownership boundary clean:

- `arcbox-core`: VM/agent/runtime orchestration and endpoint shape.
- `arcbox-docker`: Docker HTTP readiness, readiness caching, and transport-failure invalidation.

It also avoids the previous connect-only readiness ambiguity: `Verified` now means guest `dockerd` answered an actual Docker HTTP request.

## Tests

Added readiness state tests for:

- `Unverified -> Verified` on successful prepare + `_ping`
- cache hit while already `Verified`
- failure rollback to `Unverified`
- invalidation from `Verified` to `Unverified`
- per-role isolation
- concurrent verification serialization

## Verification

- `cargo fmt --check`
- `cargo check -p arcbox-core -p arcbox-docker`
- `cargo clippy -p arcbox-core -p arcbox-docker --all-targets -- -D warnings`
- `cargo test -p arcbox-core -p arcbox-docker`

## Docs

Updated `app/arcbox-docker/README.md` with the proxy readiness ownership model, state machine, and focused test command.
