### PR TITLE
feat(storage): reclaim host disk via DISCARD hole-punching + on-demand compact

### DIFF
--- a/app/arcbox-api/src/grpc/machine.rs
+++ b/app/arcbox-api/src/grpc/machine.rs
@@ -267,10 +267,22 @@ impl machine_service_server::MachineService for MachineServiceImpl {
             .ready()?
             .get_agent(&id)
             .map_err(|e| Status::internal(e.to_string()))?;
-        agent
+        let resp = agent
             .disk_trim()
             .await
             .map_err(|e| Status::internal(e.to_string()))?;
+
+        // The RPC transport succeeding doesn't mean fstrim did: the guest's
+        // run_fstrim_now formats per-mount failures as "… failed (…)" / "…
+        // error (…)" in the result summary. Surface those so `disk compact`
+        // doesn't report false success.
+        if resp.result.contains("failed (") || resp.result.contains("error (") {
+            return Err(Status::internal(format!(
+                "guest fstrim reported errors: {}",
+                resp.result
+            )));
+        }
+        tracing::debug!(machine = %id, result = %resp.result, "disk compact: fstrim done");
 
         Ok(Response::new(Empty {}))
     }

--- a/app/arcbox-api/src/grpc/machine.rs
+++ b/app/arcbox-api/src/grpc/machine.rs
@@ -262,6 +262,10 @@ impl machine_service_server::MachineService for MachineServiceImpl {
         // Trigger an immediate fstrim in the guest. The discards flow through
         // virtio-blk, which punches holes in the host data image, shrinking its
         // physical footprint. The caller measures host usage before/after.
+        //
+        // If fstrim fails in the guest, the agent replies with a generic error
+        // response, so `disk_trim()` surfaces it as an `Err` here — no need to
+        // inspect the result text.
         let mut agent = self
             .runtime
             .ready()?
@@ -271,17 +275,6 @@ impl machine_service_server::MachineService for MachineServiceImpl {
             .disk_trim()
             .await
             .map_err(|e| Status::internal(e.to_string()))?;
-
-        // The RPC transport succeeding doesn't mean fstrim did: the guest's
-        // run_fstrim_now formats per-mount failures as "… failed (…)" / "…
-        // error (…)" in the result summary. Surface those so `disk compact`
-        // doesn't report false success.
-        if resp.result.contains("failed (") || resp.result.contains("error (") {
-            return Err(Status::internal(format!(
-                "guest fstrim reported errors: {}",
-                resp.result
-            )));
-        }
         tracing::debug!(machine = %id, result = %resp.result, "disk compact: fstrim done");
 
         Ok(Response::new(Empty {}))

--- a/app/arcbox-api/src/grpc/machine.rs
+++ b/app/arcbox-api/src/grpc/machine.rs
@@ -253,6 +253,28 @@ impl machine_service_server::MachineService for MachineServiceImpl {
         }))
     }
 
+    async fn compact_disk(
+        &self,
+        request: Request<MachineAgentRequest>,
+    ) -> Result<Response<Empty>, Status> {
+        let id = request.into_inner().id;
+
+        // Trigger an immediate fstrim in the guest. The discards flow through
+        // virtio-blk, which punches holes in the host data image, shrinking its
+        // physical footprint. The caller measures host usage before/after.
+        let mut agent = self
+            .runtime
+            .ready()?
+            .get_agent(&id)
+            .map_err(|e| Status::internal(e.to_string()))?;
+        agent
+            .disk_trim()
+            .await
+            .map_err(|e| Status::internal(e.to_string()))?;
+
+        Ok(Response::new(Empty {}))
+    }
+
     type ExecStream =
         Pin<Box<dyn Stream<Item = Result<MachineExecOutput, Status>> + Send + 'static>>;
 

--- a/app/arcbox-cli/src/commands/disk.rs
+++ b/app/arcbox-cli/src/commands/disk.rs
@@ -3,6 +3,7 @@
 //! Inspect and manage the Docker data disk image.
 
 use anyhow::{Context, Result};
+use arcbox_protocol::v1::MachineAgentRequest;
 use clap::Subcommand;
 
 /// Disk management commands.
@@ -105,6 +106,10 @@ async fn execute_usage() -> Result<()> {
     Ok(())
 }
 
+/// Machine whose data disk `disk compact` targets. The Docker data image
+/// belongs to the default native machine — the same one `disk usage` inspects.
+const DEFAULT_MACHINE: &str = "default";
+
 async fn execute_compact() -> Result<()> {
     let config = arcbox_core::Config::load().unwrap_or_default();
     let img_path = config.docker_img_path();
@@ -114,20 +119,29 @@ async fn execute_compact() -> Result<()> {
         return Ok(());
     }
 
-    println!("On-demand compaction via this command is not yet implemented.");
-    println!("The guest VM runs fstrim hourly and the host disk uses sparse allocation, so freed");
-    println!("blocks are reclaimed automatically — but this command itself triggers no trim.");
-    println!();
-    println!("To reclaim space inside the VM, run:");
-    println!("  docker system prune --all --volumes");
-    println!();
+    let before = read_disk_usage(&img_path)?;
 
-    let usage = read_disk_usage(&img_path)?;
+    // Ask the daemon to run fstrim in the guest. The resulting discards flow
+    // through virtio-blk, which punches holes in this sparse image, so the
+    // physical footprint we re-stat below shrinks by the freed amount.
+    println!("Compacting Docker data disk (running fstrim in the guest)...");
+    let mut client = super::machine::machine_client().await?;
+    client
+        .compact_disk(tonic::Request::new(MachineAgentRequest {
+            id: DEFAULT_MACHINE.to_string(),
+        }))
+        .await
+        .context("Failed to compact data disk via the daemon")?;
+
+    let after = read_disk_usage(&img_path)?;
+    let reclaimed = before.physical_bytes.saturating_sub(after.physical_bytes);
+
     println!(
-        "Current: {:.1} GiB physical / {:.1} GiB logical",
-        usage.physical_gib(),
-        usage.logical_gib(),
+        "  Physical: {:.1} GiB -> {:.1} GiB",
+        before.physical_gib(),
+        after.physical_gib(),
     );
+    println!("  Reclaimed: {:.1} GiB", reclaimed as f64 / BYTES_PER_GIB);
 
     Ok(())
 }

--- a/app/arcbox-cli/src/commands/machine.rs
+++ b/app/arcbox-cli/src/commands/machine.rs
@@ -20,7 +20,7 @@ use tokio::net::UnixStream;
 use tonic::codegen::{Service, http::Uri};
 use tonic::transport::{Channel, Endpoint};
 
-async fn machine_client() -> Result<MachineServiceClient<Channel>> {
+pub async fn machine_client() -> Result<MachineServiceClient<Channel>> {
     let socket_path = super::resolve_grpc_socket_path();
 
     let channel = Endpoint::from_static("http://[::]:50051")

--- a/guest/arcbox-agent/src/agent/linux/disk.rs
+++ b/guest/arcbox-agent/src/agent/linux/disk.rs
@@ -9,7 +9,7 @@ use tokio::time::MissedTickBehavior;
 use arcbox_constants::paths::{CONTAINERD_DATA_MOUNT_POINT, DOCKER_DATA_MOUNT_POINT};
 use arcbox_protocol::agent::DiskTrimResponse;
 
-use crate::rpc::RpcResponse;
+use crate::rpc::{ErrorResponse, RpcResponse};
 
 /// Interval between successive periodic trims.
 const FSTRIM_INTERVAL: Duration = Duration::from_secs(3600);
@@ -47,9 +47,12 @@ pub(super) async fn fstrim_loop() {
     }
 }
 
-/// Runs `fstrim -v` once on each data mount, returning a per-mount summary.
-async fn run_fstrim_now() -> String {
+/// Runs `fstrim -v` once on each data mount. Returns `Ok(summary)` when every
+/// mount trimmed, or `Err(summary)` if any mount failed. The summary lists the
+/// per-mount outcome either way.
+async fn run_fstrim_now() -> Result<String, String> {
     let mut results = Vec::new();
+    let mut all_ok = true;
     for mount in FSTRIM_MOUNTS {
         match Command::new("fstrim").arg("-v").arg(mount).output().await {
             Ok(output) if output.status.success() => {
@@ -57,20 +60,30 @@ async fn run_fstrim_now() -> String {
                 results.push(format!("{}: {}", mount, msg.trim()));
             }
             Ok(output) => {
+                all_ok = false;
                 let msg = String::from_utf8_lossy(&output.stderr);
                 results.push(format!("{}: failed ({})", mount, msg.trim()));
             }
             Err(e) => {
+                all_ok = false;
                 results.push(format!("{}: error ({})", mount, e));
             }
         }
     }
-    results.join("; ")
+    let summary = results.join("; ");
+    if all_ok { Ok(summary) } else { Err(summary) }
 }
 
-/// Handles a `DiskTrim` RPC: triggers an immediate trim and returns the
-/// per-mount summary.
+/// Handles a `DiskTrim` RPC: triggers an immediate trim. Returns the per-mount
+/// summary on success, or a generic error response if any mount failed — so the
+/// daemon's `disk_trim()` surfaces a real `Err` rather than a success-looking
+/// summary string the caller would have to parse.
 pub(super) async fn handle_disk_trim() -> RpcResponse {
-    let result = run_fstrim_now().await;
-    RpcResponse::DiskTrim(DiskTrimResponse { result })
+    match run_fstrim_now().await {
+        Ok(result) => RpcResponse::DiskTrim(DiskTrimResponse { result }),
+        Err(summary) => RpcResponse::Error(ErrorResponse::new(
+            500,
+            format!("disk trim failed: {summary}"),
+        )),
+    }
 }

--- a/rpc/arcbox-protocol/proto/machine.proto
+++ b/rpc/arcbox-protocol/proto/machine.proto
@@ -39,6 +39,10 @@ service MachineService {
     // Gets guest system information for a machine.
     rpc GetSystemInfo(MachineAgentRequest) returns (MachineSystemInfo);
 
+    // Compacts a machine's data disk by running fstrim in the guest, which
+    // discards free blocks so the host punches them out of the sparse image.
+    rpc CompactDisk(MachineAgentRequest) returns (Empty);
+
     // Executes a command in a machine.
     rpc Exec(MachineExecRequest) returns (stream MachineExecOutput);
 

--- a/virt/arcbox-virtio-blk/AGENTS.md
+++ b/virt/arcbox-virtio-blk/AGENTS.md
@@ -1,0 +1,26 @@
+# arcbox-virtio-blk Agent Guidance
+
+This crate is the source of truth for virtio-blk feature semantics.
+
+## Feature Implementation Rule
+
+If this crate advertises a virtio-blk feature bit, the feature must be implemented and tested in every block I/O path that can handle the request:
+
+- the generic `VirtioBlock::process_descriptor_chain` path in this crate;
+- the macOS HV async worker path in `virt/arcbox-vmm/src/blk_worker.rs` when the feature can reach P0 macOS;
+- any future fast path that parses block requests without delegating to `VirtioBlock`.
+
+Do not add or keep an advertised feature as a best-effort placeholder. If a path cannot honor a feature, do not advertise it for devices that use that path.
+
+## Request Parsing
+
+Guest-controlled request fields must be validated before host I/O:
+
+- concatenate scatter-gather payload descriptors before parsing structs that may cross descriptor boundaries;
+- reject malformed lengths, reserved flags, out-of-bounds descriptors, arithmetic overflow, and ranges beyond device capacity;
+- enforce the advertised per-request limits (`max_discard_sectors`, `max_write_zeroes_sectors`, segment counts, and alignment) in every path;
+- treat partial host reads/writes as I/O errors unless a caller has a documented EOF policy.
+
+## Tests
+
+Tests for a new or changed block feature must cover the real request path, not only a leaf helper. For P0 macOS behavior, include coverage for the HV worker parser/executor in `arcbox-vmm` as well as the generic handler here.

--- a/virt/arcbox-virtio-blk/README.md
+++ b/virt/arcbox-virtio-blk/README.md
@@ -1,0 +1,30 @@
+# arcbox-virtio-blk
+
+VirtIO block device implementation for ArcBox.
+
+This crate owns the virtio-blk wire contract: feature bits, config fields, request headers, status values, generic descriptor-chain handling, and shared host-file primitives such as sparse hole punching and zeroing.
+
+## Current I/O Paths
+
+ArcBox has more than one block I/O path:
+
+- **Generic path** — `VirtioBlock::process_descriptor_chain` parses and handles virtqueue descriptors directly.
+- **macOS HV worker path** — `arcbox-vmm::blk_worker` parses descriptors on the vCPU side and performs async host I/O on a worker thread. This is the P0 macOS path.
+
+Any advertised virtio-blk feature must be correct in both paths. A feature implemented only in the generic path is not implemented for ArcBox's primary platform.
+
+## DISCARD and WRITE_ZEROES
+
+- `DISCARD` is advisory: ArcBox validates the request shape, then punches aligned host-file holes where possible. Host punch failure is logged and reported as success because the guest has already freed the blocks logically.
+- `WRITE_ZEROES` is mandatory: ArcBox must make the requested range read back as zero. The shared `zero_range` primitive punches the aligned interior for sparseness and writes zeros on unaligned edges; if punching fails, it falls back to writing zeros.
+
+Both operations use the same range-list parser and checked sector-to-byte conversion. Keep that shared validation in sync with the macOS HV worker.
+
+## Review Checklist
+
+Before changing a virtio-blk feature:
+
+1. Is the feature bit advertised only when every active path can honor it?
+2. Are descriptor payloads concatenated before parsing structs that may be split across descriptors?
+3. Are sector arithmetic, capacity bounds, flags, limits, and short I/O checked?
+4. Do tests cover both generic handling and the macOS HV worker path?

--- a/virt/arcbox-virtio-blk/src/device.rs
+++ b/virt/arcbox-virtio-blk/src/device.rs
@@ -10,7 +10,7 @@ use arcbox_virtio_core::{QueueConfig, VirtioDevice, VirtioDeviceId, virtio_bindi
 
 use crate::request::{
     BlockConfig, BlockRequestHeader, BlockRequestType, BlockStatus, WRITE_ZEROES_FLAG_UNMAP,
-    parse_range_list,
+    checked_io_byte_range, parse_range_list,
 };
 
 /// `VirtIO` block device.
@@ -244,25 +244,41 @@ impl VirtioBlock {
             .raw_fd
             .ok_or_else(|| VirtioError::NotReady("Block device not activated".into()))?;
 
+        let (offset, _) = checked_io_byte_range(
+            sector,
+            data.len(),
+            self.config.blk_size,
+            self.config.capacity,
+        )?;
         #[allow(clippy::cast_possible_wrap)]
-        let offset = (sector * u64::from(self.config.blk_size)) as libc::off_t;
-        // SAFETY: fd is valid, data is a valid mutable buffer.
-        let n = unsafe {
-            libc::pread(
-                fd,
-                data.as_mut_ptr().cast::<libc::c_void>(),
-                data.len(),
-                offset,
-            )
-        };
-        if n < 0 {
-            return Err(VirtioError::Io(format!(
-                "pread failed at sector {}: {}",
-                sector,
-                std::io::Error::last_os_error()
-            )));
+        let mut off = offset as libc::off_t;
+        let mut read = 0usize;
+        while read < data.len() {
+            // SAFETY: fd is valid, and `data[read..]` is a valid mutable buffer.
+            let n = unsafe {
+                libc::pread(
+                    fd,
+                    data[read..].as_mut_ptr().cast::<libc::c_void>(),
+                    data.len() - read,
+                    off,
+                )
+            };
+            if n < 0 {
+                return Err(VirtioError::Io(format!(
+                    "pread failed at sector {}: {}",
+                    sector,
+                    std::io::Error::last_os_error()
+                )));
+            }
+            if n == 0 {
+                return Err(VirtioError::Io(format!(
+                    "pread reached EOF before completing sector {sector}"
+                )));
+            }
+            read += n as usize;
+            off += n as libc::off_t;
         }
-        Ok(n as usize)
+        Ok(data.len())
     }
 
     /// Writes to disk using pwrite — no seek, no lock, position-independent.
@@ -275,19 +291,41 @@ impl VirtioBlock {
             .raw_fd
             .ok_or_else(|| VirtioError::NotReady("Block device not activated".into()))?;
 
+        let (offset, _) = checked_io_byte_range(
+            sector,
+            data.len(),
+            self.config.blk_size,
+            self.config.capacity,
+        )?;
         #[allow(clippy::cast_possible_wrap)]
-        let offset = (sector * u64::from(self.config.blk_size)) as libc::off_t;
-        // SAFETY: fd is valid, data is a valid buffer.
-        let n =
-            unsafe { libc::pwrite(fd, data.as_ptr().cast::<libc::c_void>(), data.len(), offset) };
-        if n < 0 {
-            return Err(VirtioError::Io(format!(
-                "pwrite failed at sector {}: {}",
-                sector,
-                std::io::Error::last_os_error()
-            )));
+        let mut off = offset as libc::off_t;
+        let mut written = 0usize;
+        while written < data.len() {
+            // SAFETY: fd is valid, and `data[written..]` is a valid buffer.
+            let n = unsafe {
+                libc::pwrite(
+                    fd,
+                    data[written..].as_ptr().cast::<libc::c_void>(),
+                    data.len() - written,
+                    off,
+                )
+            };
+            if n < 0 {
+                return Err(VirtioError::Io(format!(
+                    "pwrite failed at sector {}: {}",
+                    sector,
+                    std::io::Error::last_os_error()
+                )));
+            }
+            if n == 0 {
+                return Err(VirtioError::Io(format!(
+                    "pwrite made no progress at sector {sector}"
+                )));
+            }
+            written += n as usize;
+            off += n as libc::off_t;
         }
-        Ok(n as usize)
+        Ok(data.len())
     }
 
     fn handle_flush(&self) -> Result<usize> {
@@ -1194,5 +1232,16 @@ mod tests {
         bytes.extend_from_slice(&0u32.to_le_bytes());
 
         assert!(device.handle_write_zeroes_list(&bytes).is_err());
+    }
+
+    #[test]
+    fn test_handle_write_rejects_past_capacity() {
+        let mut temp_file = NamedTempFile::new().unwrap();
+        temp_file.write_all(&vec![0u8; 4096]).unwrap();
+
+        let device = VirtioBlock::from_path(temp_file.path(), false).unwrap();
+
+        assert!(device.handle_write(7, &[0xAB; 1024]).is_err());
+        assert_eq!(std::fs::metadata(temp_file.path()).unwrap().len(), 4096);
     }
 }

--- a/virt/arcbox-virtio-blk/src/device.rs
+++ b/virt/arcbox-virtio-blk/src/device.rs
@@ -62,9 +62,9 @@ impl VirtioBlock {
     /// allocation + one `pwrite` syscall. The guest splits larger requests.
     pub const MAX_WRITE_ZEROES_SECTORS: u32 = 2048;
 
-    /// Largest range a single DISCARD request may cover. Since DISCARD is a
-    /// spec-compliant no-op on our backend (advisory hint), we accept any
-    /// reasonable cap — 16 MiB keeps the guest from fragmenting `fstrim`.
+    /// Largest range a single DISCARD request may cover, in 512-byte sectors.
+    /// 16 MiB keeps the guest from fragmenting `fstrim` into excessive requests
+    /// while bounding the work of a single hole-punch.
     pub const MAX_DISCARD_SECTORS: u32 = 32768;
 
     /// Creates a new block device.
@@ -301,12 +301,26 @@ impl VirtioBlock {
         Ok(len)
     }
 
-    /// DISCARD is an advisory hint under the virtio-blk spec — the device
-    /// "MAY" reclaim storage but is free to ignore it entirely. We accept the
-    /// request, validate the range list is well-formed, and return OK without
-    /// touching the backing file. Real hole-punching via `fallocate` /
-    /// `F_PUNCHHOLE` can slot in here later without a wire-protocol change.
+    /// DISCARD reclaims host disk for the named sector ranges by punching holes
+    /// in the backing file (`fallocate` PUNCH_HOLE on Linux, `F_PUNCHHOLE` on
+    /// macOS). This is what makes guest `fstrim` / `discard=async` actually
+    /// shrink the sparse data image instead of growing forever.
+    ///
+    /// Under the virtio-blk spec DISCARD is advisory — the device "MAY" reclaim
+    /// storage but the guest must not rely on it. So a punch *failure* is logged
+    /// and swallowed rather than failing the request: the blocks are already
+    /// logically free in the guest either way, and failing would only break the
+    /// guest's `fstrim`. Malformed requests still error.
     fn handle_discard_list(&self, data: &[u8]) -> Result<usize> {
+        if self.config.read_only {
+            return Err(VirtioError::InvalidOperation("Device is read-only".into()));
+        }
+
+        let fd = self
+            .raw_fd
+            .ok_or_else(|| VirtioError::NotReady("Block device not activated".into()))?;
+        let block_size = u64::from(self.config.blk_size);
+
         for range in parse_range_list(data)? {
             if u64::from(range.num_sectors) > u64::from(Self::MAX_DISCARD_SECTORS) {
                 return Err(VirtioError::InvalidOperation(format!(
@@ -320,6 +334,27 @@ impl VirtioBlock {
                     "discard range has reserved flags set: 0x{:x}",
                     range.flags
                 )));
+            }
+
+            let start = range.sector * block_size;
+            let end = start + u64::from(range.num_sectors) * block_size;
+            // Align inward to the host FS allocation unit: macOS `F_PUNCHHOLE`
+            // rejects unaligned ranges, and only fully-covered blocks are freed
+            // on Linux anyway. Punching just the aligned interior is always
+            // safe — the guest already considers the whole range free, and we
+            // lose at most one block of reclaim at each edge.
+            let aligned_start = (start + (PUNCH_HOLE_ALIGNMENT - 1)) & !(PUNCH_HOLE_ALIGNMENT - 1);
+            let aligned_end = end & !(PUNCH_HOLE_ALIGNMENT - 1);
+            if aligned_end <= aligned_start {
+                continue;
+            }
+            if let Err(e) = punch_hole(fd, aligned_start, aligned_end - aligned_start) {
+                tracing::warn!(
+                    sector = range.sector,
+                    num_sectors = range.num_sectors,
+                    error = %e,
+                    "discard hole-punch failed; range left allocated on host"
+                );
             }
         }
         Ok(0)
@@ -502,6 +537,54 @@ impl VirtioBlock {
             }
         }
     }
+}
+
+/// Host filesystem allocation unit used to align hole-punch ranges. APFS and
+/// modern ext4/btrfs all use 4 KiB blocks; macOS `F_PUNCHHOLE` requires the
+/// punch offset and length to be multiples of this, and Linux only frees
+/// fully-covered blocks regardless.
+const PUNCH_HOLE_ALIGNMENT: u64 = 4096;
+
+/// Deallocates `[offset, offset + len)` in the file behind `fd`, leaving a
+/// sparse hole without changing the file's logical size. `offset` and `len`
+/// must be `PUNCH_HOLE_ALIGNMENT`-aligned.
+#[cfg(target_os = "linux")]
+fn punch_hole(fd: std::os::unix::io::RawFd, offset: u64, len: u64) -> std::io::Result<()> {
+    // PUNCH_HOLE must be combined with KEEP_SIZE: free the range but keep EOF.
+    let mode = libc::FALLOC_FL_PUNCH_HOLE | libc::FALLOC_FL_KEEP_SIZE;
+    #[allow(clippy::cast_possible_wrap)]
+    let (off, length) = (offset as libc::off_t, len as libc::off_t);
+    // SAFETY: `fd` is a valid writable descriptor; `off`/`length` are aligned,
+    // non-negative, and fit `off_t` (the backing file is at most 8 TiB).
+    let ret = unsafe { libc::fallocate(fd, mode, off, length) };
+    if ret != 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    Ok(())
+}
+
+#[cfg(target_os = "macos")]
+fn punch_hole(fd: std::os::unix::io::RawFd, offset: u64, len: u64) -> std::io::Result<()> {
+    #[allow(clippy::cast_possible_wrap)]
+    let mut ph = libc::fpunchhole_t {
+        fp_flags: 0,
+        reserved: 0,
+        fp_offset: offset as libc::off_t,
+        fp_length: len as libc::off_t,
+    };
+    // SAFETY: `fd` is a valid writable descriptor and `ph` is a fully
+    // initialized `fpunchhole_t` that outlives the `fcntl` call.
+    let ret = unsafe { libc::fcntl(fd, libc::F_PUNCHHOLE, &mut ph) };
+    if ret != 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    Ok(())
+}
+
+#[cfg(not(any(target_os = "linux", target_os = "macos")))]
+fn punch_hole(_fd: std::os::unix::io::RawFd, _offset: u64, _len: u64) -> std::io::Result<()> {
+    // No portable hole-punch; leave the range allocated (DISCARD is advisory).
+    Ok(())
 }
 
 /// One entry in a DISCARD / WRITE_ZEROES request's range list. The on-wire
@@ -831,6 +914,69 @@ mod tests {
 
         let device = VirtioBlock::from_path(temp_file.path(), false).unwrap();
         assert_eq!(device.config.capacity, 8); // 4096 / 512
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn punch_hole_reclaims_physical_blocks() {
+        use std::os::unix::fs::MetadataExt;
+        use std::os::unix::io::AsRawFd;
+
+        let mut temp = NamedTempFile::new().unwrap();
+        // Allocate 1 MiB of real (non-zero) data so the host backs it with
+        // physical blocks rather than a hole.
+        temp.write_all(&vec![0xABu8; 1024 * 1024]).unwrap();
+        temp.as_file().sync_all().unwrap();
+
+        let before = std::fs::metadata(temp.path()).unwrap().blocks() * 512;
+        assert!(
+            before >= 1024 * 1024,
+            "expected ~1 MiB allocated before punch, got {before}"
+        );
+
+        punch_hole(temp.as_file().as_raw_fd(), 0, 1024 * 1024).unwrap();
+        temp.as_file().sync_all().unwrap();
+
+        let after = std::fs::metadata(temp.path()).unwrap().blocks() * 512;
+        assert!(
+            after < 64 * 1024,
+            "expected the hole-punch to free the blocks, still {after} allocated"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn discard_punches_backing_file() {
+        use std::os::unix::fs::MetadataExt;
+
+        let mut temp = NamedTempFile::new().unwrap();
+        temp.write_all(&vec![0xCDu8; 1024 * 1024]).unwrap();
+        temp.as_file().sync_all().unwrap();
+
+        let config = BlockConfig {
+            capacity: 2048, // 1 MiB / 512
+            blk_size: 512,
+            path: temp.path().to_path_buf(),
+            read_only: false,
+            num_queues: 1,
+        };
+        let mut device = VirtioBlock::new(config);
+        device.activate().unwrap();
+
+        // One discard range covering sectors [0, 2048) — the whole 1 MiB.
+        let mut entry = Vec::new();
+        entry.extend_from_slice(&0u64.to_le_bytes()); // sector
+        entry.extend_from_slice(&2048u32.to_le_bytes()); // num_sectors
+        entry.extend_from_slice(&0u32.to_le_bytes()); // flags
+
+        device.handle_discard_list(&entry).unwrap();
+        temp.as_file().sync_all().unwrap();
+
+        let after = std::fs::metadata(temp.path()).unwrap().blocks() * 512;
+        assert!(
+            after < 64 * 1024,
+            "discard should have punched the backing file, still {after} allocated"
+        );
     }
 
     #[test]

--- a/virt/arcbox-virtio-blk/src/device.rs
+++ b/virt/arcbox-virtio-blk/src/device.rs
@@ -8,7 +8,10 @@ use arcbox_virtio_core::error::{Result, VirtioError};
 use arcbox_virtio_core::queue::{Descriptor, VirtQueue};
 use arcbox_virtio_core::{QueueConfig, VirtioDevice, VirtioDeviceId, virtio_bindings};
 
-use crate::request::{BlockConfig, BlockRequestHeader, BlockRequestType, BlockStatus};
+use crate::request::{
+    BlockConfig, BlockRequestHeader, BlockRequestType, BlockStatus, WRITE_ZEROES_FLAG_UNMAP,
+    parse_range_list,
+};
 
 /// `VirtIO` block device.
 pub struct VirtioBlock {
@@ -169,6 +172,12 @@ impl VirtioBlock {
         self.config.capacity * u64::from(self.config.blk_size)
     }
 
+    /// Returns the disk capacity in 512-byte sectors.
+    #[must_use]
+    pub fn capacity_sectors(&self) -> u64 {
+        self.config.capacity
+    }
+
     /// Returns the raw fd for pread/pwrite (if activated).
     #[must_use]
     pub fn raw_fd(&self) -> Option<std::os::unix::io::RawFd> {
@@ -326,7 +335,7 @@ impl VirtioBlock {
         let fd = self
             .raw_fd
             .ok_or_else(|| VirtioError::NotReady("Block device not activated".into()))?;
-        let block_size = u64::from(self.config.blk_size);
+        let block_size = self.config.blk_size;
 
         for range in parse_range_list(data)? {
             if u64::from(range.num_sectors) > u64::from(Self::MAX_DISCARD_SECTORS) {
@@ -343,8 +352,7 @@ impl VirtioBlock {
                 )));
             }
 
-            let start = range.sector * block_size;
-            let end = start + u64::from(range.num_sectors) * block_size;
+            let (start, end) = range.checked_byte_range(block_size, self.config.capacity)?;
             if let Some((offset, len)) = crate::punch::aligned_punch_range(start, end) {
                 if let Err(e) = crate::punch::punch_hole(fd, offset, len) {
                     tracing::warn!(
@@ -371,7 +379,7 @@ impl VirtioBlock {
         let fd = self
             .raw_fd
             .ok_or_else(|| VirtioError::NotReady("Block device not activated".into()))?;
-        let block_size = u64::from(self.config.blk_size);
+        let block_size = self.config.blk_size;
 
         for range in parse_range_list(data)? {
             if u64::from(range.num_sectors) > u64::from(Self::MAX_WRITE_ZEROES_SECTORS) {
@@ -381,29 +389,23 @@ impl VirtioBlock {
                     Self::MAX_WRITE_ZEROES_SECTORS
                 )));
             }
-            // Ignore the UNMAP flag: we advertise write_zeroes_may_unmap=0,
-            // so the guest must treat the range as zeroed regardless.
-            let bytes = u64::from(range.num_sectors) * block_size;
-            if bytes == 0 {
+            if range.flags & !WRITE_ZEROES_FLAG_UNMAP != 0 {
+                return Err(VirtioError::InvalidOperation(format!(
+                    "write_zeroes range has reserved flags set: 0x{:x}",
+                    range.flags
+                )));
+            }
+            // Ignore the UNMAP flag: we advertise write_zeroes_may_unmap=0, so
+            // the guest must treat the range as zeroed regardless of whether the
+            // host implementation chooses to keep it sparse.
+            let (start, end) = range.checked_byte_range(block_size, self.config.capacity)?;
+            if start == end {
                 continue;
             }
-            #[allow(clippy::cast_possible_wrap)]
-            let offset = (range.sector * block_size) as libc::off_t;
-            let zeros = vec![0u8; bytes as usize];
-            // SAFETY: fd is valid; zeros is a borrowed slice of length `bytes`.
-            let n = unsafe {
-                libc::pwrite(
-                    fd,
-                    zeros.as_ptr().cast::<libc::c_void>(),
-                    zeros.len(),
-                    offset,
-                )
-            };
-            if n < 0 {
+            if let Err(e) = crate::punch::zero_range(fd, start, end) {
                 return Err(VirtioError::Io(format!(
-                    "pwrite (write_zeroes) failed at sector {}: {}",
-                    range.sector,
-                    std::io::Error::last_os_error()
+                    "write_zeroes failed at sector {}: {}",
+                    range.sector, e
                 )));
             }
         }
@@ -536,36 +538,6 @@ impl VirtioBlock {
             }
         }
     }
-}
-
-/// One entry in a DISCARD / WRITE_ZEROES request's range list. The on-wire
-/// struct is `virtio_blk_discard_write_zeroes`: sector (le64), num_sectors
-/// (le32), flags (le32) — 16 bytes total.
-#[derive(Debug, Clone, Copy)]
-struct DiscardWriteZeroesRange {
-    sector: u64,
-    num_sectors: u32,
-    flags: u32,
-}
-
-const RANGE_ENTRY_SIZE: usize = 16;
-
-fn parse_range_list(bytes: &[u8]) -> Result<Vec<DiscardWriteZeroesRange>> {
-    if bytes.is_empty() || bytes.len() % RANGE_ENTRY_SIZE != 0 {
-        return Err(VirtioError::InvalidOperation(format!(
-            "range list size {} not a multiple of 16",
-            bytes.len()
-        )));
-    }
-    let mut ranges = Vec::with_capacity(bytes.len() / RANGE_ENTRY_SIZE);
-    for chunk in bytes.chunks_exact(RANGE_ENTRY_SIZE) {
-        ranges.push(DiscardWriteZeroesRange {
-            sector: u64::from_le_bytes(chunk[0..8].try_into().unwrap()),
-            num_sectors: u32::from_le_bytes(chunk[8..12].try_into().unwrap()),
-            flags: u32::from_le_bytes(chunk[12..16].try_into().unwrap()),
-        });
-    }
-    Ok(ranges)
 }
 
 impl VirtioDevice for VirtioBlock {

--- a/virt/arcbox-virtio-blk/src/device.rs
+++ b/virt/arcbox-virtio-blk/src/device.rs
@@ -74,13 +74,17 @@ impl VirtioBlock {
             | Self::FEATURE_SEG_MAX
             | Self::FEATURE_BLK_SIZE
             | Self::FEATURE_FLUSH
-            | Self::FEATURE_DISCARD
-            | Self::FEATURE_WRITE_ZEROES
             | Self::FEATURE_VERSION_1
             | arcbox_virtio_core::queue::VIRTIO_F_EVENT_IDX;
 
         if config.read_only {
             features |= Self::FEATURE_RO;
+        } else {
+            // DISCARD and WRITE_ZEROES both mutate the backing file, so only a
+            // writable device advertises them. (A read-only device that
+            // advertised DISCARD would force the handler to error on requests
+            // it cannot honor.)
+            features |= Self::FEATURE_DISCARD | Self::FEATURE_WRITE_ZEROES;
         }
         if config.num_queues > 1 {
             features |= Self::FEATURE_MQ;
@@ -313,7 +317,10 @@ impl VirtioBlock {
     /// guest's `fstrim`. Malformed requests still error.
     fn handle_discard_list(&self, data: &[u8]) -> Result<usize> {
         if self.config.read_only {
-            return Err(VirtioError::InvalidOperation("Device is read-only".into()));
+            // Read-only devices don't advertise FEATURE_DISCARD, so this is only
+            // reached by a misbehaving guest. DISCARD is advisory — answer OK
+            // (no-op) rather than failing the request.
+            return Ok(0);
         }
 
         let fd = self
@@ -338,23 +345,15 @@ impl VirtioBlock {
 
             let start = range.sector * block_size;
             let end = start + u64::from(range.num_sectors) * block_size;
-            // Align inward to the host FS allocation unit: macOS `F_PUNCHHOLE`
-            // rejects unaligned ranges, and only fully-covered blocks are freed
-            // on Linux anyway. Punching just the aligned interior is always
-            // safe — the guest already considers the whole range free, and we
-            // lose at most one block of reclaim at each edge.
-            let aligned_start = (start + (PUNCH_HOLE_ALIGNMENT - 1)) & !(PUNCH_HOLE_ALIGNMENT - 1);
-            let aligned_end = end & !(PUNCH_HOLE_ALIGNMENT - 1);
-            if aligned_end <= aligned_start {
-                continue;
-            }
-            if let Err(e) = punch_hole(fd, aligned_start, aligned_end - aligned_start) {
-                tracing::warn!(
-                    sector = range.sector,
-                    num_sectors = range.num_sectors,
-                    error = %e,
-                    "discard hole-punch failed; range left allocated on host"
-                );
+            if let Some((offset, len)) = crate::punch::aligned_punch_range(start, end) {
+                if let Err(e) = crate::punch::punch_hole(fd, offset, len) {
+                    tracing::warn!(
+                        sector = range.sector,
+                        num_sectors = range.num_sectors,
+                        error = %e,
+                        "discard hole-punch failed; range left allocated on host"
+                    );
+                }
             }
         }
         Ok(0)
@@ -539,54 +538,6 @@ impl VirtioBlock {
     }
 }
 
-/// Host filesystem allocation unit used to align hole-punch ranges. APFS and
-/// modern ext4/btrfs all use 4 KiB blocks; macOS `F_PUNCHHOLE` requires the
-/// punch offset and length to be multiples of this, and Linux only frees
-/// fully-covered blocks regardless.
-const PUNCH_HOLE_ALIGNMENT: u64 = 4096;
-
-/// Deallocates `[offset, offset + len)` in the file behind `fd`, leaving a
-/// sparse hole without changing the file's logical size. `offset` and `len`
-/// must be `PUNCH_HOLE_ALIGNMENT`-aligned.
-#[cfg(target_os = "linux")]
-fn punch_hole(fd: std::os::unix::io::RawFd, offset: u64, len: u64) -> std::io::Result<()> {
-    // PUNCH_HOLE must be combined with KEEP_SIZE: free the range but keep EOF.
-    let mode = libc::FALLOC_FL_PUNCH_HOLE | libc::FALLOC_FL_KEEP_SIZE;
-    #[allow(clippy::cast_possible_wrap)]
-    let (off, length) = (offset as libc::off_t, len as libc::off_t);
-    // SAFETY: `fd` is a valid writable descriptor; `off`/`length` are aligned,
-    // non-negative, and fit `off_t` (the backing file is at most 8 TiB).
-    let ret = unsafe { libc::fallocate(fd, mode, off, length) };
-    if ret != 0 {
-        return Err(std::io::Error::last_os_error());
-    }
-    Ok(())
-}
-
-#[cfg(target_os = "macos")]
-fn punch_hole(fd: std::os::unix::io::RawFd, offset: u64, len: u64) -> std::io::Result<()> {
-    #[allow(clippy::cast_possible_wrap)]
-    let mut ph = libc::fpunchhole_t {
-        fp_flags: 0,
-        reserved: 0,
-        fp_offset: offset as libc::off_t,
-        fp_length: len as libc::off_t,
-    };
-    // SAFETY: `fd` is a valid writable descriptor and `ph` is a fully
-    // initialized `fpunchhole_t` that outlives the `fcntl` call.
-    let ret = unsafe { libc::fcntl(fd, libc::F_PUNCHHOLE, &mut ph) };
-    if ret != 0 {
-        return Err(std::io::Error::last_os_error());
-    }
-    Ok(())
-}
-
-#[cfg(not(any(target_os = "linux", target_os = "macos")))]
-fn punch_hole(_fd: std::os::unix::io::RawFd, _offset: u64, _len: u64) -> std::io::Result<()> {
-    // No portable hole-punch; leave the range allocated (DISCARD is advisory).
-    Ok(())
-}
-
 /// One entry in a DISCARD / WRITE_ZEROES request's range list. The on-wire
 /// struct is `virtio_blk_discard_write_zeroes`: sector (le64), num_sectors
 /// (le32), flags (le32) — 16 bytes total.
@@ -661,7 +612,7 @@ impl VirtioDevice for VirtioBlock {
             &self.config.num_queues.to_le_bytes(),
             &Self::MAX_DISCARD_SECTORS.to_le_bytes(),
             &1u32.to_le_bytes(), // max_discard_seg: one range per request
-            &1u32.to_le_bytes(), // discard_sector_alignment: any sector
+            &8u32.to_le_bytes(), // discard_sector_alignment: 4 KiB (8 × 512), matches host punch
             &Self::MAX_WRITE_ZEROES_SECTORS.to_le_bytes(),
             &1u32.to_le_bytes(), // max_write_zeroes_seg
             &[0u8; 4],           // write_zeroes_may_unmap=0 + 3 pad bytes
@@ -918,34 +869,6 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
-    fn punch_hole_reclaims_physical_blocks() {
-        use std::os::unix::fs::MetadataExt;
-        use std::os::unix::io::AsRawFd;
-
-        let mut temp = NamedTempFile::new().unwrap();
-        // Allocate 1 MiB of real (non-zero) data so the host backs it with
-        // physical blocks rather than a hole.
-        temp.write_all(&vec![0xABu8; 1024 * 1024]).unwrap();
-        temp.as_file().sync_all().unwrap();
-
-        let before = std::fs::metadata(temp.path()).unwrap().blocks() * 512;
-        assert!(
-            before >= 1024 * 1024,
-            "expected ~1 MiB allocated before punch, got {before}"
-        );
-
-        punch_hole(temp.as_file().as_raw_fd(), 0, 1024 * 1024).unwrap();
-        temp.as_file().sync_all().unwrap();
-
-        let after = std::fs::metadata(temp.path()).unwrap().blocks() * 512;
-        assert!(
-            after < 64 * 1024,
-            "expected the hole-punch to free the blocks, still {after} allocated"
-        );
-    }
-
-    #[cfg(unix)]
-    #[test]
     fn discard_punches_backing_file() {
         use std::os::unix::fs::MetadataExt;
 
@@ -991,6 +914,9 @@ mod tests {
 
         let device = VirtioBlock::new(ro_config);
         assert!(device.features() & VirtioBlock::FEATURE_RO != 0);
+        // A read-only device must not advertise mutating ops it cannot honor.
+        assert_eq!(device.features() & VirtioBlock::FEATURE_DISCARD, 0);
+        assert_eq!(device.features() & VirtioBlock::FEATURE_WRITE_ZEROES, 0);
     }
 
     #[test]
@@ -1150,6 +1076,9 @@ mod tests {
         device.read_config(36, &mut buf); // max_discard_sectors
         assert_eq!(u32::from_le_bytes(buf), VirtioBlock::MAX_DISCARD_SECTORS,);
 
+        device.read_config(44, &mut buf); // discard_sector_alignment
+        assert_eq!(u32::from_le_bytes(buf), 8); // 4 KiB / 512, matches host punch
+
         device.read_config(48, &mut buf); // max_write_zeroes_sectors
         assert_eq!(
             u32::from_le_bytes(buf),
@@ -1190,23 +1119,37 @@ mod tests {
     }
 
     #[test]
-    fn test_handle_discard_accepts_valid_range() {
+    fn test_handle_discard_punches_aligned_range() {
         let mut temp_file = NamedTempFile::new().unwrap();
-        temp_file.write_all(&vec![0xAAu8; 4096]).unwrap();
+        temp_file.write_all(&vec![0xAAu8; 8192]).unwrap();
+        temp_file.as_file().sync_all().unwrap();
 
         let device = VirtioBlock::from_path(temp_file.path(), false).unwrap();
 
+        // Discard the first 4 KiB (8 × 512-byte sectors) — block-aligned, so it
+        // is actually punched.
         let mut bytes = Vec::new();
         bytes.extend_from_slice(&0u64.to_le_bytes()); // sector
-        bytes.extend_from_slice(&4u32.to_le_bytes()); // num_sectors
+        bytes.extend_from_slice(&8u32.to_le_bytes()); // num_sectors (4 KiB)
         bytes.extend_from_slice(&0u32.to_le_bytes()); // flags
 
         assert!(device.handle_discard_list(&bytes).is_ok());
 
-        // DISCARD is advisory — underlying bytes must be unchanged.
-        let mut buf = vec![0u8; 512];
-        device.handle_read(0, &mut buf).unwrap();
-        assert!(buf.iter().all(|&b| b == 0xAA));
+        // The punched range is now a hole and reads back as zeros; data beyond
+        // it (sector 8) is untouched.
+        let mut hole = vec![0xFFu8; 512];
+        device.handle_read(0, &mut hole).unwrap();
+        assert!(
+            hole.iter().all(|&b| b == 0),
+            "punched range should read as zeros"
+        );
+
+        let mut kept = vec![0u8; 512];
+        device.handle_read(8, &mut kept).unwrap();
+        assert!(
+            kept.iter().all(|&b| b == 0xAA),
+            "data past the range is intact"
+        );
     }
 
     #[test]

--- a/virt/arcbox-virtio-blk/src/lib.rs
+++ b/virt/arcbox-virtio-blk/src/lib.rs
@@ -44,4 +44,7 @@ pub use device::VirtioBlock;
 pub use direct_io::DirectIoBackend;
 pub use mmap::MmapBackend;
 pub use punch::{PUNCH_HOLE_ALIGNMENT, aligned_punch_range, punch_hole, zero_range};
-pub use request::{BlockConfig, BlockRequestHeader, BlockRequestType, BlockStatus};
+pub use request::{
+    BlockConfig, BlockRequestHeader, BlockRequestType, BlockStatus, DiscardWriteZeroesRange,
+    WRITE_ZEROES_FLAG_UNMAP, parse_range_list,
+};

--- a/virt/arcbox-virtio-blk/src/lib.rs
+++ b/virt/arcbox-virtio-blk/src/lib.rs
@@ -35,6 +35,7 @@ mod device;
 #[cfg(target_os = "linux")]
 mod direct_io;
 mod mmap;
+mod punch;
 mod request;
 
 pub use backend::AsyncBlockBackend;
@@ -42,4 +43,5 @@ pub use device::VirtioBlock;
 #[cfg(target_os = "linux")]
 pub use direct_io::DirectIoBackend;
 pub use mmap::MmapBackend;
+pub use punch::{PUNCH_HOLE_ALIGNMENT, aligned_punch_range, punch_hole};
 pub use request::{BlockConfig, BlockRequestHeader, BlockRequestType, BlockStatus};

--- a/virt/arcbox-virtio-blk/src/lib.rs
+++ b/virt/arcbox-virtio-blk/src/lib.rs
@@ -43,5 +43,5 @@ pub use device::VirtioBlock;
 #[cfg(target_os = "linux")]
 pub use direct_io::DirectIoBackend;
 pub use mmap::MmapBackend;
-pub use punch::{PUNCH_HOLE_ALIGNMENT, aligned_punch_range, punch_hole};
+pub use punch::{PUNCH_HOLE_ALIGNMENT, aligned_punch_range, punch_hole, zero_range};
 pub use request::{BlockConfig, BlockRequestHeader, BlockRequestType, BlockStatus};

--- a/virt/arcbox-virtio-blk/src/lib.rs
+++ b/virt/arcbox-virtio-blk/src/lib.rs
@@ -46,5 +46,5 @@ pub use mmap::MmapBackend;
 pub use punch::{PUNCH_HOLE_ALIGNMENT, aligned_punch_range, punch_hole, zero_range};
 pub use request::{
     BlockConfig, BlockRequestHeader, BlockRequestType, BlockStatus, DiscardWriteZeroesRange,
-    WRITE_ZEROES_FLAG_UNMAP, parse_range_list,
+    WRITE_ZEROES_FLAG_UNMAP, checked_io_byte_range, parse_range_list,
 };

--- a/virt/arcbox-virtio-blk/src/punch.rs
+++ b/virt/arcbox-virtio-blk/src/punch.rs
@@ -52,7 +52,13 @@ pub fn zero_range(fd: RawFd, start: u64, end: u64) -> std::io::Result<()> {
     }
     match block_aligned_interior(start, end) {
         Some((aligned_start, aligned_end)) => {
-            punch_hole(fd, aligned_start, aligned_end - aligned_start)?;
+            // Hole-punch the aligned interior for sparseness. If the host fs
+            // rejects punching (e.g. EOPNOTSUPP), fall back to writing zeros:
+            // WRITE_ZEROES requires the range to read back as zero, and the
+            // sparse punch is only an optimization, not a requirement.
+            if punch_hole(fd, aligned_start, aligned_end - aligned_start).is_err() {
+                zero_pwrite(fd, aligned_start, aligned_end)?;
+            }
             zero_pwrite(fd, start, aligned_start)?; // head (may be empty)
             zero_pwrite(fd, aligned_end, end)?; // tail (may be empty)
         }

--- a/virt/arcbox-virtio-blk/src/punch.rs
+++ b/virt/arcbox-virtio-blk/src/punch.rs
@@ -1,9 +1,12 @@
-//! Cross-platform sparse-file hole punching.
+//! Cross-platform sparse-file zeroing primitives, shared across both block I/O
+//! paths (the generic `VirtioBlock::process_descriptor_chain` and the macOS HV
+//! `blk_worker`).
 //!
-//! Shared by the block device's DISCARD handling on both I/O paths: the generic
-//! `VirtioBlock::process_descriptor_chain` and the macOS HV `blk_worker`. A
-//! DISCARD that lands here deallocates the named range from the backing image,
-//! so guest `fstrim` / `discard=async` actually shrinks the sparse file.
+//! - [`punch_hole`] deallocates a range so guest `fstrim` / `discard=async`
+//!   shrinks the sparse image (DISCARD).
+//! - [`zero_range`] makes a range read back as zeros while staying as sparse as
+//!   possible — hole-punch the aligned interior, write zeros only on the
+//!   unaligned edges (WRITE_ZEROES).
 
 use std::os::unix::io::RawFd;
 
@@ -14,22 +17,67 @@ use std::os::unix::io::RawFd;
 /// only frees fully-covered blocks regardless.
 pub const PUNCH_HOLE_ALIGNMENT: u64 = 4096;
 
-/// Aligns the byte range `[start, end)` inward to [`PUNCH_HOLE_ALIGNMENT`] and
-/// returns the `(offset, len)` that may be safely punched, or `None` if nothing
-/// remains after alignment.
+/// The [`PUNCH_HOLE_ALIGNMENT`]-aligned interior `[aligned_start, aligned_end)`
+/// of `[start, end)`, or `None` if the range spans no whole block.
 ///
-/// Punching only the aligned interior is always correct: the guest already
-/// considers the whole range free, and we give up at most one block of reclaim
-/// at each edge. It also keeps macOS `F_PUNCHHOLE` (which rejects unaligned
-/// ranges) and Linux (which only frees fully-covered blocks) happy.
-#[must_use]
-pub fn aligned_punch_range(start: u64, end: u64) -> Option<(u64, u64)> {
+/// This is the portion that may be hole-punched; the unaligned head/tail are
+/// handled by the caller (DISCARD ignores them as advisory; WRITE_ZEROES zeros
+/// them). macOS `F_PUNCHHOLE` rejects unaligned ranges and Linux only frees
+/// fully-covered blocks, so punching just the interior is the safe maximum.
+fn block_aligned_interior(start: u64, end: u64) -> Option<(u64, u64)> {
     let aligned_start =
         start.saturating_add(PUNCH_HOLE_ALIGNMENT - 1) & !(PUNCH_HOLE_ALIGNMENT - 1);
     let aligned_end = end & !(PUNCH_HOLE_ALIGNMENT - 1);
-    // `.then(||…)` is lazy: the subtraction only runs when end > start, so it
-    // never underflows (e.g. a sub-block range where aligned_end < aligned_start).
-    (aligned_end > aligned_start).then(|| (aligned_start, aligned_end - aligned_start))
+    (aligned_end > aligned_start).then_some((aligned_start, aligned_end))
+}
+
+/// Aligns `[start, end)` inward and returns the `(offset, len)` that may be
+/// safely hole-punched (for DISCARD), or `None` if nothing remains.
+#[must_use]
+pub fn aligned_punch_range(start: u64, end: u64) -> Option<(u64, u64)> {
+    block_aligned_interior(start, end).map(|(s, e)| (s, e - s))
+}
+
+/// Makes `[start, end)` read back as zeros, kept as sparse as possible.
+///
+/// The block-aligned interior is hole-punched (zeroed *and* reclaimed), and
+/// only the unaligned head/tail are physically written with zeros. This is the
+/// WRITE_ZEROES primitive.
+///
+/// # Errors
+/// Propagates I/O errors from the underlying `punch`/`pwrite` syscalls.
+pub fn zero_range(fd: RawFd, start: u64, end: u64) -> std::io::Result<()> {
+    if end <= start {
+        return Ok(());
+    }
+    match block_aligned_interior(start, end) {
+        Some((aligned_start, aligned_end)) => {
+            punch_hole(fd, aligned_start, aligned_end - aligned_start)?;
+            zero_pwrite(fd, start, aligned_start)?; // head (may be empty)
+            zero_pwrite(fd, aligned_end, end)?; // tail (may be empty)
+        }
+        // No whole block inside the range (< 2 blocks): just write the zeros.
+        None => zero_pwrite(fd, start, end)?,
+    }
+    Ok(())
+}
+
+/// Writes zeros over `[start, end)` with a single `pwrite`. Only used for the
+/// unaligned edges of [`zero_range`] (each strictly smaller than one block) or
+/// ranges with no aligned interior, so the temporary buffer stays small.
+fn zero_pwrite(fd: RawFd, start: u64, end: u64) -> std::io::Result<()> {
+    if end <= start {
+        return Ok(());
+    }
+    let zeros = vec![0u8; (end - start) as usize];
+    #[allow(clippy::cast_possible_wrap)]
+    let off = start as libc::off_t;
+    // SAFETY: `zeros` is a valid buffer of `zeros.len()` bytes; `fd` is writable.
+    let n = unsafe { libc::pwrite(fd, zeros.as_ptr().cast::<libc::c_void>(), zeros.len(), off) };
+    if n < 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    Ok(())
 }
 
 /// Deallocates `[offset, offset + len)` in the file behind `fd`, leaving a
@@ -119,6 +167,59 @@ mod tests {
         assert!(
             after < 64 * 1024,
             "expected the hole-punch to free the blocks, still {after} allocated"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    #[allow(clippy::cast_possible_wrap)] // off_t / pread-return casts on small test sizes
+    fn zero_range_zeros_edges_and_reclaims_interior() {
+        use std::io::Write;
+        use std::os::unix::fs::MetadataExt;
+        use std::os::unix::io::AsRawFd;
+
+        // 2 MiB of real data so the ~1 MiB punched interior is well above any
+        // host allocation-clumping noise.
+        let mut temp = tempfile::NamedTempFile::new().unwrap();
+        temp.write_all(&vec![0xCDu8; 2 * 1024 * 1024]).unwrap();
+        temp.as_file().sync_all().unwrap();
+        let fd = temp.as_file().as_raw_fd();
+        let before = std::fs::metadata(temp.path()).unwrap().blocks() * 512;
+
+        // Unaligned range [512, 1 MiB + 512): a head edge, a ~1 MiB aligned
+        // interior to punch, and a tail edge.
+        let (start, end) = (512u64, 1024 * 1024 + 512);
+        zero_range(fd, start, end).unwrap();
+        temp.as_file().sync_all().unwrap();
+
+        // The whole requested range reads back as zeros (edges + interior)...
+        let mut buf = vec![0xFFu8; (end - start) as usize];
+        // SAFETY: reading our own file into a sized buffer.
+        let n =
+            unsafe { libc::pread(fd, buf.as_mut_ptr().cast(), buf.len(), start as libc::off_t) };
+        assert_eq!(n, buf.len() as isize);
+        assert!(
+            buf.iter().all(|&b| b == 0),
+            "zeroed range must read back as zeros"
+        );
+
+        // ...while data past the range is untouched.
+        let mut tail = [0xFFu8; 512];
+        // SAFETY: reading our own file into a sized buffer.
+        let n =
+            unsafe { libc::pread(fd, tail.as_mut_ptr().cast(), tail.len(), end as libc::off_t) };
+        assert_eq!(n, 512);
+        assert!(
+            tail.iter().all(|&b| b == 0xCD),
+            "data past the range is intact"
+        );
+
+        // The aligned interior was punched (not written), so usage drops by
+        // roughly the interior size.
+        let after = std::fs::metadata(temp.path()).unwrap().blocks() * 512;
+        assert!(
+            after < before,
+            "interior should be reclaimed: before={before} after={after}"
         );
     }
 }

--- a/virt/arcbox-virtio-blk/src/punch.rs
+++ b/virt/arcbox-virtio-blk/src/punch.rs
@@ -1,0 +1,124 @@
+//! Cross-platform sparse-file hole punching.
+//!
+//! Shared by the block device's DISCARD handling on both I/O paths: the generic
+//! `VirtioBlock::process_descriptor_chain` and the macOS HV `blk_worker`. A
+//! DISCARD that lands here deallocates the named range from the backing image,
+//! so guest `fstrim` / `discard=async` actually shrinks the sparse file.
+
+use std::os::unix::io::RawFd;
+
+/// Host filesystem allocation unit used to align hole-punch ranges.
+///
+/// APFS and modern ext4/btrfs all use 4 KiB blocks; macOS `F_PUNCHHOLE`
+/// requires the punch offset and length to be multiples of this, and Linux
+/// only frees fully-covered blocks regardless.
+pub const PUNCH_HOLE_ALIGNMENT: u64 = 4096;
+
+/// Aligns the byte range `[start, end)` inward to [`PUNCH_HOLE_ALIGNMENT`] and
+/// returns the `(offset, len)` that may be safely punched, or `None` if nothing
+/// remains after alignment.
+///
+/// Punching only the aligned interior is always correct: the guest already
+/// considers the whole range free, and we give up at most one block of reclaim
+/// at each edge. It also keeps macOS `F_PUNCHHOLE` (which rejects unaligned
+/// ranges) and Linux (which only frees fully-covered blocks) happy.
+#[must_use]
+pub fn aligned_punch_range(start: u64, end: u64) -> Option<(u64, u64)> {
+    let aligned_start =
+        start.saturating_add(PUNCH_HOLE_ALIGNMENT - 1) & !(PUNCH_HOLE_ALIGNMENT - 1);
+    let aligned_end = end & !(PUNCH_HOLE_ALIGNMENT - 1);
+    // `.then(||…)` is lazy: the subtraction only runs when end > start, so it
+    // never underflows (e.g. a sub-block range where aligned_end < aligned_start).
+    (aligned_end > aligned_start).then(|| (aligned_start, aligned_end - aligned_start))
+}
+
+/// Deallocates `[offset, offset + len)` in the file behind `fd`, leaving a
+/// sparse hole without changing the file's logical size. `offset` and `len`
+/// should be [`PUNCH_HOLE_ALIGNMENT`]-aligned (see [`aligned_punch_range`]).
+#[cfg(target_os = "linux")]
+pub fn punch_hole(fd: RawFd, offset: u64, len: u64) -> std::io::Result<()> {
+    // PUNCH_HOLE must be combined with KEEP_SIZE: free the range but keep EOF.
+    let mode = libc::FALLOC_FL_PUNCH_HOLE | libc::FALLOC_FL_KEEP_SIZE;
+    #[allow(clippy::cast_possible_wrap)]
+    let (off, length) = (offset as libc::off_t, len as libc::off_t);
+    // SAFETY: `fd` is a valid writable descriptor; `off`/`length` are aligned,
+    // non-negative, and fit `off_t` (the backing file is at most 8 TiB).
+    let ret = unsafe { libc::fallocate(fd, mode, off, length) };
+    if ret != 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    Ok(())
+}
+
+#[cfg(target_os = "macos")]
+pub fn punch_hole(fd: RawFd, offset: u64, len: u64) -> std::io::Result<()> {
+    #[allow(clippy::cast_possible_wrap)]
+    let mut ph = libc::fpunchhole_t {
+        fp_flags: 0,
+        reserved: 0,
+        fp_offset: offset as libc::off_t,
+        fp_length: len as libc::off_t,
+    };
+    // SAFETY: `fd` is a valid writable descriptor and `ph` is a fully
+    // initialized `fpunchhole_t` that outlives the `fcntl` call.
+    let ret = unsafe { libc::fcntl(fd, libc::F_PUNCHHOLE, &mut ph) };
+    if ret != 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    Ok(())
+}
+
+#[cfg(not(any(target_os = "linux", target_os = "macos")))]
+pub fn punch_hole(_fd: RawFd, _offset: u64, _len: u64) -> std::io::Result<()> {
+    // No portable hole-punch; leave the range allocated (DISCARD is advisory).
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn aligned_punch_range_skips_sub_block() {
+        // A 2 KiB range inside a single 4 KiB block punches nothing.
+        assert_eq!(aligned_punch_range(0, 2048), None);
+        assert_eq!(aligned_punch_range(1024, 3072), None);
+    }
+
+    #[test]
+    fn aligned_punch_range_trims_edges_inward() {
+        // [2 KiB, 10 KiB) -> aligned interior [4 KiB, 8 KiB) = (4096, 4096).
+        assert_eq!(aligned_punch_range(2048, 10 * 1024), Some((4096, 4096)));
+        // Already aligned: kept as-is.
+        assert_eq!(aligned_punch_range(4096, 12288), Some((4096, 8192)));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn punch_hole_reclaims_physical_blocks() {
+        use std::io::Write;
+        use std::os::unix::fs::MetadataExt;
+        use std::os::unix::io::AsRawFd;
+
+        let mut temp = tempfile::NamedTempFile::new().unwrap();
+        // Allocate 1 MiB of real (non-zero) data so the host backs it with
+        // physical blocks rather than a hole.
+        temp.write_all(&vec![0xABu8; 1024 * 1024]).unwrap();
+        temp.as_file().sync_all().unwrap();
+
+        let before = std::fs::metadata(temp.path()).unwrap().blocks() * 512;
+        assert!(
+            before >= 1024 * 1024,
+            "expected ~1 MiB allocated before punch, got {before}"
+        );
+
+        punch_hole(temp.as_file().as_raw_fd(), 0, 1024 * 1024).unwrap();
+        temp.as_file().sync_all().unwrap();
+
+        let after = std::fs::metadata(temp.path()).unwrap().blocks() * 512;
+        assert!(
+            after < 64 * 1024,
+            "expected the hole-punch to free the blocks, still {after} allocated"
+        );
+    }
+}

--- a/virt/arcbox-virtio-blk/src/punch.rs
+++ b/virt/arcbox-virtio-blk/src/punch.rs
@@ -77,11 +77,29 @@ fn zero_pwrite(fd: RawFd, start: u64, end: u64) -> std::io::Result<()> {
     }
     let zeros = vec![0u8; (end - start) as usize];
     #[allow(clippy::cast_possible_wrap)]
-    let off = start as libc::off_t;
-    // SAFETY: `zeros` is a valid buffer of `zeros.len()` bytes; `fd` is writable.
-    let n = unsafe { libc::pwrite(fd, zeros.as_ptr().cast::<libc::c_void>(), zeros.len(), off) };
-    if n < 0 {
-        return Err(std::io::Error::last_os_error());
+    let mut off = start as libc::off_t;
+    let mut written = 0usize;
+    while written < zeros.len() {
+        // SAFETY: `zeros[written..]` is a valid buffer; `fd` is writable.
+        let n = unsafe {
+            libc::pwrite(
+                fd,
+                zeros[written..].as_ptr().cast::<libc::c_void>(),
+                zeros.len() - written,
+                off,
+            )
+        };
+        if n < 0 {
+            return Err(std::io::Error::last_os_error());
+        }
+        if n == 0 {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::WriteZero,
+                "pwrite made no progress while zeroing range",
+            ));
+        }
+        written += n as usize;
+        off += n as libc::off_t;
     }
     Ok(())
 }

--- a/virt/arcbox-virtio-blk/src/request.rs
+++ b/virt/arcbox-virtio-blk/src/request.rs
@@ -117,6 +117,39 @@ impl DiscardWriteZeroesRange {
     }
 }
 
+/// Converts a normal read/write request to a checked byte range.
+///
+/// # Errors
+///
+/// Returns an error if the byte offset overflows, the requested byte length
+/// overflows the device capacity, or the request extends past capacity.
+pub fn checked_io_byte_range(
+    sector: u64,
+    byte_len: usize,
+    blk_size: u32,
+    capacity_sectors: u64,
+) -> std::result::Result<(u64, u64), VirtioError> {
+    let block_size = u64::from(blk_size);
+    let capacity_bytes = capacity_sectors
+        .checked_mul(block_size)
+        .ok_or_else(|| VirtioError::InvalidOperation("device capacity overflow".into()))?;
+    let start = sector
+        .checked_mul(block_size)
+        .ok_or_else(|| VirtioError::InvalidOperation("I/O byte offset overflow".into()))?;
+    let len = u64::try_from(byte_len)
+        .map_err(|_| VirtioError::InvalidOperation("I/O byte length overflow".into()))?;
+    let end = start
+        .checked_add(len)
+        .ok_or_else(|| VirtioError::InvalidOperation("I/O byte end overflow".into()))?;
+    if end > capacity_bytes {
+        return Err(VirtioError::InvalidOperation(format!(
+            "I/O exceeds device capacity: bytes {}..{} > {}",
+            start, end, capacity_bytes
+        )));
+    }
+    Ok((start, end))
+}
+
 /// `VirtIO` block request types.
 ///
 /// Values sourced from `virtio_bindings::virtio_blk::VIRTIO_BLK_T_*`.

--- a/virt/arcbox-virtio-blk/src/request.rs
+++ b/virt/arcbox-virtio-blk/src/request.rs
@@ -32,6 +32,91 @@ impl Default for BlockConfig {
     }
 }
 
+/// `virtio_blk_discard_write_zeroes.flags` bit requesting deallocation while
+/// zeroing. ArcBox advertises `write_zeroes_may_unmap=0`, so callers must still
+/// guarantee zero reads even when this bit is set.
+pub const WRITE_ZEROES_FLAG_UNMAP: u32 = 1;
+
+/// One entry in a DISCARD / WRITE_ZEROES request's range list.
+///
+/// The on-wire struct is `virtio_blk_discard_write_zeroes`: sector (le64),
+/// num_sectors (le32), flags (le32) — 16 bytes total.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct DiscardWriteZeroesRange {
+    /// Starting sector in the guest block device.
+    pub sector: u64,
+    /// Number of sectors covered by this range.
+    pub num_sectors: u32,
+    /// Request flags (`WRITE_ZEROES_FLAG_UNMAP` is valid for WRITE_ZEROES only).
+    pub flags: u32,
+}
+
+const RANGE_ENTRY_SIZE: usize = 16;
+
+/// Parses a DISCARD / WRITE_ZEROES range list.
+///
+/// # Errors
+///
+/// Returns an error if the list is empty or not composed of whole 16-byte
+/// entries.
+pub fn parse_range_list(
+    bytes: &[u8],
+) -> std::result::Result<Vec<DiscardWriteZeroesRange>, VirtioError> {
+    if bytes.is_empty() || bytes.len() % RANGE_ENTRY_SIZE != 0 {
+        return Err(VirtioError::InvalidOperation(format!(
+            "range list size {} not a multiple of 16",
+            bytes.len()
+        )));
+    }
+    let mut ranges = Vec::with_capacity(bytes.len() / RANGE_ENTRY_SIZE);
+    for chunk in bytes.chunks_exact(RANGE_ENTRY_SIZE) {
+        ranges.push(DiscardWriteZeroesRange {
+            sector: u64::from_le_bytes(chunk[0..8].try_into().unwrap()),
+            num_sectors: u32::from_le_bytes(chunk[8..12].try_into().unwrap()),
+            flags: u32::from_le_bytes(chunk[12..16].try_into().unwrap()),
+        });
+    }
+    Ok(ranges)
+}
+
+impl DiscardWriteZeroesRange {
+    /// Converts the sector range to a checked byte range `[start, end)`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the sector range overflows the configured block size
+    /// or extends past the device capacity.
+    pub fn checked_byte_range(
+        self,
+        blk_size: u32,
+        capacity_sectors: u64,
+    ) -> std::result::Result<(u64, u64), VirtioError> {
+        let sector_end = self
+            .sector
+            .checked_add(u64::from(self.num_sectors))
+            .ok_or_else(|| VirtioError::InvalidOperation("range sector overflow".into()))?;
+        if sector_end > capacity_sectors {
+            return Err(VirtioError::InvalidOperation(format!(
+                "range exceeds device capacity: {}..{} > {} sectors",
+                self.sector, sector_end, capacity_sectors
+            )));
+        }
+
+        let block_size = u64::from(blk_size);
+        let start = self
+            .sector
+            .checked_mul(block_size)
+            .ok_or_else(|| VirtioError::InvalidOperation("range byte offset overflow".into()))?;
+        let bytes = u64::from(self.num_sectors)
+            .checked_mul(block_size)
+            .ok_or_else(|| VirtioError::InvalidOperation("range byte length overflow".into()))?;
+        let end = start
+            .checked_add(bytes)
+            .ok_or_else(|| VirtioError::InvalidOperation("range byte end overflow".into()))?;
+        Ok((start, end))
+    }
+}
+
 /// `VirtIO` block request types.
 ///
 /// Values sourced from `virtio_bindings::virtio_blk::VIRTIO_BLK_T_*`.

--- a/virt/arcbox-vmm/AGENTS.md
+++ b/virt/arcbox-vmm/AGENTS.md
@@ -1,0 +1,15 @@
+# arcbox-vmm Agent Guidance
+
+## macOS HV Block Worker Contract
+
+`src/blk_worker.rs` is an independent virtio-blk request parser and executor for the macOS HV backend. It does not automatically inherit behavior from `arcbox-virtio-blk::VirtioBlock`.
+
+When adding, advertising, or changing a virtio-blk feature, keep the HV worker in lockstep with `virt/arcbox-virtio-blk`:
+
+- parse the same request types;
+- validate the same guest-controlled fields, flags, limits, and capacity bounds;
+- preserve the same read/write/flush ordering guarantees;
+- report malformed mandatory requests as I/O errors instead of silently succeeding;
+- add tests that exercise the worker parser/executor, not just shared leaf helpers.
+
+If the worker cannot honor a feature on P0 macOS, do not advertise that feature for devices using this backend.

--- a/virt/arcbox-vmm/src/blk_worker.rs
+++ b/virt/arcbox-vmm/src/blk_worker.rs
@@ -42,6 +42,9 @@ pub enum BlkRequestType {
     Write,
     Flush,
     GetId,
+    /// DISCARD — deallocate (hole-punch) the listed ranges from the backing
+    /// image. The range list travels in the read-only data descriptors.
+    Discard,
 }
 
 // ============================================================================
@@ -345,6 +348,7 @@ fn process_item(ctx: &BlkWorkerContext, item: &BlkWorkItem) {
             process_flush(ctx)
         }
         BlkRequestType::GetId => process_get_id(ctx, item),
+        BlkRequestType::Discard => process_discard(ctx, item),
     };
 
     if is_io {
@@ -569,6 +573,59 @@ fn process_get_id(ctx: &BlkWorkerContext, item: &BlkWorkItem) -> u8 {
     0
 }
 
+/// DISCARD — punch holes for the listed ranges so the host reclaims disk for
+/// blocks the guest freed via `fstrim` / `discard=async`. DISCARD is advisory
+/// under the virtio-blk spec, so a read-only device or a punch failure is
+/// reported as a successful no-op rather than an I/O error.
+fn process_discard(ctx: &BlkWorkerContext, item: &BlkWorkItem) -> u8 {
+    if !ctx.read_only {
+        punch_discard_ranges(&ctx.guest_mem, ctx.raw_fd, ctx.blk_size, &item.buffers);
+    }
+    0 // VIRTIO_BLK_S_OK
+}
+
+/// Punches holes for every range in a DISCARD request's read-only payload
+/// descriptors. Factored out of [`process_discard`] so it can be tested without
+/// a full `BlkWorkerContext`.
+fn punch_discard_ranges(
+    guest_mem: &GuestMemWriter,
+    raw_fd: i32,
+    blk_size: u32,
+    buffers: &[(u64, u32, bool)],
+) {
+    use arcbox_virtio::blk::{aligned_punch_range, punch_hole};
+
+    let block_size = u64::from(blk_size);
+    // The range list travels in the read-only data descriptors: 16-byte entries
+    // of (sector le64, num_sectors le32, flags le32). The device-writable
+    // descriptor is the 1-byte status, which we skip.
+    for &(gpa, len, is_write) in buffers {
+        if is_write {
+            continue;
+        }
+        let Some(bytes) = guest_mem.slice(gpa as usize, len as usize) else {
+            continue;
+        };
+        for entry in bytes.chunks_exact(16) {
+            let sector = u64::from_le_bytes(entry[0..8].try_into().unwrap());
+            let num_sectors = u32::from_le_bytes(entry[8..12].try_into().unwrap());
+            // entry[12..16] = flags (UNMAP/reserved); ignored for advisory discard.
+            let start = sector * block_size;
+            let end = start + u64::from(num_sectors) * block_size;
+            if let Some((offset, hole_len)) = aligned_punch_range(start, end) {
+                if let Err(e) = punch_hole(raw_fd, offset, hole_len) {
+                    tracing::warn!(
+                        sector,
+                        num_sectors,
+                        error = %e,
+                        "discard hole-punch failed (HV worker); range left allocated"
+                    );
+                }
+            }
+        }
+    }
+}
+
 // Shared VirtIO queue helpers — extracted to virtqueue_util.rs.
 use crate::virtqueue_util::{read_used_idx, should_notify, write_used_entry};
 
@@ -704,6 +761,7 @@ impl BlkWorkerHandle {
                                 1 => BlkRequestType::Write,
                                 4 => BlkRequestType::Flush,
                                 8 => BlkRequestType::GetId,
+                                11 => BlkRequestType::Discard,
                                 _ => BlkRequestType::Read,
                             };
                         }
@@ -782,5 +840,48 @@ impl Default for FlushBarrier {
 impl FlushBarrier {
     pub fn new() -> Self {
         Self::default()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The HV worker's DISCARD path must actually reclaim host blocks — this is
+    /// the path the macOS backend uses, where DISCARD previously fell through to
+    /// a no-op `Read`.
+    #[cfg(unix)]
+    #[test]
+    fn punch_discard_ranges_reclaims_blocks() {
+        use std::io::Write;
+        use std::os::unix::fs::MetadataExt;
+        use std::os::unix::io::AsRawFd;
+
+        // Backing file with 1 MiB of real (non-zero) data.
+        let mut temp = tempfile::NamedTempFile::new().unwrap();
+        temp.write_all(&vec![0xEEu8; 1024 * 1024]).unwrap();
+        temp.as_file().sync_all().unwrap();
+        let fd = temp.as_file().as_raw_fd();
+
+        // Guest memory holding one 16-byte discard entry for sectors [0, 2048)
+        // — the whole 1 MiB — followed by where the 1-byte status would live.
+        let mut mem = vec![0u8; 4096];
+        mem[0..8].copy_from_slice(&0u64.to_le_bytes()); // sector
+        mem[8..12].copy_from_slice(&2048u32.to_le_bytes()); // num_sectors (1 MiB)
+        mem[12..16].copy_from_slice(&0u32.to_le_bytes()); // flags
+        // SAFETY: `mem` outlives `gm`; gpa_base 0 means gpa == buffer offset.
+        let gm = unsafe { GuestMemWriter::new(mem.as_mut_ptr(), mem.len(), 0) };
+
+        // Descriptors: the read-only range list, then the write-only status byte
+        // (which must be skipped, not parsed as a range).
+        let buffers = vec![(0u64, 16u32, false), (16u64, 1u32, true)];
+        punch_discard_ranges(&gm, fd, 512, &buffers);
+        temp.as_file().sync_all().unwrap();
+
+        let after = std::fs::metadata(temp.path()).unwrap().blocks() * 512;
+        assert!(
+            after < 64 * 1024,
+            "worker discard should have punched the backing file, still {after} allocated"
+        );
     }
 }

--- a/virt/arcbox-vmm/src/blk_worker.rs
+++ b/virt/arcbox-vmm/src/blk_worker.rs
@@ -42,6 +42,7 @@ pub enum BlkRequestType {
     Write,
     Flush,
     GetId,
+    Unsupported,
     /// DISCARD — deallocate (hole-punch) the listed ranges from the backing
     /// image. The range list travels in the read-only data descriptors.
     Discard,
@@ -239,12 +240,10 @@ pub fn blk_io_worker_loop(ctx: BlkWorkerContext, rx: std::sync::mpsc::Receiver<B
             }
         }
 
-        // Process batch in segments split at Flush/GetId boundaries.
-        // Within each segment, Read/Write items are sorted by (type, sector)
-        // for merge-friendly ordering. Flush/GetId items are processed after
-        // all preceding Read/Write items complete, preserving durability
-        // semantics: a Flush must not overtake a Write from the same batch.
-        process_batch(&ctx, &mut batch);
+        // Process batch in segments split at Flush/GetId boundaries. Adjacent
+        // compatible Read/Write items may be merged, but FIFO order is preserved
+        // so reads cannot overtake earlier writes.
+        process_batch(&ctx, &batch);
 
         let new_used = read_used_idx(&ctx.guest_mem, used_addr);
 
@@ -262,11 +261,10 @@ pub fn blk_io_worker_loop(ctx: BlkWorkerContext, rx: std::sync::mpsc::Receiver<B
 
 /// Processes a batch of work items, splitting at Flush/GetId boundaries.
 ///
-/// Within each segment of Read/Write items, we sort by (type, sector) for
-/// merge-friendly ordering. Flush/GetId items execute only after all
-/// preceding Read/Write items in the batch have completed, preserving the
-/// guest's durability invariant: `[Write, Flush]` must not be reordered.
-fn process_batch(ctx: &BlkWorkerContext, batch: &mut [BlkWorkItem]) {
+/// Within each segment of Read/Write items, we merge only already-adjacent
+/// same-type contiguous requests. We must preserve virtqueue FIFO order:
+/// reordering a read ahead of an earlier write can return stale data.
+fn process_batch(ctx: &BlkWorkerContext, batch: &[BlkWorkItem]) {
     let mut start = 0;
     while start < batch.len() {
         // Find the end of this Read/Write segment (up to next Flush/GetId).
@@ -280,21 +278,7 @@ fn process_batch(ctx: &BlkWorkerContext, batch: &mut [BlkWorkItem]) {
             seg_end += 1;
         }
 
-        // Sort the Read/Write segment by (type, sector) for merging.
-        if seg_end - start > 1 {
-            batch[start..seg_end].sort_unstable_by(|a, b| {
-                let type_ord = |t: &BlkRequestType| match t {
-                    BlkRequestType::Read => 0u8,
-                    BlkRequestType::Write => 1,
-                    _ => 2,
-                };
-                type_ord(&a.request_type)
-                    .cmp(&type_ord(&b.request_type))
-                    .then(a.sector.cmp(&b.sector))
-            });
-        }
-
-        // Process the sorted Read/Write segment with merging.
+        // Process in original order, merging only adjacent compatible items.
         let mut i = start;
         while i < seg_end {
             let item = &batch[i];
@@ -355,6 +339,7 @@ fn process_item(ctx: &BlkWorkerContext, item: &BlkWorkItem) {
             process_flush(ctx)
         }
         BlkRequestType::GetId => process_get_id(ctx, item),
+        BlkRequestType::Unsupported => 2, // VIRTIO_BLK_S_UNSUPP
         BlkRequestType::Discard => process_discard(ctx, item),
         BlkRequestType::WriteZeroes => process_write_zeroes(ctx, item),
     };
@@ -406,8 +391,13 @@ fn process_read(ctx: &BlkWorkerContext, item: &BlkWorkItem) -> u8 {
         return 0;
     }
     let expected_len = iovecs.iter().map(|iov| iov.iov_len).sum::<usize>();
-    let Some(byte_offset) = item.sector.checked_mul(u64::from(ctx.blk_size)) else {
-        tracing::warn!("blk read: sector offset overflow: {}", item.sector);
+    let Ok((byte_offset, _)) = arcbox_virtio::blk::checked_io_byte_range(
+        item.sector,
+        expected_len,
+        ctx.blk_size,
+        ctx.capacity_sectors,
+    ) else {
+        tracing::warn!("blk read: range out of capacity at sector {}", item.sector);
         return 1;
     };
     #[allow(clippy::cast_possible_wrap)]
@@ -457,8 +447,13 @@ fn process_write(ctx: &BlkWorkerContext, item: &BlkWorkItem) -> u8 {
         return 0;
     }
     let expected_len = iovecs.iter().map(|iov| iov.iov_len).sum::<usize>();
-    let Some(byte_offset) = item.sector.checked_mul(u64::from(ctx.blk_size)) else {
-        tracing::warn!("blk write: sector offset overflow: {}", item.sector);
+    let Ok((byte_offset, _)) = arcbox_virtio::blk::checked_io_byte_range(
+        item.sector,
+        expected_len,
+        ctx.blk_size,
+        ctx.capacity_sectors,
+    ) else {
+        tracing::warn!("blk write: range out of capacity at sector {}", item.sector);
         return 1;
     };
     #[allow(clippy::cast_possible_wrap)]
@@ -517,33 +512,37 @@ fn process_merged(ctx: &BlkWorkerContext, items: &[BlkWorkItem]) {
                         iov_base: buf.as_mut_ptr().cast(),
                         iov_len: buf.len(),
                     });
+                } else {
+                    tracing::warn!("blk merged read: GPA {:#x} len {} out of bounds", gpa, len);
+                    complete_merged(ctx, items, 1);
+                    return;
                 }
             } else if let Some(buf) = ctx.guest_mem.slice(gpa as usize, len as usize) {
                 iovecs.push(libc::iovec {
                     iov_base: buf.as_ptr().cast_mut().cast(),
                     iov_len: buf.len(),
                 });
+            } else {
+                tracing::warn!("blk merged write: GPA {:#x} len {} out of bounds", gpa, len);
+                complete_merged(ctx, items, 1);
+                return;
             }
         }
     }
 
     // Single merged I/O syscall.
     let expected_len = iovecs.iter().map(|iov| iov.iov_len).sum::<usize>();
-    let Some(byte_offset) = start_sector.checked_mul(u64::from(ctx.blk_size)) else {
-        tracing::warn!("blk merged: sector offset overflow: {}", start_sector);
-        for item in items {
-            ctx.guest_mem.write_byte(item.status_gpa as usize, 1);
-            write_used_entry(
-                &ctx.guest_mem,
-                item.used_addr,
-                item.queue_size,
-                item.head_idx,
-                1,
-            );
-        }
-        ctx.flush_barrier
-            .in_flight
-            .fetch_sub(items.len() as u32, Ordering::Release);
+    let Ok((byte_offset, _)) = arcbox_virtio::blk::checked_io_byte_range(
+        start_sector,
+        expected_len,
+        ctx.blk_size,
+        ctx.capacity_sectors,
+    ) else {
+        tracing::warn!(
+            "blk merged: range out of capacity at sector {}",
+            start_sector
+        );
+        complete_merged(ctx, items, 1);
         return;
     };
     #[allow(clippy::cast_possible_wrap)]
@@ -576,7 +575,21 @@ fn process_merged(ctx: &BlkWorkerContext, items: &[BlkWorkItem]) {
         0
     };
 
-    // Write individual used ring entries for each item.
+    complete_merged(ctx, items, status);
+
+    tracing::trace!(
+        "blk merged {} items: sector {}..+{}, {} iovecs, {} bytes",
+        items.len(),
+        start_sector,
+        items.last().map_or(0, |i| i.sector
+            + u64::from(i.total_data_len) / u64::from(ctx.blk_size))
+            - start_sector,
+        iovecs.len(),
+        n,
+    );
+}
+
+fn complete_merged(ctx: &BlkWorkerContext, items: &[BlkWorkItem], status: u8) {
     for item in items {
         ctx.guest_mem.write_byte(item.status_gpa as usize, status);
         let total_bytes = if status == 0 {
@@ -596,17 +609,6 @@ fn process_merged(ctx: &BlkWorkerContext, items: &[BlkWorkItem]) {
     ctx.flush_barrier
         .in_flight
         .fetch_sub(items.len() as u32, Ordering::Release);
-
-    tracing::trace!(
-        "blk merged {} items: sector {}..+{}, {} iovecs, {} bytes",
-        items.len(),
-        start_sector,
-        items.last().map_or(0, |i| i.sector
-            + u64::from(i.total_data_len) / u64::from(ctx.blk_size))
-            - start_sector,
-        iovecs.len(),
-        n,
-    );
 }
 
 fn process_flush(ctx: &BlkWorkerContext) -> u8 {
@@ -977,7 +979,7 @@ impl BlkWorkerHandle {
                                 8 => BlkRequestType::GetId,
                                 11 => BlkRequestType::Discard,
                                 13 => BlkRequestType::WriteZeroes,
-                                _ => BlkRequestType::Read,
+                                _ => BlkRequestType::Unsupported,
                             };
                         }
                     }
@@ -1061,6 +1063,124 @@ impl FlushBarrier {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn test_context<'a>(mem: &'a mut [u8], raw_fd: i32, capacity_sectors: u64) -> BlkWorkerContext {
+        BlkWorkerContext {
+            // SAFETY: test memory outlives the returned context.
+            guest_mem: unsafe { GuestMemWriter::new(mem.as_mut_ptr(), mem.len(), 0) },
+            raw_fd,
+            blk_size: 512,
+            capacity_sectors,
+            read_only: false,
+            device_id: "test-blk".to_string(),
+            mmio_state: Arc::new(RwLock::new(VirtioMmioState::new(2, 0))),
+            irq_callback: Arc::new(|_, _| Ok(())),
+            irq: 32,
+            running: Arc::new(AtomicBool::new(true)),
+            flush_barrier: Arc::new(FlushBarrier::new()),
+        }
+    }
+
+    fn work_item(
+        request_type: BlkRequestType,
+        sector: u64,
+        buffers: Vec<(u64, u32, bool)>,
+        status_gpa: u64,
+    ) -> BlkWorkItem {
+        let total_data_len = buffers
+            .iter()
+            .filter(|(_, len, _)| *len > 1)
+            .map(|(_, len, _)| *len)
+            .sum();
+        BlkWorkItem {
+            head_idx: status_gpa as u16,
+            request_type,
+            sector,
+            buffers,
+            status_gpa,
+            total_data_len,
+            used_addr: 2048,
+            avail_addr: 3072,
+            queue_size: 8,
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn batch_preserves_write_then_read_order() {
+        use std::io::Write;
+        use std::os::unix::io::AsRawFd;
+
+        let mut temp = tempfile::NamedTempFile::new().unwrap();
+        temp.write_all(&vec![0u8; 4096]).unwrap();
+        temp.as_file().sync_all().unwrap();
+
+        let mut mem = vec![0u8; 4096];
+        mem[0..512].fill(0xAB);
+        let ctx = test_context(&mut mem, temp.as_file().as_raw_fd(), 8);
+        let batch = vec![
+            work_item(BlkRequestType::Write, 0, vec![(0, 512, false)], 1500),
+            work_item(BlkRequestType::Read, 0, vec![(512, 512, true)], 1501),
+        ];
+
+        process_batch(&ctx, &batch);
+
+        assert_eq!(mem[1500], 0);
+        assert_eq!(mem[1501], 0);
+        assert!(mem[512..1024].iter().all(|&b| b == 0xAB));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn write_past_capacity_is_rejected() {
+        use std::io::Write;
+        use std::os::unix::io::AsRawFd;
+
+        let mut temp = tempfile::NamedTempFile::new().unwrap();
+        temp.write_all(&vec![0u8; 4096]).unwrap();
+        temp.as_file().sync_all().unwrap();
+
+        let mut mem = vec![0xCCu8; 4096];
+        let ctx = test_context(&mut mem, temp.as_file().as_raw_fd(), 8);
+        let item = work_item(BlkRequestType::Write, 7, vec![(0, 1024, false)], 1500);
+
+        assert_eq!(process_write(&ctx, &item), 1);
+        assert_eq!(std::fs::metadata(temp.path()).unwrap().len(), 4096);
+    }
+
+    #[test]
+    fn unsupported_request_completes_unsupp() {
+        let mut mem = vec![0u8; 4096];
+        let ctx = test_context(&mut mem, -1, 8);
+        let item = work_item(BlkRequestType::Unsupported, 0, Vec::new(), 1500);
+
+        process_item(&ctx, &item);
+
+        assert_eq!(mem[1500], 2);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn merged_oob_buffer_fails_group() {
+        use std::io::Write;
+        use std::os::unix::io::AsRawFd;
+
+        let mut temp = tempfile::NamedTempFile::new().unwrap();
+        temp.write_all(&vec![0xDDu8; 4096]).unwrap();
+        temp.as_file().sync_all().unwrap();
+
+        let mut mem = vec![0u8; 4096];
+        let ctx = test_context(&mut mem, temp.as_file().as_raw_fd(), 8);
+        let batch = vec![
+            work_item(BlkRequestType::Read, 0, vec![(0, 512, true)], 1500),
+            work_item(BlkRequestType::Read, 1, vec![(4090, 512, true)], 1501),
+        ];
+
+        process_batch(&ctx, &batch);
+
+        assert_eq!(mem[1500], 1);
+        assert_eq!(mem[1501], 1);
+    }
 
     /// The HV worker's DISCARD path must actually reclaim host blocks — this is
     /// the path the macOS backend uses, where DISCARD previously fell through to

--- a/virt/arcbox-vmm/src/blk_worker.rs
+++ b/virt/arcbox-vmm/src/blk_worker.rs
@@ -45,6 +45,9 @@ pub enum BlkRequestType {
     /// DISCARD — deallocate (hole-punch) the listed ranges from the backing
     /// image. The range list travels in the read-only data descriptors.
     Discard,
+    /// WRITE_ZEROES — make the listed ranges read back as zeros. Same range-list
+    /// layout as DISCARD, but the device must guarantee the zero read.
+    WriteZeroes,
 }
 
 // ============================================================================
@@ -326,9 +329,11 @@ fn process_batch(ctx: &BlkWorkerContext, batch: &mut [BlkWorkItem]) {
 
 /// Processes a single block I/O work item.
 fn process_item(ctx: &BlkWorkerContext, item: &BlkWorkItem) {
+    // WRITE_ZEROES mutates data like a write, so a following Flush must wait for
+    // it. DISCARD is advisory and excluded from the flush barrier.
     let is_io = matches!(
         item.request_type,
-        BlkRequestType::Read | BlkRequestType::Write
+        BlkRequestType::Read | BlkRequestType::Write | BlkRequestType::WriteZeroes
     );
 
     if is_io {
@@ -349,6 +354,7 @@ fn process_item(ctx: &BlkWorkerContext, item: &BlkWorkItem) {
         }
         BlkRequestType::GetId => process_get_id(ctx, item),
         BlkRequestType::Discard => process_discard(ctx, item),
+        BlkRequestType::WriteZeroes => process_write_zeroes(ctx, item),
     };
 
     if is_io {
@@ -584,21 +590,27 @@ fn process_discard(ctx: &BlkWorkerContext, item: &BlkWorkItem) -> u8 {
     0 // VIRTIO_BLK_S_OK
 }
 
-/// Punches holes for every range in a DISCARD request's read-only payload
-/// descriptors. Factored out of [`process_discard`] so it can be tested without
-/// a full `BlkWorkerContext`.
-fn punch_discard_ranges(
+/// WRITE_ZEROES — make the listed ranges read back as zeros. Same range-list
+/// layout as DISCARD; unlike DISCARD it must be honored, so a read-only device
+/// is an I/O error (and we don't advertise the feature for one).
+fn process_write_zeroes(ctx: &BlkWorkerContext, item: &BlkWorkItem) -> u8 {
+    if ctx.read_only {
+        return 1; // VIRTIO_BLK_S_IOERR
+    }
+    zero_ranges(&ctx.guest_mem, ctx.raw_fd, ctx.blk_size, &item.buffers)
+}
+
+/// Calls `f(start_byte, end_byte)` for each range in a DISCARD / WRITE_ZEROES
+/// request's read-only payload descriptors: 16-byte entries of (sector le64,
+/// num_sectors le32, flags le32). The device-writable 1-byte status descriptor
+/// is skipped.
+fn for_each_range(
     guest_mem: &GuestMemWriter,
-    raw_fd: i32,
     blk_size: u32,
     buffers: &[(u64, u32, bool)],
+    mut f: impl FnMut(u64, u64),
 ) {
-    use arcbox_virtio::blk::{aligned_punch_range, punch_hole};
-
     let block_size = u64::from(blk_size);
-    // The range list travels in the read-only data descriptors: 16-byte entries
-    // of (sector le64, num_sectors le32, flags le32). The device-writable
-    // descriptor is the 1-byte status, which we skip.
     for &(gpa, len, is_write) in buffers {
         if is_write {
             continue;
@@ -609,21 +621,55 @@ fn punch_discard_ranges(
         for entry in bytes.chunks_exact(16) {
             let sector = u64::from_le_bytes(entry[0..8].try_into().unwrap());
             let num_sectors = u32::from_le_bytes(entry[8..12].try_into().unwrap());
-            // entry[12..16] = flags (UNMAP/reserved); ignored for advisory discard.
+            // entry[12..16] = flags (UNMAP/reserved); ignored.
             let start = sector * block_size;
             let end = start + u64::from(num_sectors) * block_size;
-            if let Some((offset, hole_len)) = aligned_punch_range(start, end) {
-                if let Err(e) = punch_hole(raw_fd, offset, hole_len) {
-                    tracing::warn!(
-                        sector,
-                        num_sectors,
-                        error = %e,
-                        "discard hole-punch failed (HV worker); range left allocated"
-                    );
-                }
-            }
+            f(start, end);
         }
     }
+}
+
+/// Punches holes for every DISCARD range. Factored out so it can be tested
+/// without a full `BlkWorkerContext`.
+fn punch_discard_ranges(
+    guest_mem: &GuestMemWriter,
+    raw_fd: i32,
+    blk_size: u32,
+    buffers: &[(u64, u32, bool)],
+) {
+    use arcbox_virtio::blk::{aligned_punch_range, punch_hole};
+
+    for_each_range(guest_mem, blk_size, buffers, |start, end| {
+        if let Some((offset, hole_len)) = aligned_punch_range(start, end) {
+            if let Err(e) = punch_hole(raw_fd, offset, hole_len) {
+                tracing::warn!(
+                    start,
+                    end,
+                    error = %e,
+                    "discard hole-punch failed (HV worker); range left allocated"
+                );
+            }
+        }
+    });
+}
+
+/// Zeroes every WRITE_ZEROES range via the shared sparse-aware primitive
+/// (hole-punch the aligned interior, write zeros on the edges). Returns the
+/// virtio status (0 = OK, 1 = an I/O error occurred on some range).
+fn zero_ranges(
+    guest_mem: &GuestMemWriter,
+    raw_fd: i32,
+    blk_size: u32,
+    buffers: &[(u64, u32, bool)],
+) -> u8 {
+    let mut status = 0u8;
+    for_each_range(guest_mem, blk_size, buffers, |start, end| {
+        if let Err(e) = arcbox_virtio::blk::zero_range(raw_fd, start, end) {
+            tracing::warn!(start, end, error = %e, "write_zeroes failed (HV worker)");
+            status = 1;
+        }
+    });
+    status
 }
 
 // Shared VirtIO queue helpers — extracted to virtqueue_util.rs.
@@ -762,6 +808,7 @@ impl BlkWorkerHandle {
                                 4 => BlkRequestType::Flush,
                                 8 => BlkRequestType::GetId,
                                 11 => BlkRequestType::Discard,
+                                13 => BlkRequestType::WriteZeroes,
                                 _ => BlkRequestType::Read,
                             };
                         }
@@ -882,6 +929,52 @@ mod tests {
         assert!(
             after < 64 * 1024,
             "worker discard should have punched the backing file, still {after} allocated"
+        );
+    }
+
+    /// The HV worker's WRITE_ZEROES path must actually zero the target sectors —
+    /// previously it fell through to a no-op `Read` and silently left stale data.
+    #[cfg(unix)]
+    #[test]
+    #[allow(clippy::cast_possible_wrap)] // pread-return comparison on a small test buffer
+    fn zero_ranges_zeroes_backing_file() {
+        use std::io::Write;
+        use std::os::unix::io::AsRawFd;
+
+        let mut temp = tempfile::NamedTempFile::new().unwrap();
+        temp.write_all(&vec![0xCDu8; 16 * 1024]).unwrap();
+        temp.as_file().sync_all().unwrap();
+        let fd = temp.as_file().as_raw_fd();
+
+        // One write-zeroes entry for sectors [0, 16) — the first 8 KiB.
+        let mut mem = vec![0u8; 4096];
+        mem[0..8].copy_from_slice(&0u64.to_le_bytes()); // sector
+        mem[8..12].copy_from_slice(&16u32.to_le_bytes()); // num_sectors (8 KiB)
+        mem[12..16].copy_from_slice(&0u32.to_le_bytes()); // flags
+        // SAFETY: `mem` outlives `gm`; gpa_base 0 means gpa == buffer offset.
+        let gm = unsafe { GuestMemWriter::new(mem.as_mut_ptr(), mem.len(), 0) };
+        let buffers = vec![(0u64, 16u32, false), (16u64, 1u32, true)];
+
+        assert_eq!(zero_ranges(&gm, fd, 512, &buffers), 0);
+        temp.as_file().sync_all().unwrap();
+
+        // The first 8 KiB now reads back as zeros; the rest is untouched.
+        let mut buf = vec![0xFFu8; 8 * 1024];
+        // SAFETY: reading our own file into a sized buffer.
+        let n = unsafe { libc::pread(fd, buf.as_mut_ptr().cast(), buf.len(), 0) };
+        assert_eq!(n, buf.len() as isize);
+        assert!(
+            buf.iter().all(|&b| b == 0),
+            "write_zeroes range must read as zeros"
+        );
+
+        let mut rest = [0xFFu8; 512];
+        // SAFETY: reading our own file into a sized buffer.
+        let n = unsafe { libc::pread(fd, rest.as_mut_ptr().cast(), rest.len(), 8 * 1024) };
+        assert_eq!(n, 512);
+        assert!(
+            rest.iter().all(|&b| b == 0xCD),
+            "data past the range is intact"
         );
     }
 }

--- a/virt/arcbox-vmm/src/blk_worker.rs
+++ b/virt/arcbox-vmm/src/blk_worker.rs
@@ -182,6 +182,8 @@ pub struct BlkWorkerContext {
     pub raw_fd: i32,
     /// Block size (typically 512).
     pub blk_size: u32,
+    /// Device capacity in 512-byte sectors.
+    pub capacity_sectors: u64,
     /// Whether the device is read-only.
     pub read_only: bool,
     /// Device ID string for GetId requests.
@@ -403,8 +405,13 @@ fn process_read(ctx: &BlkWorkerContext, item: &BlkWorkItem) -> u8 {
     if iovecs.is_empty() {
         return 0;
     }
+    let expected_len = iovecs.iter().map(|iov| iov.iov_len).sum::<usize>();
+    let Some(byte_offset) = item.sector.checked_mul(u64::from(ctx.blk_size)) else {
+        tracing::warn!("blk read: sector offset overflow: {}", item.sector);
+        return 1;
+    };
     #[allow(clippy::cast_possible_wrap)]
-    let offset = (item.sector * u64::from(ctx.blk_size)) as libc::off_t;
+    let offset = byte_offset as libc::off_t;
     #[allow(clippy::cast_possible_truncation, clippy::cast_possible_wrap)]
     let n = unsafe { libc::preadv(ctx.raw_fd, iovecs.as_ptr(), iovecs.len() as i32, offset) };
     if n < 0 {
@@ -412,6 +419,15 @@ fn process_read(ctx: &BlkWorkerContext, item: &BlkWorkItem) -> u8 {
             "blk preadv failed at sector {}: {}",
             item.sector,
             std::io::Error::last_os_error()
+        );
+        return 1;
+    }
+    if n as usize != expected_len {
+        tracing::warn!(
+            "blk preadv short read at sector {}: {} < {}",
+            item.sector,
+            n,
+            expected_len
         );
         return 1;
     }
@@ -440,8 +456,13 @@ fn process_write(ctx: &BlkWorkerContext, item: &BlkWorkItem) -> u8 {
     if iovecs.is_empty() {
         return 0;
     }
+    let expected_len = iovecs.iter().map(|iov| iov.iov_len).sum::<usize>();
+    let Some(byte_offset) = item.sector.checked_mul(u64::from(ctx.blk_size)) else {
+        tracing::warn!("blk write: sector offset overflow: {}", item.sector);
+        return 1;
+    };
     #[allow(clippy::cast_possible_wrap)]
-    let offset = (item.sector * u64::from(ctx.blk_size)) as libc::off_t;
+    let offset = byte_offset as libc::off_t;
     #[allow(clippy::cast_possible_truncation, clippy::cast_possible_wrap)]
     let n = unsafe { libc::pwritev(ctx.raw_fd, iovecs.as_ptr(), iovecs.len() as i32, offset) };
     if n < 0 {
@@ -449,6 +470,15 @@ fn process_write(ctx: &BlkWorkerContext, item: &BlkWorkItem) -> u8 {
             "blk pwritev failed at sector {}: {}",
             item.sector,
             std::io::Error::last_os_error()
+        );
+        return 1;
+    }
+    if n as usize != expected_len {
+        tracing::warn!(
+            "blk pwritev short write at sector {}: {} < {}",
+            item.sector,
+            n,
+            expected_len
         );
         return 1;
     }
@@ -498,8 +528,26 @@ fn process_merged(ctx: &BlkWorkerContext, items: &[BlkWorkItem]) {
     }
 
     // Single merged I/O syscall.
+    let expected_len = iovecs.iter().map(|iov| iov.iov_len).sum::<usize>();
+    let Some(byte_offset) = start_sector.checked_mul(u64::from(ctx.blk_size)) else {
+        tracing::warn!("blk merged: sector offset overflow: {}", start_sector);
+        for item in items {
+            ctx.guest_mem.write_byte(item.status_gpa as usize, 1);
+            write_used_entry(
+                &ctx.guest_mem,
+                item.used_addr,
+                item.queue_size,
+                item.head_idx,
+                1,
+            );
+        }
+        ctx.flush_barrier
+            .in_flight
+            .fetch_sub(items.len() as u32, Ordering::Release);
+        return;
+    };
     #[allow(clippy::cast_possible_wrap)]
-    let offset = (start_sector * u64::from(ctx.blk_size)) as libc::off_t;
+    let offset = byte_offset as libc::off_t;
     #[allow(clippy::cast_possible_truncation, clippy::cast_possible_wrap)]
     let n = if is_read {
         unsafe { libc::preadv(ctx.raw_fd, iovecs.as_ptr(), iovecs.len() as i32, offset) }
@@ -513,6 +561,15 @@ fn process_merged(ctx: &BlkWorkerContext, items: &[BlkWorkItem]) {
             if is_read { "preadv" } else { "pwritev" },
             start_sector,
             std::io::Error::last_os_error()
+        );
+        1
+    } else if n as usize != expected_len {
+        tracing::warn!(
+            "blk merged short {} at sector {}: {} < {}",
+            if is_read { "read" } else { "write" },
+            start_sector,
+            n,
+            expected_len
         );
         1
     } else {
@@ -585,7 +642,13 @@ fn process_get_id(ctx: &BlkWorkerContext, item: &BlkWorkItem) -> u8 {
 /// reported as a successful no-op rather than an I/O error.
 fn process_discard(ctx: &BlkWorkerContext, item: &BlkWorkItem) -> u8 {
     if !ctx.read_only {
-        punch_discard_ranges(&ctx.guest_mem, ctx.raw_fd, ctx.blk_size, &item.buffers);
+        return punch_discard_ranges(
+            &ctx.guest_mem,
+            ctx.raw_fd,
+            ctx.blk_size,
+            ctx.capacity_sectors,
+            &item.buffers,
+        );
     }
     0 // VIRTIO_BLK_S_OK
 }
@@ -597,36 +660,131 @@ fn process_write_zeroes(ctx: &BlkWorkerContext, item: &BlkWorkItem) -> u8 {
     if ctx.read_only {
         return 1; // VIRTIO_BLK_S_IOERR
     }
-    zero_ranges(&ctx.guest_mem, ctx.raw_fd, ctx.blk_size, &item.buffers)
+    zero_ranges(
+        &ctx.guest_mem,
+        ctx.raw_fd,
+        ctx.blk_size,
+        ctx.capacity_sectors,
+        &item.buffers,
+    )
 }
 
-/// Calls `f(start_byte, end_byte)` for each range in a DISCARD / WRITE_ZEROES
-/// request's read-only payload descriptors: 16-byte entries of (sector le64,
-/// num_sectors le32, flags le32). The device-writable 1-byte status descriptor
-/// is skipped.
-fn for_each_range(
+/// Parses a DISCARD / WRITE_ZEROES request's read-only payload descriptors. The
+/// device-writable 1-byte status descriptor is skipped. Payload descriptors are
+/// concatenated before parsing so legal scatter-gather layouts with a 16-byte
+/// range split across descriptors behave exactly like the generic path.
+fn parse_ranges_from_buffers(
     guest_mem: &GuestMemWriter,
-    blk_size: u32,
     buffers: &[(u64, u32, bool)],
-    mut f: impl FnMut(u64, u64),
-) {
-    let block_size = u64::from(blk_size);
+    log_context: &str,
+) -> Result<Vec<arcbox_virtio::blk::DiscardWriteZeroesRange>, ()> {
+    let mut payload = Vec::new();
     for &(gpa, len, is_write) in buffers {
         if is_write {
             continue;
         }
         let Some(bytes) = guest_mem.slice(gpa as usize, len as usize) else {
-            continue;
+            tracing::warn!("{log_context}: range payload GPA {gpa:#x} len {len} out of bounds");
+            return Err(());
         };
-        for entry in bytes.chunks_exact(16) {
-            let sector = u64::from_le_bytes(entry[0..8].try_into().unwrap());
-            let num_sectors = u32::from_le_bytes(entry[8..12].try_into().unwrap());
-            // entry[12..16] = flags (UNMAP/reserved); ignored.
-            let start = sector * block_size;
-            let end = start + u64::from(num_sectors) * block_size;
-            f(start, end);
-        }
+        payload.extend_from_slice(bytes);
     }
+    arcbox_virtio::blk::parse_range_list(&payload).map_err(|e| {
+        tracing::warn!(error = %e, "{log_context}: malformed range list");
+    })
+}
+
+fn checked_range_bytes(
+    range: arcbox_virtio::blk::DiscardWriteZeroesRange,
+    blk_size: u32,
+    capacity_sectors: u64,
+    max_sectors: u32,
+    log_context: &str,
+) -> Result<(u64, u64), ()> {
+    if range.num_sectors > max_sectors {
+        tracing::warn!(
+            sector = range.sector,
+            num_sectors = range.num_sectors,
+            max_sectors,
+            "{log_context}: range exceeds advertised maximum"
+        );
+        return Err(());
+    }
+    range
+        .checked_byte_range(blk_size, capacity_sectors)
+        .map_err(|e| {
+            tracing::warn!(sector = range.sector, num_sectors = range.num_sectors, error = %e, "{log_context}: invalid range");
+        })
+}
+
+fn validate_discard_flags(
+    range: arcbox_virtio::blk::DiscardWriteZeroesRange,
+    log_context: &str,
+) -> Result<(), ()> {
+    if range.flags != 0 {
+        tracing::warn!(
+            flags = range.flags,
+            "{log_context}: discard reserved flags set"
+        );
+        return Err(());
+    }
+    Ok(())
+}
+
+fn validate_write_zeroes_flags(
+    range: arcbox_virtio::blk::DiscardWriteZeroesRange,
+    log_context: &str,
+) -> Result<(), ()> {
+    if range.flags & !arcbox_virtio::blk::WRITE_ZEROES_FLAG_UNMAP != 0 {
+        tracing::warn!(
+            flags = range.flags,
+            "{log_context}: write_zeroes reserved flags set"
+        );
+        return Err(());
+    }
+    Ok(())
+}
+
+fn discard_byte_ranges(
+    guest_mem: &GuestMemWriter,
+    blk_size: u32,
+    capacity_sectors: u64,
+    buffers: &[(u64, u32, bool)],
+) -> Result<Vec<(u64, u64)>, ()> {
+    let ranges = parse_ranges_from_buffers(guest_mem, buffers, "discard")?;
+    let mut byte_ranges = Vec::with_capacity(ranges.len());
+    for range in ranges {
+        validate_discard_flags(range, "discard")?;
+        byte_ranges.push(checked_range_bytes(
+            range,
+            blk_size,
+            capacity_sectors,
+            arcbox_virtio::blk::VirtioBlock::MAX_DISCARD_SECTORS,
+            "discard",
+        )?);
+    }
+    Ok(byte_ranges)
+}
+
+fn write_zeroes_byte_ranges(
+    guest_mem: &GuestMemWriter,
+    blk_size: u32,
+    capacity_sectors: u64,
+    buffers: &[(u64, u32, bool)],
+) -> Result<Vec<(u64, u64)>, ()> {
+    let ranges = parse_ranges_from_buffers(guest_mem, buffers, "write_zeroes")?;
+    let mut byte_ranges = Vec::with_capacity(ranges.len());
+    for range in ranges {
+        validate_write_zeroes_flags(range, "write_zeroes")?;
+        byte_ranges.push(checked_range_bytes(
+            range,
+            blk_size,
+            capacity_sectors,
+            arcbox_virtio::blk::VirtioBlock::MAX_WRITE_ZEROES_SECTORS,
+            "write_zeroes",
+        )?);
+    }
+    Ok(byte_ranges)
 }
 
 /// Punches holes for every DISCARD range. Factored out so it can be tested
@@ -635,11 +793,15 @@ fn punch_discard_ranges(
     guest_mem: &GuestMemWriter,
     raw_fd: i32,
     blk_size: u32,
+    capacity_sectors: u64,
     buffers: &[(u64, u32, bool)],
-) {
+) -> u8 {
     use arcbox_virtio::blk::{aligned_punch_range, punch_hole};
 
-    for_each_range(guest_mem, blk_size, buffers, |start, end| {
+    let Ok(ranges) = discard_byte_ranges(guest_mem, blk_size, capacity_sectors, buffers) else {
+        return 1;
+    };
+    for (start, end) in ranges {
         if let Some((offset, hole_len)) = aligned_punch_range(start, end) {
             if let Err(e) = punch_hole(raw_fd, offset, hole_len) {
                 tracing::warn!(
@@ -650,7 +812,8 @@ fn punch_discard_ranges(
                 );
             }
         }
-    });
+    }
+    0
 }
 
 /// Zeroes every WRITE_ZEROES range via the shared sparse-aware primitive
@@ -660,15 +823,20 @@ fn zero_ranges(
     guest_mem: &GuestMemWriter,
     raw_fd: i32,
     blk_size: u32,
+    capacity_sectors: u64,
     buffers: &[(u64, u32, bool)],
 ) -> u8 {
     let mut status = 0u8;
-    for_each_range(guest_mem, blk_size, buffers, |start, end| {
+    let Ok(ranges) = write_zeroes_byte_ranges(guest_mem, blk_size, capacity_sectors, buffers)
+    else {
+        return 1;
+    };
+    for (start, end) in ranges {
         if let Err(e) = arcbox_virtio::blk::zero_range(raw_fd, start, end) {
             tracing::warn!(start, end, error = %e, "write_zeroes failed (HV worker)");
             status = 1;
         }
-    });
+    }
     status
 }
 
@@ -922,7 +1090,7 @@ mod tests {
         // Descriptors: the read-only range list, then the write-only status byte
         // (which must be skipped, not parsed as a range).
         let buffers = vec![(0u64, 16u32, false), (16u64, 1u32, true)];
-        punch_discard_ranges(&gm, fd, 512, &buffers);
+        assert_eq!(punch_discard_ranges(&gm, fd, 512, 2048, &buffers), 0);
         temp.as_file().sync_all().unwrap();
 
         let after = std::fs::metadata(temp.path()).unwrap().blocks() * 512;
@@ -955,7 +1123,7 @@ mod tests {
         let gm = unsafe { GuestMemWriter::new(mem.as_mut_ptr(), mem.len(), 0) };
         let buffers = vec![(0u64, 16u32, false), (16u64, 1u32, true)];
 
-        assert_eq!(zero_ranges(&gm, fd, 512, &buffers), 0);
+        assert_eq!(zero_ranges(&gm, fd, 512, 32, &buffers), 0);
         temp.as_file().sync_all().unwrap();
 
         // The first 8 KiB now reads back as zeros; the rest is untouched.
@@ -976,5 +1144,52 @@ mod tests {
             rest.iter().all(|&b| b == 0xCD),
             "data past the range is intact"
         );
+    }
+
+    #[test]
+    fn range_parser_concatenates_split_payload_descriptors() {
+        let mut mem = vec![0u8; 4096];
+        mem[0..8].copy_from_slice(&8u64.to_le_bytes());
+        mem[8..12].copy_from_slice(&8u32.to_le_bytes());
+        mem[12..16].copy_from_slice(&0u32.to_le_bytes());
+        // SAFETY: `mem` outlives `gm`; gpa_base 0 means gpa == buffer offset.
+        let gm = unsafe { GuestMemWriter::new(mem.as_mut_ptr(), mem.len(), 0) };
+
+        let buffers = vec![
+            (0u64, 8u32, false),
+            (8u64, 8u32, false),
+            (16u64, 1u32, true),
+        ];
+        let ranges = discard_byte_ranges(&gm, 512, 32, &buffers).unwrap();
+
+        assert_eq!(ranges, vec![(4096, 8192)]);
+    }
+
+    #[test]
+    fn write_zeroes_rejects_trailing_payload_bytes() {
+        let mut mem = vec![0u8; 4096];
+        mem[0..8].copy_from_slice(&0u64.to_le_bytes());
+        mem[8..12].copy_from_slice(&8u32.to_le_bytes());
+        mem[12..16].copy_from_slice(&0u32.to_le_bytes());
+        // SAFETY: `mem` outlives `gm`; gpa_base 0 means gpa == buffer offset.
+        let gm = unsafe { GuestMemWriter::new(mem.as_mut_ptr(), mem.len(), 0) };
+
+        let buffers = vec![(0u64, 17u32, false), (17u64, 1u32, true)];
+
+        assert!(write_zeroes_byte_ranges(&gm, 512, 32, &buffers).is_err());
+    }
+
+    #[test]
+    fn write_zeroes_rejects_ranges_past_capacity() {
+        let mut mem = vec![0u8; 4096];
+        mem[0..8].copy_from_slice(&31u64.to_le_bytes());
+        mem[8..12].copy_from_slice(&2u32.to_le_bytes());
+        mem[12..16].copy_from_slice(&0u32.to_le_bytes());
+        // SAFETY: `mem` outlives `gm`; gpa_base 0 means gpa == buffer offset.
+        let gm = unsafe { GuestMemWriter::new(mem.as_mut_ptr(), mem.len(), 0) };
+
+        let buffers = vec![(0u64, 16u32, false), (16u64, 1u32, true)];
+
+        assert!(write_zeroes_byte_ranges(&gm, 512, 32, &buffers).is_err());
     }
 }

--- a/virt/arcbox-vmm/src/vmm/darwin_hv/hvc_blk.rs
+++ b/virt/arcbox-vmm/src/vmm/darwin_hv/hvc_blk.rs
@@ -29,7 +29,7 @@ pub const ARCBOX_HVC_BLK_FLUSH: u64 = 0xC200_0003;
 /// `is_write`: false=pread, true=pwrite.
 pub fn handle_hvc_blk_io(
     vcpu: &arcbox_hv::HvVcpu,
-    hvc_blk_fds: &[(i32, u32)],
+    hvc_blk_fds: &[(i32, u32, u64)],
     device_manager: &crate::device::DeviceManager,
     is_write: bool,
 ) -> u64 {
@@ -51,7 +51,7 @@ pub fn handle_hvc_blk_io(
         return (-libc::EINVAL as i64) as u64;
     }
 
-    let Some(&(raw_fd, blk_size)) = hvc_blk_fds.get(device_idx as usize) else {
+    let Some(&(raw_fd, blk_size, capacity_sectors)) = hvc_blk_fds.get(device_idx as usize) else {
         return (-libc::ENODEV as i64) as u64;
     };
 
@@ -75,7 +75,9 @@ pub fn handle_hvc_blk_io(
     // live host mapping tracked by `DeviceManager` for the VM's lifetime.
     let host_ptr = unsafe { ram_base.add(gpa - gpa_base) };
 
-    let Some(byte_offset) = sector.checked_mul(u64::from(blk_size)) else {
+    let Ok((byte_offset, _)) =
+        arcbox_virtio::blk::checked_io_byte_range(sector, byte_len, blk_size, capacity_sectors)
+    else {
         return (-libc::EINVAL as i64) as u64;
     };
     #[allow(clippy::cast_possible_wrap)]
@@ -96,15 +98,18 @@ pub fn handle_hvc_blk_io(
             .unwrap_or(libc::EIO);
         return (-errno as i64) as u64;
     }
-    n as u64
+    if n as usize != byte_len {
+        return (-libc::EIO as i64) as u64;
+    }
+    byte_len as u64
 }
 
 /// HVC block flush (fsync). X1=device_idx.
-pub fn handle_hvc_blk_flush(vcpu: &arcbox_hv::HvVcpu, hvc_blk_fds: &[(i32, u32)]) -> u64 {
+pub fn handle_hvc_blk_flush(vcpu: &arcbox_hv::HvVcpu, hvc_blk_fds: &[(i32, u32, u64)]) -> u64 {
     let Ok(device_idx) = vcpu.get_reg(X1) else {
         return (-libc::EINVAL as i64) as u64;
     };
-    let Some(&(raw_fd, _)) = hvc_blk_fds.get(device_idx as usize) else {
+    let Some(&(raw_fd, _, _)) = hvc_blk_fds.get(device_idx as usize) else {
         return (-libc::ENODEV as i64) as u64;
     };
     // SAFETY: `raw_fd` is an open fd from `hvc_blk_fds` owned by the VMM;

--- a/virt/arcbox-vmm/src/vmm/darwin_hv/mod.rs
+++ b/virt/arcbox-vmm/src/vmm/darwin_hv/mod.rs
@@ -554,10 +554,12 @@ impl Vmm {
         // Build HVC fast-path fd table from all block devices.
         // device_idx 0 = first block device (vda), 1 = second (vdb), etc.
         {
-            let fds: Vec<(i32, u32)> = self
+            let fds: Vec<(i32, u32, u64)> = self
                 .hv_blk_devices
                 .iter()
-                .map(|(_, raw_fd, blk_size, _, _, _, _)| (*raw_fd, *blk_size))
+                .map(|(_, raw_fd, blk_size, capacity_sectors, _, _, _)| {
+                    (*raw_fd, *blk_size, *capacity_sectors)
+                })
                 .collect();
             self.hvc_blk_fds = Arc::new(fds);
         }

--- a/virt/arcbox-vmm/src/vmm/darwin_hv/mod.rs
+++ b/virt/arcbox-vmm/src/vmm/darwin_hv/mod.rs
@@ -526,6 +526,7 @@ impl Vmm {
             blk.set_num_queues(blk_num_queues);
             let raw_fd = blk.raw_fd().unwrap_or(-1);
             let blk_size = blk.blk_size();
+            let capacity_sectors = blk.capacity_sectors();
             let read_only = blk.is_read_only();
             let num_queues = blk.num_queues();
             let dev_id_str = blk.device_id_string().to_string();
@@ -539,7 +540,13 @@ impl Vmm {
             )?;
             if raw_fd >= 0 {
                 self.hv_blk_devices.push((
-                    device_id, raw_fd, blk_size, read_only, dev_id_str, num_queues,
+                    device_id,
+                    raw_fd,
+                    blk_size,
+                    capacity_sectors,
+                    read_only,
+                    dev_id_str,
+                    num_queues,
                 ));
             }
         }
@@ -550,7 +557,7 @@ impl Vmm {
             let fds: Vec<(i32, u32)> = self
                 .hv_blk_devices
                 .iter()
-                .map(|(_, raw_fd, blk_size, _, _, _)| (*raw_fd, *blk_size))
+                .map(|(_, raw_fd, blk_size, _, _, _, _)| (*raw_fd, *blk_size))
                 .collect();
             self.hvc_blk_fds = Arc::new(fds);
         }
@@ -950,20 +957,44 @@ impl Vmm {
             let blk_infos = std::mem::take(&mut self.hv_blk_devices)
                 .into_iter()
                 .filter_map(
-                    |(dev_id, raw_fd, blk_size, read_only, dev_id_str, num_queues)| {
+                    |(
+                        dev_id,
+                        raw_fd,
+                        blk_size,
+                        capacity_sectors,
+                        read_only,
+                        dev_id_str,
+                        num_queues,
+                    )| {
                         let dev = dm.get_registered_device(dev_id)?;
                         let irq = dev.info.irq?;
                         let mmio_state = dev.mmio_state.as_ref()?.clone();
                         Some((
-                            dev_id, raw_fd, blk_size, read_only, dev_id_str, num_queues, irq,
+                            dev_id,
+                            raw_fd,
+                            blk_size,
+                            capacity_sectors,
+                            read_only,
+                            dev_id_str,
+                            num_queues,
+                            irq,
                             mmio_state,
                         ))
                     },
                 )
                 .collect::<Vec<_>>();
 
-            for (dev_id, raw_fd, blk_size, read_only, dev_id_str, num_queues, irq, mmio_state) in
-                blk_infos
+            for (
+                dev_id,
+                raw_fd,
+                blk_size,
+                capacity_sectors,
+                read_only,
+                dev_id_str,
+                num_queues,
+                irq,
+                mmio_state,
+            ) in blk_infos
             {
                 let irq_cb = dm.irq_callback_clone().unwrap_or_else(|| {
                     Arc::new(|_: crate::irq::Irq, _: bool| -> crate::error::Result<()> { Ok(()) })
@@ -987,6 +1018,7 @@ impl Vmm {
                         },
                         raw_fd,
                         blk_size,
+                        capacity_sectors,
                         read_only,
                         device_id: dev_id_str.clone(),
                         mmio_state: mmio_state.clone(),

--- a/virt/arcbox-vmm/src/vmm/darwin_hv/vcpu_loop.rs
+++ b/virt/arcbox-vmm/src/vmm/darwin_hv/vcpu_loop.rs
@@ -63,7 +63,7 @@ pub(super) struct VcpuContext {
     /// `hv_vcpus_exit` (which on arm64 requires a concrete list, not NULL).
     pub hv_vcpu_ids: HvVcpuIds,
     /// Per-block-device file descriptors and sector sizes for HVC fast path.
-    pub hvc_blk_fds: Arc<Vec<(i32, u32)>>,
+    pub hvc_blk_fds: Arc<Vec<(i32, u32, u64)>>,
 }
 
 /// Reads the value of an MMIO write source register, handling the ARM64

--- a/virt/arcbox-vmm/src/vmm/mod.rs
+++ b/virt/arcbox-vmm/src/vmm/mod.rs
@@ -310,9 +310,9 @@ pub struct Vmm {
     /// Block I/O worker thread handles for join on shutdown.
     #[cfg(target_os = "macos")]
     hv_blk_worker_threads: Vec<std::thread::JoinHandle<()>>,
-    /// HVC fast path: device_idx → (raw_fd, blk_size). Shared with vCPU threads.
+    /// HVC fast path: device_idx → (raw_fd, blk_size, capacity_sectors). Shared with vCPU threads.
     #[cfg(target_os = "macos")]
-    hvc_blk_fds: Arc<Vec<(i32, u32)>>,
+    hvc_blk_fds: Arc<Vec<(i32, u32, u64)>>,
     /// Per-VirtioFS-share DAX mappers (concrete type).
     ///
     /// One `Arc<HvDaxMapper>` per configured shared directory, in the

--- a/virt/arcbox-vmm/src/vmm/mod.rs
+++ b/virt/arcbox-vmm/src/vmm/mod.rs
@@ -304,10 +304,9 @@ pub struct Vmm {
     #[cfg(target_os = "macos")]
     hv_bridge_net_fd: Option<OwnedFd>,
     /// Block device info captured during initialize for worker thread spawn.
-    /// (DeviceId, raw_fd, blk_size, read_only, device_id_string)
     #[cfg(target_os = "macos")]
-    /// (DeviceId, raw_fd, blk_size, read_only, device_id_string, num_queues)
-    hv_blk_devices: Vec<(crate::device::DeviceId, i32, u32, bool, String, u16)>,
+    /// (DeviceId, raw_fd, blk_size, capacity_sectors, read_only, device_id_string, num_queues)
+    hv_blk_devices: Vec<(crate::device::DeviceId, i32, u32, u64, bool, String, u16)>,
     /// Block I/O worker thread handles for join on shutdown.
     #[cfg(target_os = "macos")]
     hv_blk_worker_threads: Vec<std::thread::JoinHandle<()>>,


### PR DESCRIPTION
Stacked on #334 (base: `fix/storage-drop-upfront-prealloc`). Review/merge #334 first.

Follow-up to #334. That PR stops *new* installs from over-allocating, but it doesn't reclaim space — neither for existing installs (whose data image already holds the preallocated ~64 GiB) nor for day-to-day churn after containers/images are removed. The reclaim chain was built on the guest side (hourly + on-demand `fstrim`, `discard=async`) but dropped on the host: the virtio-blk DISCARD handler was a no-op. This wires up that last hop.

Addresses the disk-footprint half of arcboxlabs/arcbox-desktop#244 (ABXD-95).

## Changes

### 1. `feat(virtio-blk): punch holes on DISCARD`
- Replace the no-op `handle_discard_list` with real hole-punching: a cross-platform `punch_hole` helper using `fallocate(PUNCH_HOLE | KEEP_SIZE)` on Linux and `fcntl(F_PUNCHHOLE, fpunchhole_t)` on macOS (both via existing `libc` definitions).
- Ranges are aligned inward to a 4 KiB block: macOS `F_PUNCHHOLE` rejects unaligned ranges and Linux only frees fully-covered blocks anyway.
- DISCARD is advisory under the virtio-blk spec, so a punch failure is logged and swallowed rather than failing the guest request; malformed requests still error.
- Tests cover the helper and the end-to-end discard path, asserting allocated blocks drop.

### 2. `feat(cli): make 'disk compact' trigger an on-demand trim`
- Add `MachineService.CompactDisk(MachineAgentRequest) -> Empty`, routing to the guest agent's existing `disk_trim` (fstrim) RPC.
- `arcbox disk compact` was a stub; it now stats the data image before/after and reports reclaimed physical space. Removed the stale 'reclaimed automatically' messaging.

## Why this matters

With the host punch in place, the guest's already-running hourly `fstrim` reclaims free blocks automatically — so existing installs shed the previously preallocated space non-destructively, with no migration code. `disk compact` gives an immediate, manual trigger.

## Testing
`cargo build` (incl. daemon) / `cargo test` / `cargo clippy --all-targets` / `cargo fmt` all clean. Hole-punch reclamation verified on APFS via the new tests.