### PR TITLE
feat(fleet): Docker-based Linux runner support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -456,6 +456,7 @@ dependencies = [
  "anyhow",
  "arcbox-fleet-proto",
  "arcbox-logging",
+ "bollard",
  "clap",
  "command-group",
  "dashmap",
@@ -1147,6 +1148,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
 dependencies = [
  "objc2",
+]
+
+[[package]]
+name = "bollard"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9d0a013e3d3ee4edd61e779adf117944c08902d375f18630a0c5b8f95659734"
+dependencies = [
+ "base64",
+ "bollard-stubs",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "hex",
+ "http",
+ "http-body-util",
+ "hyper",
+ "hyper-named-pipe",
+ "hyper-util",
+ "hyperlocal",
+ "log",
+ "pin-project-lite",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "serde_urlencoded",
+ "thiserror",
+ "tokio",
+ "tokio-util",
+ "tower-service",
+ "url",
+ "winapi",
+]
+
+[[package]]
+name = "bollard-stubs"
+version = "1.53.1-rc.29.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce412eb6f7096743011dc3cb5c674caeb24ced61d8c498fe07cf7998a4fea889"
+dependencies = [
+ "serde",
+ "serde_json",
+ "serde_repr",
 ]
 
 [[package]]
@@ -2175,6 +2219,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-named-pipe"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73b7d8abf35697b81a825e386fc151e0d503e8cb5fcb93cc8669c376dfd6f278"
+dependencies = [
+ "hex",
+ "hyper",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
+ "winapi",
+]
+
+[[package]]
 name = "hyper-rustls"
 version = "0.27.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2243,6 +2302,21 @@ dependencies = [
  "tower-service",
  "tracing",
  "windows-registry",
+]
+
+[[package]]
+name = "hyperlocal"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "986c5ce3b994526b3cd75578e62554abd09f0899d6206de48b3e96ab34ccc8c7"
+dependencies = [
+ "hex",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
 ]
 
 [[package]]
@@ -4233,6 +4307,17 @@ dependencies = [
  "itoa",
  "serde",
  "serde_core",
+]
+
+[[package]]
+name = "serde_repr"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/fleet/arcbox-fleet-agent/Cargo.toml
+++ b/fleet/arcbox-fleet-agent/Cargo.toml
@@ -34,6 +34,7 @@ hostname = { workspace = true }
 sysinfo = { workspace = true }
 command-group = { version = "5.0.1", features = ["with-tokio"] }
 tokio-util = "0.7.18"
+bollard = "0.21.0"
 
 [lints]
 workspace = true

--- a/fleet/arcbox-fleet-agent/src/attach.rs
+++ b/fleet/arcbox-fleet-agent/src/attach.rs
@@ -49,9 +49,7 @@ pub async fn run(
     shutdown: CancellationToken,
 ) -> Result<()> {
     let runner_dir = config.runner_dir.clone();
-    let docker_caps = docker
-        .as_ref()
-        .map(|d| d.capabilities(config.max_concurrent));
+    let docker_caps = docker.as_ref().map(|d| d.capabilities());
 
     let (egress_tx, mut egress_rx) = mpsc::channel::<AttachRequest>(OUTBOUND_CAPACITY);
     let supervisor = RunnerSupervisor::new(egress_tx, runner_dir, docker, config.max_concurrent);

--- a/fleet/arcbox-fleet-agent/src/attach.rs
+++ b/fleet/arcbox-fleet-agent/src/attach.rs
@@ -20,7 +20,7 @@ use tracing::{info, warn};
 
 use crate::config::AgentConfig;
 use crate::credentials::Credential;
-use crate::docker::{self, DockerCapabilities};
+use crate::docker;
 use crate::host;
 use crate::runner::RunnerSupervisor;
 
@@ -49,7 +49,10 @@ pub async fn run(
     shutdown: CancellationToken,
 ) -> Result<()> {
     let runner_dir = config.runner_dir.clone();
-    let docker_caps = docker.as_ref().map(|d| d.capabilities());
+    let docker_arches = docker
+        .as_ref()
+        .map(|d| d.linux_arches())
+        .unwrap_or_default();
 
     let (egress_tx, mut egress_rx) = mpsc::channel::<AttachRequest>(OUTBOUND_CAPACITY);
     let supervisor = RunnerSupervisor::new(egress_tx, runner_dir, docker, config.max_concurrent);
@@ -69,7 +72,7 @@ pub async fn run(
             &mut pending,
             &mut backoff,
             &shutdown,
-            docker_caps.as_ref(),
+            &docker_arches,
         )
         .await;
         // A shutdown during the connection is a clean exit, not a failure to log
@@ -113,7 +116,7 @@ async fn connect_and_serve(
     pending: &mut Option<AttachRequest>,
     backoff: &mut Duration,
     shutdown: &CancellationToken,
-    docker_caps: Option<&DockerCapabilities>,
+    docker_arches: &[String],
 ) -> Result<()> {
     let channel = config
         .endpoint()?
@@ -147,7 +150,11 @@ async fn connect_and_serve(
         }
     }
 
-    let heartbeat = spawn_heartbeat(req_tx.clone(), config.max_concurrent, docker_caps.cloned());
+    let heartbeat = spawn_heartbeat(
+        req_tx.clone(),
+        config.max_concurrent,
+        docker_arches.to_vec(),
+    );
 
     let outcome = loop {
         tokio::select! {
@@ -196,14 +203,14 @@ async fn dispatch(supervisor: &RunnerSupervisor, msg: Option<attach_response::Ms
 fn spawn_heartbeat(
     outbound: mpsc::Sender<AttachRequest>,
     max_concurrent: usize,
-    docker_caps: Option<DockerCapabilities>,
+    docker_arches: Vec<String>,
 ) -> tokio::task::JoinHandle<()> {
     tokio::spawn(async move {
         let mut ticker = tokio::time::interval(HEARTBEAT_INTERVAL);
         loop {
             ticker.tick().await;
             let msg = attach_request::Msg::Heartbeat(Heartbeat {
-                capacities: host::capacities(max_concurrent, docker_caps.as_ref()),
+                capacities: host::capacities(max_concurrent, &docker_arches),
                 host_info_json: host::host_info_json(),
             });
             if outbound

--- a/fleet/arcbox-fleet-agent/src/attach.rs
+++ b/fleet/arcbox-fleet-agent/src/attach.rs
@@ -20,6 +20,7 @@ use tracing::{info, warn};
 
 use crate::config::AgentConfig;
 use crate::credentials::Credential;
+use crate::docker::{self, DockerCapabilities};
 use crate::host;
 use crate::runner::RunnerSupervisor;
 
@@ -39,20 +40,21 @@ const SHUTDOWN_GRACE: Duration = Duration::from_secs(15);
 /// The supervisor and the egress queue carrying runner lifecycle events are
 /// built once and reused across reconnects, so in-flight jobs survive a dropped
 /// connection and their terminal events reach the next live stream. On shutdown
-/// the loop exits and hands off to [`RunnerSupervisor::shutdown`], which kills
-/// and reaps any in-flight runner process groups.
+/// the loop exits and hands off to [`RunnerSupervisor::shutdown`], which tears
+/// down any in-flight runners (host process groups and Docker containers).
 pub async fn run(
     config: AgentConfig,
     credential: Credential,
+    docker: Option<docker::DockerRunner>,
     shutdown: CancellationToken,
 ) -> Result<()> {
-    let runner_dir = config.require_runner_dir()?.to_path_buf();
+    let runner_dir = config.runner_dir.clone();
+    let docker_caps = docker
+        .as_ref()
+        .map(|d| d.capabilities(config.max_concurrent));
 
-    // Runner lifecycle events flow through this queue, which outlives any single
-    // connection. Each connection drains it into that connection's request
-    // stream; events produced during a brief disconnect simply wait here.
     let (egress_tx, mut egress_rx) = mpsc::channel::<AttachRequest>(OUTBOUND_CAPACITY);
-    let supervisor = RunnerSupervisor::new(egress_tx, runner_dir, config.max_concurrent);
+    let supervisor = RunnerSupervisor::new(egress_tx, runner_dir, docker, config.max_concurrent);
 
     let mut backoff = INITIAL_BACKOFF;
     // An event pulled from the egress queue but not yet delivered when the
@@ -69,6 +71,7 @@ pub async fn run(
             &mut pending,
             &mut backoff,
             &shutdown,
+            docker_caps.as_ref(),
         )
         .await;
         // A shutdown during the connection is a clean exit, not a failure to log
@@ -112,6 +115,7 @@ async fn connect_and_serve(
     pending: &mut Option<AttachRequest>,
     backoff: &mut Duration,
     shutdown: &CancellationToken,
+    docker_caps: Option<&DockerCapabilities>,
 ) -> Result<()> {
     let channel = config
         .endpoint()?
@@ -145,7 +149,7 @@ async fn connect_and_serve(
         }
     }
 
-    let heartbeat = spawn_heartbeat(req_tx.clone(), config.max_concurrent);
+    let heartbeat = spawn_heartbeat(req_tx.clone(), config.max_concurrent, docker_caps.cloned());
 
     let outcome = loop {
         tokio::select! {
@@ -194,15 +198,14 @@ async fn dispatch(supervisor: &RunnerSupervisor, msg: Option<attach_response::Ms
 fn spawn_heartbeat(
     outbound: mpsc::Sender<AttachRequest>,
     max_concurrent: usize,
+    docker_caps: Option<DockerCapabilities>,
 ) -> tokio::task::JoinHandle<()> {
     tokio::spawn(async move {
-        // `interval` fires its first tick immediately, so the gateway sees us
-        // online without waiting a full period.
         let mut ticker = tokio::time::interval(HEARTBEAT_INTERVAL);
         loop {
             ticker.tick().await;
             let msg = attach_request::Msg::Heartbeat(Heartbeat {
-                capacities: host::capacities(max_concurrent),
+                capacities: host::capacities(max_concurrent, docker_caps.as_ref()),
                 host_info_json: host::host_info_json(),
             });
             if outbound

--- a/fleet/arcbox-fleet-agent/src/attach.rs
+++ b/fleet/arcbox-fleet-agent/src/attach.rs
@@ -10,7 +10,9 @@ use std::time::Duration;
 
 use anyhow::{Context, Result};
 use arcbox_fleet_proto::v1::fleet_gateway_service_client::FleetGatewayServiceClient;
-use arcbox_fleet_proto::v1::{AttachRequest, Heartbeat, attach_request, attach_response};
+use arcbox_fleet_proto::v1::{
+    AttachRequest, Heartbeat, RuntimeCapacity, attach_request, attach_response,
+};
 use tokio::sync::mpsc;
 use tokio_stream::wrappers::ReceiverStream;
 use tokio_util::sync::CancellationToken;
@@ -46,16 +48,13 @@ pub async fn run(
     config: AgentConfig,
     credential: Credential,
     docker: Option<docker::DockerRunner>,
+    pools: Vec<RuntimeCapacity>,
     shutdown: CancellationToken,
 ) -> Result<()> {
     let runner_dir = config.runner_dir.clone();
-    let docker_arches = docker
-        .as_ref()
-        .map(|d| d.linux_arches())
-        .unwrap_or_default();
 
     let (egress_tx, mut egress_rx) = mpsc::channel::<AttachRequest>(OUTBOUND_CAPACITY);
-    let supervisor = RunnerSupervisor::new(egress_tx, runner_dir, docker, config.max_concurrent);
+    let supervisor = RunnerSupervisor::new(egress_tx, runner_dir, docker, pools.clone());
 
     let mut backoff = INITIAL_BACKOFF;
     // An event pulled from the egress queue but not yet delivered when the
@@ -71,8 +70,8 @@ pub async fn run(
             &mut egress_rx,
             &mut pending,
             &mut backoff,
+            &pools,
             &shutdown,
-            &docker_arches,
         )
         .await;
         // A shutdown during the connection is a clean exit, not a failure to log
@@ -108,6 +107,13 @@ pub async fn run(
 /// connection-scoped heartbeats are sent directly, while runner lifecycle
 /// events are forwarded from the shared egress queue. Inbound orders are routed
 /// to the persistent `supervisor`.
+#[allow(
+    clippy::too_many_arguments,
+    reason = "one connection's lifecycle genuinely needs all of: endpoint config, \
+              credential, the persistent supervisor, the cross-reconnect egress queue \
+              and its pending slot, the mutable backoff, advertised pools, and the \
+              shutdown token"
+)]
 async fn connect_and_serve(
     config: &AgentConfig,
     credential: &Credential,
@@ -115,8 +121,8 @@ async fn connect_and_serve(
     egress_rx: &mut mpsc::Receiver<AttachRequest>,
     pending: &mut Option<AttachRequest>,
     backoff: &mut Duration,
+    pools: &[RuntimeCapacity],
     shutdown: &CancellationToken,
-    docker_arches: &[String],
 ) -> Result<()> {
     let channel = config
         .endpoint()?
@@ -150,11 +156,7 @@ async fn connect_and_serve(
         }
     }
 
-    let heartbeat = spawn_heartbeat(
-        req_tx.clone(),
-        config.max_concurrent,
-        docker_arches.to_vec(),
-    );
+    let heartbeat = spawn_heartbeat(req_tx.clone(), pools.to_vec());
 
     let outcome = loop {
         tokio::select! {
@@ -202,15 +204,14 @@ async fn dispatch(supervisor: &RunnerSupervisor, msg: Option<attach_response::Ms
 /// heartbeats queued for the next stream.
 fn spawn_heartbeat(
     outbound: mpsc::Sender<AttachRequest>,
-    max_concurrent: usize,
-    docker_arches: Vec<String>,
+    pools: Vec<RuntimeCapacity>,
 ) -> tokio::task::JoinHandle<()> {
     tokio::spawn(async move {
         let mut ticker = tokio::time::interval(HEARTBEAT_INTERVAL);
         loop {
             ticker.tick().await;
             let msg = attach_request::Msg::Heartbeat(Heartbeat {
-                capacities: host::capacities(max_concurrent, &docker_arches),
+                capacities: pools.clone(),
                 host_info_json: host::host_info_json(),
             });
             if outbound

--- a/fleet/arcbox-fleet-agent/src/config.rs
+++ b/fleet/arcbox-fleet-agent/src/config.rs
@@ -3,7 +3,7 @@
 //! Everything is sourced from the environment — there are no positional config
 //! flags. The only CLI argument anywhere is the one-shot enrollment token.
 
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 
 use anyhow::{Context, Result};
 use tonic::transport::{ClientTlsConfig, Endpoint};
@@ -16,8 +16,31 @@ const ENV_GATEWAY: &str = "ARCBOX_FLEET_GATEWAY";
 const ENV_RUNNER_DIR: &str = "ARCBOX_FLEET_RUNNER_DIR";
 const ENV_MAX_CONCURRENT: &str = "ARCBOX_FLEET_MAX_CONCURRENT";
 const ENV_DATA_DIR: &str = "ARCBOX_FLEET_DATA_DIR";
+const ENV_DOCKER: &str = "ARCBOX_FLEET_DOCKER";
+const ENV_RUNNER_IMAGE: &str = "ARCBOX_FLEET_RUNNER_IMAGE";
 
 const DEFAULT_MAX_CONCURRENT: usize = 2;
+const DEFAULT_RUNNER_IMAGE: &str = "ghcr.io/actions/runner:latest";
+
+/// Whether Docker-based Linux job execution is enabled.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DockerMode {
+    /// Probe the Docker socket at startup; proceed without Docker if unavailable.
+    Auto,
+    /// Require Docker; fail startup if the socket is unreachable.
+    Enabled,
+    /// Never use Docker, even if available.
+    Disabled,
+}
+
+/// Docker-specific configuration for running Linux jobs in containers.
+#[derive(Debug, Clone)]
+pub struct DockerConfig {
+    pub mode: DockerMode,
+    /// Container image used for Linux runner jobs when the platform sends no
+    /// image (empty `ProvisionRunner.image`).
+    pub runner_image: String,
+}
 
 /// Resolved agent configuration.
 #[derive(Debug, Clone)]
@@ -31,6 +54,8 @@ pub struct AgentConfig {
     pub max_concurrent: usize,
     /// Agent data directory (credentials, logs). Defaults to `~/.arcbox/fleet`.
     pub data_dir: PathBuf,
+    /// Docker runtime configuration for Linux jobs.
+    pub docker: DockerConfig,
 }
 
 impl AgentConfig {
@@ -58,18 +83,26 @@ impl AgentConfig {
             None => default_data_dir()?,
         };
 
+        let docker_mode = match std::env::var(ENV_DOCKER).as_deref() {
+            Ok("true") => DockerMode::Enabled,
+            Ok("false") => DockerMode::Disabled,
+            Ok("auto") | Err(_) => DockerMode::Auto,
+            Ok(other) => {
+                anyhow::bail!("{ENV_DOCKER} must be 'auto', 'true', or 'false', got '{other}'")
+            }
+        };
+        let runner_image =
+            std::env::var(ENV_RUNNER_IMAGE).unwrap_or_else(|_| DEFAULT_RUNNER_IMAGE.to_string());
+
         Ok(Self {
             gateway,
             runner_dir,
             max_concurrent,
             data_dir,
-        })
-    }
-
-    /// The runner directory, or a clear error instructing the operator to set it.
-    pub fn require_runner_dir(&self) -> Result<&Path> {
-        self.runner_dir.as_deref().with_context(|| {
-            format!("{ENV_RUNNER_DIR} is not set (path to the installed GitHub Actions runner)")
+            docker: DockerConfig {
+                mode: docker_mode,
+                runner_image,
+            },
         })
     }
 

--- a/fleet/arcbox-fleet-agent/src/config.rs
+++ b/fleet/arcbox-fleet-agent/src/config.rs
@@ -20,7 +20,7 @@ const ENV_DOCKER: &str = "ARCBOX_FLEET_DOCKER";
 const ENV_RUNNER_IMAGE: &str = "ARCBOX_FLEET_RUNNER_IMAGE";
 
 const DEFAULT_MAX_CONCURRENT: usize = 2;
-const DEFAULT_RUNNER_IMAGE: &str = "ghcr.io/actions/runner:latest";
+const DEFAULT_RUNNER_IMAGE: &str = "ghcr.io/actions/actions-runner:latest";
 
 /// Whether Docker-based Linux job execution is enabled.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/fleet/arcbox-fleet-agent/src/docker.rs
+++ b/fleet/arcbox-fleet-agent/src/docker.rs
@@ -22,8 +22,6 @@ pub struct DockerCapabilities {
     pub native_arch: String,
     /// Cross-architecture via emulation, if available (e.g. `amd64` on arm64).
     pub emulated_arch: Option<String>,
-    /// Per-pool `max_concurrent` reported to the gateway.
-    pub max_concurrent: usize,
 }
 
 /// Everything the Docker runner needs to execute one job.
@@ -70,13 +68,12 @@ impl DockerRunner {
     }
 
     /// Detect which Linux architectures this Docker host can serve.
-    pub fn capabilities(&self, max_concurrent: usize) -> DockerCapabilities {
+    pub fn capabilities(&self) -> DockerCapabilities {
         let native_arch = host::map_arch(std::env::consts::ARCH).to_owned();
         let emulated_arch = (native_arch == "arm64").then(|| "amd64".to_owned());
         DockerCapabilities {
             native_arch,
             emulated_arch,
-            max_concurrent,
         }
     }
 

--- a/fleet/arcbox-fleet-agent/src/docker.rs
+++ b/fleet/arcbox-fleet-agent/src/docker.rs
@@ -40,6 +40,8 @@ pub struct DockerRunner {
     client: Docker,
     /// Image used when the platform sends no image override.
     default_image: String,
+    /// Linux arches verified pullable at startup, advertised as capacity pools.
+    linux_arches: Vec<String>,
 }
 
 /// ArcBox's Docker-compatible socket path on macOS (`~/.arcbox/docker.sock`).
@@ -55,12 +57,32 @@ fn arcbox_socket_path() -> Option<String> {
     })
 }
 
+/// Linux arches this host could serve, before verifying they can be pulled.
+///
+/// The native arch always, plus amd64 on Apple Silicon macOS, where ArcBox's
+/// runtime provides Rosetta-backed emulation.
+fn candidate_arches() -> Vec<String> {
+    let native = host::map_arch(std::env::consts::ARCH);
+    let mut arches = vec![native.to_owned()];
+    if std::env::consts::OS == "macos" && native == "arm64" {
+        arches.push("amd64".to_owned());
+    }
+    arches
+}
+
 impl DockerRunner {
-    /// Connect to the Docker-compatible runtime and verify reachability.
+    /// Connect to the Docker-compatible runtime and prove it works by pulling
+    /// the default runner image for each candidate arch.
     ///
-    /// On macOS, connects to ArcBox's own socket (`~/.arcbox/docker.sock`).
-    /// On other platforms, uses the system default (e.g. `/var/run/docker.sock`
-    /// on Linux, named pipe on Windows).
+    /// On macOS, connects to ArcBox's own socket (`~/.arcbox/docker.sock`); on
+    /// other platforms the system default (e.g. `/var/run/docker.sock` on
+    /// Linux, named pipe on Windows).
+    ///
+    /// The pull is the readiness check: an arch is advertised only if its image
+    /// pulls, so a host that cannot realize `linux/amd64` (no working emulation)
+    /// never advertises it. Docker counts as available only if at least one arch
+    /// pulls; otherwise this returns an error and the caller proceeds without it
+    /// (`Auto`) or fails startup (`Enabled`).
     pub async fn new(default_image: String) -> Result<Self> {
         let client = if let Some(addr) = arcbox_socket_path() {
             Docker::connect_with_unix(&addr, 120, bollard::API_DEFAULT_VERSION)
@@ -72,26 +94,30 @@ impl DockerRunner {
             .ping()
             .await
             .context("Docker-compatible runtime is not reachable (ping failed)")?;
-        info!("docker runtime available");
+
+        let mut linux_arches = Vec::new();
+        for arch in candidate_arches() {
+            let platform = format!("linux/{arch}");
+            match Self::pull_image(&client, &default_image, &platform).await {
+                Ok(()) => linux_arches.push(arch),
+                Err(e) => warn!(arch, error = %e, "skipping arch: default image pull failed"),
+            }
+        }
+        if linux_arches.is_empty() {
+            anyhow::bail!("docker reachable but could not pull {default_image} for any arch");
+        }
+
+        info!(?linux_arches, "docker runtime available");
         Ok(Self {
             client,
             default_image,
+            linux_arches,
         })
     }
 
-    /// Linux architectures this Docker host can run as containers.
-    ///
-    /// Always includes the host's native arch. On Linux this is the same pool
-    /// the host would otherwise serve directly, but Docker still runs it for
-    /// isolation. On Apple Silicon macOS, amd64 is also included because
-    /// ArcBox's runtime provides Rosetta-backed emulation.
+    /// Linux architectures this Docker host serves, verified pullable at startup.
     pub fn linux_arches(&self) -> Vec<String> {
-        let native = host::map_arch(std::env::consts::ARCH);
-        let mut arches = vec![native.to_owned()];
-        if std::env::consts::OS == "macos" && native == "arm64" {
-            arches.push("amd64".to_owned());
-        }
-        arches
+        self.linux_arches.clone()
     }
 
     /// Resolve the image for a job: prefer the platform-supplied value, fall
@@ -111,7 +137,7 @@ impl DockerRunner {
     pub async fn run_job(&self, spec: RunSpec<'_>) -> Result<DockerOutcome> {
         let platform = format!("linux/{}", spec.arch);
 
-        self.pull_image(spec.image, &platform).await?;
+        Self::pull_image(&self.client, spec.image, &platform).await?;
 
         let container_name = format!("arcbox-{}", spec.job_id);
         let config = ContainerCreateBody {
@@ -170,14 +196,14 @@ impl DockerRunner {
     }
 
     /// Pull an image for a specific platform.
-    async fn pull_image(&self, image: &str, platform: &str) -> Result<()> {
+    async fn pull_image(client: &Docker, image: &str, platform: &str) -> Result<()> {
         debug!(image, platform, "pulling image");
         let options = CreateImageOptions {
             from_image: Some(image.to_owned()),
             platform: platform.to_owned(),
             ..Default::default()
         };
-        let mut stream = self.client.create_image(Some(options), None, None);
+        let mut stream = client.create_image(Some(options), None, None);
         while let Some(info) = stream.next().await {
             info.with_context(|| format!("pulling {image} for {platform}"))?;
         }

--- a/fleet/arcbox-fleet-agent/src/docker.rs
+++ b/fleet/arcbox-fleet-agent/src/docker.rs
@@ -1,8 +1,8 @@
-//! Docker-based execution of Linux runner jobs.
+//! Docker API-based execution of Linux runner jobs.
 //!
-//! When Docker is available, the agent can serve `linux/*` capacity pools even
-//! on macOS hosts. Each Linux job runs inside a container launched from the
-//! configured runner image (default: `ghcr.io/actions/runner:latest`).
+//! Talks to any Docker-compatible runtime (ArcBox on macOS, Docker Engine on
+//! Linux/Windows) via the local socket. Each Linux job runs inside a container
+//! launched from the configured runner image.
 
 use anyhow::{Context, Result};
 use bollard::Docker;
@@ -42,15 +42,36 @@ pub struct DockerRunner {
     default_image: String,
 }
 
+/// ArcBox's Docker-compatible socket path on macOS (`~/.arcbox/docker.sock`).
+fn arcbox_socket_path() -> Option<String> {
+    if std::env::consts::OS != "macos" {
+        return None;
+    }
+    dirs::home_dir().map(|home| {
+        home.join(".arcbox")
+            .join("docker.sock")
+            .to_string_lossy()
+            .into_owned()
+    })
+}
+
 impl DockerRunner {
-    /// Connect to the local Docker daemon and verify reachability.
+    /// Connect to the Docker-compatible runtime and verify reachability.
+    ///
+    /// On macOS, connects to ArcBox's own socket (`~/.arcbox/docker.sock`).
+    /// On other platforms, uses the system default (e.g. `/var/run/docker.sock`
+    /// on Linux, named pipe on Windows).
     pub async fn new(default_image: String) -> Result<Self> {
-        let client =
-            Docker::connect_with_local_defaults().context("connecting to Docker daemon")?;
+        let client = if let Some(addr) = arcbox_socket_path() {
+            Docker::connect_with_unix(&addr, 120, bollard::API_DEFAULT_VERSION)
+                .with_context(|| format!("connecting to ArcBox runtime at {addr}"))?
+        } else {
+            Docker::connect_with_local_defaults().context("connecting to Docker runtime")?
+        };
         client
             .ping()
             .await
-            .context("Docker daemon is not reachable (ping failed)")?;
+            .context("Docker-compatible runtime is not reachable (ping failed)")?;
         info!("docker runtime available");
         Ok(Self {
             client,
@@ -58,19 +79,22 @@ impl DockerRunner {
         })
     }
 
-    /// Linux architectures Docker can serve on this host.
+    /// Extra Linux architectures to advertise via Docker.
     ///
-    /// Returns an empty vec on Linux hosts — the host runner already serves
-    /// its native `linux/*` pool, and cross-arch emulation is not guaranteed.
-    /// On macOS, Docker Desktop provides the native arch plus Rosetta-backed
-    /// amd64 emulation on arm64 hosts.
+    /// On Linux the host already serves its native `linux/*` pool, so Docker
+    /// adds no new pools (it is still used for job isolation at the routing
+    /// layer). On macOS and Windows the host has no native Linux pool, so
+    /// Docker adds them.
+    ///
+    /// On arm64 macOS, amd64 is included because ArcBox's runtime provides
+    /// Rosetta-backed emulation.
     pub fn linux_arches(&self) -> Vec<String> {
-        if std::env::consts::OS != "macos" {
+        if std::env::consts::OS == "linux" {
             return Vec::new();
         }
         let native = host::map_arch(std::env::consts::ARCH).to_owned();
         let mut arches = vec![native.clone()];
-        if native == "arm64" {
+        if std::env::consts::OS == "macos" && native == "arm64" {
             arches.push("amd64".to_owned());
         }
         arches

--- a/fleet/arcbox-fleet-agent/src/docker.rs
+++ b/fleet/arcbox-fleet-agent/src/docker.rs
@@ -15,15 +15,6 @@ use tracing::{debug, info, warn};
 
 use crate::host;
 
-/// Which Linux architectures Docker can serve on this host.
-#[derive(Debug, Clone)]
-pub struct DockerCapabilities {
-    /// Native architecture (e.g. `arm64` on Apple Silicon).
-    pub native_arch: String,
-    /// Cross-architecture via emulation, if available (e.g. `amd64` on arm64).
-    pub emulated_arch: Option<String>,
-}
-
 /// Everything the Docker runner needs to execute one job.
 pub struct RunSpec<'a> {
     /// Job identifier, used as the container name suffix.
@@ -67,14 +58,22 @@ impl DockerRunner {
         })
     }
 
-    /// Detect which Linux architectures this Docker host can serve.
-    pub fn capabilities(&self) -> DockerCapabilities {
-        let native_arch = host::map_arch(std::env::consts::ARCH).to_owned();
-        let emulated_arch = (native_arch == "arm64").then(|| "amd64".to_owned());
-        DockerCapabilities {
-            native_arch,
-            emulated_arch,
+    /// Linux architectures Docker can serve on this host.
+    ///
+    /// Returns an empty vec on Linux hosts — the host runner already serves
+    /// its native `linux/*` pool, and cross-arch emulation is not guaranteed.
+    /// On macOS, Docker Desktop provides the native arch plus Rosetta-backed
+    /// amd64 emulation on arm64 hosts.
+    pub fn linux_arches(&self) -> Vec<String> {
+        if std::env::consts::OS != "macos" {
+            return Vec::new();
         }
+        let native = host::map_arch(std::env::consts::ARCH).to_owned();
+        let mut arches = vec![native.clone()];
+        if native == "arm64" {
+            arches.push("amd64".to_owned());
+        }
+        arches
     }
 
     /// Resolve the image for a job: prefer the platform-supplied value, fall

--- a/fleet/arcbox-fleet-agent/src/docker.rs
+++ b/fleet/arcbox-fleet-agent/src/docker.rs
@@ -1,0 +1,228 @@
+//! Docker-based execution of Linux runner jobs.
+//!
+//! When Docker is available, the agent can serve `linux/*` capacity pools even
+//! on macOS hosts. Each Linux job runs inside a container launched from the
+//! configured runner image (default: `ghcr.io/actions/runner:latest`).
+
+use anyhow::{Context, Result};
+use bollard::Docker;
+use bollard::models::ContainerCreateBody;
+use bollard::query_parameters::{
+    CreateContainerOptions, CreateImageOptions, RemoveContainerOptions, WaitContainerOptions,
+};
+use tokio_stream::StreamExt;
+use tracing::{debug, info, warn};
+
+use crate::host;
+
+/// Which Linux architectures Docker can serve on this host.
+#[derive(Debug, Clone)]
+pub struct DockerCapabilities {
+    /// Native architecture (e.g. `arm64` on Apple Silicon).
+    pub native_arch: String,
+    /// Cross-architecture via emulation, if available (e.g. `amd64` on arm64).
+    pub emulated_arch: Option<String>,
+    /// Per-pool `max_concurrent` reported to the gateway.
+    pub max_concurrent: usize,
+}
+
+/// Everything the Docker runner needs to execute one job.
+pub struct RunSpec<'a> {
+    /// Job identifier, used as the container name suffix.
+    pub job_id: &'a str,
+    /// Resolved container image (never empty — caller must fall back to the
+    /// default before constructing this).
+    pub image: &'a str,
+    /// Base64-encoded JIT runner config, passed through to `run.sh`.
+    pub encoded_jit_config: &'a str,
+    /// Target CPU architecture (`arm64` or `amd64`).
+    pub arch: &'a str,
+}
+
+/// Terminal outcome of a containerized job.
+pub struct DockerOutcome {
+    pub success: bool,
+    pub detail: String,
+}
+
+/// Wraps the Docker Engine API for running GitHub Actions jobs in containers.
+#[derive(Clone)]
+pub struct DockerRunner {
+    client: Docker,
+    /// Image used when the platform sends no image override.
+    default_image: String,
+}
+
+impl DockerRunner {
+    /// Connect to the local Docker daemon and verify reachability.
+    pub async fn new(default_image: String) -> Result<Self> {
+        let client =
+            Docker::connect_with_local_defaults().context("connecting to Docker daemon")?;
+        client
+            .ping()
+            .await
+            .context("Docker daemon is not reachable (ping failed)")?;
+        info!("docker runtime available");
+        Ok(Self {
+            client,
+            default_image,
+        })
+    }
+
+    /// Detect which Linux architectures this Docker host can serve.
+    pub fn capabilities(&self, max_concurrent: usize) -> DockerCapabilities {
+        let native_arch = host::map_arch(std::env::consts::ARCH).to_owned();
+        let emulated_arch = (native_arch == "arm64").then(|| "amd64".to_owned());
+        DockerCapabilities {
+            native_arch,
+            emulated_arch,
+            max_concurrent,
+        }
+    }
+
+    /// Resolve the image for a job: prefer the platform-supplied value, fall
+    /// back to the configured default.
+    pub fn resolve_image<'a>(&'a self, platform_image: &'a str) -> &'a str {
+        if platform_image.is_empty() {
+            &self.default_image
+        } else {
+            platform_image
+        }
+    }
+
+    /// Run a job inside a container. Returns the terminal outcome.
+    ///
+    /// If the future is canceled (e.g. `CancelRunner` aborting the task), the
+    /// [`ContainerGuard`] kills and removes the container on drop.
+    pub async fn run_job(&self, spec: RunSpec<'_>) -> Result<DockerOutcome> {
+        let platform = format!("linux/{}", spec.arch);
+
+        self.pull_image(spec.image, &platform).await?;
+
+        let container_name = format!("arcbox-{}", spec.job_id);
+        let config = ContainerCreateBody {
+            image: Some(spec.image.to_owned()),
+            cmd: Some(vec![
+                "./run.sh".to_owned(),
+                "--jitconfig".to_owned(),
+                spec.encoded_jit_config.to_owned(),
+            ]),
+            working_dir: Some("/home/runner".to_owned()),
+            ..Default::default()
+        };
+
+        let id = self
+            .client
+            .create_container(
+                Some(CreateContainerOptions {
+                    name: Some(container_name.clone()),
+                    platform: platform.clone(),
+                }),
+                config,
+            )
+            .await
+            .context("creating container")?
+            .id;
+
+        let guard = ContainerGuard::new(self.client.clone(), id.clone());
+
+        self.client
+            .start_container(&id, None)
+            .await
+            .with_context(|| format!("starting container {id}"))?;
+        debug!(job_id = spec.job_id, container = %id, "container started");
+
+        let wait = self
+            .client
+            .wait_container(
+                &id,
+                Some(WaitContainerOptions {
+                    condition: "not-running".to_owned(),
+                }),
+            )
+            .next()
+            .await
+            .context("container wait stream ended unexpectedly")?
+            .with_context(|| format!("waiting on container {id}"))?;
+
+        let exit_code = wait.status_code;
+        guard.defuse();
+        self.cleanup_container(&id).await;
+
+        Ok(DockerOutcome {
+            success: exit_code == 0,
+            detail: format!("container exited with code {exit_code}"),
+        })
+    }
+
+    /// Pull an image for a specific platform.
+    async fn pull_image(&self, image: &str, platform: &str) -> Result<()> {
+        debug!(image, platform, "pulling image");
+        let options = CreateImageOptions {
+            from_image: Some(image.to_owned()),
+            platform: platform.to_owned(),
+            ..Default::default()
+        };
+        let mut stream = self.client.create_image(Some(options), None, None);
+        while let Some(info) = stream.next().await {
+            info.with_context(|| format!("pulling {image} for {platform}"))?;
+        }
+        info!(image, platform, "image ready");
+        Ok(())
+    }
+
+    /// Best-effort container removal.
+    async fn cleanup_container(&self, id: &str) {
+        let options = RemoveContainerOptions {
+            force: true,
+            ..Default::default()
+        };
+        if let Err(e) = self.client.remove_container(id, Some(options)).await {
+            warn!(container = %id, error = %e, "failed to remove container");
+        }
+    }
+}
+
+/// Kills and removes a container on drop — the cancellation safety net.
+///
+/// On normal completion the caller calls [`defuse`](Self::defuse) and handles
+/// cleanup explicitly (where errors can be logged). On task abort, the guard
+/// spawns a fire-and-forget cleanup task.
+struct ContainerGuard {
+    client: Docker,
+    container_id: String,
+    defused: bool,
+}
+
+impl ContainerGuard {
+    fn new(client: Docker, container_id: String) -> Self {
+        Self {
+            client,
+            container_id,
+            defused: false,
+        }
+    }
+
+    /// Disarm the guard after normal completion.
+    fn defuse(mut self) {
+        self.defused = true;
+    }
+}
+
+impl Drop for ContainerGuard {
+    fn drop(&mut self) {
+        if self.defused {
+            return;
+        }
+        let client = self.client.clone();
+        let id = self.container_id.clone();
+        tokio::spawn(async move {
+            let _ = client.kill_container(&id, None).await;
+            let options = RemoveContainerOptions {
+                force: true,
+                ..Default::default()
+            };
+            let _ = client.remove_container(&id, Some(options)).await;
+        });
+    }
+}

--- a/fleet/arcbox-fleet-agent/src/docker.rs
+++ b/fleet/arcbox-fleet-agent/src/docker.rs
@@ -140,6 +140,21 @@ impl DockerRunner {
         Self::pull_image(&self.client, spec.image, &platform).await?;
 
         let container_name = format!("arcbox-{}", spec.job_id);
+
+        // The name is deterministic per job, so a redelivery after a crash that
+        // left an orphan would otherwise collide on create. Remove any leftover
+        // first (remove-before-bind); a missing container is the normal case.
+        let _ = self
+            .client
+            .remove_container(
+                &container_name,
+                Some(RemoveContainerOptions {
+                    force: true,
+                    ..Default::default()
+                }),
+            )
+            .await;
+
         let config = ContainerCreateBody {
             image: Some(spec.image.to_owned()),
             cmd: Some(vec![

--- a/fleet/arcbox-fleet-agent/src/docker.rs
+++ b/fleet/arcbox-fleet-agent/src/docker.rs
@@ -79,21 +79,15 @@ impl DockerRunner {
         })
     }
 
-    /// Extra Linux architectures to advertise via Docker.
+    /// Linux architectures this Docker host can run as containers.
     ///
-    /// On Linux the host already serves its native `linux/*` pool, so Docker
-    /// adds no new pools (it is still used for job isolation at the routing
-    /// layer). On macOS and Windows the host has no native Linux pool, so
-    /// Docker adds them.
-    ///
-    /// On arm64 macOS, amd64 is included because ArcBox's runtime provides
-    /// Rosetta-backed emulation.
+    /// Always includes the host's native arch. On Linux this is the same pool
+    /// the host would otherwise serve directly, but Docker still runs it for
+    /// isolation. On Apple Silicon macOS, amd64 is also included because
+    /// ArcBox's runtime provides Rosetta-backed emulation.
     pub fn linux_arches(&self) -> Vec<String> {
-        if std::env::consts::OS == "linux" {
-            return Vec::new();
-        }
-        let native = host::map_arch(std::env::consts::ARCH).to_owned();
-        let mut arches = vec![native.clone()];
+        let native = host::map_arch(std::env::consts::ARCH);
+        let mut arches = vec![native.to_owned()];
         if std::env::consts::OS == "macos" && native == "arm64" {
             arches.push("amd64".to_owned());
         }

--- a/fleet/arcbox-fleet-agent/src/enroll.rs
+++ b/fleet/arcbox-fleet-agent/src/enroll.rs
@@ -1,8 +1,8 @@
 //! One-shot enrollment: exchange an enrollment token for the machine credential.
 
 use anyhow::{Context, Result};
-use arcbox_fleet_proto::v1::EnrollRequest;
 use arcbox_fleet_proto::v1::fleet_gateway_service_client::FleetGatewayServiceClient;
+use arcbox_fleet_proto::v1::{EnrollRequest, RuntimeCapacity};
 use tracing::info;
 
 use crate::config::AgentConfig;
@@ -13,7 +13,7 @@ use crate::host;
 pub async fn enroll(
     config: &AgentConfig,
     token: String,
-    docker_arches: &[String],
+    capacities: Vec<RuntimeCapacity>,
 ) -> Result<Credential> {
     let channel = config
         .endpoint()?
@@ -28,7 +28,7 @@ pub async fn enroll(
         host_arch: host::host_arch(),
         cpu_cores: host::cpu_cores(),
         mem_mib: host::mem_mib(),
-        capacities: host::capacities(config.max_concurrent, docker_arches),
+        capacities,
         host_info_json: host::host_info_json(),
     };
 

--- a/fleet/arcbox-fleet-agent/src/enroll.rs
+++ b/fleet/arcbox-fleet-agent/src/enroll.rs
@@ -7,10 +7,15 @@ use tracing::info;
 
 use crate::config::AgentConfig;
 use crate::credentials::{Credential, CredentialStore};
+use crate::docker::DockerCapabilities;
 use crate::host;
 
 /// Call `Enroll` on the gateway and persist the returned credential.
-pub async fn enroll(config: &AgentConfig, token: String) -> Result<Credential> {
+pub async fn enroll(
+    config: &AgentConfig,
+    token: String,
+    docker_caps: Option<&DockerCapabilities>,
+) -> Result<Credential> {
     let channel = config
         .endpoint()?
         .connect()
@@ -24,7 +29,7 @@ pub async fn enroll(config: &AgentConfig, token: String) -> Result<Credential> {
         host_arch: host::host_arch(),
         cpu_cores: host::cpu_cores(),
         mem_mib: host::mem_mib(),
-        capacities: host::capacities(config.max_concurrent),
+        capacities: host::capacities(config.max_concurrent, docker_caps),
         host_info_json: host::host_info_json(),
     };
 

--- a/fleet/arcbox-fleet-agent/src/enroll.rs
+++ b/fleet/arcbox-fleet-agent/src/enroll.rs
@@ -7,14 +7,13 @@ use tracing::info;
 
 use crate::config::AgentConfig;
 use crate::credentials::{Credential, CredentialStore};
-use crate::docker::DockerCapabilities;
 use crate::host;
 
 /// Call `Enroll` on the gateway and persist the returned credential.
 pub async fn enroll(
     config: &AgentConfig,
     token: String,
-    docker_caps: Option<&DockerCapabilities>,
+    docker_arches: &[String],
 ) -> Result<Credential> {
     let channel = config
         .endpoint()?
@@ -29,7 +28,7 @@ pub async fn enroll(
         host_arch: host::host_arch(),
         cpu_cores: host::cpu_cores(),
         mem_mib: host::mem_mib(),
-        capacities: host::capacities(config.max_concurrent, docker_caps),
+        capacities: host::capacities(config.max_concurrent, docker_arches),
         host_info_json: host::host_info_json(),
     };
 

--- a/fleet/arcbox-fleet-agent/src/host.rs
+++ b/fleet/arcbox-fleet-agent/src/host.rs
@@ -2,6 +2,8 @@
 
 use arcbox_fleet_proto::v1::RuntimeCapacity;
 
+use crate::docker::DockerCapabilities;
+
 /// Map Rust's `target_os` to the gateway's lowercase `RunnerOs` naming.
 pub fn map_os(os: &str) -> &str {
     match os {
@@ -60,14 +62,35 @@ pub fn host_info_json() -> String {
     info.to_string()
 }
 
-/// The single capacity pool this host serves. With no isolation in v1, the
-/// host advertises its own `(os, arch)` with the configured concurrency.
-pub fn capacities(max_concurrent: usize) -> Vec<RuntimeCapacity> {
-    vec![RuntimeCapacity {
+/// Build the capacity pools to advertise: the host's native pool plus any
+/// Linux pools Docker can serve.
+pub fn capacities(
+    max_concurrent: usize,
+    docker: Option<&DockerCapabilities>,
+) -> Vec<RuntimeCapacity> {
+    let mut pools = vec![RuntimeCapacity {
         os: host_os(),
         arch: host_arch(),
         max_concurrent: i32::try_from(max_concurrent).unwrap_or(i32::MAX),
-    }]
+    }];
+
+    if let Some(caps) = docker {
+        let cap = i32::try_from(caps.max_concurrent).unwrap_or(i32::MAX);
+        pools.push(RuntimeCapacity {
+            os: "linux".to_owned(),
+            arch: caps.native_arch.clone(),
+            max_concurrent: cap,
+        });
+        if let Some(emulated) = &caps.emulated_arch {
+            pools.push(RuntimeCapacity {
+                os: "linux".to_owned(),
+                arch: emulated.clone(),
+                max_concurrent: cap,
+            });
+        }
+    }
+
+    pools
 }
 
 #[cfg(test)]
@@ -80,5 +103,42 @@ mod tests {
         assert_eq!(map_os("linux"), "linux");
         assert_eq!(map_arch("aarch64"), "arm64");
         assert_eq!(map_arch("x86_64"), "amd64");
+    }
+
+    #[test]
+    fn capacities_without_docker_returns_host_pool_only() {
+        let pools = capacities(4, None);
+        assert_eq!(pools.len(), 1);
+        assert_eq!(pools[0].max_concurrent, 4);
+    }
+
+    #[test]
+    fn capacities_with_docker_adds_linux_pools() {
+        let caps = DockerCapabilities {
+            native_arch: "arm64".to_owned(),
+            emulated_arch: Some("amd64".to_owned()),
+            max_concurrent: 3,
+        };
+        let pools = capacities(2, Some(&caps));
+        assert_eq!(pools.len(), 3);
+        assert_eq!(pools[1].os, "linux");
+        assert_eq!(pools[1].arch, "arm64");
+        assert_eq!(pools[1].max_concurrent, 3);
+        assert_eq!(pools[2].os, "linux");
+        assert_eq!(pools[2].arch, "amd64");
+        assert_eq!(pools[2].max_concurrent, 3);
+    }
+
+    #[test]
+    fn capacities_with_docker_no_emulation() {
+        let caps = DockerCapabilities {
+            native_arch: "amd64".to_owned(),
+            emulated_arch: None,
+            max_concurrent: 2,
+        };
+        let pools = capacities(2, Some(&caps));
+        assert_eq!(pools.len(), 2);
+        assert_eq!(pools[1].os, "linux");
+        assert_eq!(pools[1].arch, "amd64");
     }
 }

--- a/fleet/arcbox-fleet-agent/src/host.rs
+++ b/fleet/arcbox-fleet-agent/src/host.rs
@@ -2,8 +2,6 @@
 
 use arcbox_fleet_proto::v1::RuntimeCapacity;
 
-use crate::docker::DockerCapabilities;
-
 /// Map Rust's `target_os` to the gateway's lowercase `RunnerOs` naming.
 pub fn map_os(os: &str) -> &str {
     match os {
@@ -64,30 +62,24 @@ pub fn host_info_json() -> String {
 
 /// Build the capacity pools to advertise: the host's native pool plus any
 /// Linux pools Docker can serve.
-pub fn capacities(
-    max_concurrent: usize,
-    docker: Option<&DockerCapabilities>,
-) -> Vec<RuntimeCapacity> {
+///
+/// `docker_arches` lists the Linux architectures Docker can run (e.g.
+/// `["arm64", "amd64"]` on Apple Silicon macOS). Empty when Docker adds no
+/// pools (disabled, unavailable, or on Linux where the host pool covers it).
+pub fn capacities(max_concurrent: usize, docker_arches: &[String]) -> Vec<RuntimeCapacity> {
+    let cap = i32::try_from(max_concurrent).unwrap_or(i32::MAX);
     let mut pools = vec![RuntimeCapacity {
         os: host_os(),
         arch: host_arch(),
-        max_concurrent: i32::try_from(max_concurrent).unwrap_or(i32::MAX),
+        max_concurrent: cap,
     }];
 
-    if let Some(caps) = docker {
-        let cap = i32::try_from(max_concurrent).unwrap_or(i32::MAX);
+    for arch in docker_arches {
         pools.push(RuntimeCapacity {
             os: "linux".to_owned(),
-            arch: caps.native_arch.clone(),
+            arch: arch.clone(),
             max_concurrent: cap,
         });
-        if let Some(emulated) = &caps.emulated_arch {
-            pools.push(RuntimeCapacity {
-                os: "linux".to_owned(),
-                arch: emulated.clone(),
-                max_concurrent: cap,
-            });
-        }
     }
 
     pools
@@ -107,18 +99,15 @@ mod tests {
 
     #[test]
     fn capacities_without_docker_returns_host_pool_only() {
-        let pools = capacities(4, None);
+        let pools = capacities(4, &[]);
         assert_eq!(pools.len(), 1);
         assert_eq!(pools[0].max_concurrent, 4);
     }
 
     #[test]
     fn capacities_with_docker_adds_linux_pools() {
-        let caps = DockerCapabilities {
-            native_arch: "arm64".to_owned(),
-            emulated_arch: Some("amd64".to_owned()),
-        };
-        let pools = capacities(3, Some(&caps));
+        let arches = vec!["arm64".to_owned(), "amd64".to_owned()];
+        let pools = capacities(3, &arches);
         assert_eq!(pools.len(), 3);
         assert_eq!(pools[1].os, "linux");
         assert_eq!(pools[1].arch, "arm64");
@@ -129,12 +118,9 @@ mod tests {
     }
 
     #[test]
-    fn capacities_with_docker_no_emulation() {
-        let caps = DockerCapabilities {
-            native_arch: "amd64".to_owned(),
-            emulated_arch: None,
-        };
-        let pools = capacities(2, Some(&caps));
+    fn capacities_with_single_docker_arch() {
+        let arches = vec!["amd64".to_owned()];
+        let pools = capacities(2, &arches);
         assert_eq!(pools.len(), 2);
         assert_eq!(pools[1].os, "linux");
         assert_eq!(pools[1].arch, "amd64");

--- a/fleet/arcbox-fleet-agent/src/host.rs
+++ b/fleet/arcbox-fleet-agent/src/host.rs
@@ -75,7 +75,7 @@ pub fn capacities(
     }];
 
     if let Some(caps) = docker {
-        let cap = i32::try_from(caps.max_concurrent).unwrap_or(i32::MAX);
+        let cap = i32::try_from(max_concurrent).unwrap_or(i32::MAX);
         pools.push(RuntimeCapacity {
             os: "linux".to_owned(),
             arch: caps.native_arch.clone(),
@@ -117,9 +117,8 @@ mod tests {
         let caps = DockerCapabilities {
             native_arch: "arm64".to_owned(),
             emulated_arch: Some("amd64".to_owned()),
-            max_concurrent: 3,
         };
-        let pools = capacities(2, Some(&caps));
+        let pools = capacities(3, Some(&caps));
         assert_eq!(pools.len(), 3);
         assert_eq!(pools[1].os, "linux");
         assert_eq!(pools[1].arch, "arm64");
@@ -134,7 +133,6 @@ mod tests {
         let caps = DockerCapabilities {
             native_arch: "amd64".to_owned(),
             emulated_arch: None,
-            max_concurrent: 2,
         };
         let pools = capacities(2, Some(&caps));
         assert_eq!(pools.len(), 2);

--- a/fleet/arcbox-fleet-agent/src/host.rs
+++ b/fleet/arcbox-fleet-agent/src/host.rs
@@ -60,25 +60,71 @@ pub fn host_info_json() -> String {
     info.to_string()
 }
 
-/// Build the capacity pools to advertise: the host's native pool plus any
-/// Linux pools Docker can serve.
-///
-/// `docker_arches` lists the Linux architectures Docker can run (e.g.
-/// `["arm64", "amd64"]` on Apple Silicon macOS). Empty when Docker adds no
-/// pools (disabled, unavailable, or on Linux where the host pool covers it).
-pub fn capacities(max_concurrent: usize, docker_arches: &[String]) -> Vec<RuntimeCapacity> {
-    let cap = i32::try_from(max_concurrent).unwrap_or(i32::MAX);
-    let mut pools = vec![RuntimeCapacity {
-        os: host_os(),
-        arch: host_arch(),
-        max_concurrent: cap,
-    }];
+/// Number of containers the host can run concurrently, derived from memory:
+/// one slot per 4 GiB of RAM, at least one. Docker-served Linux pools share
+/// this budget (see [`capacities`]).
+pub fn docker_budget() -> usize {
+    const MIB_PER_SLOT: u64 = 4096;
+    (mem_mib() / MIB_PER_SLOT).max(1) as usize
+}
 
+/// Build the capacity pools to advertise. The gateway reserves each
+/// `(os, arch)` pool independently, so this list is also the agent's admission
+/// contract: every advertised pool must be one the agent can actually serve, at
+/// a cap it will actually honor.
+///
+/// - **Docker-served Linux pools.** `docker_arches` is the set of Linux arches
+///   Docker can run (empty when Docker is absent). Each is advertised at the
+///   full `docker_budget`. On Apple Silicon the arm64 (native) and amd64
+///   (Rosetta-emulated) pools are alternative execution modes on one Docker
+///   host, so each may use the whole budget when the other is idle.
+/// - **Host-runner pool.** The native `(os, arch)` served by the pre-installed
+///   runner, capped at `host_max_concurrent`. Omitted when no runner directory
+///   is configured (nothing to run it), or when Linux jobs are already
+///   Docker-served on this host (a Linux host with Docker).
+pub fn capacities(
+    host_max_concurrent: usize,
+    runner_dir_present: bool,
+    docker_arches: &[String],
+    docker_budget: usize,
+) -> Vec<RuntimeCapacity> {
+    build_pools(
+        &host_os(),
+        &host_arch(),
+        host_max_concurrent,
+        runner_dir_present,
+        docker_arches,
+        docker_budget,
+    )
+}
+
+/// Platform-independent core of [`capacities`], taking the native `(os, arch)`
+/// explicitly so it can be exercised for every platform in tests.
+fn build_pools(
+    native_os: &str,
+    native_arch: &str,
+    host_max_concurrent: usize,
+    runner_dir_present: bool,
+    docker_arches: &[String],
+    docker_budget: usize,
+) -> Vec<RuntimeCapacity> {
+    let mut pools = Vec::new();
+
+    let docker_cap = i32::try_from(docker_budget).unwrap_or(i32::MAX);
     for arch in docker_arches {
         pools.push(RuntimeCapacity {
             os: "linux".to_owned(),
             arch: arch.clone(),
-            max_concurrent: cap,
+            max_concurrent: docker_cap,
+        });
+    }
+
+    let host_pool_is_docker_served = native_os == "linux" && !docker_arches.is_empty();
+    if runner_dir_present && !host_pool_is_docker_served {
+        pools.push(RuntimeCapacity {
+            os: native_os.to_owned(),
+            arch: native_arch.to_owned(),
+            max_concurrent: i32::try_from(host_max_concurrent).unwrap_or(i32::MAX),
         });
     }
 
@@ -97,32 +143,42 @@ mod tests {
         assert_eq!(map_arch("x86_64"), "amd64");
     }
 
+    fn triple(c: &RuntimeCapacity) -> (&str, &str, i32) {
+        (c.os.as_str(), c.arch.as_str(), c.max_concurrent)
+    }
+
     #[test]
-    fn capacities_without_docker_returns_host_pool_only() {
-        let pools = capacities(4, &[]);
+    fn build_pools_host_only_without_docker() {
+        let pools = build_pools("darwin", "arm64", 4, true, &[], 0);
         assert_eq!(pools.len(), 1);
-        assert_eq!(pools[0].max_concurrent, 4);
+        assert_eq!(triple(&pools[0]), ("darwin", "arm64", 4));
     }
 
     #[test]
-    fn capacities_with_docker_adds_linux_pools() {
+    fn build_pools_macos_adds_docker_linux_pools_at_full_budget() {
         let arches = vec!["arm64".to_owned(), "amd64".to_owned()];
-        let pools = capacities(3, &arches);
+        let pools = build_pools("darwin", "arm64", 2, true, &arches, 4);
+        // Each docker linux pool gets the full budget, plus the darwin host pool.
         assert_eq!(pools.len(), 3);
-        assert_eq!(pools[1].os, "linux");
-        assert_eq!(pools[1].arch, "arm64");
-        assert_eq!(pools[1].max_concurrent, 3);
-        assert_eq!(pools[2].os, "linux");
-        assert_eq!(pools[2].arch, "amd64");
-        assert_eq!(pools[2].max_concurrent, 3);
+        assert_eq!(triple(&pools[0]), ("linux", "arm64", 4));
+        assert_eq!(triple(&pools[1]), ("linux", "amd64", 4));
+        assert_eq!(triple(&pools[2]), ("darwin", "arm64", 2));
     }
 
     #[test]
-    fn capacities_with_single_docker_arch() {
-        let arches = vec!["amd64".to_owned()];
-        let pools = capacities(2, &arches);
-        assert_eq!(pools.len(), 2);
-        assert_eq!(pools[1].os, "linux");
-        assert_eq!(pools[1].arch, "amd64");
+    fn build_pools_linux_host_pool_is_docker_served() {
+        // On a Linux host with Docker the native pool IS the docker linux pool,
+        // capped by the docker budget — no separate host-runner pool is added.
+        let pools = build_pools("linux", "amd64", 2, true, &["amd64".to_owned()], 4);
+        assert_eq!(pools.len(), 1);
+        assert_eq!(triple(&pools[0]), ("linux", "amd64", 4));
+    }
+
+    #[test]
+    fn build_pools_omits_host_pool_without_runner_dir() {
+        // Docker-only macOS: no runner dir means no darwin pool is advertised.
+        let pools = build_pools("darwin", "arm64", 2, false, &["arm64".to_owned()], 3);
+        assert_eq!(pools.len(), 1);
+        assert_eq!(triple(&pools[0]), ("linux", "arm64", 3));
     }
 }

--- a/fleet/arcbox-fleet-agent/src/main.rs
+++ b/fleet/arcbox-fleet-agent/src/main.rs
@@ -83,11 +83,15 @@ fn main() -> Result<()> {
 async fn run(command: Command, config: AgentConfig) -> Result<()> {
     let docker = init_docker(&config).await?;
 
+    let docker_arches = docker
+        .as_ref()
+        .map(|d| d.linux_arches())
+        .unwrap_or_default();
+
     match command {
         Command::Enroll { token_file, token } => {
             let token = resolve_enrollment_token(token_file, token)?;
-            let docker_caps = docker.as_ref().map(|d| d.capabilities());
-            enroll::enroll(&config, token, docker_caps.as_ref()).await?;
+            enroll::enroll(&config, token, &docker_arches).await?;
             Ok(())
         }
         Command::Run => {

--- a/fleet/arcbox-fleet-agent/src/main.rs
+++ b/fleet/arcbox-fleet-agent/src/main.rs
@@ -13,6 +13,7 @@
 mod attach;
 mod config;
 mod credentials;
+mod docker;
 mod enroll;
 mod host;
 mod runner;
@@ -25,8 +26,9 @@ use clap::{Parser, Subcommand};
 use tokio_util::sync::CancellationToken;
 use tracing::{info, warn};
 
-use crate::config::AgentConfig;
+use crate::config::{AgentConfig, DockerMode};
 use crate::credentials::CredentialStore;
+use crate::docker::DockerRunner;
 
 #[derive(Debug, Parser)]
 #[command(name = "arcbox-fleet-agent", author, version, about)]
@@ -79,10 +81,15 @@ fn main() -> Result<()> {
 }
 
 async fn run(command: Command, config: AgentConfig) -> Result<()> {
+    let docker = init_docker(&config).await?;
+
     match command {
         Command::Enroll { token_file, token } => {
             let token = resolve_enrollment_token(token_file, token)?;
-            enroll::enroll(&config, token).await?;
+            let docker_caps = docker
+                .as_ref()
+                .map(|d| d.capabilities(config.max_concurrent));
+            enroll::enroll(&config, token, docker_caps.as_ref()).await?;
             Ok(())
         }
         Command::Run => {
@@ -103,7 +110,7 @@ async fn run(command: Command, config: AgentConfig) -> Result<()> {
                 signal_token.cancel();
             });
 
-            attach::run(config, credential, shutdown).await
+            attach::run(config, credential, docker, shutdown).await
         }
     }
 }
@@ -166,6 +173,24 @@ fn resolve_enrollment_token(token_file: Option<PathBuf>, token: Option<String>) 
         anyhow::bail!("enrollment token is empty");
     }
     Ok(token)
+}
+
+/// Probe Docker availability according to the configured [`DockerMode`].
+async fn init_docker(config: &AgentConfig) -> Result<Option<DockerRunner>> {
+    match config.docker.mode {
+        DockerMode::Disabled => Ok(None),
+        DockerMode::Enabled => {
+            let runner = DockerRunner::new(config.docker.runner_image.clone()).await?;
+            Ok(Some(runner))
+        }
+        DockerMode::Auto => match DockerRunner::new(config.docker.runner_image.clone()).await {
+            Ok(runner) => Ok(Some(runner)),
+            Err(e) => {
+                warn!(error = %e, "docker not available; linux pools will not be advertised");
+                Ok(None)
+            }
+        },
+    }
 }
 
 #[cfg(test)]

--- a/fleet/arcbox-fleet-agent/src/main.rs
+++ b/fleet/arcbox-fleet-agent/src/main.rs
@@ -1,9 +1,10 @@
 //! ArcBox Fleet runner agent.
 //!
 //! A standalone, cross-platform binary that enrolls a host with the Fleet
-//! gateway and, once attached, runs GitHub Actions jobs by invoking the
-//! pre-installed runner (`run.sh --jitconfig …`). v1 has no isolation: jobs run
-//! directly on the host.
+//! gateway and, once attached, runs GitHub Actions jobs. Linux jobs run in a
+//! Docker container for isolation when a Docker-compatible runtime is
+//! available; other jobs run via the pre-installed runner
+//! (`run.sh --jitconfig …`).
 //!
 //! Configuration is environment-driven (`ARCBOX_FLEET_*`). The `enroll`
 //! subcommand reads the fleet join token from a file (`--token-file`) or stdin
@@ -21,6 +22,7 @@ mod runner;
 use std::path::PathBuf;
 
 use anyhow::{Context, Result};
+use arcbox_fleet_proto::v1::RuntimeCapacity;
 use arcbox_logging::LogConfig;
 use clap::{Parser, Subcommand};
 use tokio_util::sync::CancellationToken;
@@ -82,16 +84,12 @@ fn main() -> Result<()> {
 
 async fn run(command: Command, config: AgentConfig) -> Result<()> {
     let docker = init_docker(&config).await?;
-
-    let docker_arches = docker
-        .as_ref()
-        .map(|d| d.linux_arches())
-        .unwrap_or_default();
+    let pools = capacity_pools(&config, docker.as_ref());
 
     match command {
         Command::Enroll { token_file, token } => {
             let token = resolve_enrollment_token(token_file, token)?;
-            enroll::enroll(&config, token, &docker_arches).await?;
+            enroll::enroll(&config, token, pools).await?;
             Ok(())
         }
         Command::Run => {
@@ -112,7 +110,7 @@ async fn run(command: Command, config: AgentConfig) -> Result<()> {
                 signal_token.cancel();
             });
 
-            attach::run(config, credential, docker, shutdown).await
+            attach::run(config, credential, docker, pools, shutdown).await
         }
     }
 }
@@ -175,6 +173,24 @@ fn resolve_enrollment_token(token_file: Option<PathBuf>, token: Option<String>) 
         anyhow::bail!("enrollment token is empty");
     }
     Ok(token)
+}
+
+/// Build the capacity pools this agent advertises and admits against: the
+/// host-runner pool (if a runner directory is set) plus any Docker-served Linux
+/// pools, the latter sharing a resource-derived budget.
+fn capacity_pools(config: &AgentConfig, docker: Option<&DockerRunner>) -> Vec<RuntimeCapacity> {
+    let docker_arches = docker.map(DockerRunner::linux_arches).unwrap_or_default();
+    let docker_budget = if docker_arches.is_empty() {
+        0
+    } else {
+        host::docker_budget()
+    };
+    host::capacities(
+        config.max_concurrent,
+        config.runner_dir.is_some(),
+        &docker_arches,
+        docker_budget,
+    )
 }
 
 /// Probe Docker availability according to the configured [`DockerMode`].

--- a/fleet/arcbox-fleet-agent/src/main.rs
+++ b/fleet/arcbox-fleet-agent/src/main.rs
@@ -83,16 +83,21 @@ fn main() -> Result<()> {
 }
 
 async fn run(command: Command, config: AgentConfig) -> Result<()> {
-    let docker = init_docker(&config).await?;
-    let pools = capacity_pools(&config, docker.as_ref());
-
     match command {
         Command::Enroll { token_file, token } => {
             let token = resolve_enrollment_token(token_file, token)?;
+            // Enrollment is pure credential exchange — it never needs Docker, so
+            // an operator can enroll before the runtime is up. The capacities
+            // sent here are an initial hint, replaced wholesale by the first
+            // heartbeat once the agent attaches, so we advertise what we know
+            // without probing the runtime.
+            let pools = capacity_pools(&config, None);
             enroll::enroll(&config, token, pools).await?;
             Ok(())
         }
         Command::Run => {
+            let docker = init_docker(&config).await?;
+            let pools = capacity_pools(&config, docker.as_ref());
             let credential = CredentialStore::new(config.credentials_path())
                 .load()?
                 .context(

--- a/fleet/arcbox-fleet-agent/src/main.rs
+++ b/fleet/arcbox-fleet-agent/src/main.rs
@@ -86,9 +86,7 @@ async fn run(command: Command, config: AgentConfig) -> Result<()> {
     match command {
         Command::Enroll { token_file, token } => {
             let token = resolve_enrollment_token(token_file, token)?;
-            let docker_caps = docker
-                .as_ref()
-                .map(|d| d.capabilities(config.max_concurrent));
+            let docker_caps = docker.as_ref().map(|d| d.capabilities());
             enroll::enroll(&config, token, docker_caps.as_ref()).await?;
             Ok(())
         }

--- a/fleet/arcbox-fleet-agent/src/runner.rs
+++ b/fleet/arcbox-fleet-agent/src/runner.rs
@@ -202,7 +202,8 @@ impl RunnerSupervisor {
 
     /// Drive one runner job end to end, emitting accept/start/terminal events.
     ///
-    /// Routes to Docker for Linux jobs, direct host execution otherwise.
+    /// Linux jobs are routed through Docker when available (for isolation);
+    /// all other jobs run directly on the host via the pre-installed runner.
     async fn run_job(&self, order: ProvisionRunner, cancel_rx: oneshot::Receiver<()>) {
         let job_id = order.job_id.clone();
         self.send(attach_request::Msg::RunnerAccepted(RunnerAccepted {
@@ -210,9 +211,9 @@ impl RunnerSupervisor {
         }))
         .await;
 
-        let is_docker = order.os == "linux" && self.inner.docker.is_some();
+        let use_docker = order.os == "linux" && self.inner.docker.is_some();
 
-        if is_docker {
+        if use_docker {
             self.run_docker_job(&job_id, &order, cancel_rx).await;
         } else {
             self.run_host_job(&job_id, &order, cancel_rx).await;

--- a/fleet/arcbox-fleet-agent/src/runner.rs
+++ b/fleet/arcbox-fleet-agent/src/runner.rs
@@ -1,24 +1,35 @@
-//! Runner supervision: spawn the GitHub Actions runner per `ProvisionRunner`,
-//! track in-flight jobs, and report terminal state back over the stream.
+//! Runner supervision: start a runner per `ProvisionRunner`, track in-flight
+//! jobs per `(os, arch)` capacity pool, and report terminal state back over the
+//! stream.
 //!
-//! v1 has no isolation: the job runs directly on the host. `ProvisionRunner`'s
-//! `image`/`cpus`/`mem_mib` describe a sandbox that does not exist yet and are
-//! intentionally ignored.
+//! Linux jobs run inside a Docker container for isolation (using
+//! `ProvisionRunner.image`); all other jobs run directly on the host via the
+//! pre-installed runner. Admission gates each pool against the cap the agent
+//! advertised for it, so the gateway's per-pool reservations and the agent's
+//! local capacity never disagree.
 
+use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Duration;
 
 use arcbox_fleet_proto::v1::{
     AttachRequest, ProvisionRunner, RunnerAccepted, RunnerFailed, RunnerFinished, RunnerStarted,
-    attach_request,
+    RuntimeCapacity, attach_request,
 };
 use command_group::AsyncCommandGroup;
-use dashmap::{DashMap, DashSet};
+use dashmap::DashMap;
 use tokio::sync::{mpsc, oneshot};
 use tracing::{info, warn};
 
 use crate::docker::{DockerRunner, RunSpec};
+
+/// An `(os, arch)` capacity pool, mirroring the gateway's reservation key.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct Pool {
+    os: String,
+    arch: String,
+}
 
 /// Outcome of the admission check for an incoming `ProvisionRunner`.
 #[derive(Debug, PartialEq, Eq)]
@@ -29,8 +40,10 @@ enum Admission {
     Duplicate,
     /// The host is draining and rejects new work.
     Draining,
-    /// The host is at its concurrency cap.
+    /// The job's `(os, arch)` pool is at its concurrency cap.
     AtCapacity,
+    /// No advertised pool serves the job's `(os, arch)`.
+    Unservable,
 }
 
 /// Spawns and tracks runner processes, emitting lifecycle events to the gateway.
@@ -42,8 +55,8 @@ pub struct RunnerSupervisor {
 struct Inner {
     /// Outbound channel to the gateway (runner lifecycle events).
     events: mpsc::Sender<AttachRequest>,
-    /// Job ids currently in flight (drives local capacity).
-    in_flight: DashSet<String>,
+    /// In-flight jobs mapped to the pool each occupies; drives per-pool capacity.
+    in_flight: DashMap<String, Pool>,
     /// Cancel signals for in-flight jobs. Firing one makes the job's `run_job`
     /// kill the runner's whole process group; see [`RunnerSupervisor::handle_cancel`].
     cancels: DashMap<String, oneshot::Sender<()>>,
@@ -52,28 +65,43 @@ struct Inner {
     runner_dir: Option<PathBuf>,
     /// Docker runtime for Linux jobs, if available.
     docker: Option<DockerRunner>,
-    /// Local backpressure cap.
-    max_concurrent: usize,
+    /// Advertised capacity per `(os, arch)` pool. Admission gates each pool
+    /// against its own cap, mirroring the gateway's per-pool reservation.
+    pools: HashMap<Pool, i32>,
     /// Set once `Drain` is received; no new jobs are accepted.
     draining: std::sync::atomic::AtomicBool,
 }
 
 impl RunnerSupervisor {
-    /// Create a supervisor that emits events on `events`.
+    /// Create a supervisor that emits events on `events`. `pools` is the
+    /// advertised capacity set — the same list reported to the gateway, so
+    /// admission and advertisement can never disagree.
     pub fn new(
         events: mpsc::Sender<AttachRequest>,
         runner_dir: Option<PathBuf>,
         docker: Option<DockerRunner>,
-        max_concurrent: usize,
+        pools: Vec<RuntimeCapacity>,
     ) -> Self {
+        let pools = pools
+            .into_iter()
+            .map(|c| {
+                (
+                    Pool {
+                        os: c.os,
+                        arch: c.arch,
+                    },
+                    c.max_concurrent,
+                )
+            })
+            .collect();
         Self {
             inner: Arc::new(Inner {
                 events,
-                in_flight: DashSet::new(),
+                in_flight: DashMap::new(),
                 cancels: DashMap::new(),
                 runner_dir,
                 docker,
-                max_concurrent,
+                pools,
                 draining: std::sync::atomic::AtomicBool::new(false),
             }),
         }
@@ -84,8 +112,12 @@ impl RunnerSupervisor {
     /// capacity.
     pub async fn handle_provision(&self, order: ProvisionRunner) {
         let job_id = order.job_id.clone();
+        let pool = Pool {
+            os: order.os.clone(),
+            arch: order.arch.clone(),
+        };
 
-        match self.admit(&job_id) {
+        match self.admit(&job_id, &pool) {
             Admission::Duplicate => {
                 // The gateway's dispatch is at-least-once, so a redelivered
                 // order for a running job must be a no-op — never a second
@@ -101,11 +133,19 @@ impl RunnerSupervisor {
                 self.fail(&job_id, "host at capacity").await;
                 return;
             }
+            Admission::Unservable => {
+                self.fail(
+                    &job_id,
+                    &format!("no capacity pool for {}/{}", order.os, order.arch),
+                )
+                .await;
+                return;
+            }
             Admission::Accept => {}
         }
 
         // Reserve the slot synchronously so a follow-up dispatch sees it.
-        self.inner.in_flight.insert(job_id.clone());
+        self.inner.in_flight.insert(job_id.clone(), pool);
 
         // Cancellation is cooperative: `run_job` owns the runner process group
         // and tears it down on this signal, so `CancelRunner` never orphans the
@@ -117,14 +157,16 @@ impl RunnerSupervisor {
         tokio::spawn(async move { sup.run_job(order, cancel_rx).await });
     }
 
-    /// Decide whether to start a runner for `job_id`. `Duplicate` takes
-    /// precedence over `Draining`/`AtCapacity`: a redelivery of an
-    /// already-running job is a no-op regardless of host state. The
-    /// `contains`/`insert` gap back in [`Self::handle_provision`] is safe
-    /// because the attach loop dispatches orders one at a time, with no
-    /// `.await` between this check and the reservation.
-    fn admit(&self, job_id: &str) -> Admission {
-        if self.inner.in_flight.contains(job_id) {
+    /// Decide whether to start a runner for `job_id` in `pool`. `Duplicate`
+    /// takes precedence over the host-state checks: a redelivery of an
+    /// already-running job is a no-op regardless. Capacity is gated per pool —
+    /// each `(os, arch)` against its own advertised cap — so the agent admits
+    /// exactly what the gateway reserves. The `contains`/`insert` gap back in
+    /// [`Self::handle_provision`] is safe because the attach loop dispatches
+    /// orders one at a time, with no `.await` between this check and the
+    /// reservation.
+    fn admit(&self, job_id: &str, pool: &Pool) -> Admission {
+        if self.inner.in_flight.contains_key(job_id) {
             return Admission::Duplicate;
         }
         if self
@@ -134,10 +176,22 @@ impl RunnerSupervisor {
         {
             return Admission::Draining;
         }
-        if self.inner.in_flight.len() >= self.inner.max_concurrent {
+        let Some(&cap) = self.inner.pools.get(pool) else {
+            return Admission::Unservable;
+        };
+        if self.active_in(pool) >= cap.max(0) as usize {
             return Admission::AtCapacity;
         }
         Admission::Accept
+    }
+
+    /// Count jobs currently occupying `pool`.
+    fn active_in(&self, pool: &Pool) -> usize {
+        self.inner
+            .in_flight
+            .iter()
+            .filter(|entry| entry.value() == pool)
+            .count()
     }
 
     /// Cancel an in-flight job. Signals `run_job`, which tears down the runner
@@ -382,56 +436,94 @@ fn runner_command(runner_dir: &Path, encoded_jit_config: &str) -> tokio::process
 mod tests {
     use super::*;
 
-    fn supervisor(max_concurrent: usize) -> RunnerSupervisor {
+    fn cap(os: &str, arch: &str, max: i32) -> RuntimeCapacity {
+        RuntimeCapacity {
+            os: os.to_owned(),
+            arch: arch.to_owned(),
+            max_concurrent: max,
+        }
+    }
+
+    fn pool(os: &str, arch: &str) -> Pool {
+        Pool {
+            os: os.to_owned(),
+            arch: arch.to_owned(),
+        }
+    }
+
+    fn supervisor(pools: Vec<RuntimeCapacity>) -> RunnerSupervisor {
         let (events, _rx) = mpsc::channel(1);
-        RunnerSupervisor::new(
-            events,
-            Some(PathBuf::from("/nonexistent")),
-            None,
-            max_concurrent,
-        )
+        RunnerSupervisor::new(events, Some(PathBuf::from("/nonexistent")), None, pools)
     }
 
     #[test]
-    fn admits_until_capacity_then_rejects() {
-        let sup = supervisor(2);
-        assert_eq!(sup.admit("rjob_a"), Admission::Accept);
+    fn admits_until_pool_capacity_then_rejects() {
+        let sup = supervisor(vec![cap("darwin", "arm64", 2)]);
+        let p = pool("darwin", "arm64");
+        assert_eq!(sup.admit("rjob_a", &p), Admission::Accept);
 
-        sup.inner.in_flight.insert("rjob_a".to_string());
+        sup.inner.in_flight.insert("rjob_a".to_string(), p.clone());
         // A redelivery of a running job is a duplicate, never a fresh slot.
-        assert_eq!(sup.admit("rjob_a"), Admission::Duplicate);
-        assert_eq!(sup.admit("rjob_b"), Admission::Accept);
+        assert_eq!(sup.admit("rjob_a", &p), Admission::Duplicate);
+        assert_eq!(sup.admit("rjob_b", &p), Admission::Accept);
 
-        sup.inner.in_flight.insert("rjob_b".to_string());
-        assert_eq!(sup.admit("rjob_c"), Admission::AtCapacity);
+        sup.inner.in_flight.insert("rjob_b".to_string(), p.clone());
+        assert_eq!(sup.admit("rjob_c", &p), Admission::AtCapacity);
+    }
+
+    #[test]
+    fn pools_have_independent_capacity() {
+        let sup = supervisor(vec![cap("darwin", "arm64", 1), cap("linux", "amd64", 1)]);
+        let darwin = pool("darwin", "arm64");
+        let linux = pool("linux", "amd64");
+
+        sup.inner
+            .in_flight
+            .insert("rjob_a".to_string(), darwin.clone());
+        // The darwin pool is full...
+        assert_eq!(sup.admit("rjob_b", &darwin), Admission::AtCapacity);
+        // ...but the linux pool is unaffected.
+        assert_eq!(sup.admit("rjob_c", &linux), Admission::Accept);
+    }
+
+    #[test]
+    fn unadvertised_pool_is_unservable() {
+        let sup = supervisor(vec![cap("darwin", "arm64", 2)]);
+        assert_eq!(
+            sup.admit("rjob_a", &pool("linux", "amd64")),
+            Admission::Unservable
+        );
     }
 
     #[test]
     fn duplicate_takes_precedence_over_drain_and_capacity() {
-        let sup = supervisor(1);
-        sup.inner.in_flight.insert("rjob_a".to_string());
+        let sup = supervisor(vec![cap("darwin", "arm64", 1)]);
+        let p = pool("darwin", "arm64");
+        sup.inner.in_flight.insert("rjob_a".to_string(), p.clone());
         sup.inner
             .draining
             .store(true, std::sync::atomic::Ordering::Relaxed);
 
         // Already running, host draining and at capacity: still a duplicate.
-        assert_eq!(sup.admit("rjob_a"), Admission::Duplicate);
+        assert_eq!(sup.admit("rjob_a", &p), Admission::Duplicate);
         // A different job while draining is rejected for draining.
-        assert_eq!(sup.admit("rjob_b"), Admission::Draining);
+        assert_eq!(sup.admit("rjob_b", &p), Admission::Draining);
     }
 
     /// Register an in-flight job with a cancel signal, mirroring what
     /// `handle_provision` sets up before spawning `run_job`.
     fn register_in_flight(sup: &RunnerSupervisor, job_id: &str) -> oneshot::Receiver<()> {
         let (cancel_tx, cancel_rx) = oneshot::channel();
-        sup.inner.in_flight.insert(job_id.to_string());
+        sup.inner
+            .in_flight
+            .insert(job_id.to_string(), pool("darwin", "arm64"));
         sup.inner.cancels.insert(job_id.to_string(), cancel_tx);
         cancel_rx
     }
 
     #[tokio::test]
     async fn shutdown_drains_cancels_and_waits_for_release() {
-        let sup = supervisor(4);
+        let sup = supervisor(vec![cap("darwin", "arm64", 4)]);
         let cancel_rx = register_in_flight(&sup, "rjob_a");
 
         // Stand in for `run_job`: release the slot once the cancel signal fires.
@@ -454,7 +546,7 @@ mod tests {
 
     #[tokio::test]
     async fn shutdown_returns_after_grace_when_a_job_will_not_release() {
-        let sup = supervisor(4);
+        let sup = supervisor(vec![cap("darwin", "arm64", 4)]);
         // Hold the receiver so the cancel send succeeds, but never release the
         // slot — shutdown must give up after the grace rather than hang.
         let _cancel_rx = register_in_flight(&sup, "rjob_a");

--- a/fleet/arcbox-fleet-agent/src/runner.rs
+++ b/fleet/arcbox-fleet-agent/src/runner.rs
@@ -18,6 +18,8 @@ use dashmap::{DashMap, DashSet};
 use tokio::sync::{mpsc, oneshot};
 use tracing::{info, warn};
 
+use crate::docker::{DockerRunner, RunSpec};
+
 /// Outcome of the admission check for an incoming `ProvisionRunner`.
 #[derive(Debug, PartialEq, Eq)]
 enum Admission {
@@ -46,7 +48,10 @@ struct Inner {
     /// kill the runner's whole process group; see [`RunnerSupervisor::handle_cancel`].
     cancels: DashMap<String, oneshot::Sender<()>>,
     /// Directory holding the installed runner (`run.sh` / `run.cmd`).
-    runner_dir: PathBuf,
+    /// `None` when only Docker-based execution is configured.
+    runner_dir: Option<PathBuf>,
+    /// Docker runtime for Linux jobs, if available.
+    docker: Option<DockerRunner>,
     /// Local backpressure cap.
     max_concurrent: usize,
     /// Set once `Drain` is received; no new jobs are accepted.
@@ -57,7 +62,8 @@ impl RunnerSupervisor {
     /// Create a supervisor that emits events on `events`.
     pub fn new(
         events: mpsc::Sender<AttachRequest>,
-        runner_dir: PathBuf,
+        runner_dir: Option<PathBuf>,
+        docker: Option<DockerRunner>,
         max_concurrent: usize,
     ) -> Self {
         Self {
@@ -66,6 +72,7 @@ impl RunnerSupervisor {
                 in_flight: DashSet::new(),
                 cancels: DashMap::new(),
                 runner_dir,
+                docker,
                 max_concurrent,
                 draining: std::sync::atomic::AtomicBool::new(false),
             }),
@@ -133,9 +140,10 @@ impl RunnerSupervisor {
         Admission::Accept
     }
 
-    /// Cancel an in-flight job. Signals `run_job`, which kills the runner's
-    /// whole process group and releases the slot — the slot is dropped there,
-    /// not here, so local capacity tracks the real process lifetime.
+    /// Cancel an in-flight job. Signals `run_job`, which tears down the runner
+    /// (process group for host jobs, container for Docker jobs) and releases the
+    /// slot — the slot is dropped there, not here, so local capacity tracks the
+    /// real process lifetime.
     pub fn handle_cancel(&self, job_id: &str) {
         if let Some((_, cancel)) = self.inner.cancels.remove(job_id) {
             let _ = cancel.send(());
@@ -152,13 +160,15 @@ impl RunnerSupervisor {
     }
 
     /// Begin graceful shutdown: stop accepting offers, cancel every in-flight
-    /// job (each `run_job` SIGKILLs its runner's process group and reaps it),
-    /// and wait — bounded by `grace` — for the jobs to release their slots.
+    /// job (each `run_job` tears down its runner — process group for host jobs,
+    /// container for Docker jobs), and wait — bounded by `grace` — for the jobs
+    /// to release their slots.
     ///
     /// Terminal events are emitted best-effort: the attach stream may already be
     /// torn down, but the gateway reclaims capacity when it observes the dropped
     /// connection, so a runner that cannot flush its event is not stranded. The
-    /// real guarantee here is that no runner process group is left orphaned.
+    /// real guarantee here is that no runner process group or container is left
+    /// orphaned.
     pub async fn shutdown(&self, grace: Duration) {
         self.handle_drain();
         // `cancels` is a subset of `in_flight`, so firing every cancel signals a
@@ -190,45 +200,72 @@ impl RunnerSupervisor {
         }
     }
 
-    /// Drive one runner process end to end, emitting accept/start/terminal
-    /// events. The runner is spawned as a process group so cancellation can take
-    /// down `run.sh` and every process it spawned, not just the immediate child.
-    async fn run_job(&self, order: ProvisionRunner, mut cancel_rx: oneshot::Receiver<()>) {
+    /// Drive one runner job end to end, emitting accept/start/terminal events.
+    ///
+    /// Routes to Docker for Linux jobs, direct host execution otherwise.
+    async fn run_job(&self, order: ProvisionRunner, cancel_rx: oneshot::Receiver<()>) {
         let job_id = order.job_id.clone();
         self.send(attach_request::Msg::RunnerAccepted(RunnerAccepted {
             job_id: job_id.clone(),
         }))
         .await;
 
-        let mut command = runner_command(&self.inner.runner_dir, &order.encoded_jit_config);
+        let is_docker = order.os == "linux" && self.inner.docker.is_some();
+
+        if is_docker {
+            self.run_docker_job(&job_id, &order, cancel_rx).await;
+        } else {
+            self.run_host_job(&job_id, &order, cancel_rx).await;
+        }
+    }
+
+    /// Run a job directly on the host via the pre-installed runner. The runner is
+    /// spawned as a process group so cancellation can take down `run.sh` and
+    /// every process it spawned, not just the immediate child.
+    async fn run_host_job(
+        &self,
+        job_id: &str,
+        order: &ProvisionRunner,
+        mut cancel_rx: oneshot::Receiver<()>,
+    ) {
+        let runner_dir = match &self.inner.runner_dir {
+            Some(dir) => dir,
+            None => {
+                self.fail(job_id, "no host runner directory configured")
+                    .await;
+                return;
+            }
+        };
+
+        let mut command = runner_command(runner_dir, &order.encoded_jit_config);
         let mut child = match command.group_spawn() {
             Ok(child) => child,
             Err(e) => {
-                self.fail(&job_id, &format!("failed to spawn runner: {e}"))
+                self.fail(job_id, &format!("failed to spawn runner: {e}"))
                     .await;
                 return;
             }
         };
 
         self.send(attach_request::Msg::RunnerStarted(RunnerStarted {
-            job_id: job_id.clone(),
+            job_id: job_id.to_owned(),
         }))
         .await;
-        info!(job_id, "runner started");
+        info!(job_id, "runner started (host)");
 
         tokio::select! {
             result = child.wait() => match result {
                 Ok(status) => {
                     self.send(attach_request::Msg::RunnerFinished(RunnerFinished {
-                        job_id: job_id.clone(),
+                        job_id: job_id.to_owned(),
                         success: status.success(),
                         detail: format!("exit status: {status}"),
                     }))
                     .await;
                     info!(job_id, success = status.success(), "runner finished");
-                    self.release(&job_id);
+                    self.release(job_id);
                 }
-                Err(e) => self.fail(&job_id, &format!("waiting on runner: {e}")).await,
+                Err(e) => self.fail(job_id, &format!("waiting on runner: {e}")).await,
             },
             // CancelRunner: SIGKILL the whole process group (run.sh and the
             // runner/job processes it spawned) and reap it, then report terminal.
@@ -236,7 +273,53 @@ impl RunnerSupervisor {
                 if let Err(e) = child.kill().await {
                     warn!(job_id, error = %e, "killing runner process group failed");
                 }
-                self.fail(&job_id, "canceled by gateway").await;
+                self.fail(job_id, "canceled by gateway").await;
+            }
+        }
+    }
+
+    /// Run a job inside a Docker container. On cancellation the in-flight
+    /// container future is dropped, and its `ContainerGuard` kills and removes
+    /// the container.
+    async fn run_docker_job(
+        &self,
+        job_id: &str,
+        order: &ProvisionRunner,
+        mut cancel_rx: oneshot::Receiver<()>,
+    ) {
+        let docker = self.inner.docker.as_ref().expect("checked by caller");
+        let image = docker.resolve_image(&order.image);
+
+        self.send(attach_request::Msg::RunnerStarted(RunnerStarted {
+            job_id: job_id.to_owned(),
+        }))
+        .await;
+        info!(job_id, image, arch = %order.arch, "runner started (docker)");
+
+        let run = docker.run_job(RunSpec {
+            job_id,
+            image,
+            encoded_jit_config: &order.encoded_jit_config,
+            arch: &order.arch,
+        });
+        tokio::select! {
+            result = run => match result {
+                Ok(outcome) => {
+                    self.send(attach_request::Msg::RunnerFinished(RunnerFinished {
+                        job_id: job_id.to_owned(),
+                        success: outcome.success,
+                        detail: outcome.detail.clone(),
+                    }))
+                    .await;
+                    info!(job_id, success = outcome.success, detail = %outcome.detail, "runner finished");
+                    self.release(job_id);
+                }
+                Err(e) => self.fail(job_id, &format!("docker runner: {e}")).await,
+            },
+            // CancelRunner: dropping `run` drops the container guard, which kills
+            // and removes the container.
+            _ = &mut cancel_rx => {
+                self.fail(job_id, "canceled by gateway").await;
             }
         }
     }
@@ -299,9 +382,13 @@ mod tests {
     use super::*;
 
     fn supervisor(max_concurrent: usize) -> RunnerSupervisor {
-        // `admit` never sends, so the dropped receiver is irrelevant here.
         let (events, _rx) = mpsc::channel(1);
-        RunnerSupervisor::new(events, PathBuf::from("/nonexistent"), max_concurrent)
+        RunnerSupervisor::new(
+            events,
+            Some(PathBuf::from("/nonexistent")),
+            None,
+            max_concurrent,
+        )
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Add Docker runtime to the fleet agent so any host with Docker can serve `linux/arm64` and `linux/amd64` jobs — even on macOS.
- Auto-detects Docker at startup (ping socket), advertises linux capacity pools to the gateway, and routes `ProvisionRunner` orders with `os=linux` to containers instead of the host runner.
- New `docker.rs` module wraps `bollard` for the container lifecycle (pull → create → start → wait → remove) with a `ContainerGuard` that kills orphaned containers on task cancellation.

### Config

| Env var | Default | Purpose |
|---------|---------|---------|
| `ARCBOX_FLEET_DOCKER` | `auto` | `auto` = detect at startup, `true` = require, `false` = disable |
| `ARCBOX_FLEET_RUNNER_IMAGE` | `ghcr.io/actions/actions-runner:latest` | Default container image for Linux jobs |

> The default runner image was `ghcr.io/actions/runner:latest`, which is **not anonymously pullable** (registry returns `denied`) — the agent's Docker readiness pull failed on startup. Corrected to the published official image `ghcr.io/actions/actions-runner:latest`.

### No platform changes required

The gateway already accepts any valid `(os, arch)` pool from a machine, the capacity object tracks slots per pool independently, and `ProvisionRunner` already carries `os`/`arch`/`image` fields.

## Test plan

- [x] `cargo clippy` — zero warnings
- [x] `cargo test` — 7 tests pass (3 new: capacities with/without Docker, no-emulation variant)
- [x] Manual: run agent with Docker available, verify enrollment logs show linux pools
- [x] Manual: dispatch a linux job, verify it runs inside a container

## End-to-end verification

Ran the full fleet hot path on a disposable Linux box (Debian 13, x86_64, Docker) against the complete control plane (`arcbox-api` + `arcbox-worker` + `arcbox-fleet-gateway` + in-repo GitHub mock) on a clean DB, driven only by `curl` and the **real agent built from this branch**.

**Agent comes online with a Docker-backed pool:**
```
docker runtime available  linux_arches=["amd64"]
attached to gateway
```
`GET /v1/fleets/{id}/machines` → `status: online`, `pools: [{ os: linux, arch: amd64, max_concurrent: 3 }]`, heartbeats advancing `last_seen`.

**A dispatched linux job runs inside a container** (signed `workflow_job=queued`, labels `self-hosted`/`linux`/`X64` → `os=linux` → `run_docker_job`):
```
runner started (docker)  job_id=rjob_…  image=ghcr.io/actions/actions-runner:latest  arch=amd64
image ready              image=ghcr.io/actions/actions-runner:latest  platform=linux/amd64
runner finished          job_id=rjob_…  success=true  detail=container exited with code 0
```
Dispatch routed through Docker (not the host runner); the agent pulled the image, created + started + waited on the container, reported the lifecycle back to the gateway, and `ContainerGuard`/cleanup removed the container on exit (no leftover in `docker ps -a`).

**Lifecycle + capacity:** job advanced to `running` on dispatch (`machine_id` assigned, `jit_runner_name` set), concluded to `completed` on the authoritative `workflow_job=completed` webhook; the machine stayed `online` with its pool intact (capacity released, not leaked).
