### PR TITLE
chore: restrict crates.io publishing to the splicetcp cluster

### DIFF
--- a/app/arcbox-migration/Cargo.toml
+++ b/app/arcbox-migration/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "arcbox-migration"
+publish = false
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true

--- a/common/arcbox-conntrack/Cargo.toml
+++ b/common/arcbox-conntrack/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "arcbox-conntrack"
+publish = false
 description = "Stateful NAT connection tracking and zero-copy packet translation for ArcBox"
 version.workspace = true
 edition.workspace = true

--- a/common/arcbox-error/Cargo.toml
+++ b/common/arcbox-error/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "arcbox-error"
+publish = false
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true

--- a/virt/arcbox-dhcp/Cargo.toml
+++ b/virt/arcbox-dhcp/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "arcbox-dhcp"
+publish = false
 description = "Lightweight DHCP server and IP allocator for ArcBox"
 version.workspace = true
 edition.workspace = true

--- a/virt/arcbox-fs/Cargo.toml
+++ b/virt/arcbox-fs/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "arcbox-fs"
+publish = false
 description = "High-performance filesystem service for ArcBox (VirtioFS)"
 version.workspace = true
 edition.workspace = true

--- a/virt/arcbox-hv/Cargo.toml
+++ b/virt/arcbox-hv/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "arcbox-hv"
+publish = false
 version = "0.3.20" # x-release-please-version
 edition = "2024"
 description = "Safe Rust bindings for Apple Hypervisor.framework (ARM64)"

--- a/virt/arcbox-hypervisor/Cargo.toml
+++ b/virt/arcbox-hypervisor/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "arcbox-hypervisor"
+publish = false
 description = "Cross-platform hypervisor abstraction layer for ArcBox"
 version.workspace = true
 edition.workspace = true

--- a/virt/arcbox-net-inject/Cargo.toml
+++ b/virt/arcbox-net-inject/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "arcbox-net-inject"
+publish = false
 description = "Guest memory RX injection engine for ArcBox VirtIO-net"
 version.workspace = true
 edition.workspace = true

--- a/virt/arcbox-net-virtio/Cargo.toml
+++ b/virt/arcbox-net-virtio/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "arcbox-net-virtio"
+publish = false
 description = "VirtIO-net backends (NAT bridge, TSO fast path) connecting the ArcBox datapath to arcbox-virtio"
 version.workspace = true
 edition.workspace = true

--- a/virt/arcbox-net/Cargo.toml
+++ b/virt/arcbox-net/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "arcbox-net"
+publish = false
 description = "High-performance network stack for ArcBox"
 version.workspace = true
 edition.workspace = true

--- a/virt/arcbox-virtio-balloon/Cargo.toml
+++ b/virt/arcbox-virtio-balloon/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "arcbox-virtio-balloon"
+publish = false
 description = "VirtIO traditional memory balloon device for ArcBox"
 version.workspace = true
 edition.workspace = true

--- a/virt/arcbox-virtio-blk/Cargo.toml
+++ b/virt/arcbox-virtio-blk/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "arcbox-virtio-blk"
+publish = false
 description = "VirtIO block device implementation for ArcBox"
 version.workspace = true
 edition.workspace = true

--- a/virt/arcbox-virtio-console/Cargo.toml
+++ b/virt/arcbox-virtio-console/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "arcbox-virtio-console"
+publish = false
 description = "VirtIO console device implementation for ArcBox"
 version.workspace = true
 edition.workspace = true

--- a/virt/arcbox-virtio-core/Cargo.toml
+++ b/virt/arcbox-virtio-core/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "arcbox-virtio-core"
+publish = false
 description = "Foundational types and traits for ArcBox VirtIO devices"
 version.workspace = true
 edition.workspace = true

--- a/virt/arcbox-virtio-fs/Cargo.toml
+++ b/virt/arcbox-virtio-fs/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "arcbox-virtio-fs"
+publish = false
 description = "VirtIO filesystem device (virtio-fs) implementation for ArcBox"
 version.workspace = true
 edition.workspace = true

--- a/virt/arcbox-virtio-net/Cargo.toml
+++ b/virt/arcbox-virtio-net/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "arcbox-virtio-net"
+publish = false
 description = "VirtIO network device implementation for ArcBox"
 version.workspace = true
 edition.workspace = true

--- a/virt/arcbox-virtio-rng/Cargo.toml
+++ b/virt/arcbox-virtio-rng/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "arcbox-virtio-rng"
+publish = false
 description = "VirtIO entropy device implementation for ArcBox"
 version.workspace = true
 edition.workspace = true

--- a/virt/arcbox-virtio-vsock/Cargo.toml
+++ b/virt/arcbox-virtio-vsock/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "arcbox-virtio-vsock"
+publish = false
 description = "VirtIO vsock device + connection manager for ArcBox"
 version.workspace = true
 edition.workspace = true

--- a/virt/arcbox-virtio/Cargo.toml
+++ b/virt/arcbox-virtio/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "arcbox-virtio"
+publish = false
 description = "VirtIO device implementations for ArcBox"
 version.workspace = true
 edition.workspace = true

--- a/virt/arcbox-vm/Cargo.toml
+++ b/virt/arcbox-vm/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name              = "arcbox-vm"
+publish           = false
 version.workspace = true
 edition.workspace = true
 authors.workspace = true

--- a/virt/arcbox-vmm/Cargo.toml
+++ b/virt/arcbox-vmm/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "arcbox-vmm"
+publish = false
 description = "Virtual Machine Monitor for ArcBox"
 version.workspace = true
 edition.workspace = true

--- a/virt/arcbox-vmnet/Cargo.toml
+++ b/virt/arcbox-vmnet/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "arcbox-vmnet"
+publish = false
 description = "Safe Rust bindings for Apple's vmnet.framework"
 version.workspace = true
 edition.workspace = true

--- a/virt/arcbox-vz/Cargo.toml
+++ b/virt/arcbox-vz/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "arcbox-vz"
+publish = false
 version.workspace = true
 edition.workspace = true
 license.workspace = true


### PR DESCRIPTION
## What

Marks every workspace member **except the splicetcp datapath cluster** as `publish = false`, so the crates.io publish set is closed under dependencies.

Publishable after this change — exactly the 5 crates `release.yml` publishes (#319):

```
splicetcp, arcbox-proxy, arcbox-fakeip, arcbox-packet, arcbox-datapath
```

## Why

The publish flags were inconsistent: 28 members were publishable, but two of them — `arcbox-net` and `arcbox-vmm` — depend on `arcbox-dns`, which is `publish = false`. crates.io forbids a path/version dep on an unpublished crate, so those two could **never actually be published**, and a bare `cargo publish --workspace` aborts at `arcbox-net → arcbox-dns`. The rest of the VM crate family (`arcbox-virtio*`, `arcbox-vm`, `arcbox-hv`, `arcbox-vz`, …) was publishable-by-default but nothing publishes it.

This pins intent: only the splicetcp cluster (consumed downstream by aroxy) goes to crates.io.

## Effect

- Publishable members: **5** (was 28); each one's dependency closure now contains only publishable crates (verified via `cargo metadata`).
- `arcbox-net` / `arcbox-vmm` → `arcbox-dns` inconsistency resolved.
- **No build/runtime impact** — `publish = false` only gates crates.io uploads; path deps within the workspace and aroxy are unaffected.

Independent of #319 (which already publishes only the 5 via an explicit `-p` allowlist); this makes the workspace config match that intent.