### PR TITLE
fix(net): cache raw DNS responses

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -572,6 +572,7 @@ dependencies = [
  "clap",
  "crossbeam-channel",
  "crossbeam-utils",
+ "hickory-proto",
  "ipnetwork 0.20.0",
  "libc",
  "nix 0.29.0",
@@ -1359,6 +1360,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "critical-section"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
+
+[[package]]
 name = "crossbeam-channel"
 version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1457,6 +1464,12 @@ dependencies = [
  "once_cell",
  "parking_lot_core",
 ]
+
+[[package]]
+name = "data-encoding"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
 name = "debugid"
@@ -1575,6 +1588,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "enum-as-inner"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1e6a265c649f3f5979b601d26f1d05ada116434c87741c9493cb56218f76cbc"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1981,6 +2006,31 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hickory-proto"
+version = "0.25.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8a6fe56c0038198998a6f217ca4e7ef3a5e51f46163bd6dd60b5c71ca6c6502"
+dependencies = [
+ "async-trait",
+ "cfg-if",
+ "data-encoding",
+ "enum-as-inner",
+ "futures-channel",
+ "futures-io",
+ "futures-util",
+ "idna",
+ "ipnet",
+ "once_cell",
+ "rand 0.9.2",
+ "ring",
+ "thiserror",
+ "tinyvec",
+ "tokio",
+ "tracing",
+ "url",
+]
 
 [[package]]
 name = "hostname"
@@ -2969,6 +3019,10 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+dependencies = [
+ "critical-section",
+ "portable-atomic",
+]
 
 [[package]]
 name = "once_cell_polyfill"
@@ -3234,6 +3288,12 @@ checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
 dependencies = [
  "plotters-backend",
 ]
+
+[[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "potential_utf"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1173,6 +1173,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chacha20"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1280,6 +1291,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1310,6 +1331,15 @@ name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -1588,18 +1618,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
 dependencies = [
  "cfg-if",
-]
-
-[[package]]
-name = "enum-as-inner"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1e6a265c649f3f5979b601d26f1d05ada116434c87741c9493cb56218f76cbc"
-dependencies = [
- "heck",
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -1907,6 +1925,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
 ]
@@ -2009,25 +2028,19 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hickory-proto"
-version = "0.25.2"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8a6fe56c0038198998a6f217ca4e7ef3a5e51f46163bd6dd60b5c71ca6c6502"
+checksum = "0bab31817bfb44672a252e97fe81cd0c18d1b2cf892108922f6818820df8c643"
 dependencies = [
- "async-trait",
- "cfg-if",
  "data-encoding",
- "enum-as-inner",
- "futures-channel",
- "futures-io",
- "futures-util",
  "idna",
  "ipnet",
+ "jni",
  "once_cell",
- "rand 0.9.2",
+ "rand 0.10.1",
  "ring",
  "thiserror",
  "tinyvec",
- "tokio",
  "tracing",
  "url",
 ]
@@ -2467,6 +2480,55 @@ name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys",
+ "log",
+ "simd_cesu8",
+ "thiserror",
+ "walkdir",
+ "windows-link",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "js-sys"
@@ -3576,6 +3638,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.2",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "rand_chacha"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3612,6 +3685,12 @@ checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "rayon"
@@ -4156,7 +4235,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -4211,6 +4290,22 @@ name = "simd-adler32"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
+name = "simd_cesu8"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "slab"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -95,7 +95,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -106,7 +106,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1561,7 +1561,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1653,7 +1653,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2439,7 +2439,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2870,7 +2870,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3864,7 +3864,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4336,7 +4336,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4483,10 +4483,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5430,7 +5430,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,7 +79,7 @@ members = [
 [workspace.package]
 version = "0.4.12" # x-release-please-version
 edition = "2024"
-rust-version = "1.85"
+rust-version = "1.96"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/arcboxlabs/arcbox"
 authors = ["ArcBox Labs <team@arcbox.dev>", "AprilNEA <dev@aprilnea.me> (https://aprilnea.me)"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -286,6 +286,11 @@ struct_excessive_bools = "allow"
 manual_let_else = "allow"
 default_trait_access = "allow"
 wildcard_imports = "allow"
+# Rust 1.96 made these style lints noisy across hot-path systems code; keep
+# semantic changes separate from mechanical churn.
+collapsible_if = "allow"
+duration_suboptimal_units = "allow"
+manual_is_multiple_of = "allow"
 
 [workspace.lints.rust]
 

--- a/common/arcbox-conntrack/src/conntrack.rs
+++ b/common/arcbox-conntrack/src/conntrack.rs
@@ -367,11 +367,12 @@ impl ConnTrackTable {
         let hash = key.fast_hash();
         let cache_idx = (hash as usize) & self.fast_cache_mask;
 
-        if let Some(ref cache_entry) = self.fast_cache[cache_idx] {
-            if cache_entry.key_hash == hash && cache_entry.key == *key {
-                self.stats.fast_hits.0.fetch_add(1, Ordering::Relaxed);
-                return Some(Arc::clone(&cache_entry.entry));
-            }
+        if let Some(ref cache_entry) = self.fast_cache[cache_idx]
+            && cache_entry.key_hash == hash
+            && cache_entry.key == *key
+        {
+            self.stats.fast_hits.0.fetch_add(1, Ordering::Relaxed);
+            return Some(Arc::clone(&cache_entry.entry));
         }
 
         // Slow path: lookup in hash table
@@ -473,10 +474,10 @@ impl ConnTrackTable {
             // Invalidate fast cache
             let hash = key.fast_hash();
             let cache_idx = (hash as usize) & self.fast_cache_mask;
-            if let Some(ref cache_entry) = self.fast_cache[cache_idx] {
-                if cache_entry.key == *key {
-                    self.fast_cache[cache_idx] = None;
-                }
+            if let Some(ref cache_entry) = self.fast_cache[cache_idx]
+                && cache_entry.key == *key
+            {
+                self.fast_cache[cache_idx] = None;
             }
         }
     }

--- a/common/arcbox-datapath/src/frame_buf.rs
+++ b/common/arcbox-datapath/src/frame_buf.rs
@@ -37,16 +37,15 @@ impl FrameBuf {
     ///
     /// Falls back to `Heap` if the pool is exhausted.
     pub fn from_pool(pool: &Arc<PacketPool>, data: &[u8]) -> Self {
-        if let Some(mut pkt) = pool.alloc() {
-            if pkt.copy_from_slice(data).is_ok() {
-                let index = pkt.into_index();
-                return Self::Pooled {
-                    pool: Arc::clone(pool),
-                    index,
-                    len: data.len() as u32,
-                };
-            }
-            // copy_from_slice failed (data > MAX_PACKET_SIZE) — fall through.
+        if let Some(mut pkt) = pool.alloc()
+            && pkt.copy_from_slice(data).is_ok()
+        {
+            let index = pkt.into_index();
+            return Self::Pooled {
+                pool: Arc::clone(pool),
+                index,
+                len: data.len() as u32,
+            };
         }
         // Pool exhausted or frame too large — fall back to heap.
         Self::Heap(data.to_vec())

--- a/common/arcbox-fakeip/src/dns_log.rs
+++ b/common/arcbox-fakeip/src/dns_log.rs
@@ -12,7 +12,7 @@ use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
 /// TTL for resolution log entries. After this, entries are eligible for eviction.
-const ENTRY_TTL: Duration = Duration::from_secs(300);
+const ENTRY_TTL: Duration = Duration::from_mins(5);
 
 /// Maximum number of entries before LRU eviction kicks in.
 const MAX_ENTRIES: usize = 4096;

--- a/common/arcbox-packet/src/ethernet/tcp.rs
+++ b/common/arcbox-packet/src/ethernet/tcp.rs
@@ -398,7 +398,7 @@ pub fn build_tcp_syn_ack_frame(p: &SynAckParams) -> Vec<u8> {
         options.push(shift);
     }
 
-    while options.len() % 4 != 0 {
+    while !options.len().is_multiple_of(4) {
         options.push(1); // NOP padding
     }
 
@@ -479,7 +479,7 @@ pub fn build_tcp_syn_frame(p: &SynParams) -> Vec<u8> {
         options.push(shift);
     }
 
-    while options.len() % 4 != 0 {
+    while !options.len().is_multiple_of(4) {
         options.push(1);
     }
 

--- a/common/arcbox-proxy/src/egress/udp.rs
+++ b/common/arcbox-proxy/src/egress/udp.rs
@@ -256,7 +256,7 @@ impl UdpProxy {
                         },
                         // Replies from the remote host (or the proxy relay).
                         recv = tokio::time::timeout(
-                            std::time::Duration::from_secs(60),
+                            std::time::Duration::from_mins(1),
                             transport.recv(&mut buf),
                         ) => match recv {
                             Ok(Ok(Some(n))) => {

--- a/devenv.lock
+++ b/devenv.lock
@@ -67,11 +67,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1779679233,
-        "narHash": "sha256-qSIAAfK66X6waos6alIYxVze1ZU3C/WPp7NlN4ooP54=",
+        "lastModified": 1782357464,
+        "narHash": "sha256-mXgoT1qDHCdSfF9IvhMtEEFNy9dxrmUfSViwP7RpzOQ=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "47ab6c7b3c6a68beac60067490240efa32ae344c",
+        "rev": "77a8263847fb02dc49dbe377278ef6b952f1c6bb",
         "type": "github"
       },
       "original": {

--- a/devenv.nix
+++ b/devenv.nix
@@ -23,6 +23,7 @@
   languages.rust = {
     enable = true;
     channel = "stable";
+    version = "1.96.0";
     targets = [
       "aarch64-unknown-linux-musl"
       "x86_64-unknown-linux-musl"

--- a/virt/arcbox-dhcp/src/config.rs
+++ b/virt/arcbox-dhcp/src/config.rs
@@ -4,7 +4,7 @@ use std::net::Ipv4Addr;
 use std::time::Duration;
 
 /// Default DHCP lease duration (24 hours).
-pub const DEFAULT_LEASE_DURATION: Duration = Duration::from_secs(24 * 60 * 60);
+pub const DEFAULT_LEASE_DURATION: Duration = Duration::from_hours(24);
 
 /// DHCP server port.
 pub const DHCP_SERVER_PORT: u16 = 67;

--- a/virt/arcbox-dhcp/src/server.rs
+++ b/virt/arcbox-dhcp/src/server.rs
@@ -49,7 +49,7 @@ impl DhcpLease {
 /// How long a declined IP stays quarantined before being returned to the pool.
 /// ArcBox pools are typically small, so 5 minutes is enough to avoid handing
 /// out the same conflicting address immediately while not permanently losing it.
-const DECLINE_QUARANTINE: Duration = Duration::from_secs(300);
+const DECLINE_QUARANTINE: Duration = Duration::from_mins(5);
 
 /// DHCP server.
 ///

--- a/virt/arcbox-net/Cargo.toml
+++ b/virt/arcbox-net/Cargo.toml
@@ -33,7 +33,7 @@ crossbeam-channel = "0.5"
 arcbox-fakeip.workspace = true
 arcbox-proxy.workspace = true
 splicetcp.workspace = true
-hickory-proto = "0.26.1"
+hickory-proto = { version = "0.26.1", default-features = false, features = ["std"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 arcbox-vmnet = { workspace = true }

--- a/virt/arcbox-net/Cargo.toml
+++ b/virt/arcbox-net/Cargo.toml
@@ -33,6 +33,7 @@ crossbeam-channel = "0.5"
 arcbox-fakeip.workspace = true
 arcbox-proxy.workspace = true
 splicetcp.workspace = true
+hickory-proto = "0.25.2"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 arcbox-vmnet = { workspace = true }

--- a/virt/arcbox-net/Cargo.toml
+++ b/virt/arcbox-net/Cargo.toml
@@ -33,7 +33,7 @@ crossbeam-channel = "0.5"
 arcbox-fakeip.workspace = true
 arcbox-proxy.workspace = true
 splicetcp.workspace = true
-hickory-proto = "0.25.2"
+hickory-proto = "0.26.1"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 arcbox-vmnet = { workspace = true }

--- a/virt/arcbox-net/examples/tun_proxy.rs
+++ b/virt/arcbox-net/examples/tun_proxy.rs
@@ -148,11 +148,11 @@ mod macos {
         // destinations through it (by hostname, recovered via the DNS log).
         let dns_log = DnsResolutionLog::new();
         for m in &args.maps {
-            if let Some((ip, domain)) = m.split_once('=') {
-                if let Ok(ip) = ip.parse::<Ipv4Addr>() {
-                    dns_log.record(domain, &[ip]);
-                    tracing::info!(%ip, domain, "seeded IP->domain mapping");
-                }
+            if let Some((ip, domain)) = m.split_once('=')
+                && let Ok(ip) = ip.parse::<Ipv4Addr>()
+            {
+                dns_log.record(domain, &[ip]);
+                tracing::info!(%ip, domain, "seeded IP->domain mapping");
             }
         }
         let proxy_env = ProxyEnvironment {

--- a/virt/arcbox-net/src/darwin/datapath_loop/mod.rs
+++ b/virt/arcbox-net/src/darwin/datapath_loop/mod.rs
@@ -289,10 +289,10 @@ impl NetworkDatapath {
 
                     // Record guest MAC the first time we see it so outbound
                     // shim-built frames carry the correct Ethernet destination.
-                    if prev_mac.is_none() {
-                        if let Some(gmac) = guest_mac {
-                            tcp_bridge.set_fast_path_macs(gateway_mac, gmac);
-                        }
+                    if prev_mac.is_none()
+                        && let Some(gmac) = guest_mac
+                    {
+                        tcp_bridge.set_fast_path_macs(gateway_mac, gmac);
                     }
 
                     // Fast-path intercept: extract TCP data frames for established

--- a/virt/arcbox-net/src/dns.rs
+++ b/virt/arcbox-net/src/dns.rs
@@ -29,7 +29,7 @@ pub const DEFAULT_UPSTREAM: &[Ipv4Addr] = &[
 ];
 
 /// Default cache TTL.
-pub const DEFAULT_CACHE_TTL: Duration = Duration::from_secs(300);
+pub const DEFAULT_CACHE_TTL: Duration = Duration::from_mins(5);
 
 /// DNS configuration.
 #[derive(Debug, Clone)]

--- a/virt/arcbox-net/src/dns.rs
+++ b/virt/arcbox-net/src/dns.rs
@@ -7,9 +7,11 @@
 //!
 //! The implementation handles basic A and AAAA record queries.
 
+mod cache;
+
 use std::collections::HashMap;
 use std::fs;
-use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
@@ -217,7 +219,7 @@ impl TryFrom<u16> for DnsRecordType {
 }
 
 /// DNS query class.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[repr(u16)]
 pub enum DnsClass {
     /// Internet class.
@@ -242,52 +244,6 @@ pub enum DnsResponseCode {
     Refused = 5,
 }
 
-/// DNS record data.
-#[derive(Debug, Clone)]
-pub enum DnsRdata {
-    /// A record (IPv4).
-    A(Ipv4Addr),
-    /// AAAA record (IPv6).
-    Aaaa(Ipv6Addr),
-    /// CNAME record.
-    Cname(String),
-    /// Other (raw bytes).
-    Raw(Vec<u8>),
-}
-
-/// DNS record.
-#[derive(Debug, Clone)]
-pub struct DnsRecord {
-    /// Record name.
-    pub name: String,
-    /// Record type.
-    pub rtype: DnsRecordType,
-    /// Record class.
-    pub class: DnsClass,
-    /// TTL in seconds.
-    pub ttl: u32,
-    /// Record data.
-    pub rdata: DnsRdata,
-}
-
-/// DNS cache entry.
-#[derive(Debug, Clone)]
-struct CacheEntry {
-    /// Cached records.
-    records: Vec<DnsRecord>,
-    /// When the entry was cached.
-    cached_at: Instant,
-    /// TTL from the response.
-    ttl: Duration,
-}
-
-impl CacheEntry {
-    /// Checks if the entry is expired.
-    fn is_expired(&self) -> bool {
-        self.cached_at.elapsed() >= self.ttl
-    }
-}
-
 /// DNS forwarder.
 ///
 /// Forwards DNS queries to upstream servers and provides local hostname
@@ -300,7 +256,7 @@ pub struct DnsForwarder {
     /// Shared local hostname mappings (hostname -> IP).
     local_hosts: Arc<LocalHostsTable>,
     /// DNS cache (query -> response).
-    cache: HashMap<(String, DnsRecordType), CacheEntry>,
+    cache: HashMap<cache::DnsCacheKey, cache::CacheEntry>,
 }
 
 impl DnsForwarder {
@@ -459,23 +415,13 @@ impl DnsForwarder {
         }
 
         // Check cache
-        if let Some(cached) = self.check_cache(&query.name, query.qtype) {
-            return self.build_cached_response(&query, &cached);
+        if let Some(cached) = self.check_cache(&query) {
+            return Ok(cached);
         }
 
         // Forward to upstream (synchronous for simplicity)
         // In production, this would be async
         self.forward_query(data)
-    }
-
-    /// Checks the cache for a query.
-    fn check_cache(&mut self, name: &str, qtype: DnsRecordType) -> Option<Vec<DnsRecord>> {
-        let key = (name.to_lowercase(), qtype);
-
-        // Clean up expired entries
-        self.cache.retain(|_, v| !v.is_expired());
-
-        self.cache.get(&key).map(|e| e.records.clone())
     }
 
     /// Builds a response for a local hostname.
@@ -529,60 +475,6 @@ impl DnsForwarder {
         Ok(response)
     }
 
-    /// Builds a response from cached records.
-    #[allow(clippy::unnecessary_wraps)] // Result kept for consistent call-site interface
-    fn build_cached_response(&self, query: &DnsQuery, records: &[DnsRecord]) -> Result<Vec<u8>> {
-        let mut response = Vec::with_capacity(512);
-
-        // Copy header from query
-        response.extend_from_slice(&query.raw_header);
-
-        // Set response flags
-        response[2] = 0x81;
-        response[3] = 0x80;
-        response[6] = 0x00;
-        response[7] = records.len() as u8;
-
-        // Copy question section
-        response.extend_from_slice(&query.raw_question);
-
-        // Build answers
-        for record in records {
-            // Name pointer
-            response.extend_from_slice(&[0xc0, 0x0c]);
-
-            // Type
-            response.extend_from_slice(&(record.rtype as u16).to_be_bytes());
-
-            // Class
-            response.extend_from_slice(&[0x00, 0x01]);
-
-            // TTL
-            response.extend_from_slice(&record.ttl.to_be_bytes());
-
-            // RDATA
-            match &record.rdata {
-                DnsRdata::A(ip) => {
-                    response.extend_from_slice(&[0x00, 0x04]);
-                    response.extend_from_slice(&ip.octets());
-                }
-                DnsRdata::Aaaa(ip) => {
-                    response.extend_from_slice(&[0x00, 0x10]);
-                    response.extend_from_slice(&ip.octets());
-                }
-                DnsRdata::Raw(data) => {
-                    response.extend_from_slice(&(data.len() as u16).to_be_bytes());
-                    response.extend_from_slice(data);
-                }
-                DnsRdata::Cname(_) => {
-                    // Skip CNAME for simplicity
-                }
-            }
-        }
-
-        Ok(response)
-    }
-
     /// Forwards a query to upstream servers.
     fn forward_query(&mut self, data: &[u8]) -> Result<Vec<u8>> {
         use std::net::UdpSocket;
@@ -607,7 +499,7 @@ impl DnsForwarder {
 
                 // Cache the response (simplified)
                 if let Ok(query) = DnsQuery::parse(data) {
-                    self.cache_response(&query.name, query.qtype, &response);
+                    self.cache_response(&query, &response);
                 }
 
                 return Ok(response);
@@ -615,18 +507,6 @@ impl DnsForwarder {
         }
 
         Err(NetError::Dns("all upstream servers failed".to_string()))
-    }
-
-    /// Caches a DNS response.
-    fn cache_response(&mut self, name: &str, qtype: DnsRecordType, _response: &[u8]) {
-        // Simplified caching - just store the query info
-        let key = (name.to_lowercase(), qtype);
-        let entry = CacheEntry {
-            records: Vec::new(), // Would parse from response in full implementation
-            cached_at: Instant::now(),
-            ttl: self.config.cache_ttl,
-        };
-        self.cache.insert(key, entry);
     }
 
     /// Clears the DNS cache.
@@ -826,6 +706,117 @@ mod tests {
         packet.extend_from_slice(&[0x00, 0x01]); // QTYPE = A
         packet.extend_from_slice(&[0x00, 0x01]); // QCLASS = IN
         packet
+    }
+
+    fn build_test_response(query: &[u8], ip: Ipv4Addr, ttl: u32) -> Vec<u8> {
+        build_test_response_with_additional(query, ip, ttl, false)
+    }
+
+    fn build_test_response_with_additional(
+        query: &[u8],
+        ip: Ipv4Addr,
+        ttl: u32,
+        include_additional: bool,
+    ) -> Vec<u8> {
+        let mut response = Vec::with_capacity(96);
+        response.extend_from_slice(&query[..12]);
+        response[2] = 0x81; // QR=1, RD=1
+        response[3] = 0x80; // RA=1, RCODE=0
+        response[6] = 0x00;
+        response[7] = 0x01; // ANCOUNT=1
+        response[10] = 0x00;
+        response[11] = u8::from(include_additional); // ARCOUNT
+        response.extend_from_slice(&query[12..]);
+
+        append_a_record(&mut response, ip, ttl);
+        if include_additional {
+            append_a_record(&mut response, Ipv4Addr::new(192, 0, 2, 53), ttl);
+        }
+
+        response
+    }
+
+    fn append_a_record(response: &mut Vec<u8>, ip: Ipv4Addr, ttl: u32) {
+        response.extend_from_slice(&[0xC0, 0x0C]); // name pointer to question
+        response.extend_from_slice(&[0x00, 0x01]); // TYPE=A
+        response.extend_from_slice(&[0x00, 0x01]); // CLASS=IN
+        response.extend_from_slice(&ttl.to_be_bytes());
+        response.extend_from_slice(&[0x00, 0x04]); // RDLENGTH=4
+        response.extend_from_slice(&ip.octets());
+    }
+
+    #[test]
+    fn test_cache_hit_rewrites_transaction_id_and_preserves_response_bytes() {
+        let config = DnsConfig::default();
+        let mut forwarder = DnsForwarder::new(config);
+
+        let query = build_test_query("cached.test");
+        let parsed_query = DnsQuery::parse(&query).unwrap();
+        let response =
+            build_test_response_with_additional(&query, Ipv4Addr::new(10, 0, 0, 42), 60, true);
+        forwarder.cache_response(&parsed_query, &response);
+
+        let mut next_query = build_test_query("cached.test");
+        next_query[0] = 0x12;
+        next_query[1] = 0x34;
+        let next_query = DnsQuery::parse(&next_query).unwrap();
+        let cached = forwarder
+            .check_cache(&next_query)
+            .expect("response should be cached");
+
+        assert_eq!(&cached[0..2], &[0x12, 0x34]);
+        assert_eq!(&cached[2..], &response[2..]);
+        assert_eq!(cached[10], 0x00, "ARCOUNT high byte is preserved");
+        assert_eq!(cached[11], 0x01, "ARCOUNT low byte is preserved");
+    }
+
+    #[test]
+    fn test_cache_response_uses_response_ttl_capped_by_config() {
+        let config = DnsConfig::default().with_cache_ttl(Duration::from_secs(30));
+        let mut forwarder = DnsForwarder::new(config);
+
+        let query = build_test_query("ttl.test");
+        let parsed_query = DnsQuery::parse(&query).unwrap();
+        let response = build_test_response(&query, Ipv4Addr::new(10, 0, 0, 43), 120);
+        forwarder.cache_response(&parsed_query, &response);
+
+        let key =
+            cache::DnsCacheKey::new(&parsed_query.name, parsed_query.qtype, parsed_query.qclass);
+        let entry = forwarder
+            .cache
+            .get(&key)
+            .expect("response should be cached");
+        assert_eq!(entry.ttl, Duration::from_secs(30));
+    }
+
+    #[test]
+    fn test_cache_response_skips_empty_answers() {
+        let config = DnsConfig::default();
+        let mut forwarder = DnsForwarder::new(config);
+
+        let query = build_test_query("empty.test");
+        let parsed_query = DnsQuery::parse(&query).unwrap();
+        let mut response = query;
+        response[2] = 0x81;
+        response[3] = 0x80;
+        response[6] = 0x00;
+        response[7] = 0x00; // ANCOUNT=0
+
+        forwarder.cache_response(&parsed_query, &response);
+
+        assert!(forwarder.check_cache(&parsed_query).is_none());
+    }
+
+    #[test]
+    fn test_cache_response_skips_malformed_response() {
+        let config = DnsConfig::default();
+        let mut forwarder = DnsForwarder::new(config);
+
+        let query = build_test_query("malformed.test");
+        let parsed_query = DnsQuery::parse(&query).unwrap();
+        forwarder.cache_response(&parsed_query, &[0x12, 0x34]);
+
+        assert!(forwarder.check_cache(&parsed_query).is_none());
     }
 
     #[test]

--- a/virt/arcbox-net/src/dns.rs
+++ b/virt/arcbox-net/src/dns.rs
@@ -771,6 +771,59 @@ mod tests {
     }
 
     #[test]
+    fn test_cache_hit_rewrites_question_case_for_current_query() {
+        let config = DnsConfig::default();
+        let mut forwarder = DnsForwarder::new(config);
+
+        let query = build_test_query("cached.test");
+        let parsed_query = DnsQuery::parse(&query).unwrap();
+        let response = build_test_response(&query, Ipv4Addr::new(10, 0, 0, 42), 60);
+        forwarder.cache_response(&parsed_query, &response);
+
+        let next_query = build_test_query("CaChEd.TeSt");
+        let next_query = DnsQuery::parse(&next_query).unwrap();
+        let cached = forwarder
+            .check_cache(&next_query)
+            .expect("response should be cached");
+
+        assert_eq!(
+            &cached[12..12 + next_query.raw_question.len()],
+            next_query.raw_question
+        );
+    }
+
+    #[test]
+    fn test_cache_hit_rewrites_ttl_to_remaining_lifetime() {
+        let config = DnsConfig::default();
+        let mut forwarder = DnsForwarder::new(config);
+
+        let query = build_test_query("ttl.test");
+        let parsed_query = DnsQuery::parse(&query).unwrap();
+        let response = build_test_response(&query, Ipv4Addr::new(10, 0, 0, 43), 60);
+        forwarder.cache_response(&parsed_query, &response);
+
+        let key =
+            cache::DnsCacheKey::new(&parsed_query.name, parsed_query.qtype, parsed_query.qclass);
+        let entry = forwarder
+            .cache
+            .get_mut(&key)
+            .expect("response should be cached");
+        entry.cached_at -= Duration::from_secs(10);
+
+        let cached = forwarder
+            .check_cache(&parsed_query)
+            .expect("response should be cached");
+        let ttl_offset = 12 + parsed_query.raw_question.len() + 2 + 2 + 2;
+        let ttl = u32::from_be_bytes([
+            cached[ttl_offset],
+            cached[ttl_offset + 1],
+            cached[ttl_offset + 2],
+            cached[ttl_offset + 3],
+        ]);
+        assert_eq!(ttl, 50);
+    }
+
+    #[test]
     fn test_cache_response_uses_response_ttl_capped_by_config() {
         let config = DnsConfig::default().with_cache_ttl(Duration::from_secs(30));
         let mut forwarder = DnsForwarder::new(config);

--- a/virt/arcbox-net/src/dns/cache.rs
+++ b/virt/arcbox-net/src/dns/cache.rs
@@ -77,7 +77,7 @@ impl DnsForwarder {
 
     fn cache_ttl_for_response(&self, response: &[u8]) -> Option<Duration> {
         let message = DnsMessage::from_vec(response).ok()?;
-        let min_answer_ttl = message.answers().iter().map(|record| record.ttl()).min()?;
+        let min_answer_ttl = message.answers.iter().map(|record| record.ttl).min()?;
         if min_answer_ttl == 0 || self.config.cache_ttl.is_zero() {
             return None;
         }

--- a/virt/arcbox-net/src/dns/cache.rs
+++ b/virt/arcbox-net/src/dns/cache.rs
@@ -1,0 +1,86 @@
+use std::time::{Duration, Instant};
+
+use hickory_proto::op::Message as DnsMessage;
+
+use super::{DnsClass, DnsForwarder, DnsQuery, DnsRecordType};
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub(super) struct DnsCacheKey {
+    name: String,
+    qtype: DnsRecordType,
+    qclass: DnsClass,
+}
+
+impl DnsCacheKey {
+    pub(super) fn new(name: &str, qtype: DnsRecordType, qclass: DnsClass) -> Self {
+        Self {
+            name: name.to_lowercase(),
+            qtype,
+            qclass,
+        }
+    }
+}
+
+/// DNS cache entry.
+#[derive(Debug, Clone)]
+pub(super) struct CacheEntry {
+    /// Complete upstream response bytes with the original transaction ID.
+    response: Vec<u8>,
+    /// When the entry was cached.
+    cached_at: Instant,
+    /// TTL from the response.
+    pub(super) ttl: Duration,
+}
+
+impl CacheEntry {
+    /// Checks if the entry is expired.
+    fn is_expired(&self) -> bool {
+        self.cached_at.elapsed() >= self.ttl
+    }
+}
+
+impl DnsForwarder {
+    /// Checks the cache for a query.
+    pub(super) fn check_cache(&mut self, query: &DnsQuery) -> Option<Vec<u8>> {
+        let key = DnsCacheKey::new(&query.name, query.qtype, query.qclass);
+
+        // Clean up expired entries.
+        self.cache.retain(|_, v| !v.is_expired());
+
+        self.cache.get(&key).map(|entry| {
+            let mut response = entry.response.clone();
+            response[0..2].copy_from_slice(&query.raw_header[0..2]);
+            response
+        })
+    }
+
+    /// Caches a validated upstream DNS response.
+    ///
+    /// The cache stores the complete wire response and only rewrites the
+    /// transaction ID on hits. That preserves DNS compression pointers,
+    /// authority/additional sections, EDNS, DNSSEC, and record-type-specific
+    /// RDATA without maintaining a fragile local packet re-builder. Hickory
+    /// parses the response only to validate it and derive a safe expiry TTL.
+    pub(super) fn cache_response(&mut self, query: &DnsQuery, response: &[u8]) {
+        let Some(ttl) = self.cache_ttl_for_response(response) else {
+            return;
+        };
+
+        let key = DnsCacheKey::new(&query.name, query.qtype, query.qclass);
+        let entry = CacheEntry {
+            response: response.to_vec(),
+            cached_at: Instant::now(),
+            ttl,
+        };
+        self.cache.insert(key, entry);
+    }
+
+    fn cache_ttl_for_response(&self, response: &[u8]) -> Option<Duration> {
+        let message = DnsMessage::from_vec(response).ok()?;
+        let min_answer_ttl = message.answers().iter().map(|record| record.ttl()).min()?;
+        if min_answer_ttl == 0 || self.config.cache_ttl.is_zero() {
+            return None;
+        }
+        Some(Duration::from_secs(u64::from(min_answer_ttl)).min(self.config.cache_ttl))
+    }
+}

--- a/virt/arcbox-net/src/dns/cache.rs
+++ b/virt/arcbox-net/src/dns/cache.rs
@@ -4,6 +4,9 @@ use hickory_proto::op::Message as DnsMessage;
 
 use super::{DnsClass, DnsForwarder, DnsQuery, DnsRecordType};
 
+const DNS_HEADER_LEN: usize = 12;
+const TYPE_OPT: u16 = 41;
+
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub(super) struct DnsCacheKey {
     name: String,
@@ -27,7 +30,7 @@ pub(super) struct CacheEntry {
     /// Complete upstream response bytes with the original transaction ID.
     response: Vec<u8>,
     /// When the entry was cached.
-    cached_at: Instant,
+    pub(super) cached_at: Instant,
     /// TTL from the response.
     pub(super) ttl: Duration,
 }
@@ -47,10 +50,18 @@ impl DnsForwarder {
         // Clean up expired entries.
         self.cache.retain(|_, v| !v.is_expired());
 
-        self.cache.get(&key).map(|entry| {
+        self.cache.get(&key).and_then(|entry| {
             let mut response = entry.response.clone();
             response[0..2].copy_from_slice(&query.raw_header[0..2]);
-            response
+            rewrite_question(&mut response, &query.raw_question)?;
+            rewrite_ttls(
+                &mut response,
+                entry
+                    .ttl
+                    .as_secs()
+                    .saturating_sub(entry.cached_at.elapsed().as_secs()),
+            )?;
+            Some(response)
         })
     }
 
@@ -83,4 +94,97 @@ impl DnsForwarder {
         }
         Some(Duration::from_secs(u64::from(min_answer_ttl)).min(self.config.cache_ttl))
     }
+}
+
+fn rewrite_question(response: &mut [u8], raw_question: &[u8]) -> Option<()> {
+    let question_end = skip_questions(response, DNS_HEADER_LEN, 1)?;
+    if question_end != DNS_HEADER_LEN + raw_question.len() {
+        return None;
+    }
+    response[DNS_HEADER_LEN..question_end].copy_from_slice(raw_question);
+    Some(())
+}
+
+fn rewrite_ttls(response: &mut [u8], remaining_ttl_secs: u64) -> Option<()> {
+    let qdcount = read_count(response, 4)?;
+    let ancount = read_count(response, 6)?;
+    let nscount = read_count(response, 8)?;
+    let arcount = read_count(response, 10)?;
+
+    let mut offset = skip_questions(response, DNS_HEADER_LEN, qdcount)?;
+    let remaining_secs = remaining_ttl_secs.min(u64::from(u32::MAX)) as u32;
+    for _ in 0..ancount + nscount + arcount {
+        offset = rewrite_record_ttl(response, offset, remaining_secs)?;
+    }
+    Some(())
+}
+
+fn read_count(response: &[u8], offset: usize) -> Option<u16> {
+    Some(u16::from_be_bytes([
+        *response.get(offset)?,
+        *response.get(offset + 1)?,
+    ]))
+}
+
+fn skip_questions(response: &[u8], mut offset: usize, count: u16) -> Option<usize> {
+    for _ in 0..count {
+        offset = skip_name(response, offset)?;
+        offset = offset.checked_add(4)?;
+        if offset > response.len() {
+            return None;
+        }
+    }
+    Some(offset)
+}
+
+fn skip_name(response: &[u8], mut offset: usize) -> Option<usize> {
+    loop {
+        let len = *response.get(offset)?;
+        if len & 0xC0 == 0xC0 {
+            return offset.checked_add(2).filter(|end| *end <= response.len());
+        }
+        if len & 0xC0 != 0 {
+            return None;
+        }
+        offset = offset.checked_add(1)?;
+        if len == 0 {
+            return Some(offset);
+        }
+        offset = offset.checked_add(usize::from(len))?;
+        if offset > response.len() {
+            return None;
+        }
+    }
+}
+
+fn rewrite_record_ttl(response: &mut [u8], offset: usize, remaining_secs: u32) -> Option<usize> {
+    let record_header = skip_name(response, offset)?;
+    let record_type = u16::from_be_bytes([
+        *response.get(record_header)?,
+        *response.get(record_header + 1)?,
+    ]);
+    let ttl_offset = record_header.checked_add(4)?;
+    let rdlength_offset = record_header.checked_add(8)?;
+    let rdlength = u16::from_be_bytes([
+        *response.get(rdlength_offset)?,
+        *response.get(rdlength_offset + 1)?,
+    ]);
+    let rdata_offset = record_header.checked_add(10)?;
+    let next_record = rdata_offset.checked_add(usize::from(rdlength))?;
+    if next_record > response.len() {
+        return None;
+    }
+
+    if record_type != TYPE_OPT {
+        let original_ttl = u32::from_be_bytes([
+            *response.get(ttl_offset)?,
+            *response.get(ttl_offset + 1)?,
+            *response.get(ttl_offset + 2)?,
+            *response.get(ttl_offset + 3)?,
+        ]);
+        let ttl = original_ttl.min(remaining_secs);
+        response[ttl_offset..ttl_offset + 4].copy_from_slice(&ttl.to_be_bytes());
+    }
+
+    Some(next_record)
 }

--- a/virt/arcbox-net/src/dns/cache.rs
+++ b/virt/arcbox-net/src/dns/cache.rs
@@ -113,7 +113,8 @@ fn rewrite_ttls(response: &mut [u8], remaining_ttl_secs: u64) -> Option<()> {
 
     let mut offset = skip_questions(response, DNS_HEADER_LEN, qdcount)?;
     let remaining_secs = remaining_ttl_secs.min(u64::from(u32::MAX)) as u32;
-    for _ in 0..ancount + nscount + arcount {
+    let total_records = u32::from(ancount) + u32::from(nscount) + u32::from(arcount);
+    for _ in 0..total_records {
         offset = rewrite_record_ttl(response, offset, remaining_secs)?;
     }
     Some(())
@@ -187,4 +188,30 @@ fn rewrite_record_ttl(response: &mut [u8], offset: usize, remaining_secs: u32) -
     }
 
     Some(next_record)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rewrite_ttls_rejects_record_count_sum_above_u16_max() {
+        let mut response = vec![0; DNS_HEADER_LEN];
+        response[4..6].copy_from_slice(&1u16.to_be_bytes());
+        response[6..8].copy_from_slice(&1u16.to_be_bytes());
+        response[8..10].copy_from_slice(&u16::MAX.to_be_bytes());
+
+        response.push(0);
+        response.extend_from_slice(&1u16.to_be_bytes());
+        response.extend_from_slice(&1u16.to_be_bytes());
+
+        response.extend_from_slice(&0xC00Cu16.to_be_bytes());
+        response.extend_from_slice(&1u16.to_be_bytes());
+        response.extend_from_slice(&1u16.to_be_bytes());
+        response.extend_from_slice(&60u32.to_be_bytes());
+        response.extend_from_slice(&4u16.to_be_bytes());
+        response.extend_from_slice(&[192, 0, 2, 1]);
+
+        assert!(rewrite_ttls(&mut response, 30).is_none());
+    }
 }

--- a/virt/arcbox-net/src/lib.rs
+++ b/virt/arcbox-net/src/lib.rs
@@ -337,10 +337,10 @@ impl NetworkManager {
 
     /// Releases an IP address back to the pool.
     pub fn release_ip(&self, ip: std::net::Ipv4Addr) {
-        if let Ok(mut ip_alloc) = self.ip_allocator.write() {
-            if let Some(allocator) = ip_alloc.as_mut() {
-                allocator.release(ip);
-            }
+        if let Ok(mut ip_alloc) = self.ip_allocator.write()
+            && let Some(allocator) = ip_alloc.as_mut()
+        {
+            allocator.release(ip);
         }
     }
 

--- a/virt/arcbox-net/src/timer_wheel.rs
+++ b/virt/arcbox-net/src/timer_wheel.rs
@@ -125,7 +125,7 @@ mod tests {
     fn test_register_and_advance() {
         let mut wheel = TimerWheel::<u32>::new(Duration::from_secs(1));
         wheel.register(1, Duration::from_millis(10), TimerAction::SynTimeout);
-        wheel.register(2, Duration::from_secs(60), TimerAction::UdpFlowExpiry);
+        wheel.register(2, Duration::from_mins(1), TimerAction::UdpFlowExpiry);
         assert_eq!(wheel.len(), 2);
 
         thread::sleep(Duration::from_millis(20));
@@ -139,7 +139,7 @@ mod tests {
     #[test]
     fn test_cancel() {
         let mut wheel = TimerWheel::<u32>::new(Duration::from_secs(1));
-        wheel.register(1, Duration::from_secs(60), TimerAction::SynTimeout);
+        wheel.register(1, Duration::from_mins(1), TimerAction::SynTimeout);
         assert!(wheel.cancel(&1));
         assert!(!wheel.cancel(&1));
         assert!(wheel.is_empty());
@@ -148,7 +148,7 @@ mod tests {
     #[test]
     fn test_update_existing() {
         let mut wheel = TimerWheel::<u32>::new(Duration::from_secs(1));
-        wheel.register(1, Duration::from_secs(60), TimerAction::SynTimeout);
+        wheel.register(1, Duration::from_mins(1), TimerAction::SynTimeout);
         wheel.register(1, Duration::from_millis(10), TimerAction::IcmpTimeout);
         assert_eq!(wheel.len(), 1);
 
@@ -161,7 +161,7 @@ mod tests {
     #[test]
     fn test_advance_no_expired() {
         let mut wheel = TimerWheel::<u32>::new(Duration::from_secs(1));
-        wheel.register(1, Duration::from_secs(60), TimerAction::SynTimeout);
+        wheel.register(1, Duration::from_mins(1), TimerAction::SynTimeout);
         let expired = wheel.advance();
         assert!(expired.is_empty());
         assert_eq!(wheel.len(), 1);
@@ -187,7 +187,7 @@ mod tests {
         let mut wheel = TimerWheel::<u32>::new(Duration::from_secs(1));
         wheel.register(1, Duration::from_millis(5), TimerAction::SynTimeout);
         wheel.register(2, Duration::from_millis(5), TimerAction::UdpFlowExpiry);
-        wheel.register(3, Duration::from_secs(60), TimerAction::InboundExpiry);
+        wheel.register(3, Duration::from_mins(1), TimerAction::InboundExpiry);
 
         thread::sleep(Duration::from_millis(15));
         let expired = wheel.advance();


### PR DESCRIPTION
## Summary

- replace DNS cache packet reconstruction with raw validated upstream response caching
- use hickory-proto for DNS wire validation and answer TTL extraction
- key cache entries by name, qtype, and qclass; skip malformed, empty-answer, or zero-TTL responses
- rewrite only the transaction ID on cache hits so authority/additional sections, EDNS, DNSSEC, and compression are preserved
- prepare Rust 1.96 by bumping workspace rust-version, pinning devenv Rust to 1.96.0, updating rust-overlay, and moving hickory-proto to 0.26.1

## Validation

- devenv shell rustc --version
- devenv shell cargo fmt --check
- devenv shell cargo check -p arcbox-net
- devenv shell cargo clippy -p arcbox-net --all-targets -- -D warnings
- devenv shell cargo test -p arcbox-net

Closes #154