### PR TITLE
fix(daemon): reconcile vmnet routes after restart

### DIFF
--- a/app/arcbox-cli/src/commands/doctor.rs
+++ b/app/arcbox-cli/src/commands/doctor.rs
@@ -45,7 +45,7 @@ pub async fn execute() -> Result<()> {
     {
         check!("Bridge NIC", check_bridge_nic());
         check!("Container route", check_container_route());
-        check!("ArcBoxHelper", check_helper());
+        check!("ArcBoxHelper", check_helper().await);
     }
 
     // -- Summary --
@@ -211,23 +211,21 @@ fn check_container_route() -> CheckResult {
     }
 }
 
-/// Check if ArcBoxHelper is running and reachable.
+/// Check if arcbox-helper is reachable through launchd socket activation.
 #[cfg(target_os = "macos")]
-fn check_helper() -> CheckResult {
-    let Ok(output) = Command::new("pgrep").args(["-f", "ArcBoxHelper"]).output() else {
-        return CheckResult::Fail("pgrep failed".into());
-    };
-    let pids = String::from_utf8_lossy(&output.stdout);
-    if pids.trim().is_empty() {
-        return CheckResult::Fail("ArcBoxHelper not running".into());
-    }
-
-    // Check binary exists in expected location.
-    let helper_path = "/Applications/ArcBox.app/Contents/Library/HelperTools/ArcBoxHelper";
-    if std::path::Path::new(helper_path).exists() {
-        CheckResult::Pass("running".into())
-    } else {
-        CheckResult::Warn("process running but binary not found in app bundle".into())
+async fn check_helper() -> CheckResult {
+    let expected = env!("CARGO_PKG_VERSION");
+    match arcbox_helper::client::Client::connect().await {
+        Ok(client) => match client.version().await {
+            Ok(version) if version == expected => {
+                CheckResult::Pass(format!("reachable (version {version})"))
+            }
+            Ok(version) => CheckResult::Fail(format!(
+                "version {version}, expected {expected}; run 'sudo abctl _install --no-daemon --no-shell'"
+            )),
+            Err(e) => CheckResult::Fail(format!("version check failed: {e}")),
+        },
+        Err(e) => CheckResult::Fail(format!("not reachable via launchd socket: {e}")),
     }
 }
 

--- a/app/arcbox-daemon/src/recovery.rs
+++ b/app/arcbox-daemon/src/recovery.rs
@@ -19,11 +19,29 @@ use crate::self_setup::SetupTask as _;
 pub async fn run(ctx: &DaemonContext, runtime: &Arc<Runtime>) {
     recover_container_networking(runtime, &ctx.setup_state).await;
 
-    // Cold-start route reconcile (non-blocking).
-    #[cfg(target_os = "macos")]
+    // Cold-start route reconcile (non-blocking). This is load-bearing after
+    // app updates or daemon restarts where the VM survives but the host route
+    // may have been removed or stolen by another network service.
+    #[cfg(all(target_os = "macos", feature = "vmnet"))]
     {
         use arcbox_core::DEFAULT_MACHINE_NAME;
-        if let Some(mac) = runtime.machine_manager().bridge_mac(DEFAULT_MACHINE_NAME) {
+        if let Some(ColdStartRoutePlan::VmnetBridge(bridge)) = cold_start_route_plan(
+            runtime
+                .machine_manager()
+                .vmnet_bridge_name(DEFAULT_MACHINE_NAME),
+            None,
+        ) {
+            spawn_vmnet_route_reconcile(Arc::clone(&ctx.setup_state), bridge);
+        }
+    }
+
+    #[cfg(all(target_os = "macos", not(feature = "vmnet")))]
+    {
+        use arcbox_core::DEFAULT_MACHINE_NAME;
+        if let Some(ColdStartRoutePlan::BridgeMac(mac)) = cold_start_route_plan(
+            None,
+            runtime.machine_manager().bridge_mac(DEFAULT_MACHINE_NAME),
+        ) {
             let setup_state = Arc::clone(&ctx.setup_state);
             drop(tokio::spawn(async move {
                 match arcbox_core::route_reconciler::ensure_route_with_retry(&mac).await {
@@ -85,6 +103,75 @@ pub async fn run(ctx: &DaemonContext, runtime: &Arc<Runtime>) {
                 }
             }
         });
+    }
+}
+
+#[cfg(target_os = "macos")]
+#[derive(Debug, PartialEq, Eq)]
+enum ColdStartRoutePlan {
+    #[cfg(feature = "vmnet")]
+    VmnetBridge(String),
+    #[cfg(not(feature = "vmnet"))]
+    BridgeMac(String),
+}
+
+#[cfg(all(target_os = "macos", feature = "vmnet"))]
+fn cold_start_route_plan(
+    vmnet_bridge: Option<String>,
+    _bridge_mac: Option<String>,
+) -> Option<ColdStartRoutePlan> {
+    vmnet_bridge.map(ColdStartRoutePlan::VmnetBridge)
+}
+
+#[cfg(all(target_os = "macos", not(feature = "vmnet")))]
+fn cold_start_route_plan(
+    _vmnet_bridge: Option<String>,
+    bridge_mac: Option<String>,
+) -> Option<ColdStartRoutePlan> {
+    bridge_mac.map(ColdStartRoutePlan::BridgeMac)
+}
+
+#[cfg(all(target_os = "macos", feature = "vmnet"))]
+fn spawn_vmnet_route_reconcile(setup_state: Arc<arcbox_api::SetupState>, bridge: String) {
+    drop(tokio::spawn(async move {
+        match arcbox_core::route_reconciler::ensure_route_for_bridge(&bridge).await {
+            Ok(()) => setup_state.set_route_installed(true),
+            Err(e) => {
+                tracing::warn!(error = %e, "failed to install container route on cold start (vmnet)");
+            }
+        }
+    }));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[cfg(all(target_os = "macos", feature = "vmnet"))]
+    #[test]
+    fn cold_start_route_plan_uses_vmnet_bridge() {
+        let plan = cold_start_route_plan(Some("bridge100".to_string()), None);
+
+        assert_eq!(
+            plan,
+            Some(ColdStartRoutePlan::VmnetBridge("bridge100".to_string()))
+        );
+    }
+
+    #[cfg(all(target_os = "macos", feature = "vmnet"))]
+    #[test]
+    fn cold_start_route_plan_skips_when_vmnet_bridge_is_unknown() {
+        let plan = cold_start_route_plan(None, Some("fe:b2:14:4d:a4:64".to_string()));
+
+        assert_eq!(plan, None);
+    }
+
+    #[cfg(all(target_os = "macos", not(feature = "vmnet")))]
+    #[test]
+    fn cold_start_route_plan_uses_bridge_mac_without_vmnet() {
+        let plan = cold_start_route_plan(Some("bridge100".to_string()), Some("mac".to_string()));
+
+        assert_eq!(plan, Some(ColdStartRoutePlan::BridgeMac("mac".to_string())));
     }
 }
 

--- a/app/arcbox-daemon/src/self_setup.rs
+++ b/app/arcbox-daemon/src/self_setup.rs
@@ -48,6 +48,20 @@ pub async fn run(tasks: &[&dyn SetupTask]) {
         }
     };
 
+    let expected_version = env!("CARGO_PKG_VERSION");
+    match client.version().await {
+        Ok(version) if version == expected_version => {}
+        Ok(version) => tracing::warn!(
+            helper_version = %version,
+            daemon_version = expected_version,
+            "arcbox-helper version differs from daemon; run 'sudo abctl _install --no-daemon --no-shell'"
+        ),
+        Err(e) => tracing::warn!(
+            error = %e,
+            "failed to check arcbox-helper version"
+        ),
+    }
+
     for task in tasks {
         let name = task.name();
 


### PR DESCRIPTION
## Summary
- Reconcile the container subnet route through the vmnet bridge during daemon cold-start recovery
- Detect arcbox-helper/daemon version drift during self-setup