### PR TITLE
feat(fleet): cross-platform runner agent

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -467,6 +467,7 @@ dependencies = [
  "sysinfo",
  "tokio",
  "tokio-stream",
+ "tokio-util",
  "tonic",
  "tracing",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -451,12 +451,13 @@ dependencies = [
 
 [[package]]
 name = "arcbox-fleet-agent"
-version = "0.4.12"
+version = "0.4.13"
 dependencies = [
  "anyhow",
  "arcbox-fleet-proto",
  "arcbox-logging",
  "clap",
+ "command-group",
  "dashmap",
  "dirs",
  "hostname",
@@ -472,7 +473,7 @@ dependencies = [
 
 [[package]]
 name = "arcbox-fleet-proto"
-version = "0.4.12"
+version = "0.4.13"
 dependencies = [
  "prost",
  "tonic",
@@ -1328,6 +1329,18 @@ checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
 dependencies = [
  "bytes",
  "memchr",
+]
+
+[[package]]
+name = "command-group"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a68fa787550392a9d58f44c21a3022cfb3ea3e2458b7f85d3b399d0ceeccf409"
+dependencies = [
+ "async-trait",
+ "nix 0.27.1",
+ "tokio",
+ "winapi",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -450,6 +450,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "arcbox-fleet-agent"
+version = "0.4.12"
+dependencies = [
+ "anyhow",
+ "arcbox-fleet-proto",
+ "arcbox-logging",
+ "clap",
+ "dashmap",
+ "dirs",
+ "hostname",
+ "prost",
+ "serde",
+ "serde_json",
+ "sysinfo",
+ "tokio",
+ "tokio-stream",
+ "tonic",
+ "tracing",
+]
+
+[[package]]
+name = "arcbox-fleet-proto"
+version = "0.4.12"
+dependencies = [
+ "prost",
+ "tonic",
+ "tonic-build",
+]
+
+[[package]]
 name = "arcbox-fs"
 version = "0.4.13"
 dependencies = [
@@ -2144,7 +2174,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots",
+ "webpki-roots 1.0.6",
 ]
 
 [[package]]
@@ -2213,7 +2243,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -2862,6 +2892,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "585d3cb5e12e01aed9e8a1f70d5c6b5e86fe2a6e48fc8cd0b3e0b8df6f6eb174"
 dependencies = [
  "instant",
+]
+
+[[package]]
+name = "ntapi"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3b335231dfd352ffb0f8017f3b6027a4917f7df785ea2143d8af2adc66980ae"
+dependencies = [
+ "winapi",
 ]
 
 [[package]]
@@ -3816,7 +3855,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
- "webpki-roots",
+ "webpki-roots 1.0.6",
 ]
 
 [[package]]
@@ -3880,6 +3919,15 @@ dependencies = [
  "rustls-webpki",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -4409,6 +4457,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "sysinfo"
+version = "0.33.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fc858248ea01b66f19d8e8a6d55f41deaf91e9d495246fd01368d99935c6c01"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+ "memchr",
+ "ntapi",
+ "rayon",
+ "windows",
+]
+
+[[package]]
 name = "system-configuration"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4800,13 +4862,16 @@ dependencies = [
  "percent-encoding",
  "pin-project",
  "prost",
+ "rustls-pemfile",
  "socket2 0.5.10",
  "tokio",
+ "tokio-rustls",
  "tokio-stream",
  "tower 0.4.13",
  "tower-layer",
  "tower-service",
  "tracing",
+ "webpki-roots 0.26.11",
 ]
 
 [[package]]
@@ -5113,7 +5178,7 @@ dependencies = [
  "rustls-pki-types",
  "ureq-proto",
  "utf8-zero",
- "webpki-roots",
+ "webpki-roots 1.0.6",
 ]
 
 [[package]]
@@ -5401,6 +5466,15 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.6",
+]
+
+[[package]]
+name = "webpki-roots"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
@@ -5440,16 +5514,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12342cb4d8e3b046f3d80effd474a7a02447231330ef77d71daa6fbc40681143"
+dependencies = [
+ "windows-core 0.57.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2ed2439a290666cd67ecce2b0ffaad89c2a56b976b736e6ece670297897832d"
+dependencies = [
+ "windows-implement 0.57.0",
+ "windows-interface 0.57.0",
+ "windows-result 0.1.2",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
 name = "windows-core"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
- "windows-implement",
- "windows-interface",
+ "windows-implement 0.60.2",
+ "windows-interface 0.59.3",
  "windows-link",
- "windows-result",
+ "windows-result 0.4.1",
  "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9107ddc059d5b6fbfbffdfa7a7fe3e22a226def0b2608f72e9d552763d3e1ad7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -5457,6 +5564,17 @@ name = "windows-implement"
 version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29bee4b38ea3cde66011baa44dba677c432a78593e202392d1e9070cf2a7fca7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5487,8 +5605,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
 dependencies = [
  "windows-link",
- "windows-result",
+ "windows-result 0.4.1",
  "windows-strings",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,6 +74,12 @@ members = [
     "tests/e2e",
     "virt/arcbox-net-inject",
     "xtask",
+
+    # ============================================
+    # Fleet (cross-platform runner agent, MIT OR Apache-2.0)
+    # ============================================
+    "fleet/arcbox-fleet-proto",
+    "fleet/arcbox-fleet-agent",
 ]
 
 [workspace.package]
@@ -168,6 +174,9 @@ chrono = { version = "0.4", features = ["serde"] }
 # Hostname
 hostname = "0.4"
 
+# System facts (memory, OS version) — cross-platform
+sysinfo = "0.33"
+
 # Nix (Unix APIs)
 nix = { version = "0.29", features = [
     "fs",
@@ -236,6 +245,7 @@ arcbox-container = { version = "0.4.13", path = "runtime/arcbox-container" } # x
 arcbox-protocol = { version = "0.4.13", path = "rpc/arcbox-protocol" } # x-release-please-version
 arcbox-grpc = { version = "0.4.13", path = "rpc/arcbox-grpc" } # x-release-please-version
 arcbox-transport = { version = "0.4.13", path = "rpc/arcbox-transport" } # x-release-please-version
+arcbox-fleet-proto = { version = "0.4.13", path = "fleet/arcbox-fleet-proto" } # x-release-please-version
 arcbox-docker = { version = "0.4.13", path = "app/arcbox-docker" } # x-release-please-version
 arcbox-helper = { version = "0.4.13", path = "app/arcbox-helper" } # x-release-please-version
 arcbox-core = { version = "0.4.13", path = "app/arcbox-core" } # x-release-please-version

--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,7 @@ else
 endif
 
 .PHONY: build build-release build-cli build-daemon build-helper build-agent \
+        build-fleet-agent fleet-proto-sync \
         test check fmt clean \
         setup-boot-assets sign sign-daemon sign-all verify run-daemon \
         run-helper install-helper reload-helper
@@ -49,6 +50,13 @@ build-helper:
 
 build-agent:
 	cargo build -p arcbox-agent --target $(AGENT_TARGET) --release
+
+build-fleet-agent:
+	cargo build -p arcbox-fleet-agent $(CARGO_FLAGS)
+
+# Refresh the vendored Fleet proto from the published BSR module.
+fleet-proto-sync:
+	buf export buf.build/arcboxlabs/fleet -o fleet/arcbox-fleet-proto/proto
 
 ## ── Quality ────────────────────────────────────────────
 

--- a/fleet/arcbox-fleet-agent/Cargo.toml
+++ b/fleet/arcbox-fleet-agent/Cargo.toml
@@ -32,6 +32,7 @@ dashmap = { workspace = true }
 dirs = { workspace = true }
 hostname = { workspace = true }
 sysinfo = { workspace = true }
+command-group = { version = "5.0.1", features = ["with-tokio"] }
 
 [lints]
 workspace = true

--- a/fleet/arcbox-fleet-agent/Cargo.toml
+++ b/fleet/arcbox-fleet-agent/Cargo.toml
@@ -33,6 +33,7 @@ dirs = { workspace = true }
 hostname = { workspace = true }
 sysinfo = { workspace = true }
 command-group = { version = "5.0.1", features = ["with-tokio"] }
+tokio-util = "0.7.18"
 
 [lints]
 workspace = true

--- a/fleet/arcbox-fleet-agent/Cargo.toml
+++ b/fleet/arcbox-fleet-agent/Cargo.toml
@@ -1,0 +1,37 @@
+[package]
+name = "arcbox-fleet-agent"
+publish = false
+description = "Cross-platform Fleet runner agent: enrolls, attaches to the gateway, and runs GitHub Actions jobs"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+authors.workspace = true
+
+[[bin]]
+name = "arcbox-fleet-agent"
+path = "src/main.rs"
+
+[dependencies]
+arcbox-fleet-proto = { workspace = true }
+arcbox-logging = { workspace = true }
+
+tonic = { workspace = true, features = ["tls", "tls-webpki-roots"] }
+prost = { workspace = true }
+
+tokio = { workspace = true }
+tokio-stream = { workspace = true }
+
+tracing = { workspace = true }
+clap = { workspace = true }
+anyhow = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+dashmap = { workspace = true }
+dirs = { workspace = true }
+hostname = { workspace = true }
+sysinfo = { workspace = true }
+
+[lints]
+workspace = true

--- a/fleet/arcbox-fleet-agent/src/attach.rs
+++ b/fleet/arcbox-fleet-agent/src/attach.rs
@@ -13,6 +13,7 @@ use arcbox_fleet_proto::v1::fleet_gateway_service_client::FleetGatewayServiceCli
 use arcbox_fleet_proto::v1::{AttachRequest, Heartbeat, attach_request, attach_response};
 use tokio::sync::mpsc;
 use tokio_stream::wrappers::ReceiverStream;
+use tokio_util::sync::CancellationToken;
 use tonic::Request;
 use tonic::metadata::MetadataValue;
 use tracing::{info, warn};
@@ -27,13 +28,24 @@ const INITIAL_BACKOFF: Duration = Duration::from_secs(1);
 const MAX_BACKOFF: Duration = Duration::from_secs(60);
 const OUTBOUND_CAPACITY: usize = 64;
 const MACHINE_TOKEN_HEADER: &str = "x-arcbox-machine-token";
+/// How long to wait for runner process groups to be killed and reaped on
+/// shutdown before giving up. Reaping a SIGKILLed group is near-instant, so this
+/// is a generous ceiling rather than an expected wait.
+const SHUTDOWN_GRACE: Duration = Duration::from_secs(15);
 
-/// Connect and serve the attach stream forever, reconnecting on any failure.
+/// Connect and serve the attach stream, reconnecting on any failure until
+/// `shutdown` fires, then stop runners cleanly.
 ///
 /// The supervisor and the egress queue carrying runner lifecycle events are
 /// built once and reused across reconnects, so in-flight jobs survive a dropped
-/// connection and their terminal events reach the next live stream.
-pub async fn run(config: AgentConfig, credential: Credential) -> Result<()> {
+/// connection and their terminal events reach the next live stream. On shutdown
+/// the loop exits and hands off to [`RunnerSupervisor::shutdown`], which kills
+/// and reaps any in-flight runner process groups.
+pub async fn run(
+    config: AgentConfig,
+    credential: Credential,
+    shutdown: CancellationToken,
+) -> Result<()> {
     let runner_dir = config.require_runner_dir()?.to_path_buf();
 
     // Runner lifecycle events flow through this queue, which outlives any single
@@ -48,25 +60,39 @@ pub async fn run(config: AgentConfig, credential: Credential) -> Result<()> {
     // event is never lost to a closed stream.
     let mut pending: Option<AttachRequest> = None;
 
-    loop {
-        match connect_and_serve(
+    while !shutdown.is_cancelled() {
+        let outcome = connect_and_serve(
             &config,
             &credential,
             &supervisor,
             &mut egress_rx,
             &mut pending,
             &mut backoff,
+            &shutdown,
         )
-        .await
-        {
+        .await;
+        // A shutdown during the connection is a clean exit, not a failure to log
+        // or back off from.
+        if shutdown.is_cancelled() {
+            break;
+        }
+        match outcome {
             Ok(()) => info!("attach stream closed by gateway; reconnecting"),
             Err(e) => {
                 warn!(error = %e, backoff_secs = backoff.as_secs(), "attach failed; retrying");
             }
         }
-        tokio::time::sleep(backoff).await;
+        tokio::select! {
+            biased;
+            () = shutdown.cancelled() => break,
+            () = tokio::time::sleep(backoff) => {}
+        }
         backoff = (backoff * 2).min(MAX_BACKOFF);
     }
+
+    info!("shutdown signal received; stopping runners");
+    supervisor.shutdown(SHUTDOWN_GRACE).await;
+    Ok(())
 }
 
 /// One connect + stream lifetime. Returns `Ok(())` on a clean close. Resets
@@ -85,6 +111,7 @@ async fn connect_and_serve(
     egress_rx: &mut mpsc::Receiver<AttachRequest>,
     pending: &mut Option<AttachRequest>,
     backoff: &mut Duration,
+    shutdown: &CancellationToken,
 ) -> Result<()> {
     let channel = config
         .endpoint()?
@@ -122,6 +149,7 @@ async fn connect_and_serve(
 
     let outcome = loop {
         tokio::select! {
+            () = shutdown.cancelled() => break Ok(()),
             event = egress_rx.recv() => match event {
                 Some(msg) => {
                     if let Err(err) = req_tx.send(msg).await {

--- a/fleet/arcbox-fleet-agent/src/attach.rs
+++ b/fleet/arcbox-fleet-agent/src/attach.rs
@@ -1,0 +1,126 @@
+//! The durable outbound `Attach` stream: heartbeats out, dispatch in, with
+//! exponential-backoff reconnect.
+
+use std::path::PathBuf;
+use std::time::Duration;
+
+use anyhow::{Context, Result};
+use arcbox_fleet_proto::v1::fleet_gateway_service_client::FleetGatewayServiceClient;
+use arcbox_fleet_proto::v1::{AttachRequest, Heartbeat, attach_request, attach_response};
+use tokio::sync::mpsc;
+use tokio_stream::wrappers::ReceiverStream;
+use tonic::Request;
+use tonic::metadata::MetadataValue;
+use tracing::{info, warn};
+
+use crate::config::AgentConfig;
+use crate::credentials::Credential;
+use crate::host;
+use crate::runner::RunnerSupervisor;
+
+const HEARTBEAT_INTERVAL: Duration = Duration::from_secs(15);
+const INITIAL_BACKOFF: Duration = Duration::from_secs(1);
+const MAX_BACKOFF: Duration = Duration::from_secs(60);
+const OUTBOUND_CAPACITY: usize = 64;
+const MACHINE_TOKEN_HEADER: &str = "x-arcbox-machine-token";
+
+/// Connect and serve the attach stream forever, reconnecting on any failure.
+pub async fn run(config: AgentConfig, credential: Credential) -> Result<()> {
+    let runner_dir = config.require_runner_dir()?.to_path_buf();
+    let mut backoff = INITIAL_BACKOFF;
+
+    loop {
+        match attach_once(&config, &credential, runner_dir.clone()).await {
+            Ok(()) => {
+                info!("attach stream closed by gateway; reconnecting");
+                backoff = INITIAL_BACKOFF;
+            }
+            Err(e) => {
+                warn!(error = %e, backoff_secs = backoff.as_secs(), "attach failed; retrying")
+            }
+        }
+        tokio::time::sleep(backoff).await;
+        backoff = (backoff * 2).min(MAX_BACKOFF);
+    }
+}
+
+/// One connect + stream lifetime. Returns `Ok(())` on a clean close.
+async fn attach_once(
+    config: &AgentConfig,
+    credential: &Credential,
+    runner_dir: PathBuf,
+) -> Result<()> {
+    let channel = config
+        .endpoint()?
+        .connect()
+        .await
+        .with_context(|| format!("connecting to {}", config.gateway))?;
+    let mut client = FleetGatewayServiceClient::new(channel);
+
+    let (outbound, rx) = mpsc::channel::<AttachRequest>(OUTBOUND_CAPACITY);
+    let supervisor = RunnerSupervisor::new(outbound.clone(), runner_dir, config.max_concurrent);
+    let heartbeat = spawn_heartbeat(outbound, config.max_concurrent);
+
+    let mut request = Request::new(ReceiverStream::new(rx));
+    let token: MetadataValue<_> = credential
+        .machine_token
+        .parse()
+        .context("machine token is not a valid metadata value")?;
+    request.metadata_mut().insert(MACHINE_TOKEN_HEADER, token);
+
+    let mut inbound = client
+        .attach(request)
+        .await
+        .context("Attach RPC failed")?
+        .into_inner();
+    info!("attached to gateway");
+
+    let outcome = loop {
+        match inbound.message().await {
+            Ok(Some(message)) => dispatch(&supervisor, message.msg).await,
+            Ok(None) => break Ok(()),
+            Err(status) => break Err(anyhow::Error::from(status)),
+        }
+    };
+
+    heartbeat.abort();
+    outcome
+}
+
+/// Route one inbound `AttachResponse` to the supervisor.
+async fn dispatch(supervisor: &RunnerSupervisor, msg: Option<attach_response::Msg>) {
+    match msg {
+        Some(attach_response::Msg::ProvisionRunner(order)) => {
+            supervisor.handle_provision(order).await;
+        }
+        Some(attach_response::Msg::Cancel(cancel)) => supervisor.handle_cancel(&cancel.job_id),
+        Some(attach_response::Msg::Drain(_)) => supervisor.handle_drain(),
+        None => {}
+    }
+}
+
+/// Periodically push a declarative capacity heartbeat until the channel closes.
+fn spawn_heartbeat(
+    outbound: mpsc::Sender<AttachRequest>,
+    max_concurrent: usize,
+) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move {
+        // `interval` fires its first tick immediately, so the gateway sees us
+        // online without waiting a full period.
+        let mut ticker = tokio::time::interval(HEARTBEAT_INTERVAL);
+        loop {
+            ticker.tick().await;
+            let msg = attach_request::Msg::Heartbeat(Heartbeat {
+                capacities: host::capacities(max_concurrent),
+                host_info_json: host::host_info_json(),
+            });
+            if outbound
+                .send(AttachRequest { msg: Some(msg) })
+                .await
+                .is_err()
+            {
+                break;
+            }
+        }
+    })
+}

--- a/fleet/arcbox-fleet-agent/src/attach.rs
+++ b/fleet/arcbox-fleet-agent/src/attach.rs
@@ -30,13 +30,10 @@ pub async fn run(config: AgentConfig, credential: Credential) -> Result<()> {
     let mut backoff = INITIAL_BACKOFF;
 
     loop {
-        match attach_once(&config, &credential, runner_dir.clone()).await {
-            Ok(()) => {
-                info!("attach stream closed by gateway; reconnecting");
-                backoff = INITIAL_BACKOFF;
-            }
+        match attach_once(&config, &credential, runner_dir.clone(), &mut backoff).await {
+            Ok(()) => info!("attach stream closed by gateway; reconnecting"),
             Err(e) => {
-                warn!(error = %e, backoff_secs = backoff.as_secs(), "attach failed; retrying")
+                warn!(error = %e, backoff_secs = backoff.as_secs(), "attach failed; retrying");
             }
         }
         tokio::time::sleep(backoff).await;
@@ -44,11 +41,15 @@ pub async fn run(config: AgentConfig, credential: Credential) -> Result<()> {
     }
 }
 
-/// One connect + stream lifetime. Returns `Ok(())` on a clean close.
+/// One connect + stream lifetime. Returns `Ok(())` on a clean close. Resets
+/// `backoff` once the stream is established, so a connection that succeeds and
+/// later drops reconnects promptly instead of inheriting the escalated delay
+/// from earlier connect failures.
 async fn attach_once(
     config: &AgentConfig,
     credential: &Credential,
     runner_dir: PathBuf,
+    backoff: &mut Duration,
 ) -> Result<()> {
     let channel = config
         .endpoint()?
@@ -73,6 +74,7 @@ async fn attach_once(
         .await
         .context("Attach RPC failed")?
         .into_inner();
+    *backoff = INITIAL_BACKOFF;
     info!("attached to gateway");
 
     let outcome = loop {

--- a/fleet/arcbox-fleet-agent/src/attach.rs
+++ b/fleet/arcbox-fleet-agent/src/attach.rs
@@ -1,7 +1,11 @@
 //! The durable outbound `Attach` stream: heartbeats out, dispatch in, with
 //! exponential-backoff reconnect.
+//!
+//! The [`RunnerSupervisor`] and the egress queue of runner lifecycle events are
+//! created once and reused across every reconnect. A job dispatched before a
+//! reconnect keeps running, and its terminal event is forwarded to whichever
+//! stream is live instead of being lost into the dropped connection's channel.
 
-use std::path::PathBuf;
 use std::time::Duration;
 
 use anyhow::{Context, Result};
@@ -25,12 +29,36 @@ const OUTBOUND_CAPACITY: usize = 64;
 const MACHINE_TOKEN_HEADER: &str = "x-arcbox-machine-token";
 
 /// Connect and serve the attach stream forever, reconnecting on any failure.
+///
+/// The supervisor and the egress queue carrying runner lifecycle events are
+/// built once and reused across reconnects, so in-flight jobs survive a dropped
+/// connection and their terminal events reach the next live stream.
 pub async fn run(config: AgentConfig, credential: Credential) -> Result<()> {
     let runner_dir = config.require_runner_dir()?.to_path_buf();
+
+    // Runner lifecycle events flow through this queue, which outlives any single
+    // connection. Each connection drains it into that connection's request
+    // stream; events produced during a brief disconnect simply wait here.
+    let (egress_tx, mut egress_rx) = mpsc::channel::<AttachRequest>(OUTBOUND_CAPACITY);
+    let supervisor = RunnerSupervisor::new(egress_tx, runner_dir, config.max_concurrent);
+
     let mut backoff = INITIAL_BACKOFF;
+    // An event pulled from the egress queue but not yet delivered when the
+    // connection dropped; re-sent first on the next connection so a terminal
+    // event is never lost to a closed stream.
+    let mut pending: Option<AttachRequest> = None;
 
     loop {
-        match attach_once(&config, &credential, runner_dir.clone(), &mut backoff).await {
+        match connect_and_serve(
+            &config,
+            &credential,
+            &supervisor,
+            &mut egress_rx,
+            &mut pending,
+            &mut backoff,
+        )
+        .await
+        {
             Ok(()) => info!("attach stream closed by gateway; reconnecting"),
             Err(e) => {
                 warn!(error = %e, backoff_secs = backoff.as_secs(), "attach failed; retrying");
@@ -45,10 +73,17 @@ pub async fn run(config: AgentConfig, credential: Credential) -> Result<()> {
 /// `backoff` once the stream is established, so a connection that succeeds and
 /// later drops reconnects promptly instead of inheriting the escalated delay
 /// from earlier connect failures.
-async fn attach_once(
+///
+/// Outbound traffic is multiplexed onto a fresh per-connection request channel:
+/// connection-scoped heartbeats are sent directly, while runner lifecycle
+/// events are forwarded from the shared egress queue. Inbound orders are routed
+/// to the persistent `supervisor`.
+async fn connect_and_serve(
     config: &AgentConfig,
     credential: &Credential,
-    runner_dir: PathBuf,
+    supervisor: &RunnerSupervisor,
+    egress_rx: &mut mpsc::Receiver<AttachRequest>,
+    pending: &mut Option<AttachRequest>,
     backoff: &mut Duration,
 ) -> Result<()> {
     let channel = config
@@ -58,11 +93,9 @@ async fn attach_once(
         .with_context(|| format!("connecting to {}", config.gateway))?;
     let mut client = FleetGatewayServiceClient::new(channel);
 
-    let (outbound, rx) = mpsc::channel::<AttachRequest>(OUTBOUND_CAPACITY);
-    let supervisor = RunnerSupervisor::new(outbound.clone(), runner_dir, config.max_concurrent);
-    let heartbeat = spawn_heartbeat(outbound, config.max_concurrent);
+    let (req_tx, req_rx) = mpsc::channel::<AttachRequest>(OUTBOUND_CAPACITY);
 
-    let mut request = Request::new(ReceiverStream::new(rx));
+    let mut request = Request::new(ReceiverStream::new(req_rx));
     let token: MetadataValue<_> = credential
         .machine_token
         .parse()
@@ -77,11 +110,35 @@ async fn attach_once(
     *backoff = INITIAL_BACKOFF;
     info!("attached to gateway");
 
+    // Re-send the event stranded by the previous connection before anything else.
+    if let Some(msg) = pending.take() {
+        if let Err(err) = req_tx.send(msg).await {
+            *pending = Some(err.0);
+            anyhow::bail!("request stream closed before the pending event could be re-sent");
+        }
+    }
+
+    let heartbeat = spawn_heartbeat(req_tx.clone(), config.max_concurrent);
+
     let outcome = loop {
-        match inbound.message().await {
-            Ok(Some(message)) => dispatch(&supervisor, message.msg).await,
-            Ok(None) => break Ok(()),
-            Err(status) => break Err(anyhow::Error::from(status)),
+        tokio::select! {
+            event = egress_rx.recv() => match event {
+                Some(msg) => {
+                    if let Err(err) = req_tx.send(msg).await {
+                        // Stream is gone; hold the event for the next connection.
+                        *pending = Some(err.0);
+                        break Err(anyhow::anyhow!("request stream closed while forwarding event"));
+                    }
+                }
+                // The supervisor holds the only egress sender, so this cannot
+                // happen while the agent runs; treat it as a clean shutdown.
+                None => break Ok(()),
+            },
+            message = inbound.message() => match message {
+                Ok(Some(message)) => dispatch(supervisor, message.msg).await,
+                Ok(None) => break Ok(()),
+                Err(status) => break Err(anyhow::Error::from(status)),
+            },
         }
     };
 
@@ -102,6 +159,10 @@ async fn dispatch(supervisor: &RunnerSupervisor, msg: Option<attach_response::Ms
 }
 
 /// Periodically push a declarative capacity heartbeat until the channel closes.
+///
+/// Heartbeats are connection-scoped: the task is spawned per connection and
+/// aborted when it drops, so a momentary disconnect does not leave stale
+/// heartbeats queued for the next stream.
 fn spawn_heartbeat(
     outbound: mpsc::Sender<AttachRequest>,
     max_concurrent: usize,

--- a/fleet/arcbox-fleet-agent/src/config.rs
+++ b/fleet/arcbox-fleet-agent/src/config.rs
@@ -1,0 +1,94 @@
+//! Environment-driven agent configuration.
+//!
+//! Everything is sourced from the environment — there are no positional config
+//! flags. The only CLI argument anywhere is the one-shot enrollment token.
+
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+use tonic::transport::{ClientTlsConfig, Endpoint};
+
+/// Production gateway endpoint. Overridable via `ARCBOX_FLEET_GATEWAY` for
+/// local/e2e testing (e.g. `http://127.0.0.1:50061`).
+pub const DEFAULT_GATEWAY: &str = "https://fleet.arcbox.dev";
+
+const ENV_GATEWAY: &str = "ARCBOX_FLEET_GATEWAY";
+const ENV_RUNNER_DIR: &str = "ARCBOX_FLEET_RUNNER_DIR";
+const ENV_MAX_CONCURRENT: &str = "ARCBOX_FLEET_MAX_CONCURRENT";
+const ENV_DATA_DIR: &str = "ARCBOX_FLEET_DATA_DIR";
+
+const DEFAULT_MAX_CONCURRENT: usize = 2;
+
+/// Resolved agent configuration.
+#[derive(Debug, Clone)]
+pub struct AgentConfig {
+    /// Gateway endpoint URI (scheme selects transport: `https` → TLS, `http` → h2c).
+    pub gateway: String,
+    /// Directory holding the pre-installed GitHub Actions runner (`run.sh`/`run.cmd`).
+    /// `None` until set; required only by the `run` command.
+    pub runner_dir: Option<PathBuf>,
+    /// Maximum number of concurrently executing runner jobs.
+    pub max_concurrent: usize,
+    /// Agent data directory (credentials, logs). Defaults to `~/.arcbox/fleet`.
+    pub data_dir: PathBuf,
+}
+
+impl AgentConfig {
+    /// Build the configuration from environment variables, applying defaults.
+    pub fn from_env() -> Result<Self> {
+        let gateway = std::env::var(ENV_GATEWAY).unwrap_or_else(|_| DEFAULT_GATEWAY.to_string());
+
+        let runner_dir = std::env::var_os(ENV_RUNNER_DIR).map(PathBuf::from);
+
+        let max_concurrent = match std::env::var(ENV_MAX_CONCURRENT) {
+            Ok(v) => v
+                .parse()
+                .with_context(|| format!("{ENV_MAX_CONCURRENT} must be a positive integer"))?,
+            Err(_) => DEFAULT_MAX_CONCURRENT,
+        };
+
+        let data_dir = match std::env::var_os(ENV_DATA_DIR) {
+            Some(dir) => PathBuf::from(dir),
+            None => default_data_dir()?,
+        };
+
+        Ok(Self {
+            gateway,
+            runner_dir,
+            max_concurrent,
+            data_dir,
+        })
+    }
+
+    /// The runner directory, or a clear error instructing the operator to set it.
+    pub fn require_runner_dir(&self) -> Result<&Path> {
+        self.runner_dir.as_deref().with_context(|| {
+            format!("{ENV_RUNNER_DIR} is not set (path to the installed GitHub Actions runner)")
+        })
+    }
+
+    /// Path to the persisted machine credential.
+    pub fn credentials_path(&self) -> PathBuf {
+        self.data_dir.join("credentials.json")
+    }
+
+    /// Build a gateway [`Endpoint`], enabling TLS for `https` URIs.
+    pub fn endpoint(&self) -> Result<Endpoint> {
+        let endpoint = Endpoint::from_shared(self.gateway.clone())
+            .with_context(|| format!("invalid gateway URI: {}", self.gateway))?;
+
+        if self.gateway.starts_with("https://") {
+            // Bundled webpki roots keep trust uniform across macOS/Linux/Windows.
+            return endpoint
+                .tls_config(ClientTlsConfig::new().with_webpki_roots())
+                .context("failed to configure TLS");
+        }
+        Ok(endpoint)
+    }
+}
+
+/// `~/.arcbox/fleet`, resolved from the user's home directory.
+fn default_data_dir() -> Result<PathBuf> {
+    let home = dirs::home_dir().context("could not determine home directory")?;
+    Ok(home.join(".arcbox").join("fleet"))
+}

--- a/fleet/arcbox-fleet-agent/src/config.rs
+++ b/fleet/arcbox-fleet-agent/src/config.rs
@@ -41,9 +41,15 @@ impl AgentConfig {
         let runner_dir = std::env::var_os(ENV_RUNNER_DIR).map(PathBuf::from);
 
         let max_concurrent = match std::env::var(ENV_MAX_CONCURRENT) {
-            Ok(v) => v
-                .parse()
-                .with_context(|| format!("{ENV_MAX_CONCURRENT} must be a positive integer"))?,
+            Ok(v) => {
+                let n: usize = v
+                    .parse()
+                    .with_context(|| format!("{ENV_MAX_CONCURRENT} must be a positive integer"))?;
+                if n == 0 {
+                    anyhow::bail!("{ENV_MAX_CONCURRENT} must be a positive integer, got 0");
+                }
+                n
+            }
             Err(_) => DEFAULT_MAX_CONCURRENT,
         };
 

--- a/fleet/arcbox-fleet-agent/src/credentials.rs
+++ b/fleet/arcbox-fleet-agent/src/credentials.rs
@@ -51,28 +51,43 @@ impl CredentialStore {
         let json = serde_json::to_vec_pretty(cred).context("serializing credential")?;
         // Write-then-rename so a crash mid-write can't leave a truncated
         // credentials.json that fails to parse and strands the host unenrolled.
-        // Permissions are restricted on the temp file before the rename, so the
-        // final path is never briefly world-readable.
+        // The temp file is created `0600` from the open(2) call, so the raw
+        // token is never briefly world-readable — not in the temp file and not
+        // (via rename, which preserves the mode) in the final path.
         let tmp = self.path.with_extension("json.tmp");
-        std::fs::write(&tmp, &json).with_context(|| format!("writing {}", tmp.display()))?;
-        restrict_permissions(&tmp)?;
+        write_private(&tmp, &json)?;
         std::fs::rename(&tmp, &self.path)
             .with_context(|| format!("renaming {} -> {}", tmp.display(), self.path.display()))?;
         Ok(())
     }
 }
 
+/// Write `bytes` to `path`, owner-only (`0600`) from creation on Unix.
 #[cfg(unix)]
-fn restrict_permissions(path: &Path) -> Result<()> {
-    use std::os::unix::fs::PermissionsExt;
-    std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600))
-        .with_context(|| format!("chmod 0600 {}", path.display()))
+fn write_private(path: &Path, bytes: &[u8]) -> Result<()> {
+    use std::io::Write;
+    use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
+
+    let mut file = std::fs::OpenOptions::new()
+        .write(true)
+        .create(true)
+        .truncate(true)
+        .mode(0o600)
+        .open(path)
+        .with_context(|| format!("creating {}", path.display()))?;
+    // `mode` only takes effect when this call creates the file; a leftover temp
+    // from a crashed run keeps its old mode, so fchmod the open handle as a
+    // backstop (operating on the fd, never racing a path lookup).
+    file.set_permissions(std::fs::Permissions::from_mode(0o600))
+        .with_context(|| format!("chmod 0600 {}", path.display()))?;
+    file.write_all(bytes)
+        .with_context(|| format!("writing {}", path.display()))
 }
 
+/// Windows ACL hardening is deferred to a later slice.
 #[cfg(not(unix))]
-fn restrict_permissions(_path: &Path) -> Result<()> {
-    // Windows ACL hardening is deferred to a later slice.
-    Ok(())
+fn write_private(path: &Path, bytes: &[u8]) -> Result<()> {
+    std::fs::write(path, bytes).with_context(|| format!("writing {}", path.display()))
 }
 
 #[cfg(test)]

--- a/fleet/arcbox-fleet-agent/src/credentials.rs
+++ b/fleet/arcbox-fleet-agent/src/credentials.rs
@@ -49,9 +49,15 @@ impl CredentialStore {
                 .with_context(|| format!("creating {}", parent.display()))?;
         }
         let json = serde_json::to_vec_pretty(cred).context("serializing credential")?;
-        std::fs::write(&self.path, &json)
-            .with_context(|| format!("writing {}", self.path.display()))?;
-        restrict_permissions(&self.path)?;
+        // Write-then-rename so a crash mid-write can't leave a truncated
+        // credentials.json that fails to parse and strands the host unenrolled.
+        // Permissions are restricted on the temp file before the rename, so the
+        // final path is never briefly world-readable.
+        let tmp = self.path.with_extension("json.tmp");
+        std::fs::write(&tmp, &json).with_context(|| format!("writing {}", tmp.display()))?;
+        restrict_permissions(&tmp)?;
+        std::fs::rename(&tmp, &self.path)
+            .with_context(|| format!("renaming {} -> {}", tmp.display(), self.path.display()))?;
         Ok(())
     }
 }

--- a/fleet/arcbox-fleet-agent/src/credentials.rs
+++ b/fleet/arcbox-fleet-agent/src/credentials.rs
@@ -1,0 +1,101 @@
+//! Persistence of the long-lived machine credential.
+//!
+//! The credential is written once at enrollment and read on every `run`. On
+//! Unix the file is locked down to `0600`; Windows ACL hardening is deferred.
+
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+
+/// The machine identity returned by `Enroll`, persisted to disk.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Credential {
+    /// Prefixed machine id (`fltm_...`).
+    pub machine_id: String,
+    /// Long-lived machine token, presented in `Attach` metadata.
+    pub machine_token: String,
+}
+
+/// Reads and writes [`Credential`] at a fixed path.
+pub struct CredentialStore {
+    path: PathBuf,
+}
+
+impl CredentialStore {
+    /// Create a store backed by `path` (typically `<data_dir>/credentials.json`).
+    pub fn new(path: impl Into<PathBuf>) -> Self {
+        Self { path: path.into() }
+    }
+
+    /// Load the stored credential, or `None` if the host has not enrolled yet.
+    pub fn load(&self) -> Result<Option<Credential>> {
+        match std::fs::read(&self.path) {
+            Ok(bytes) => {
+                let cred = serde_json::from_slice(&bytes)
+                    .with_context(|| format!("malformed credential at {}", self.path.display()))?;
+                Ok(Some(cred))
+            }
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),
+            Err(e) => Err(e).with_context(|| format!("reading {}", self.path.display())),
+        }
+    }
+
+    /// Persist the credential, creating the parent directory and restricting
+    /// permissions to the owner.
+    pub fn store(&self, cred: &Credential) -> Result<()> {
+        if let Some(parent) = self.path.parent() {
+            std::fs::create_dir_all(parent)
+                .with_context(|| format!("creating {}", parent.display()))?;
+        }
+        let json = serde_json::to_vec_pretty(cred).context("serializing credential")?;
+        std::fs::write(&self.path, &json)
+            .with_context(|| format!("writing {}", self.path.display()))?;
+        restrict_permissions(&self.path)?;
+        Ok(())
+    }
+}
+
+#[cfg(unix)]
+fn restrict_permissions(path: &Path) -> Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+    std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600))
+        .with_context(|| format!("chmod 0600 {}", path.display()))
+}
+
+#[cfg(not(unix))]
+fn restrict_permissions(_path: &Path) -> Result<()> {
+    // Windows ACL hardening is deferred to a later slice.
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn round_trips_credential() {
+        let dir = std::env::temp_dir().join(format!("fleet-cred-{}", std::process::id()));
+        let store = CredentialStore::new(dir.join("credentials.json"));
+        assert!(store.load().unwrap().is_none());
+
+        let cred = Credential {
+            machine_id: "fltm_test".into(),
+            machine_token: "secret".into(),
+        };
+        store.store(&cred).unwrap();
+
+        let loaded = store.load().unwrap().expect("credential present");
+        assert_eq!(loaded.machine_id, cred.machine_id);
+        assert_eq!(loaded.machine_token, cred.machine_token);
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mode = std::fs::metadata(store.path).unwrap().permissions().mode();
+            assert_eq!(mode & 0o777, 0o600);
+        }
+
+        let _ = std::fs::remove_dir_all(dir);
+    }
+}

--- a/fleet/arcbox-fleet-agent/src/credentials.rs
+++ b/fleet/arcbox-fleet-agent/src/credentials.rs
@@ -1,7 +1,9 @@
 //! Persistence of the long-lived machine credential.
 //!
 //! The credential is written once at enrollment and read on every `run`. On
-//! Unix the file is locked down to `0600`; Windows ACL hardening is deferred.
+//! Unix the file is locked down to `0600`. Other platforms are unsupported:
+//! without an equivalent owner-only ACL the agent refuses to persist the
+//! long-lived machine token rather than write it at default permissions.
 
 use std::path::{Path, PathBuf};
 
@@ -84,18 +86,29 @@ fn write_private(path: &Path, bytes: &[u8]) -> Result<()> {
         .with_context(|| format!("writing {}", path.display()))
 }
 
-/// Windows ACL hardening is deferred to a later slice.
+/// Refuse to persist the machine token on platforms without owner-only file
+/// permissions. Windows ACL hardening (a protected, owner-only DACL) is not yet
+/// implemented, and writing the long-lived token at the default ACL would leave
+/// it readable by other local accounts — so credential storage is Unix-only for
+/// now.
 #[cfg(not(unix))]
-fn write_private(path: &Path, bytes: &[u8]) -> Result<()> {
-    std::fs::write(path, bytes).with_context(|| format!("writing {}", path.display()))
+fn write_private(_path: &Path, _bytes: &[u8]) -> Result<()> {
+    anyhow::bail!(
+        "Fleet agent credential storage is only supported on Unix; Windows ACL \
+         hardening is not yet implemented"
+    )
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
+    // Storage is Unix-only (owner-only `0600`); other platforms refuse to write.
+    #[cfg(unix)]
     #[test]
     fn round_trips_credential() {
+        use std::os::unix::fs::PermissionsExt;
+
         let dir = std::env::temp_dir().join(format!("fleet-cred-{}", std::process::id()));
         let store = CredentialStore::new(dir.join("credentials.json"));
         assert!(store.load().unwrap().is_none());
@@ -110,12 +123,8 @@ mod tests {
         assert_eq!(loaded.machine_id, cred.machine_id);
         assert_eq!(loaded.machine_token, cred.machine_token);
 
-        #[cfg(unix)]
-        {
-            use std::os::unix::fs::PermissionsExt;
-            let mode = std::fs::metadata(store.path).unwrap().permissions().mode();
-            assert_eq!(mode & 0o777, 0o600);
-        }
+        let mode = std::fs::metadata(store.path).unwrap().permissions().mode();
+        assert_eq!(mode & 0o777, 0o600);
 
         let _ = std::fs::remove_dir_all(dir);
     }

--- a/fleet/arcbox-fleet-agent/src/enroll.rs
+++ b/fleet/arcbox-fleet-agent/src/enroll.rs
@@ -1,0 +1,44 @@
+//! One-shot enrollment: exchange an enrollment token for the machine credential.
+
+use anyhow::{Context, Result};
+use arcbox_fleet_proto::v1::EnrollRequest;
+use arcbox_fleet_proto::v1::fleet_gateway_service_client::FleetGatewayServiceClient;
+use tracing::info;
+
+use crate::config::AgentConfig;
+use crate::credentials::{Credential, CredentialStore};
+use crate::host;
+
+/// Call `Enroll` on the gateway and persist the returned credential.
+pub async fn enroll(config: &AgentConfig, token: String) -> Result<Credential> {
+    let channel = config
+        .endpoint()?
+        .connect()
+        .await
+        .with_context(|| format!("connecting to fleet gateway at {}", config.gateway))?;
+    let mut client = FleetGatewayServiceClient::new(channel);
+
+    let request = EnrollRequest {
+        enrollment_token: token,
+        machine_name: host::machine_name(),
+        host_arch: host::host_arch(),
+        cpu_cores: host::cpu_cores(),
+        mem_mib: host::mem_mib(),
+        capacities: host::capacities(config.max_concurrent),
+        host_info_json: host::host_info_json(),
+    };
+
+    let response = client
+        .enroll(request)
+        .await
+        .context("Enroll RPC failed")?
+        .into_inner();
+
+    let credential = Credential {
+        machine_id: response.machine_id,
+        machine_token: response.machine_token,
+    };
+    CredentialStore::new(config.credentials_path()).store(&credential)?;
+    info!(machine_id = %credential.machine_id, "enrolled");
+    Ok(credential)
+}

--- a/fleet/arcbox-fleet-agent/src/host.rs
+++ b/fleet/arcbox-fleet-agent/src/host.rs
@@ -1,0 +1,84 @@
+//! Host facts reported to the gateway at enrollment and in heartbeats.
+
+use arcbox_fleet_proto::v1::RuntimeCapacity;
+
+/// Map Rust's `target_os` to the gateway's lowercase `RunnerOs` naming.
+pub fn map_os(os: &str) -> &str {
+    match os {
+        "macos" => "darwin",
+        other => other, // linux, windows
+    }
+}
+
+/// Map Rust's `target_arch` to the gateway's lowercase `RunnerArch` naming.
+pub fn map_arch(arch: &str) -> &str {
+    match arch {
+        "aarch64" => "arm64",
+        "x86_64" => "amd64",
+        other => other,
+    }
+}
+
+/// Gateway OS string for this host (e.g. `darwin`).
+pub fn host_os() -> String {
+    map_os(std::env::consts::OS).to_string()
+}
+
+/// Gateway arch string for this host (e.g. `arm64`).
+pub fn host_arch() -> String {
+    map_arch(std::env::consts::ARCH).to_string()
+}
+
+/// Best-effort host name; falls back to `"unknown"`.
+pub fn machine_name() -> String {
+    hostname::get()
+        .ok()
+        .and_then(|h| h.into_string().ok())
+        .unwrap_or_else(|| "unknown".to_string())
+}
+
+/// Logical CPU count, at least 1.
+pub fn cpu_cores() -> u32 {
+    std::thread::available_parallelism().map_or(1, |n| n.get() as u32)
+}
+
+/// Total physical memory in MiB.
+pub fn mem_mib() -> u64 {
+    let mut sys = sysinfo::System::new();
+    sys.refresh_memory();
+    sys.total_memory() / 1024 / 1024
+}
+
+/// Free-form host facts as a JSON string (OS version, kernel, arch).
+pub fn host_info_json() -> String {
+    let info = serde_json::json!({
+        "os": sysinfo::System::name(),
+        "os_version": sysinfo::System::long_os_version(),
+        "kernel": sysinfo::System::kernel_version(),
+        "arch": std::env::consts::ARCH,
+    });
+    info.to_string()
+}
+
+/// The single capacity pool this host serves. With no isolation in v1, the
+/// host advertises its own `(os, arch)` with the configured concurrency.
+pub fn capacities(max_concurrent: usize) -> Vec<RuntimeCapacity> {
+    vec![RuntimeCapacity {
+        os: host_os(),
+        arch: host_arch(),
+        max_concurrent: i32::try_from(max_concurrent).unwrap_or(i32::MAX),
+    }]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn maps_os_and_arch_to_gateway_naming() {
+        assert_eq!(map_os("macos"), "darwin");
+        assert_eq!(map_os("linux"), "linux");
+        assert_eq!(map_arch("aarch64"), "arm64");
+        assert_eq!(map_arch("x86_64"), "amd64");
+    }
+}

--- a/fleet/arcbox-fleet-agent/src/main.rs
+++ b/fleet/arcbox-fleet-agent/src/main.rs
@@ -5,8 +5,10 @@
 //! pre-installed runner (`run.sh --jitconfig …`). v1 has no isolation: jobs run
 //! directly on the host.
 //!
-//! Configuration is environment-driven (`ARCBOX_FLEET_*`); the only CLI
-//! argument is the one-shot enrollment token.
+//! Configuration is environment-driven (`ARCBOX_FLEET_*`). The `enroll`
+//! subcommand reads the fleet join token from a file (`--token-file`) or stdin
+//! by default; `--token` is accepted for convenience but discouraged, as it
+//! leaks the token through the process argument list and shell history.
 
 mod attach;
 mod config;
@@ -14,6 +16,8 @@ mod credentials;
 mod enroll;
 mod host;
 mod runner;
+
+use std::path::PathBuf;
 
 use anyhow::{Context, Result};
 use arcbox_logging::LogConfig;
@@ -33,11 +37,21 @@ struct Cli {
 #[derive(Debug, Subcommand)]
 enum Command {
     /// Exchange an enrollment token for the machine credential and persist it.
+    ///
+    /// The token is a multi-use fleet join token (valid until it expires or is
+    /// rotated). Provide it via `--token-file`, on stdin, or — discouraged —
+    /// `--token`.
     Enroll {
-        /// Fleet enrollment token issued by the control plane (a multi-use
-        /// join token valid until it expires or is rotated).
-        #[arg(long)]
-        token: String,
+        /// File holding the enrollment token (recommended). Keeps the token out
+        /// of the process argument list, shell history, and service logs.
+        #[arg(long, value_name = "PATH")]
+        token_file: Option<PathBuf>,
+
+        /// Enrollment token passed directly. Convenient but insecure: it leaks
+        /// via the process argument list and shell history. Prefer
+        /// `--token-file`, or pipe the token on stdin.
+        #[arg(long, conflicts_with = "token_file")]
+        token: Option<String>,
     },
     /// Attach to the gateway and run dispatched jobs until terminated.
     Run,
@@ -65,16 +79,70 @@ fn main() -> Result<()> {
 
 async fn run(command: Command, config: AgentConfig) -> Result<()> {
     match command {
-        Command::Enroll { token } => {
+        Command::Enroll { token_file, token } => {
+            let token = resolve_enrollment_token(token_file, token)?;
             enroll::enroll(&config, token).await?;
             Ok(())
         }
         Command::Run => {
             let credential = CredentialStore::new(config.credentials_path())
                 .load()?
-                .context("no credential found — run `arcbox-fleet-agent enroll --token …` first")?;
+                .context(
+                    "no credential found — run `arcbox-fleet-agent enroll --token-file …` first",
+                )?;
             info!(machine_id = %credential.machine_id, "starting fleet agent");
             attach::run(config, credential).await
         }
+    }
+}
+
+/// Resolve the enrollment token from its chosen source: a file, an explicit
+/// `--token`, or stdin when neither is given (the two flags are mutually
+/// exclusive). Surrounding whitespace — a trailing newline from a file or
+/// `echo` — is trimmed.
+fn resolve_enrollment_token(token_file: Option<PathBuf>, token: Option<String>) -> Result<String> {
+    let raw = match (token_file, token) {
+        (Some(path), _) => std::fs::read_to_string(&path)
+            .with_context(|| format!("reading enrollment token from {}", path.display()))?,
+        (None, Some(token)) => token,
+        (None, None) => {
+            use std::io::Read;
+            let mut buf = String::new();
+            std::io::stdin()
+                .read_to_string(&mut buf)
+                .context("reading enrollment token from stdin")?;
+            buf
+        }
+    };
+    let token = raw.trim().to_owned();
+    if token.is_empty() {
+        anyhow::bail!("enrollment token is empty");
+    }
+    Ok(token)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn direct_token_is_trimmed() {
+        let token = resolve_enrollment_token(None, Some("  flt_join_abc\n".to_owned())).unwrap();
+        assert_eq!(token, "flt_join_abc");
+    }
+
+    #[test]
+    fn blank_token_is_rejected() {
+        assert!(resolve_enrollment_token(None, Some("   \n".to_owned())).is_err());
+    }
+
+    #[test]
+    fn token_file_takes_precedence_and_is_trimmed() {
+        let path = std::env::temp_dir().join(format!("fleet-tok-{}", std::process::id()));
+        std::fs::write(&path, "flt_from_file\n").unwrap();
+        let token =
+            resolve_enrollment_token(Some(path.clone()), Some("ignored".to_owned())).unwrap();
+        assert_eq!(token, "flt_from_file");
+        let _ = std::fs::remove_file(path);
     }
 }

--- a/fleet/arcbox-fleet-agent/src/main.rs
+++ b/fleet/arcbox-fleet-agent/src/main.rs
@@ -34,7 +34,8 @@ struct Cli {
 enum Command {
     /// Exchange an enrollment token for the machine credential and persist it.
     Enroll {
-        /// Single-use enrollment token issued by the control plane.
+        /// Fleet enrollment token issued by the control plane (a multi-use
+        /// join token valid until it expires or is rotated).
         #[arg(long)]
         token: String,
     },

--- a/fleet/arcbox-fleet-agent/src/main.rs
+++ b/fleet/arcbox-fleet-agent/src/main.rs
@@ -1,0 +1,79 @@
+//! ArcBox Fleet runner agent.
+//!
+//! A standalone, cross-platform binary that enrolls a host with the Fleet
+//! gateway and, once attached, runs GitHub Actions jobs by invoking the
+//! pre-installed runner (`run.sh --jitconfig …`). v1 has no isolation: jobs run
+//! directly on the host.
+//!
+//! Configuration is environment-driven (`ARCBOX_FLEET_*`); the only CLI
+//! argument is the one-shot enrollment token.
+
+mod attach;
+mod config;
+mod credentials;
+mod enroll;
+mod host;
+mod runner;
+
+use anyhow::{Context, Result};
+use arcbox_logging::LogConfig;
+use clap::{Parser, Subcommand};
+use tracing::info;
+
+use crate::config::AgentConfig;
+use crate::credentials::CredentialStore;
+
+#[derive(Debug, Parser)]
+#[command(name = "arcbox-fleet-agent", author, version, about)]
+struct Cli {
+    #[command(subcommand)]
+    command: Command,
+}
+
+#[derive(Debug, Subcommand)]
+enum Command {
+    /// Exchange an enrollment token for the machine credential and persist it.
+    Enroll {
+        /// Single-use enrollment token issued by the control plane.
+        #[arg(long)]
+        token: String,
+    },
+    /// Attach to the gateway and run dispatched jobs until terminated.
+    Run,
+}
+
+fn main() -> Result<()> {
+    let cli = Cli::parse();
+    let config = AgentConfig::from_env()?;
+
+    let _log_guard = arcbox_logging::init(LogConfig {
+        log_dir: config.data_dir.join("log"),
+        file_name: "fleet-agent.log".to_string(),
+        default_filter: "info".to_string(),
+        foreground: true,
+        ..LogConfig::default()
+    });
+
+    let runtime = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .context("building tokio runtime")?;
+
+    runtime.block_on(run(cli.command, config))
+}
+
+async fn run(command: Command, config: AgentConfig) -> Result<()> {
+    match command {
+        Command::Enroll { token } => {
+            enroll::enroll(&config, token).await?;
+            Ok(())
+        }
+        Command::Run => {
+            let credential = CredentialStore::new(config.credentials_path())
+                .load()?
+                .context("no credential found — run `arcbox-fleet-agent enroll --token …` first")?;
+            info!(machine_id = %credential.machine_id, "starting fleet agent");
+            attach::run(config, credential).await
+        }
+    }
+}

--- a/fleet/arcbox-fleet-agent/src/main.rs
+++ b/fleet/arcbox-fleet-agent/src/main.rs
@@ -22,7 +22,8 @@ use std::path::PathBuf;
 use anyhow::{Context, Result};
 use arcbox_logging::LogConfig;
 use clap::{Parser, Subcommand};
-use tracing::info;
+use tokio_util::sync::CancellationToken;
+use tracing::{info, warn};
 
 use crate::config::AgentConfig;
 use crate::credentials::CredentialStore;
@@ -91,8 +92,54 @@ async fn run(command: Command, config: AgentConfig) -> Result<()> {
                     "no credential found — run `arcbox-fleet-agent enroll --token-file …` first",
                 )?;
             info!(machine_id = %credential.machine_id, "starting fleet agent");
-            attach::run(config, credential).await
+
+            // Cancelled on the first termination signal; `attach::run` then
+            // stops accepting work and tears down in-flight runners.
+            let shutdown = CancellationToken::new();
+            let signal_token = shutdown.clone();
+            tokio::spawn(async move {
+                shutdown_signal().await;
+                info!("termination signal received; draining runners");
+                signal_token.cancel();
+            });
+
+            attach::run(config, credential, shutdown).await
         }
+    }
+}
+
+/// Resolve when the process receives a termination signal: Ctrl-C on any
+/// platform, or SIGTERM on Unix (e.g. a service-manager stop). If a listener
+/// cannot be installed, that signal simply never fires rather than aborting
+/// startup.
+async fn shutdown_signal() {
+    let ctrl_c = async {
+        if let Err(e) = tokio::signal::ctrl_c().await {
+            warn!(error = %e, "failed to listen for Ctrl-C; ignoring");
+            std::future::pending::<()>().await;
+        }
+    };
+
+    #[cfg(unix)]
+    let terminate = async {
+        use tokio::signal::unix::{SignalKind, signal};
+        match signal(SignalKind::terminate()) {
+            Ok(mut term) => {
+                term.recv().await;
+            }
+            Err(e) => {
+                warn!(error = %e, "failed to listen for SIGTERM; ignoring");
+                std::future::pending::<()>().await;
+            }
+        }
+    };
+
+    #[cfg(not(unix))]
+    let terminate = std::future::pending::<()>();
+
+    tokio::select! {
+        () = ctrl_c => {}
+        () = terminate => {}
     }
 }
 

--- a/fleet/arcbox-fleet-agent/src/runner.rs
+++ b/fleet/arcbox-fleet-agent/src/runner.rs
@@ -12,9 +12,9 @@ use arcbox_fleet_proto::v1::{
     AttachRequest, ProvisionRunner, RunnerAccepted, RunnerFailed, RunnerFinished, RunnerStarted,
     attach_request,
 };
+use command_group::AsyncCommandGroup;
 use dashmap::{DashMap, DashSet};
-use tokio::sync::mpsc;
-use tokio::task::AbortHandle;
+use tokio::sync::{mpsc, oneshot};
 use tracing::{info, warn};
 
 /// Outcome of the admission check for an incoming `ProvisionRunner`.
@@ -41,8 +41,9 @@ struct Inner {
     events: mpsc::Sender<AttachRequest>,
     /// Job ids currently in flight (drives local capacity).
     in_flight: DashSet<String>,
-    /// Abort handles for in-flight jobs, for `CancelRunner`.
-    cancels: DashMap<String, AbortHandle>,
+    /// Cancel signals for in-flight jobs. Firing one makes the job's `run_job`
+    /// kill the runner's whole process group; see [`RunnerSupervisor::handle_cancel`].
+    cancels: DashMap<String, oneshot::Sender<()>>,
     /// Directory holding the installed runner (`run.sh` / `run.cmd`).
     runner_dir: PathBuf,
     /// Local backpressure cap.
@@ -98,9 +99,14 @@ impl RunnerSupervisor {
         // Reserve the slot synchronously so a follow-up dispatch sees it.
         self.inner.in_flight.insert(job_id.clone());
 
+        // Cancellation is cooperative: `run_job` owns the runner process group
+        // and tears it down on this signal, so `CancelRunner` never orphans the
+        // runner's child processes (a task abort would kill only the immediate
+        // `run.sh`/`cmd` child, not the runner and job it spawns).
+        let (cancel_tx, cancel_rx) = oneshot::channel();
+        self.inner.cancels.insert(job_id, cancel_tx);
         let sup = self.clone();
-        let handle = tokio::spawn(async move { sup.run_job(order).await });
-        self.inner.cancels.insert(job_id, handle.abort_handle());
+        tokio::spawn(async move { sup.run_job(order, cancel_rx).await });
     }
 
     /// Decide whether to start a runner for `job_id`. `Duplicate` takes
@@ -126,12 +132,13 @@ impl RunnerSupervisor {
         Admission::Accept
     }
 
-    /// Cancel an in-flight job: aborting the task drops the child (kill-on-drop).
+    /// Cancel an in-flight job. Signals `run_job`, which kills the runner's
+    /// whole process group and releases the slot — the slot is dropped there,
+    /// not here, so local capacity tracks the real process lifetime.
     pub fn handle_cancel(&self, job_id: &str) {
-        if let Some((_, handle)) = self.inner.cancels.remove(job_id) {
-            handle.abort();
-            self.inner.in_flight.remove(job_id);
-            warn!(job_id, "runner canceled");
+        if let Some((_, cancel)) = self.inner.cancels.remove(job_id) {
+            let _ = cancel.send(());
+            warn!(job_id, "runner cancel requested");
         }
     }
 
@@ -143,8 +150,10 @@ impl RunnerSupervisor {
         info!("draining: no new runners will be accepted");
     }
 
-    /// Drive one runner process end to end, emitting accept/start/terminal events.
-    async fn run_job(&self, order: ProvisionRunner) {
+    /// Drive one runner process end to end, emitting accept/start/terminal
+    /// events. The runner is spawned as a process group so cancellation can take
+    /// down `run.sh` and every process it spawned, not just the immediate child.
+    async fn run_job(&self, order: ProvisionRunner, mut cancel_rx: oneshot::Receiver<()>) {
         let job_id = order.job_id.clone();
         self.send(attach_request::Msg::RunnerAccepted(RunnerAccepted {
             job_id: job_id.clone(),
@@ -152,7 +161,7 @@ impl RunnerSupervisor {
         .await;
 
         let mut command = runner_command(&self.inner.runner_dir, &order.encoded_jit_config);
-        let mut child = match command.kill_on_drop(true).spawn() {
+        let mut child = match command.group_spawn() {
             Ok(child) => child,
             Err(e) => {
                 self.fail(&job_id, &format!("failed to spawn runner: {e}"))
@@ -167,18 +176,28 @@ impl RunnerSupervisor {
         .await;
         info!(job_id, "runner started");
 
-        match child.wait().await {
-            Ok(status) => {
-                self.send(attach_request::Msg::RunnerFinished(RunnerFinished {
-                    job_id: job_id.clone(),
-                    success: status.success(),
-                    detail: format!("exit status: {status}"),
-                }))
-                .await;
-                info!(job_id, success = status.success(), "runner finished");
-                self.release(&job_id);
+        tokio::select! {
+            result = child.wait() => match result {
+                Ok(status) => {
+                    self.send(attach_request::Msg::RunnerFinished(RunnerFinished {
+                        job_id: job_id.clone(),
+                        success: status.success(),
+                        detail: format!("exit status: {status}"),
+                    }))
+                    .await;
+                    info!(job_id, success = status.success(), "runner finished");
+                    self.release(&job_id);
+                }
+                Err(e) => self.fail(&job_id, &format!("waiting on runner: {e}")).await,
+            },
+            // CancelRunner: SIGKILL the whole process group (run.sh and the
+            // runner/job processes it spawned) and reap it, then report terminal.
+            _ = &mut cancel_rx => {
+                if let Err(e) = child.kill().await {
+                    warn!(job_id, error = %e, "killing runner process group failed");
+                }
+                self.fail(&job_id, "canceled by gateway").await;
             }
-            Err(e) => self.fail(&job_id, &format!("waiting on runner: {e}")).await,
         }
     }
 

--- a/fleet/arcbox-fleet-agent/src/runner.rs
+++ b/fleet/arcbox-fleet-agent/src/runner.rs
@@ -7,6 +7,7 @@
 
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
+use std::time::Duration;
 
 use arcbox_fleet_proto::v1::{
     AttachRequest, ProvisionRunner, RunnerAccepted, RunnerFailed, RunnerFinished, RunnerStarted,
@@ -150,6 +151,45 @@ impl RunnerSupervisor {
         info!("draining: no new runners will be accepted");
     }
 
+    /// Begin graceful shutdown: stop accepting offers, cancel every in-flight
+    /// job (each `run_job` SIGKILLs its runner's process group and reaps it),
+    /// and wait — bounded by `grace` — for the jobs to release their slots.
+    ///
+    /// Terminal events are emitted best-effort: the attach stream may already be
+    /// torn down, but the gateway reclaims capacity when it observes the dropped
+    /// connection, so a runner that cannot flush its event is not stranded. The
+    /// real guarantee here is that no runner process group is left orphaned.
+    pub async fn shutdown(&self, grace: Duration) {
+        self.handle_drain();
+        // `cancels` is a subset of `in_flight`, so firing every cancel signals a
+        // teardown for each running job; jobs already mid-cancel keep tearing
+        // down and are covered by the wait below.
+        let jobs: Vec<String> = self
+            .inner
+            .cancels
+            .iter()
+            .map(|entry| entry.key().clone())
+            .collect();
+        for job_id in &jobs {
+            self.handle_cancel(job_id);
+        }
+        if self.inner.in_flight.is_empty() {
+            return;
+        }
+        info!(jobs = jobs.len(), "shutdown: waiting for runners to stop");
+        let drained = async {
+            while !self.inner.in_flight.is_empty() {
+                tokio::time::sleep(Duration::from_millis(100)).await;
+            }
+        };
+        if tokio::time::timeout(grace, drained).await.is_err() {
+            warn!(
+                remaining = self.inner.in_flight.len(),
+                "shutdown grace elapsed; some runners may still be terminating"
+            );
+        }
+    }
+
     /// Drive one runner process end to end, emitting accept/start/terminal
     /// events. The runner is spawned as a process group so cancellation can take
     /// down `run.sh` and every process it spawned, not just the immediate child.
@@ -290,5 +330,49 @@ mod tests {
         assert_eq!(sup.admit("rjob_a"), Admission::Duplicate);
         // A different job while draining is rejected for draining.
         assert_eq!(sup.admit("rjob_b"), Admission::Draining);
+    }
+
+    /// Register an in-flight job with a cancel signal, mirroring what
+    /// `handle_provision` sets up before spawning `run_job`.
+    fn register_in_flight(sup: &RunnerSupervisor, job_id: &str) -> oneshot::Receiver<()> {
+        let (cancel_tx, cancel_rx) = oneshot::channel();
+        sup.inner.in_flight.insert(job_id.to_string());
+        sup.inner.cancels.insert(job_id.to_string(), cancel_tx);
+        cancel_rx
+    }
+
+    #[tokio::test]
+    async fn shutdown_drains_cancels_and_waits_for_release() {
+        let sup = supervisor(4);
+        let cancel_rx = register_in_flight(&sup, "rjob_a");
+
+        // Stand in for `run_job`: release the slot once the cancel signal fires.
+        let inner = sup.inner.clone();
+        tokio::spawn(async move {
+            let _ = cancel_rx.await;
+            inner.in_flight.remove("rjob_a");
+            inner.cancels.remove("rjob_a");
+        });
+
+        sup.shutdown(Duration::from_secs(5)).await;
+
+        assert!(
+            sup.inner
+                .draining
+                .load(std::sync::atomic::Ordering::Relaxed)
+        );
+        assert!(sup.inner.in_flight.is_empty());
+    }
+
+    #[tokio::test]
+    async fn shutdown_returns_after_grace_when_a_job_will_not_release() {
+        let sup = supervisor(4);
+        // Hold the receiver so the cancel send succeeds, but never release the
+        // slot — shutdown must give up after the grace rather than hang.
+        let _cancel_rx = register_in_flight(&sup, "rjob_a");
+
+        sup.shutdown(Duration::from_millis(250)).await;
+
+        assert!(!sup.inner.in_flight.is_empty());
     }
 }

--- a/fleet/arcbox-fleet-agent/src/runner.rs
+++ b/fleet/arcbox-fleet-agent/src/runner.rs
@@ -1,0 +1,192 @@
+//! Runner supervision: spawn the GitHub Actions runner per `ProvisionRunner`,
+//! track in-flight jobs, and report terminal state back over the stream.
+//!
+//! v1 has no isolation: the job runs directly on the host. `ProvisionRunner`'s
+//! `image`/`cpus`/`mem_mib` describe a sandbox that does not exist yet and are
+//! intentionally ignored.
+
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use arcbox_fleet_proto::v1::{
+    AttachRequest, ProvisionRunner, RunnerAccepted, RunnerFailed, RunnerFinished, RunnerStarted,
+    attach_request,
+};
+use dashmap::{DashMap, DashSet};
+use tokio::sync::mpsc;
+use tokio::task::AbortHandle;
+use tracing::{info, warn};
+
+/// Spawns and tracks runner processes, emitting lifecycle events to the gateway.
+#[derive(Clone)]
+pub struct RunnerSupervisor {
+    inner: Arc<Inner>,
+}
+
+struct Inner {
+    /// Outbound channel to the gateway (runner lifecycle events).
+    events: mpsc::Sender<AttachRequest>,
+    /// Job ids currently in flight (drives local capacity).
+    in_flight: DashSet<String>,
+    /// Abort handles for in-flight jobs, for `CancelRunner`.
+    cancels: DashMap<String, AbortHandle>,
+    /// Directory holding the installed runner (`run.sh` / `run.cmd`).
+    runner_dir: PathBuf,
+    /// Local backpressure cap.
+    max_concurrent: usize,
+    /// Set once `Drain` is received; no new jobs are accepted.
+    draining: std::sync::atomic::AtomicBool,
+}
+
+impl RunnerSupervisor {
+    /// Create a supervisor that emits events on `events`.
+    pub fn new(
+        events: mpsc::Sender<AttachRequest>,
+        runner_dir: PathBuf,
+        max_concurrent: usize,
+    ) -> Self {
+        Self {
+            inner: Arc::new(Inner {
+                events,
+                in_flight: DashSet::new(),
+                cancels: DashMap::new(),
+                runner_dir,
+                max_concurrent,
+                draining: std::sync::atomic::AtomicBool::new(false),
+            }),
+        }
+    }
+
+    /// Start a runner for `order`, unless draining or at capacity.
+    pub async fn handle_provision(&self, order: ProvisionRunner) {
+        let job_id = order.job_id.clone();
+
+        if self
+            .inner
+            .draining
+            .load(std::sync::atomic::Ordering::Relaxed)
+        {
+            self.fail(&job_id, "host is draining").await;
+            return;
+        }
+        if self.inner.in_flight.len() >= self.inner.max_concurrent {
+            self.fail(&job_id, "host at capacity").await;
+            return;
+        }
+
+        // Reserve the slot synchronously so a follow-up dispatch sees it.
+        self.inner.in_flight.insert(job_id.clone());
+
+        let sup = self.clone();
+        let handle = tokio::spawn(async move { sup.run_job(order).await });
+        self.inner.cancels.insert(job_id, handle.abort_handle());
+    }
+
+    /// Cancel an in-flight job: aborting the task drops the child (kill-on-drop).
+    pub fn handle_cancel(&self, job_id: &str) {
+        if let Some((_, handle)) = self.inner.cancels.remove(job_id) {
+            handle.abort();
+            self.inner.in_flight.remove(job_id);
+            warn!(job_id, "runner canceled");
+        }
+    }
+
+    /// Stop accepting new work; in-flight jobs run to completion.
+    pub fn handle_drain(&self) {
+        self.inner
+            .draining
+            .store(true, std::sync::atomic::Ordering::Relaxed);
+        info!("draining: no new runners will be accepted");
+    }
+
+    /// Drive one runner process end to end, emitting accept/start/terminal events.
+    async fn run_job(&self, order: ProvisionRunner) {
+        let job_id = order.job_id.clone();
+        self.send(attach_request::Msg::RunnerAccepted(RunnerAccepted {
+            job_id: job_id.clone(),
+        }))
+        .await;
+
+        let mut command = runner_command(&self.inner.runner_dir, &order.encoded_jit_config);
+        let mut child = match command.kill_on_drop(true).spawn() {
+            Ok(child) => child,
+            Err(e) => {
+                self.fail(&job_id, &format!("failed to spawn runner: {e}"))
+                    .await;
+                return;
+            }
+        };
+
+        self.send(attach_request::Msg::RunnerStarted(RunnerStarted {
+            job_id: job_id.clone(),
+        }))
+        .await;
+        info!(job_id, "runner started");
+
+        match child.wait().await {
+            Ok(status) => {
+                self.send(attach_request::Msg::RunnerFinished(RunnerFinished {
+                    job_id: job_id.clone(),
+                    success: status.success(),
+                    detail: format!("exit status: {status}"),
+                }))
+                .await;
+                info!(job_id, success = status.success(), "runner finished");
+                self.release(&job_id);
+            }
+            Err(e) => self.fail(&job_id, &format!("waiting on runner: {e}")).await,
+        }
+    }
+
+    /// Drop bookkeeping for a job, releasing its capacity slot.
+    fn release(&self, job_id: &str) {
+        self.inner.in_flight.remove(job_id);
+        self.inner.cancels.remove(job_id);
+    }
+
+    /// Emit a `RunnerFailed` and release the slot.
+    async fn fail(&self, job_id: &str, reason: &str) {
+        warn!(job_id, reason, "runner failed");
+        self.send(attach_request::Msg::RunnerFailed(RunnerFailed {
+            job_id: job_id.to_string(),
+            reason: reason.to_string(),
+        }))
+        .await;
+        self.release(job_id);
+    }
+
+    /// Send a runner event, awaiting channel capacity.
+    async fn send(&self, msg: attach_request::Msg) {
+        if self
+            .inner
+            .events
+            .send(AttachRequest { msg: Some(msg) })
+            .await
+            .is_err()
+        {
+            warn!("event channel closed; gateway stream is reconnecting");
+        }
+    }
+}
+
+/// Build the platform-appropriate runner invocation.
+fn runner_command(runner_dir: &Path, encoded_jit_config: &str) -> tokio::process::Command {
+    #[cfg(windows)]
+    {
+        let script = runner_dir.join("run.cmd");
+        let mut command = tokio::process::Command::new("cmd");
+        command
+            .arg("/C")
+            .arg(script)
+            .arg("--jitconfig")
+            .arg(encoded_jit_config);
+        command
+    }
+    #[cfg(not(windows))]
+    {
+        let script = runner_dir.join("run.sh");
+        let mut command = tokio::process::Command::new(script);
+        command.arg("--jitconfig").arg(encoded_jit_config);
+        command
+    }
+}

--- a/fleet/arcbox-fleet-agent/src/runner.rs
+++ b/fleet/arcbox-fleet-agent/src/runner.rs
@@ -17,6 +17,19 @@ use tokio::sync::mpsc;
 use tokio::task::AbortHandle;
 use tracing::{info, warn};
 
+/// Outcome of the admission check for an incoming `ProvisionRunner`.
+#[derive(Debug, PartialEq, Eq)]
+enum Admission {
+    /// Accept the job and start a runner.
+    Accept,
+    /// The job is already in flight; ignore the redelivered order.
+    Duplicate,
+    /// The host is draining and rejects new work.
+    Draining,
+    /// The host is at its concurrency cap.
+    AtCapacity,
+}
+
 /// Spawns and tracks runner processes, emitting lifecycle events to the gateway.
 #[derive(Clone)]
 pub struct RunnerSupervisor {
@@ -57,21 +70,29 @@ impl RunnerSupervisor {
         }
     }
 
-    /// Start a runner for `order`, unless draining or at capacity.
+    /// Start a runner for `order`. A redelivered order for a job already in
+    /// flight is ignored; otherwise the job is rejected if draining or at
+    /// capacity.
     pub async fn handle_provision(&self, order: ProvisionRunner) {
         let job_id = order.job_id.clone();
 
-        if self
-            .inner
-            .draining
-            .load(std::sync::atomic::Ordering::Relaxed)
-        {
-            self.fail(&job_id, "host is draining").await;
-            return;
-        }
-        if self.inner.in_flight.len() >= self.inner.max_concurrent {
-            self.fail(&job_id, "host at capacity").await;
-            return;
+        match self.admit(&job_id) {
+            Admission::Duplicate => {
+                // The gateway's dispatch is at-least-once, so a redelivered
+                // order for a running job must be a no-op — never a second
+                // runner process for the same job.
+                info!(job_id, "duplicate provision ignored");
+                return;
+            }
+            Admission::Draining => {
+                self.fail(&job_id, "host is draining").await;
+                return;
+            }
+            Admission::AtCapacity => {
+                self.fail(&job_id, "host at capacity").await;
+                return;
+            }
+            Admission::Accept => {}
         }
 
         // Reserve the slot synchronously so a follow-up dispatch sees it.
@@ -80,6 +101,29 @@ impl RunnerSupervisor {
         let sup = self.clone();
         let handle = tokio::spawn(async move { sup.run_job(order).await });
         self.inner.cancels.insert(job_id, handle.abort_handle());
+    }
+
+    /// Decide whether to start a runner for `job_id`. `Duplicate` takes
+    /// precedence over `Draining`/`AtCapacity`: a redelivery of an
+    /// already-running job is a no-op regardless of host state. The
+    /// `contains`/`insert` gap back in [`Self::handle_provision`] is safe
+    /// because the attach loop dispatches orders one at a time, with no
+    /// `.await` between this check and the reservation.
+    fn admit(&self, job_id: &str) -> Admission {
+        if self.inner.in_flight.contains(job_id) {
+            return Admission::Duplicate;
+        }
+        if self
+            .inner
+            .draining
+            .load(std::sync::atomic::Ordering::Relaxed)
+        {
+            return Admission::Draining;
+        }
+        if self.inner.in_flight.len() >= self.inner.max_concurrent {
+            return Admission::AtCapacity;
+        }
+        Admission::Accept
     }
 
     /// Cancel an in-flight job: aborting the task drops the child (kill-on-drop).
@@ -188,5 +232,44 @@ fn runner_command(runner_dir: &Path, encoded_jit_config: &str) -> tokio::process
         let mut command = tokio::process::Command::new(script);
         command.arg("--jitconfig").arg(encoded_jit_config);
         command
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn supervisor(max_concurrent: usize) -> RunnerSupervisor {
+        // `admit` never sends, so the dropped receiver is irrelevant here.
+        let (events, _rx) = mpsc::channel(1);
+        RunnerSupervisor::new(events, PathBuf::from("/nonexistent"), max_concurrent)
+    }
+
+    #[test]
+    fn admits_until_capacity_then_rejects() {
+        let sup = supervisor(2);
+        assert_eq!(sup.admit("rjob_a"), Admission::Accept);
+
+        sup.inner.in_flight.insert("rjob_a".to_string());
+        // A redelivery of a running job is a duplicate, never a fresh slot.
+        assert_eq!(sup.admit("rjob_a"), Admission::Duplicate);
+        assert_eq!(sup.admit("rjob_b"), Admission::Accept);
+
+        sup.inner.in_flight.insert("rjob_b".to_string());
+        assert_eq!(sup.admit("rjob_c"), Admission::AtCapacity);
+    }
+
+    #[test]
+    fn duplicate_takes_precedence_over_drain_and_capacity() {
+        let sup = supervisor(1);
+        sup.inner.in_flight.insert("rjob_a".to_string());
+        sup.inner
+            .draining
+            .store(true, std::sync::atomic::Ordering::Relaxed);
+
+        // Already running, host draining and at capacity: still a duplicate.
+        assert_eq!(sup.admit("rjob_a"), Admission::Duplicate);
+        // A different job while draining is rejected for draining.
+        assert_eq!(sup.admit("rjob_b"), Admission::Draining);
     }
 }

--- a/fleet/arcbox-fleet-proto/Cargo.toml
+++ b/fleet/arcbox-fleet-proto/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "arcbox-fleet-proto"
+publish = false
+description = "Generated tonic client stubs for the Fleet gateway contract (buf.build/arcboxlabs/fleet)"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+authors.workspace = true
+
+[dependencies]
+tonic = { workspace = true }
+prost = { workspace = true }
+
+[build-dependencies]
+tonic-build = { workspace = true }
+
+[lints]
+workspace = true

--- a/fleet/arcbox-fleet-proto/buf.yaml
+++ b/fleet/arcbox-fleet-proto/buf.yaml
@@ -1,0 +1,7 @@
+# Provenance for the vendored proto under proto/. Not a build dependency:
+# the crate compiles the vendored file with tonic-build. Refresh the vendored
+# copy from the registry with `make fleet-proto-sync`
+# (buf export buf.build/arcboxlabs/fleet -o proto).
+version: v2
+deps:
+  - buf.build/arcboxlabs/fleet

--- a/fleet/arcbox-fleet-proto/build.rs
+++ b/fleet/arcbox-fleet-proto/build.rs
@@ -1,0 +1,17 @@
+//! Generates the Fleet gateway client stubs from the vendored proto.
+//!
+//! The proto is the public `buf.build/arcboxlabs/fleet` module, vendored under
+//! `proto/` (refresh with `make fleet-proto-sync`). Only the client is built —
+//! the agent is a client of the gateway, never a server.
+
+fn main() {
+    let proto = "proto/arcbox/fleet/v1/fleet.proto";
+
+    tonic_build::configure()
+        .build_client(true)
+        .build_server(false)
+        .compile_protos(&[proto], &["proto"])
+        .expect("Failed to compile fleet.proto");
+
+    println!("cargo:rerun-if-changed={proto}");
+}

--- a/fleet/arcbox-fleet-proto/proto/arcbox/fleet/v1/fleet.proto
+++ b/fleet/arcbox-fleet-proto/proto/arcbox/fleet/v1/fleet.proto
@@ -5,7 +5,7 @@ package arcbox.fleet.v1;
 // BYOC edge: terminates the outbound connection of NAT'd Fleet machines.
 // Machines dial out; nothing ever connects in to them.
 service FleetGatewayService {
-  // Exchange a single-use enrollment token for the machine's long-lived
+  // Exchange a fleet enrollment token for the machine's long-lived
   // credential. Creates the machine row and its capacity pools.
   // Unauthenticated: the enrollment token is the proof.
   rpc Enroll(EnrollRequest) returns (EnrollResponse);
@@ -17,6 +17,8 @@ service FleetGatewayService {
 }
 
 message EnrollRequest {
+  // Multi-use fleet join token: valid for any machine in the fleet until it
+  // expires or is rotated (one active token per fleet).
   string enrollment_token = 1;
   string machine_name = 2;
   // Host CPU architecture (e.g. `arm64`).

--- a/fleet/arcbox-fleet-proto/proto/arcbox/fleet/v1/fleet.proto
+++ b/fleet/arcbox-fleet-proto/proto/arcbox/fleet/v1/fleet.proto
@@ -1,0 +1,114 @@
+syntax = "proto3";
+
+package arcbox.fleet.v1;
+
+// BYOC edge: terminates the outbound connection of NAT'd Fleet machines.
+// Machines dial out; nothing ever connects in to them.
+service FleetGatewayService {
+  // Exchange a single-use enrollment token for the machine's long-lived
+  // credential. Creates the machine row and its capacity pools.
+  // Unauthenticated: the enrollment token is the proof.
+  rpc Enroll(EnrollRequest) returns (EnrollResponse);
+
+  // Long-lived bidirectional stream. Authenticated with the machine
+  // credential in the `x-arcbox-machine-token` metadata key.
+  // (Named Attach because tonic reserves `connect` on generated clients.)
+  rpc Attach(stream AttachRequest) returns (stream AttachResponse);
+}
+
+message EnrollRequest {
+  string enrollment_token = 1;
+  string machine_name = 2;
+  // Host CPU architecture (e.g. `arm64`).
+  string host_arch = 3;
+  uint32 cpu_cores = 4;
+  uint64 mem_mib = 5;
+  // Capacity pools the host serves, e.g. darwin/arm64 max 2 + linux/arm64.
+  repeated RuntimeCapacity capacities = 6;
+  // Free-form host facts as JSON (macOS version, chip, ...).
+  string host_info_json = 7;
+}
+
+message EnrollResponse {
+  // Prefixed machine id (`fltm_...`).
+  string machine_id = 1;
+  // Long-lived machine credential; transmitted exactly once, only its
+  // hash is stored server-side.
+  string machine_token = 2;
+}
+
+// One (os, arch) capacity pool of a host.
+message RuntimeCapacity {
+  // `darwin` | `linux` | `windows` (lowercase RunnerOs).
+  string os = 1;
+  // `arm64` | `amd64` (lowercase RunnerArch).
+  string arch = 2;
+  int32 max_concurrent = 3;
+}
+
+message AttachRequest {
+  oneof msg {
+    Heartbeat heartbeat = 1;
+    RunnerAccepted runner_accepted = 2;
+    RunnerStarted runner_started = 3;
+    RunnerFinished runner_finished = 4;
+    RunnerFailed runner_failed = 5;
+  }
+}
+
+// Periodic capacity + liveness report. Capacity pools are declarative: the
+// reported set replaces what is stored.
+message Heartbeat {
+  repeated RuntimeCapacity capacities = 1;
+  string host_info_json = 2;
+}
+
+message RunnerAccepted {
+  // Prefixed runner job id (`rjob_...`), echoing ProvisionRunner.
+  string job_id = 1;
+}
+
+message RunnerStarted {
+  string job_id = 1;
+}
+
+message RunnerFinished {
+  string job_id = 1;
+  bool success = 2;
+  // Human-readable detail (exit status, GitHub conclusion, ...).
+  string detail = 3;
+}
+
+message RunnerFailed {
+  string job_id = 1;
+  string reason = 2;
+}
+
+message AttachResponse {
+  oneof msg {
+    ProvisionRunner provision_runner = 1;
+    CancelRunner cancel = 2;
+    Drain drain = 3;
+  }
+}
+
+// Order to start one JIT runner for one job.
+message ProvisionRunner {
+  string job_id = 1;
+  string os = 2;
+  string arch = 3;
+  // Single-use GitHub JIT runner config (base64), passed through verbatim.
+  string encoded_jit_config = 4;
+  // Base image for the guest; empty means the fleet default.
+  string image = 5;
+  uint32 cpus = 6;
+  uint64 mem_mib = 7;
+}
+
+// Stop a runner before it picks up work (job canceled on GitHub).
+message CancelRunner {
+  string job_id = 1;
+}
+
+// Stop accepting new work ahead of removal.
+message Drain {}

--- a/fleet/arcbox-fleet-proto/src/lib.rs
+++ b/fleet/arcbox-fleet-proto/src/lib.rs
@@ -1,0 +1,10 @@
+//! Generated tonic client stubs for the Fleet gateway contract.
+//!
+//! The schema is the public module published at `buf.build/arcboxlabs/fleet`
+//! (`FleetGatewayService`: `Enroll` + `Attach`). The internal dispatch service
+//! is intentionally absent — it lives in the platform's unpublished module.
+
+/// Fleet gateway protocol (`arcbox.fleet.v1` package).
+pub mod v1 {
+    tonic::include_proto!("arcbox.fleet.v1");
+}


### PR DESCRIPTION
## What

Adds a standalone, cross-platform Fleet runner agent that enrolls a host with the Fleet gateway and runs GitHub Actions jobs directly (no isolation in v1 — the job is handed to the pre-installed runner via `run.sh --jitconfig`).

New `fleet/` layer (shares no code with the macOS virt workspace):
- **`arcbox-fleet-proto`** — tonic client stubs generated from the public BSR contract `buf.build/arcboxlabs/fleet` (vendored proto; `make fleet-proto-sync` to refresh). Client-only.
- **`arcbox-fleet-agent`** — env-configured binary (`ARCBOX_FLEET_*`):
  - `enroll --token` → exchanges the token, persists a `0600` credential.
  - `run` → durable `Attach` stream (heartbeat out, dispatch in, backoff reconnect); on `ProvisionRunner` spawns the runner and reports `RunnerAccepted/Started/Finished/Failed`.
  - `ProvisionRunner.image/cpus/mem_mib` are no-ops in v1.

Durability:
- The runner supervisor and its outbound event queue outlive any single connection, so a job dispatched before a reconnect keeps running and its terminal event reaches the next live stream instead of a dropped connection's dead channel.
- `ProvisionRunner` handling is idempotent on `job_id`: the gateway's dispatch is at-least-once "pure transport", so a redelivered order for an in-flight job is a no-op rather than a second runner process.

## Verification

Full E2E on a Linux box against the real control plane (`arcbox-api` + `arcbox-worker` + `arcbox-fleet-gateway` + Restate + Postgres/Redis), with the in-repo `github-mock`/`gh-webhook` harness standing in for GitHub:

- ✅ **Enroll** → `0600` credential persisted; gateway logs `machine enrolled`.
- ✅ **Attach + heartbeat** → machine `online`, `last_seen` set, capacity pool recorded.
- ✅ **Dispatch → run → report** → `gh-webhook queued` drives the real webhook→worker→provision→dispatch chain; the agent runs the JIT runner and reports `RunnerAccepted/Started/Finished`; `runner_jobs` reaches `completed`.
- ✅ **Reconnect durability** → bouncing the gateway mid-run delivers the in-flight job's `RunnerFinished` on the new stream (gateway logs `runner finished` after the reattach; no dropped event).
- ✅ **Duplicate dispatch** → a redelivered `ProvisionRunner` for an in-flight job is ignored (`duplicate provision ignored`), single runner spawn.
- ✅ `cargo fmt` / `clippy` / `test` clean per-crate.

## Notes
- Full client workspace doesn't cross-compile on Linux (macOS crates); build in isolation with `cargo build -p arcbox-fleet-agent`. fmt/clippy/test were run per-crate.
