### PR TITLE
fix(vmnet): match vmpktdesc ABI so vmnet_read/vmnet_write stop failing EINVAL

### DIFF
--- a/virt/arcbox-vmnet/src/ffi.rs
+++ b/virt/arcbox-vmnet/src/ffi.rs
@@ -47,6 +47,8 @@ pub enum VmnetReturnT {
     TooManyPackets = 1008,
     /// Sharing service busy.
     SharingServiceBusy = 1009,
+    /// The process is not authorized to use vmnet.
+    NotAuthorized = 1010,
 }
 
 impl VmnetReturnT {
@@ -70,6 +72,7 @@ impl VmnetReturnT {
             Self::BufferExhausted => "buffer exhausted",
             Self::TooManyPackets => "too many packets",
             Self::SharingServiceBusy => "sharing service busy",
+            Self::NotAuthorized => "not authorized",
         }
     }
 }
@@ -549,8 +552,16 @@ mod tests {
     fn test_vmnet_return_messages() {
         assert_eq!(VmnetReturnT::Success.message(), "success");
         assert_eq!(VmnetReturnT::Failure.message(), "operation failed");
+        assert_eq!(VmnetReturnT::NotAuthorized.message(), "not authorized");
         assert!(VmnetReturnT::Success.is_success());
         assert!(!VmnetReturnT::Failure.is_success());
+    }
+
+    #[test]
+    fn test_vmnet_return_values() {
+        assert_eq!(VmnetReturnT::Success as i32, 1000);
+        assert_eq!(VmnetReturnT::SharingServiceBusy as i32, 1009);
+        assert_eq!(VmnetReturnT::NotAuthorized as i32, 1010);
     }
 
     #[test]
@@ -565,6 +576,7 @@ mod tests {
     /// iovec pointer, then two `uint32_t`s. A layout drift shifts every
     /// field offset and makes vmnet_read/vmnet_write reject the
     /// descriptor with VMNET_INVALID_ARGUMENT.
+    #[cfg(target_pointer_width = "64")]
     #[test]
     fn vmnet_packet_matches_vmpktdesc_abi() {
         use std::mem::{offset_of, size_of};

--- a/virt/arcbox-vmnet/src/ffi.rs
+++ b/virt/arcbox-vmnet/src/ffi.rs
@@ -95,15 +95,21 @@ pub enum VmnetInterfaceEvent {
 }
 
 /// Packet descriptor for vmnet read/write operations.
+///
+/// Field order and types must match `struct vmpktdesc` in
+/// `<vmnet/vmnet.h>` exactly: `vm_pkt_size` is a `size_t` and comes
+/// first. Any deviation shifts every field offset and makes
+/// `vmnet_read`/`vmnet_write` fail with `VMNET_INVALID_ARGUMENT`.
 #[repr(C)]
 #[derive(Debug)]
 pub struct VmnetPacket {
+    /// Packet size in bytes (`size_t`). On read: in = buffer capacity,
+    /// out = actual packet length.
+    pub vm_pkt_size: usize,
     /// Pointer to packet data.
     pub vm_pkt_iov: *mut iovec,
     /// Number of iovec entries.
     pub vm_pkt_iovcnt: u32,
-    /// Packet size in bytes.
-    pub vm_pkt_size: u32,
     /// Flags.
     pub vm_flags: u32,
 }
@@ -552,5 +558,21 @@ mod tests {
         assert_eq!(VmnetOperatingMode::Host as i32, 1000);
         assert_eq!(VmnetOperatingMode::Shared as i32, 1001);
         assert_eq!(VmnetOperatingMode::Bridged as i32, 1002);
+    }
+
+    /// Pins `VmnetPacket` to the ABI of `struct vmpktdesc` in
+    /// `<vmnet/vmnet.h>` (arm64/x86_64 macOS): `size_t` first, then the
+    /// iovec pointer, then two `uint32_t`s. A layout drift shifts every
+    /// field offset and makes vmnet_read/vmnet_write reject the
+    /// descriptor with VMNET_INVALID_ARGUMENT.
+    #[test]
+    fn vmnet_packet_matches_vmpktdesc_abi() {
+        use std::mem::{offset_of, size_of};
+
+        assert_eq!(size_of::<VmnetPacket>(), 24);
+        assert_eq!(offset_of!(VmnetPacket, vm_pkt_size), 0);
+        assert_eq!(offset_of!(VmnetPacket, vm_pkt_iov), 8);
+        assert_eq!(offset_of!(VmnetPacket, vm_pkt_iovcnt), 16);
+        assert_eq!(offset_of!(VmnetPacket, vm_flags), 20);
     }
 }

--- a/virt/arcbox-vmnet/src/interface.rs
+++ b/virt/arcbox-vmnet/src/interface.rs
@@ -557,11 +557,14 @@ impl Vmnet {
             iov_len: buf.len(),
         };
 
-        // Create packet descriptor.
+        // Create packet descriptor. vmnet_read's input contract requires
+        // vm_pkt_size to hold the buffer capacity (it returns
+        // VMNET_INVALID_ARGUMENT for 0); on return it carries the actual
+        // packet length.
         let mut packet = VmnetPacket {
+            vm_pkt_size: buf.len(),
             vm_pkt_iov: &raw mut iov,
             vm_pkt_iovcnt: 1,
-            vm_pkt_size: 0,
             vm_flags: 0,
         };
 
@@ -582,7 +585,7 @@ impl Vmnet {
             return Ok(0);
         }
 
-        Ok(packet.vm_pkt_size as usize)
+        Ok(packet.vm_pkt_size)
     }
 
     /// Writes a packet to the vmnet interface.
@@ -613,9 +616,9 @@ impl Vmnet {
 
         // Create packet descriptor.
         let mut packet = VmnetPacket {
+            vm_pkt_size: data.len(),
             vm_pkt_iov: &raw mut iov,
             vm_pkt_iovcnt: 1,
-            vm_pkt_size: data.len() as u32,
             vm_flags: 0,
         };
 


### PR DESCRIPTION
## Problem

After #298 shipped vmnet in default features (v0.4.6), `*.arcbox.local` domains still did not appear in the desktop UI. Debug logs showed the bridge NIC relay failing every single read with:

```
vmnet read error: invalid argument
```

## Root cause

`VmnetPacket` in `arcbox-vmnet/src/ffi.rs` did not match `struct vmpktdesc` from `<vmnet/vmnet.h>`:

```c
struct vmpktdesc {
    size_t        vm_pkt_size;   // 8 bytes, FIRST field
    struct iovec *vm_pkt_iov;
    uint32_t      vm_pkt_iovcnt;
    uint32_t      vm_flags;
};
```

The Rust struct declared `vm_pkt_size` as a `u32` in third position. Every field landed at the wrong offset: vmnet read the iov pointer as the packet size, garbage as the iov pointer, and 0 as the iov count — so **both** `vmnet_read` and `vmnet_write` returned `VMNET_INVALID_ARGUMENT` for every packet. The NIC2 data path was dead in both directions:

- guest eth1 never completed DHCP → no IP
- kernel FDB never learned the guest MAC → `resolve_bridge_by_mac` returned None
- container route `172.16/12 → bridge100` was never installed
- `route_installed` stayed false → desktop UI showed `localhost` instead of `<name>.arcbox.local`

## Fix

- Reorder `VmnetPacket` to match the C layout; `vm_pkt_size` is now `usize` (= `size_t`)
- Set `vm_pkt_size` to the buffer capacity on read (vmnet_read's documented in/out contract) instead of 0
- Add an `offset_of!`-based ABI test pinning size 24 / offsets 0, 8, 16, 20

## Verification (macOS 26.5, end-to-end)

With this fix, on a cold boot:

- the EINVAL flood is gone (0 occurrences vs ~55k before)
- guest eth1 acquires `192.168.64.2/24` from vmnet's DHCP
- host ARP resolves the guest's vmnet MAC on `bridge100`; host↔guest ICMP flows
- FDB lookup resolves `bridge100`; helper logs `route ensured subnet=172.16.0.0/12 bridge=bridge100`
- `arcbox-postgres-1.arcbox.local` resolves to its container IP via the resolver at 127.0.0.1:5553

## Follow-ups (not in this PR)

1. **Route conflict**: on LANs that themselves route `172.16/12` (mine pushes it to the LAN gateway), configd re-asserts the DHCP route and silently replaces the helper's bridge100 route minutes after install. The route reconciler needs to watch the routing socket and re-assert, or use a less conflict-prone strategy.
2. `VmnetReturnT` is missing `VMNET_NOT_AUTHORIZED` (1010); an unknown discriminant in the `repr(C)` enum returned by FFI is UB.
3. `relay.rs` guest→vmnet loop: the socketpair fd is never set `O_NONBLOCK` and the `AsyncFd` guard never calls `clear_ready()` after successful reads — works, but degenerates into blocking reads on a runtime worker.
4. Pre-existing cold-boot flakiness ("timeout waiting for agent"): the guest agent intermittently stalls in early init; today the app's own daemon needed 3+ launchd restarts before a boot succeeded (12:48–12:52 in logs). Unrelated to vmnet — tracked separately.
5. vmnet ignores `with_mac` (assigns a random MAC per boot), so `recovery.rs`'s FDB lookup by the *derived* MAC can never match — live path already uses the vmnet-reported MAC.