### PR TITLE
fix(devenv): pin apple-sdk_26 so arcbox-daemon links locally

### DIFF
--- a/devenv.nix
+++ b/devenv.nix
@@ -12,6 +12,12 @@
     cargo-about
   ] ++ lib.optionals pkgs.stdenv.isDarwin [
     pkgs.libiconv
+    # arcbox-vmm links macOS 15+ Hypervisor GIC APIs (hv_gic_*). The nix darwin
+    # stdenv defaults to the 14.4 SDK, whose Hypervisor.tbd lacks those symbols,
+    # so `cargo build -p arcbox-daemon` fails to link locally. Pin a 15+ SDK to
+    # match CI (system Xcode 26 SDK). The setup hook makes this the active
+    # DEVELOPER_DIR/SDKROOT since it is the highest-versioned SDK in scope.
+    pkgs.apple-sdk_26
   ];
 
   languages.rust = {


### PR DESCRIPTION
## Problem
`make build-rust` / `cargo build -p arcbox-daemon` fail in the devenv shell at the **link** step:

```
ld: symbol(s) not found for architecture arm64
  _hv_gic_create, _hv_gic_config_create, _hv_gic_config_set_distributor_base,
  _hv_gic_config_set_redistributor_base, _hv_gic_set_spi
```

These are **macOS 15+ Hypervisor GICv3 APIs** that `arcbox-vmm::vmm::darwin_hv` links. The nix darwin stdenv defaults to the **14.4 SDK** (`DEVELOPER_DIR`/`SDKROOT` → apple-sdk-14.4, `NIX_APPLE_SDK_VERSION=140400`), whose `Hypervisor.tbd` predates those symbols. Per-invocation overrides (`SDKROOT`, `MACOSX_DEPLOYMENT_TARGET`, system linker) don't help — the nix clang/ld wrapper resolves frameworks via `DEVELOPER_DIR`, which stays 14.4. CI is unaffected because it uses the system Xcode 26 SDK.

## Fix
Add `apple-sdk_26` to the darwin dev shell. Its setup hook makes it the active `DEVELOPER_DIR`/`SDKROOT` (highest-versioned SDK in scope), so the toolchain links against a `Hypervisor.tbd` that exports `hv_gic_*`.

## Verification
```
$ direnv exec . bash -c 'echo $NIX_APPLE_SDK_VERSION; make build-daemon PROFILE=release'
260000
...
Finished `release` profile [optimized] target(s) in 1m 36s
```
(`vtool -show-build` reports `sdk 26.0`. `minos` stays 14.0, which is harmless: the daemon only ever runs inside the macOS-15-targeted desktop app.)

Note: guest-agent cross-compilation still needs `brew install FiloSottile/musl-cross/musl-cross` (unchanged; pkgsCross on darwin isn't cached).