### PR TITLE
ci(release): publish only the cross-platform library crates

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,24 +40,23 @@ jobs:
   # ==========================================================================
   # Publish the library crates to crates.io
   # ==========================================================================
-  # Publishes the reusable library crates (datapath, VM, and common libs).
-  # `publish = false` members are skipped automatically: the application
-  # binaries + app/runtime internals (arcbox, -cli, -daemon, -helper, -agent,
-  # -api, -core, -docker, -docker-tools, -container, -oci) and the internal
-  # gRPC crates (-grpc/-protocol/-transport, whose protos aren't self-contained
-  # for standalone packaging). `arcbox-hv` is excluded here: it has its own
-  # release cadence (manually pinned version, published separately), so a
-  # workspace run would try to re-upload an unchanged version and fail.
-  # `cargo publish --workspace` packages all publishable members, verifies each
-  # against the others via a local temp registry (so unpublished inter-deps
-  # resolve), and uploads in dependency order. Independent of the binary builds
-  # — the libraries are their own deliverable and must not be gated on Apple
-  # signing. Skipped on workflow_dispatch (manual binary rebuilds must not
-  # republish).
+  # Publishes the cross-platform reusable library crates (the datapath/common
+  # libs) to crates.io. Everything else is `publish = false` and skipped:
+  #   - the macOS host/VM crate family (all virt/* — arcbox-hv/-vz/-vmm/
+  #     -hypervisor/-vmnet/-virtio*/-vm/-fs/-net*/-dhcp) and arcbox-xnu-net,
+  #     which link Apple frameworks / XNU and don't build off-macOS;
+  #   - the application binaries + app/runtime internals and the internal gRPC
+  #     crates (-grpc/-protocol/-transport).
+  # Runs on macOS (like the CI build job) — these are Apple-platform crates, so
+  # the publish verify build must run where they compile. `cargo publish
+  # --workspace` packages all publishable members, verifies each against the
+  # others via a local temp registry, and uploads in dependency order.
+  # Independent of the binary builds. Skipped on workflow_dispatch (manual
+  # binary rebuilds must not republish).
   publish-crates:
     name: Publish crates to crates.io
     if: github.event_name == 'push'
-    runs-on: ubuntu-latest
+    runs-on: macos-26
     timeout-minutes: 45
     steps:
       - name: Checkout
@@ -88,8 +87,7 @@ jobs:
         # One coordinated publish: cargo packages all publishable members,
         # verifies each against the others via a local temp registry, then
         # uploads in dependency order, waiting for the index between uploads.
-        # arcbox-hv is excluded (independent release cadence).
-        run: cargo publish --workspace --locked --exclude arcbox-hv
+        run: cargo publish --workspace --locked
 
   # ==========================================================================
   # Build + sign macOS ARM64 host binaries

--- a/app/arcbox-migration/Cargo.toml
+++ b/app/arcbox-migration/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "arcbox-migration"
+publish = false
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true

--- a/common/arcbox-xnu-net/Cargo.toml
+++ b/common/arcbox-xnu-net/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "arcbox-xnu-net"
+publish = false
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true

--- a/virt/arcbox-dhcp/Cargo.toml
+++ b/virt/arcbox-dhcp/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "arcbox-dhcp"
+publish = false
 description = "Lightweight DHCP server and IP allocator for ArcBox"
 version.workspace = true
 edition.workspace = true

--- a/virt/arcbox-fs/Cargo.toml
+++ b/virt/arcbox-fs/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "arcbox-fs"
+publish = false
 description = "High-performance filesystem service for ArcBox (VirtioFS)"
 version.workspace = true
 edition.workspace = true

--- a/virt/arcbox-hv/Cargo.toml
+++ b/virt/arcbox-hv/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "arcbox-hv"
+publish = false
 version = "0.3.20" # x-release-please-version
 edition = "2024"
 description = "Safe Rust bindings for Apple Hypervisor.framework (ARM64)"

--- a/virt/arcbox-hypervisor/Cargo.toml
+++ b/virt/arcbox-hypervisor/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "arcbox-hypervisor"
+publish = false
 description = "Cross-platform hypervisor abstraction layer for ArcBox"
 version.workspace = true
 edition.workspace = true

--- a/virt/arcbox-net-inject/Cargo.toml
+++ b/virt/arcbox-net-inject/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "arcbox-net-inject"
+publish = false
 description = "Guest memory RX injection engine for ArcBox VirtIO-net"
 version.workspace = true
 edition.workspace = true

--- a/virt/arcbox-net-virtio/Cargo.toml
+++ b/virt/arcbox-net-virtio/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "arcbox-net-virtio"
+publish = false
 description = "VirtIO-net backends (NAT bridge, TSO fast path) connecting the ArcBox datapath to arcbox-virtio"
 version.workspace = true
 edition.workspace = true

--- a/virt/arcbox-net/Cargo.toml
+++ b/virt/arcbox-net/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "arcbox-net"
+publish = false
 description = "High-performance network stack for ArcBox"
 version.workspace = true
 edition.workspace = true

--- a/virt/arcbox-virtio-balloon/Cargo.toml
+++ b/virt/arcbox-virtio-balloon/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "arcbox-virtio-balloon"
+publish = false
 description = "VirtIO traditional memory balloon device for ArcBox"
 version.workspace = true
 edition.workspace = true

--- a/virt/arcbox-virtio-blk/Cargo.toml
+++ b/virt/arcbox-virtio-blk/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "arcbox-virtio-blk"
+publish = false
 description = "VirtIO block device implementation for ArcBox"
 version.workspace = true
 edition.workspace = true

--- a/virt/arcbox-virtio-console/Cargo.toml
+++ b/virt/arcbox-virtio-console/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "arcbox-virtio-console"
+publish = false
 description = "VirtIO console device implementation for ArcBox"
 version.workspace = true
 edition.workspace = true

--- a/virt/arcbox-virtio-core/Cargo.toml
+++ b/virt/arcbox-virtio-core/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "arcbox-virtio-core"
+publish = false
 description = "Foundational types and traits for ArcBox VirtIO devices"
 version.workspace = true
 edition.workspace = true

--- a/virt/arcbox-virtio-fs/Cargo.toml
+++ b/virt/arcbox-virtio-fs/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "arcbox-virtio-fs"
+publish = false
 description = "VirtIO filesystem device (virtio-fs) implementation for ArcBox"
 version.workspace = true
 edition.workspace = true

--- a/virt/arcbox-virtio-net/Cargo.toml
+++ b/virt/arcbox-virtio-net/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "arcbox-virtio-net"
+publish = false
 description = "VirtIO network device implementation for ArcBox"
 version.workspace = true
 edition.workspace = true

--- a/virt/arcbox-virtio-rng/Cargo.toml
+++ b/virt/arcbox-virtio-rng/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "arcbox-virtio-rng"
+publish = false
 description = "VirtIO entropy device implementation for ArcBox"
 version.workspace = true
 edition.workspace = true

--- a/virt/arcbox-virtio-vsock/Cargo.toml
+++ b/virt/arcbox-virtio-vsock/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "arcbox-virtio-vsock"
+publish = false
 description = "VirtIO vsock device + connection manager for ArcBox"
 version.workspace = true
 edition.workspace = true

--- a/virt/arcbox-virtio/Cargo.toml
+++ b/virt/arcbox-virtio/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "arcbox-virtio"
+publish = false
 description = "VirtIO device implementations for ArcBox"
 version.workspace = true
 edition.workspace = true

--- a/virt/arcbox-vm/Cargo.toml
+++ b/virt/arcbox-vm/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name              = "arcbox-vm"
+publish = false
 version.workspace = true
 edition.workspace = true
 authors.workspace = true

--- a/virt/arcbox-vmm/Cargo.toml
+++ b/virt/arcbox-vmm/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "arcbox-vmm"
+publish = false
 description = "Virtual Machine Monitor for ArcBox"
 version.workspace = true
 edition.workspace = true

--- a/virt/arcbox-vmnet/Cargo.toml
+++ b/virt/arcbox-vmnet/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "arcbox-vmnet"
+publish = false
 description = "Safe Rust bindings for Apple's vmnet.framework"
 version.workspace = true
 edition.workspace = true

--- a/virt/arcbox-vz/Cargo.toml
+++ b/virt/arcbox-vz/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "arcbox-vz"
+publish = false
 version.workspace = true
 edition.workspace = true
 license.workspace = true


### PR DESCRIPTION
Fixes the failed v0.4.8 release publish.

## What broke
The publish job ran `cargo publish --workspace` on **ubuntu**, but:
- The workspace's host/VM crates are **Apple-platform** (`arcbox-hv` = Hypervisor.framework bindings, `arcbox-vz` = Virtualization.framework, etc.) — they don't build off-macOS.
- `arcbox-vmm` depends on the independently-versioned, `--exclude`d `arcbox-hv`, which isn't on crates.io → `no matching package named arcbox-hv`.

(Nothing was published — the run aborted at packaging, before any upload.)

## Fix
Publish only the **cross-platform datapath/common libraries**, on the runner where they compile:

**Published (12):** `splicetcp`, `arcbox-proxy`, `arcbox-fakeip`, `arcbox-packet`, `arcbox-datapath`, `arcbox-dns`, `arcbox-conntrack`, `arcbox-constants`, `arcbox-error`, `arcbox-logging`, `arcbox-asset`, `arcbox-route`.

**`publish = false` (newly):** the whole macOS host/VM family (`virt/*` — hv/vz/vmm/hypervisor/vmnet/virtio*/vm/fs/net*/dhcp), `arcbox-xnu-net` (XNU), and `arcbox-migration` (app-tier Docker-import).

- `publish-crates` now `runs-on: macos-26` (matches CI's build job).
- Dropped `--exclude arcbox-hv` (it's `publish = false` now).
- **Verified on macOS**: `cargo publish --workspace --dry-run --locked` packages + verifies all 12 clean (exit 0).

## ⚠️ Re-running the v0.4.8 publish
The `v0.4.8` tag points at the commit with the broken workflow (Actions takes the workflow from the tagged commit). After merging this, re-trigger publishing by either re-tagging `v0.4.8` onto the fix, or letting the next release (`v0.4.9`) carry it. Still needs the `CARGO_REGISTRY_TOKEN` secret + the 12 names free on crates.io.