### PR TITLE
ci(release): publish all workspace crates to crates.io

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,22 +38,23 @@ jobs:
           echo "Building version: $VERSION"
 
   # ==========================================================================
-  # Publish the library crates to crates.io
+  # Publish every workspace crate to crates.io
   # ==========================================================================
-  # Publishes the reusable library crates (datapath, VM, and common libs).
-  # `publish = false` members are skipped automatically: the application
-  # binaries + app/runtime internals (arcbox, -cli, -daemon, -helper, -agent,
-  # -api, -core, -docker, -docker-tools, -container, -oci) and the internal
-  # gRPC crates (-grpc/-protocol/-transport, whose protos aren't self-contained
-  # for standalone packaging). `arcbox-hv` is excluded here: it has its own
-  # release cadence (manually pinned version, published separately), so a
-  # workspace run would try to re-upload an unchanged version and fail.
-  # `cargo publish --workspace` packages all publishable members, verifies each
-  # against the others via a local temp registry (so unpublished inter-deps
-  # resolve), and uploads in dependency order. Independent of the binary builds
-  # — the libraries are their own deliverable and must not be gated on Apple
-  # signing. Skipped on workflow_dispatch (manual binary rebuilds must not
-  # republish).
+  # Publishes ALL workspace members — the reusable libraries, the Apple-platform
+  # VM family, the app binaries, and the rpc crates. Run with `--no-verify`:
+  # four crates embed files that live outside their own package directory, so
+  # the isolated per-crate verify build can't see them —
+  #   - arcbox-core / -cli / -daemon `include_str!` the repo-root `assets.lock`
+  #     (and -cli also the helper `.plist` under bundle/);
+  #   - arcbox-grpc's build.rs reads `../arcbox-protocol/proto`.
+  # `--no-verify` skips that build and packages + uploads the source as-is — the
+  # same way arcbox-grpc was already published. The whole workspace is compiled
+  # green by the CI build job, so the per-crate verify build is redundant safety
+  # here, not new coverage. cargo still resolves the dependency graph and uploads
+  # in dependency order via a local temp registry, so unpublished inter-deps
+  # (including arcbox-hv at its own 0.3.20) resolve — nothing is excluded.
+  # Platform-agnostic (no compilation happens), so it runs on ubuntu. Skipped on
+  # workflow_dispatch (manual binary rebuilds must not republish).
   publish-crates:
     name: Publish crates to crates.io
     if: github.event_name == 'push'
@@ -85,11 +86,11 @@ jobs:
       - name: Publish to crates.io
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-        # One coordinated publish: cargo packages all publishable members,
-        # verifies each against the others via a local temp registry, then
-        # uploads in dependency order, waiting for the index between uploads.
-        # arcbox-hv is excluded (independent release cadence).
-        run: cargo publish --workspace --locked --exclude arcbox-hv
+        # One coordinated publish of the whole workspace: cargo packages every
+        # member, resolves inter-deps via a local temp registry, then uploads in
+        # dependency order, waiting for the index between uploads. --no-verify:
+        # see the note above (crates that embed out-of-tree workspace files).
+        run: cargo publish --workspace --no-verify --locked
 
   # ==========================================================================
   # Build + sign macOS ARM64 host binaries

--- a/app/arcbox-api/Cargo.toml
+++ b/app/arcbox-api/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "arcbox-api"
-publish = false
 description = "API server for ArcBox (gRPC + REST)"
 version.workspace = true
 edition.workspace = true

--- a/app/arcbox-cli/Cargo.toml
+++ b/app/arcbox-cli/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "arcbox-cli"
-publish = false
 description = "Command-line interface for ArcBox"
 version.workspace = true
 edition.workspace = true

--- a/app/arcbox-core/Cargo.toml
+++ b/app/arcbox-core/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "arcbox-core"
-publish = false
 description = "Core orchestration layer for ArcBox"
 version.workspace = true
 edition.workspace = true

--- a/app/arcbox-daemon/Cargo.toml
+++ b/app/arcbox-daemon/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "arcbox-daemon"
-publish = false
 description = "ArcBox daemon process"
 version.workspace = true
 edition.workspace = true

--- a/app/arcbox-docker-tools/Cargo.toml
+++ b/app/arcbox-docker-tools/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "arcbox-docker-tools"
-publish = false
 description = "Docker CLI tool download, installation, and management"
 version.workspace = true
 edition.workspace = true

--- a/app/arcbox-docker/Cargo.toml
+++ b/app/arcbox-docker/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "arcbox-docker"
-publish = false
 description = "Docker REST API compatibility layer for ArcBox"
 version.workspace = true
 edition.workspace = true

--- a/app/arcbox-helper/Cargo.toml
+++ b/app/arcbox-helper/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "arcbox-helper"
-publish = false
 description = "Privileged helper daemon for host mutations (routes, DNS, sockets)"
 version.workspace = true
 edition.workspace = true

--- a/app/arcbox/Cargo.toml
+++ b/app/arcbox/Cargo.toml
@@ -9,7 +9,6 @@ repository.workspace = true
 authors.workspace = true
 keywords = ["container", "vm", "virtualization", "docker", "runtime"]
 categories = ["virtualization", "development-tools"]
-publish = false
 
 [dependencies]
 arcbox-hypervisor = { workspace = true }

--- a/guest/arcbox-agent/Cargo.toml
+++ b/guest/arcbox-agent/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "arcbox-agent"
-publish = false
 description = "Guest agent for ArcBox VMs"
 version.workspace = true
 edition.workspace = true

--- a/rpc/arcbox-grpc/Cargo.toml
+++ b/rpc/arcbox-grpc/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "arcbox-grpc"
-publish = false
 description = "gRPC service clients and servers for ArcBox (tonic + prost)"
 version.workspace = true
 edition.workspace = true

--- a/rpc/arcbox-protocol/Cargo.toml
+++ b/rpc/arcbox-protocol/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "arcbox-protocol"
-publish = false
 description = "Protocol definitions for ArcBox (ttrpc/protobuf)"
 version.workspace = true
 edition.workspace = true

--- a/rpc/arcbox-transport/Cargo.toml
+++ b/rpc/arcbox-transport/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "arcbox-transport"
-publish = false
 description = "Transport layer abstractions for ArcBox (Unix socket, vsock)"
 version.workspace = true
 edition.workspace = true

--- a/runtime/arcbox-container/Cargo.toml
+++ b/runtime/arcbox-container/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "arcbox-container"
-publish = false
 description = "Container runtime for ArcBox"
 version.workspace = true
 edition.workspace = true

--- a/runtime/arcbox-oci/Cargo.toml
+++ b/runtime/arcbox-oci/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "arcbox-oci"
-publish = false
 description = "OCI runtime specification support for ArcBox"
 version.workspace = true
 edition.workspace = true


### PR DESCRIPTION
## What

Publish **every** workspace crate (all 48 members) to crates.io, superseding the closed #322 (which only published the cross-platform libs).

- Remove `publish = false` from the remaining **14** members: all `app/*`, `guest/arcbox-agent`, `rpc/{grpc,protocol,transport}`, `runtime/{container,oci}`.
- `publish-crates` job → `cargo publish --workspace --no-verify --locked` (dropped `--exclude arcbox-hv`).

## Why `--no-verify`

Four crates embed files that live **outside their own package directory**, so cargo's isolated per-crate verify build can't see them (and `[package].include` can't bundle files above the crate dir):

| Crate | Out-of-tree embed |
|---|---|
| `arcbox-core` | `include_str!("../../../assets.lock")` |
| `arcbox-cli` | `assets.lock` + `bundle/…helper.plist` |
| `arcbox-daemon` | `include_str!("../../../assets.lock")` |
| `arcbox-grpc` | `build.rs` reads `../arcbox-protocol/proto` |

`--no-verify` skips the verify build and uploads the source as-is — **the same way `arcbox-grpc 0.1.6` was already published** (its tarball has no protos). The other **44** crates verify clean in isolation. The whole workspace is already compiled green by the CI build job, so the verify build is redundant safety here, not new coverage.

> ⚠️ **These 4 crates are upload-only**: `cargo install` / from-source builds of them from crates.io will fail (incomplete tarballs). That's fine **iff** consumers get binaries from the signed release artifacts and crates.io is just namespace + dependency-graph satisfaction.

## The v0.4.8 fix

v0.4.8 failed with `no matching package named arcbox-hv … required by arcbox-vmm`. Root cause: the job ran `--exclude arcbox-hv`, but `arcbox-vmm` depends on `arcbox-hv` (pinned `0.3.20`), which wasn't on crates.io to resolve against. Including `arcbox-hv` (no `--exclude`) publishes `0.3.20` first, so `arcbox-vmm` resolves it from the local temp-registry.

## Verification

`cargo publish --workspace --no-verify --dry-run --locked` → **48 "Uploading", 0 errors**, dependency-ordered, `arcbox-hv 0.3.20` ordered before `arcbox-vmm`. A separate *with-verify* coordinated dry-run compiled the Apple/VM family + `arcbox-protocol` + proxy + splicetcp **clean** in isolation, aborting only at `arcbox-core` (the `assets.lock` embed) — confirming exactly which crates need `--no-verify`. An independent 4-lens review confirmed no 5th out-of-tree-broken crate exists.

## Operational caveats (action needed)

1. **The fix is NOT on the existing `v0.4.8` tag.** Tag pushes run the workflow *at the tagged commit*, and `v0.4.8` (`dd0beca`) still has the old broken `--exclude arcbox-hv` command. After merge, **cut a new tag** on a commit containing this fixed `release.yml` (e.g. let the next release carry it, or re-tag).
2. **Deferred `arcbox-hv` risk.** Because `arcbox-hv` has an independent cadence (`0.3.20`, not lockstep), a *future* release where its version is unchanged will make `cargo publish --workspace` try to re-upload an already-published `0.3.20` and abort the job. Handle at the next bump (move `arcbox-hv` into lockstep, or re-add a conditional skip). First publish is clean.
3. Pre-merge: ensure `CARGO_REGISTRY_TOKEN` is set and the account **owns** the pre-existing names (`arcbox`, `arcbox-cli`, `arcbox-vmm`, `arcbox-protocol`, `arcbox-grpc` are already on crates.io at `0.1.x`/`0.0.0`).
