### PR TITLE
fix(core): raise agent-wait startup timeout to 90s

### DIFF
--- a/app/arcbox-core/src/vm_lifecycle/mod.rs
+++ b/app/arcbox-core/src/vm_lifecycle/mod.rs
@@ -49,7 +49,11 @@ use tokio::sync::{Mutex, RwLock};
 pub const DEFAULT_MACHINE_NAME: &str = "default";
 
 /// Default startup timeout in seconds.
-const DEFAULT_STARTUP_TIMEOUT_SECS: u64 = 30;
+///
+/// Generous enough to cover a cold guest boot (erofs rootfs + large docker.img
+/// mount) even when the host daemon is CPU/I/O constrained. A tight 30s budget
+/// raced the cold-boot path and produced "timeout waiting for agent" loops.
+const DEFAULT_STARTUP_TIMEOUT_SECS: u64 = 90;
 
 /// Default health check interval in seconds.
 const DEFAULT_HEALTH_CHECK_INTERVAL_SECS: u64 = 5;


### PR DESCRIPTION
## Problem
`wait_for_agent` uses a 30s `DEFAULT_STARTUP_TIMEOUT_SECS`. A cold guest boot (erofs rootfs + large `docker.img` mount) can reach ~28s even unthrottled, and exceeds 30s when the host daemon is CPU/I/O constrained (e.g. launchd `ProcessType=Background` QoS). The probe then fails with `VM error: timeout waiting for agent` and, under launchd KeepAlive, the daemon crash-loops.

## Fix
Raise the default startup timeout to 90s for headroom on slow cold boots. The agent typically binds well under this; the larger budget only matters on constrained/cold paths.

## Related
arcboxlabs/arcbox-desktop `fix/daemon-qos-processtype` removes the Background QoS that triggered this in the field. Either change fixes the crash loop; together they're belt-and-suspenders.