### PR TITLE
feat(fleet): offer/reject protocol, agent as admission authority (RUN-23, client side)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures 0.2.17",
+]
+
+[[package]]
 name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -114,6 +125,17 @@ name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
+name = "apple-native-keyring-store"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7be2f067ccd8d4b4d4a66ddafe0f32a5dff31732f32dbff85fefc40929b1f72"
+dependencies = [
+ "keyring-core",
+ "log",
+ "security-framework",
+]
 
 [[package]]
 name = "arcbox"
@@ -463,6 +485,7 @@ dependencies = [
  "dashmap",
  "dirs",
  "hostname",
+ "keyring",
  "prost",
  "serde",
  "serde_json",
@@ -909,6 +932,120 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-broadcast"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "435a87a52755b8f27fcf321ac4f04b2802e337c8c4872923137471ec39c37532"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-channel"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
+dependencies = [
+ "concurrent-queue",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-executor"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96bf972d85afc50bf5ab8fe2d54d1586b4e0b46c97c50a0c9e71e2f7bcd812a"
+dependencies = [
+ "async-task",
+ "concurrent-queue",
+ "fastrand",
+ "futures-lite",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "async-io"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "concurrent-queue",
+ "futures-io",
+ "futures-lite",
+ "parking",
+ "polling",
+ "rustix",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-lock"
+version = "3.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-process"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc50921ec0055cdd8a16de48773bfeec5c972598674347252c0399676be7da75"
+dependencies = [
+ "async-channel",
+ "async-io",
+ "async-lock",
+ "async-signal",
+ "async-task",
+ "blocking",
+ "cfg-if",
+ "event-listener",
+ "futures-lite",
+ "rustix",
+]
+
+[[package]]
+name = "async-recursion"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "async-signal"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52b5aaafa020cf5053a01f2a60e8ff5dccf550f0f77ec54a4e47285ac2bab485"
+dependencies = [
+ "async-io",
+ "async-lock",
+ "atomic-waker",
+ "cfg-if",
+ "futures-core",
+ "futures-io",
+ "rustix",
+ "signal-hook-registry",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "async-stream"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -929,6 +1066,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "async-task"
+version = "4.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
 
 [[package]]
 name = "async-trait"
@@ -1143,12 +1286,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-padding"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "block2"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
 dependencies = [
  "objc2",
+]
+
+[[package]]
+name = "blocking"
+version = "1.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
+dependencies = [
+ "async-channel",
+ "async-task",
+ "futures-io",
+ "futures-lite",
+ "piper",
 ]
 
 [[package]]
@@ -1207,6 +1372,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
 
 [[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
 name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1217,6 +1388,15 @@ name = "cast"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
+name = "cbc"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
+dependencies = [
+ "cipher",
+]
 
 [[package]]
 name = "cc"
@@ -1299,6 +1479,16 @@ checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
 dependencies = [
  "ciborium-io",
  "half",
+]
+
+[[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
 ]
 
 [[package]]
@@ -1387,6 +1577,15 @@ dependencies = [
  "nix 0.27.1",
  "tokio",
  "winapi",
+]
+
+[[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -1617,6 +1816,7 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -1710,6 +1910,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "endi"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66b7e2430c6dff6a955451e2cfc438f09cea1965a9d6f87f7e3b90decc014099"
+
+[[package]]
 name = "enum-ordinalize"
 version = "4.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1730,6 +1936,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "enumflags2"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1027f7680c853e056ebcec683615fb6fbbc07dbaa13b4d5d9442b146ded4ecef"
+dependencies = [
+ "enumflags2_derive",
+ "serde",
+]
+
+[[package]]
+name = "enumflags2_derive"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1743,6 +1970,27 @@ checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "event-listener"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -1927,6 +2175,19 @@ name = "futures-io"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
+name = "futures-lite"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "parking",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "futures-macro"
@@ -2132,6 +2393,24 @@ dependencies = [
  "tinyvec",
  "tracing",
  "url",
+]
+
+[[package]]
+name = "hkdf"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+dependencies = [
+ "hmac",
+]
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
 ]
 
 [[package]]
@@ -2511,6 +2790,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "block-padding",
+ "generic-array",
+]
+
+[[package]]
 name = "instant"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2659,6 +2948,27 @@ dependencies = [
  "futures-util",
  "once_cell",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "keyring"
+version = "4.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fef88805a7ddbc8f9cf52bfa8dba90b3f80dff23a1e1533cd4f1d8e8d448fc8"
+dependencies = [
+ "apple-native-keyring-store",
+ "keyring-core",
+ "windows-native-keyring-store",
+ "zbus-secret-service-keyring-store",
+]
+
+[[package]]
+name = "keyring-core"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb1e621458ca9c51aa110bd0339d4751a056b9576bf1253aee1aa560dda0fc9d"
+dependencies = [
+ "log",
 ]
 
 [[package]]
@@ -3002,10 +3312,74 @@ dependencies = [
 ]
 
 [[package]]
+name = "num"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+]
 
 [[package]]
 name = "num-traits"
@@ -3323,6 +3697,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
+name = "ordered-stream"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "os_info"
 version = "3.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3337,6 +3721,12 @@ dependencies = [
  "serde",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parking_lot"
@@ -3433,6 +3823,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "piper"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c835479a4443ded371d6c535cbfd8d31ad92c5d23ae9770a61bc155e4992a3c1"
+dependencies = [
+ "atomic-waker",
+ "fastrand",
+ "futures-io",
+]
+
+[[package]]
 name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3480,6 +3881,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "polling"
+version = "3.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
+dependencies = [
+ "cfg-if",
+ "concurrent-queue",
+ "hermit-abi",
+ "pin-project-lite",
+ "rustix",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "portable-atomic"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3517,6 +3932,15 @@ checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
  "syn",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
+dependencies = [
+ "toml_edit 0.25.12+spec-1.1.0",
 ]
 
 [[package]]
@@ -4123,6 +4547,25 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "secret-service"
+version = "5.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a62d7f86047af0077255a29494136b9aaaf697c76ff70b8e49cded4e2623c14"
+dependencies = [
+ "aes",
+ "cbc",
+ "futures-util",
+ "generic-array",
+ "getrandom 0.2.17",
+ "hkdf",
+ "num",
+ "once_cell",
+ "serde",
+ "sha2",
+ "zbus",
+]
 
 [[package]]
 name = "security-framework"
@@ -5267,6 +5710,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "uds_windows"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
+dependencies = [
+ "memoffset",
+ "tempfile",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "uname"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5742,6 +6196,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
+name = "windows-native-keyring-store"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "063426e76fdec7438d56bb777f67e318a84a25c707b07e575cb8b78e10c028f8"
+dependencies = [
+ "byteorder",
+ "keyring-core",
+ "regex",
+ "windows-sys 0.61.2",
+ "zeroize",
+]
+
+[[package]]
 name = "windows-registry"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6204,6 +6671,78 @@ dependencies = [
 ]
 
 [[package]]
+name = "zbus"
+version = "5.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eee682d202a77e4a9f3b2c2bdf48a7b28af5c08c34ddf66f98c93e5e39464285"
+dependencies = [
+ "async-broadcast",
+ "async-executor",
+ "async-io",
+ "async-lock",
+ "async-process",
+ "async-recursion",
+ "async-task",
+ "async-trait",
+ "blocking",
+ "enumflags2",
+ "event-listener",
+ "futures-core",
+ "futures-lite",
+ "hex",
+ "libc",
+ "ordered-stream",
+ "rustix",
+ "serde",
+ "serde_repr",
+ "tracing",
+ "uds_windows",
+ "uuid",
+ "windows-sys 0.61.2",
+ "winnow 1.0.1",
+ "zbus_macros",
+ "zbus_names",
+ "zvariant",
+]
+
+[[package]]
+name = "zbus-secret-service-keyring-store"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ccede190ba363386a24e8021c7f3848393976609ec9f5d1f8c6c09ef37075b4"
+dependencies = [
+ "keyring-core",
+ "secret-service",
+ "zbus",
+]
+
+[[package]]
+name = "zbus_macros"
+version = "5.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adf1bd45a81a103745b1757754762a26e8cd01e4532e4d6c8ec431624b80d1d6"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "zbus_names",
+ "zvariant",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zbus_names"
+version = "4.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7074f3e50b894eac91750142016d30d0a89be8e67dbfd9704fb875825760e52d"
+dependencies = [
+ "serde",
+ "winnow 1.0.1",
+ "zvariant",
+]
+
+[[package]]
 name = "zerocopy"
 version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6288,3 +6827,43 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zvariant"
+version = "5.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a192a0bde63360d77a7523c833d4b4ce6070a927e2c53246e4c540b1a3e27be0"
+dependencies = [
+ "endi",
+ "enumflags2",
+ "serde",
+ "winnow 1.0.1",
+ "zvariant_derive",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_derive"
+version = "5.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90bc6cde9c01c511074be97f7ccb6c19d0da89e3f8662e812e999dcfd4638737"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_utils"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e8535915cfa75547e559d8c68e8139909a4aeee076831e4ef7fc59d8172c4d6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde",
+ "syn",
+ "winnow 1.0.1",
+]

--- a/fleet/arcbox-fleet-agent/Cargo.toml
+++ b/fleet/arcbox-fleet-agent/Cargo.toml
@@ -38,3 +38,6 @@ bollard = "0.21.0"
 
 [lints]
 workspace = true
+
+[target.'cfg(any(target_os = "macos", target_os = "windows"))'.dependencies]
+keyring = "4"

--- a/fleet/arcbox-fleet-agent/src/attach.rs
+++ b/fleet/arcbox-fleet-agent/src/attach.rs
@@ -26,6 +26,10 @@ use crate::host;
 use crate::runner::RunnerSupervisor;
 
 const HEARTBEAT_INTERVAL: Duration = Duration::from_secs(15);
+/// How often to resend verdicts still awaiting an `OfferVerdictAck`. Comfortably
+/// longer than normal ack latency (sub-second), so the steady state is zero
+/// resends, yet short enough to recover a lost verdict within a placement window.
+const VERDICT_RESEND_INTERVAL: Duration = Duration::from_secs(10);
 const INITIAL_BACKOFF: Duration = Duration::from_secs(1);
 const MAX_BACKOFF: Duration = Duration::from_secs(60);
 const OUTBOUND_CAPACITY: usize = 64;
@@ -54,6 +58,12 @@ pub async fn run(
         config.load_ceiling,
         config.mem_floor_mib,
     );
+
+    // Process-scoped: resend unacked verdicts across reconnects. Re-emitted
+    // verdicts ride the same egress queue, so the reconnect-survival machinery
+    // below (egress forwarding + `pending`) delivers them to whichever stream is
+    // live. Detached for the agent's lifetime; the agent never shuts down here.
+    spawn_verdict_resend(supervisor.clone());
 
     let mut backoff = INITIAL_BACKOFF;
     // An event pulled from the egress queue but not yet delivered when the
@@ -177,8 +187,28 @@ async fn dispatch(supervisor: &RunnerSupervisor, msg: Option<attach_response::Ms
         }
         Some(attach_response::Msg::Cancel(cancel)) => supervisor.handle_cancel(&cancel.job_id),
         Some(attach_response::Msg::Drain(_)) => supervisor.handle_drain(),
+        Some(attach_response::Msg::OfferVerdictAck(ack)) => {
+            supervisor.handle_ack(&ack.offer_token);
+        }
         None => {}
     }
+}
+
+/// Periodically resend verdicts still awaiting an `OfferVerdictAck`, until the
+/// gateway acks them (or the resend cap is hit). Process-scoped so it spans
+/// reconnects; the supervisor holds the egress sender, so resends route through
+/// the same outbound path as fresh verdicts.
+fn spawn_verdict_resend(supervisor: RunnerSupervisor) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move {
+        let mut ticker = tokio::time::interval(VERDICT_RESEND_INTERVAL);
+        // Skip the immediate first tick: a verdict just sent has not had time to
+        // be acked, so there is nothing to resend yet.
+        ticker.tick().await;
+        loop {
+            ticker.tick().await;
+            supervisor.resend_outstanding();
+        }
+    })
 }
 
 /// Periodically push a declarative capability + telemetry heartbeat until the

--- a/fleet/arcbox-fleet-agent/src/attach.rs
+++ b/fleet/arcbox-fleet-agent/src/attach.rs
@@ -11,16 +11,15 @@ use std::time::Duration;
 use anyhow::{Context, Result};
 use arcbox_fleet_proto::v1::fleet_gateway_service_client::FleetGatewayServiceClient;
 use arcbox_fleet_proto::v1::{
-    AttachRequest, Heartbeat, RuntimeCapacity, attach_request, attach_response,
+    AttachRequest, Capability, Heartbeat, attach_request, attach_response,
 };
 use tokio::sync::mpsc;
 use tokio_stream::wrappers::ReceiverStream;
-use tokio_util::sync::CancellationToken;
 use tonic::Request;
 use tonic::metadata::MetadataValue;
 use tracing::{info, warn};
 
-use crate::config::AgentConfig;
+use crate::config::{AgentConfig, PROTOCOL_VERSION};
 use crate::credentials::Credential;
 use crate::docker;
 use crate::host;
@@ -31,30 +30,30 @@ const INITIAL_BACKOFF: Duration = Duration::from_secs(1);
 const MAX_BACKOFF: Duration = Duration::from_secs(60);
 const OUTBOUND_CAPACITY: usize = 64;
 const MACHINE_TOKEN_HEADER: &str = "x-arcbox-machine-token";
-/// How long to wait for runner process groups to be killed and reaped on
-/// shutdown before giving up. Reaping a SIGKILLed group is near-instant, so this
-/// is a generous ceiling rather than an expected wait.
-const SHUTDOWN_GRACE: Duration = Duration::from_secs(15);
+const PROTOCOL_VERSION_HEADER: &str = "x-arcbox-protocol-version";
 
-/// Connect and serve the attach stream, reconnecting on any failure until
-/// `shutdown` fires, then stop runners cleanly.
+/// Connect and serve the attach stream forever, reconnecting on any failure.
 ///
 /// The supervisor and the egress queue carrying runner lifecycle events are
 /// built once and reused across reconnects, so in-flight jobs survive a dropped
-/// connection and their terminal events reach the next live stream. On shutdown
-/// the loop exits and hands off to [`RunnerSupervisor::shutdown`], which tears
-/// down any in-flight runners (host process groups and Docker containers).
+/// connection and their terminal events reach the next live stream.
 pub async fn run(
     config: AgentConfig,
     credential: Credential,
     docker: Option<docker::DockerRunner>,
-    pools: Vec<RuntimeCapacity>,
-    shutdown: CancellationToken,
+    capabilities: Vec<Capability>,
 ) -> Result<()> {
     let runner_dir = config.runner_dir.clone();
 
     let (egress_tx, mut egress_rx) = mpsc::channel::<AttachRequest>(OUTBOUND_CAPACITY);
-    let supervisor = RunnerSupervisor::new(egress_tx, runner_dir, docker, pools.clone());
+    let supervisor = RunnerSupervisor::new(
+        egress_tx,
+        runner_dir,
+        docker,
+        capabilities.clone(),
+        config.load_ceiling,
+        config.mem_floor_mib,
+    );
 
     let mut backoff = INITIAL_BACKOFF;
     // An event pulled from the egress queue but not yet delivered when the
@@ -62,40 +61,26 @@ pub async fn run(
     // event is never lost to a closed stream.
     let mut pending: Option<AttachRequest> = None;
 
-    while !shutdown.is_cancelled() {
-        let outcome = connect_and_serve(
+    loop {
+        match connect_and_serve(
             &config,
             &credential,
             &supervisor,
             &mut egress_rx,
             &mut pending,
             &mut backoff,
-            &pools,
-            &shutdown,
+            &capabilities,
         )
-        .await;
-        // A shutdown during the connection is a clean exit, not a failure to log
-        // or back off from.
-        if shutdown.is_cancelled() {
-            break;
-        }
-        match outcome {
+        .await
+        {
             Ok(()) => info!("attach stream closed by gateway; reconnecting"),
             Err(e) => {
                 warn!(error = %e, backoff_secs = backoff.as_secs(), "attach failed; retrying");
             }
         }
-        tokio::select! {
-            biased;
-            () = shutdown.cancelled() => break,
-            () = tokio::time::sleep(backoff) => {}
-        }
+        tokio::time::sleep(backoff).await;
         backoff = (backoff * 2).min(MAX_BACKOFF);
     }
-
-    info!("shutdown signal received; stopping runners");
-    supervisor.shutdown(SHUTDOWN_GRACE).await;
-    Ok(())
 }
 
 /// One connect + stream lifetime. Returns `Ok(())` on a clean close. Resets
@@ -107,13 +92,6 @@ pub async fn run(
 /// connection-scoped heartbeats are sent directly, while runner lifecycle
 /// events are forwarded from the shared egress queue. Inbound orders are routed
 /// to the persistent `supervisor`.
-#[allow(
-    clippy::too_many_arguments,
-    reason = "one connection's lifecycle genuinely needs all of: endpoint config, \
-              credential, the persistent supervisor, the cross-reconnect egress queue \
-              and its pending slot, the mutable backoff, advertised pools, and the \
-              shutdown token"
-)]
 async fn connect_and_serve(
     config: &AgentConfig,
     credential: &Credential,
@@ -121,8 +99,7 @@ async fn connect_and_serve(
     egress_rx: &mut mpsc::Receiver<AttachRequest>,
     pending: &mut Option<AttachRequest>,
     backoff: &mut Duration,
-    pools: &[RuntimeCapacity],
-    shutdown: &CancellationToken,
+    capabilities: &[Capability],
 ) -> Result<()> {
     let channel = config
         .endpoint()?
@@ -139,6 +116,14 @@ async fn connect_and_serve(
         .parse()
         .context("machine token is not a valid metadata value")?;
     request.metadata_mut().insert(MACHINE_TOKEN_HEADER, token);
+    // Protocol-version handshake: the gateway rejects an unsupported version.
+    let version: MetadataValue<_> = PROTOCOL_VERSION
+        .to_string()
+        .parse()
+        .expect("protocol version is a valid metadata value");
+    request
+        .metadata_mut()
+        .insert(PROTOCOL_VERSION_HEADER, version);
 
     let mut inbound = client
         .attach(request)
@@ -156,11 +141,10 @@ async fn connect_and_serve(
         }
     }
 
-    let heartbeat = spawn_heartbeat(req_tx.clone(), pools.to_vec());
+    let heartbeat = spawn_heartbeat(req_tx.clone(), capabilities.to_vec());
 
     let outcome = loop {
         tokio::select! {
-            () = shutdown.cancelled() => break Ok(()),
             event = egress_rx.recv() => match event {
                 Some(msg) => {
                     if let Err(err) = req_tx.send(msg).await {
@@ -197,22 +181,24 @@ async fn dispatch(supervisor: &RunnerSupervisor, msg: Option<attach_response::Ms
     }
 }
 
-/// Periodically push a declarative capacity heartbeat until the channel closes.
+/// Periodically push a declarative capability + telemetry heartbeat until the
+/// channel closes.
 ///
 /// Heartbeats are connection-scoped: the task is spawned per connection and
 /// aborted when it drops, so a momentary disconnect does not leave stale
 /// heartbeats queued for the next stream.
 fn spawn_heartbeat(
     outbound: mpsc::Sender<AttachRequest>,
-    pools: Vec<RuntimeCapacity>,
+    capabilities: Vec<Capability>,
 ) -> tokio::task::JoinHandle<()> {
     tokio::spawn(async move {
         let mut ticker = tokio::time::interval(HEARTBEAT_INTERVAL);
         loop {
             ticker.tick().await;
             let msg = attach_request::Msg::Heartbeat(Heartbeat {
-                capacities: pools.clone(),
+                capabilities: capabilities.clone(),
                 host_info_json: host::host_info_json(),
+                telemetry: Some(host::telemetry()),
             });
             if outbound
                 .send(AttachRequest { msg: Some(msg) })

--- a/fleet/arcbox-fleet-agent/src/attach.rs
+++ b/fleet/arcbox-fleet-agent/src/attach.rs
@@ -200,7 +200,7 @@ async fn connect_and_serve(
                 None => break Ok(()),
             },
             message = inbound.message() => match message {
-                Ok(Some(message)) => dispatch(supervisor, message.msg).await,
+                Ok(Some(message)) => dispatch(supervisor, message.msg),
                 Ok(None) => break Ok(()),
                 Err(status) => break Err(anyhow::Error::from(status)),
             },
@@ -211,11 +211,13 @@ async fn connect_and_serve(
     outcome
 }
 
-/// Route one inbound `AttachResponse` to the supervisor.
-async fn dispatch(supervisor: &RunnerSupervisor, msg: Option<attach_response::Msg>) {
+/// Route one inbound `AttachResponse` to the supervisor. Synchronous: every
+/// handler only mutates supervisor state and spawns work, so dispatch can never
+/// stall the stream loop.
+fn dispatch(supervisor: &RunnerSupervisor, msg: Option<attach_response::Msg>) {
     match msg {
         Some(attach_response::Msg::ProvisionRunner(order)) => {
-            supervisor.handle_provision(order).await;
+            supervisor.handle_provision(order);
         }
         Some(attach_response::Msg::Cancel(cancel)) => supervisor.handle_cancel(&cancel.job_id),
         Some(attach_response::Msg::Drain(_)) => supervisor.handle_drain(),
@@ -227,9 +229,9 @@ async fn dispatch(supervisor: &RunnerSupervisor, msg: Option<attach_response::Ms
 }
 
 /// Periodically resend verdicts still awaiting an `OfferVerdictAck`, until the
-/// gateway acks them (or the resend cap is hit). Process-scoped so it spans
-/// reconnects; the supervisor holds the egress sender, so resends route through
-/// the same outbound path as fresh verdicts.
+/// gateway settles them (delivered to the workflow, or found obsolete).
+/// Process-scoped so it spans reconnects; the supervisor holds the egress
+/// sender, so resends route through the same outbound path as fresh verdicts.
 fn spawn_verdict_resend(supervisor: RunnerSupervisor) -> tokio::task::JoinHandle<()> {
     tokio::spawn(async move {
         let mut ticker = tokio::time::interval(VERDICT_RESEND_INTERVAL);

--- a/fleet/arcbox-fleet-agent/src/attach.rs
+++ b/fleet/arcbox-fleet-agent/src/attach.rs
@@ -15,6 +15,7 @@ use arcbox_fleet_proto::v1::{
 };
 use tokio::sync::mpsc;
 use tokio_stream::wrappers::ReceiverStream;
+use tokio_util::sync::CancellationToken;
 use tonic::Request;
 use tonic::metadata::MetadataValue;
 use tracing::{info, warn};
@@ -35,17 +36,25 @@ const MAX_BACKOFF: Duration = Duration::from_secs(60);
 const OUTBOUND_CAPACITY: usize = 64;
 const MACHINE_TOKEN_HEADER: &str = "x-arcbox-machine-token";
 const PROTOCOL_VERSION_HEADER: &str = "x-arcbox-protocol-version";
+/// How long to wait for runners to be torn down and reaped on shutdown before
+/// giving up. Killing a process group or container is near-instant, so this is a
+/// generous ceiling rather than an expected wait.
+const SHUTDOWN_GRACE: Duration = Duration::from_secs(15);
 
-/// Connect and serve the attach stream forever, reconnecting on any failure.
+/// Connect and serve the attach stream, reconnecting on any failure until
+/// `shutdown` fires, then stop runners cleanly.
 ///
 /// The supervisor and the egress queue carrying runner lifecycle events are
 /// built once and reused across reconnects, so in-flight jobs survive a dropped
-/// connection and their terminal events reach the next live stream.
+/// connection and their verdicts reach the next live stream. On shutdown the
+/// loop exits and hands off to [`RunnerSupervisor::shutdown`], which tears down
+/// any in-flight runners.
 pub async fn run(
     config: AgentConfig,
     credential: Credential,
     docker: Option<docker::DockerRunner>,
     capabilities: Vec<Capability>,
+    shutdown: CancellationToken,
 ) -> Result<()> {
     let runner_dir = config.runner_dir.clone();
 
@@ -71,8 +80,8 @@ pub async fn run(
     // event is never lost to a closed stream.
     let mut pending: Option<AttachRequest> = None;
 
-    loop {
-        match connect_and_serve(
+    while !shutdown.is_cancelled() {
+        let outcome = connect_and_serve(
             &config,
             &credential,
             &supervisor,
@@ -80,17 +89,31 @@ pub async fn run(
             &mut pending,
             &mut backoff,
             &capabilities,
+            &shutdown,
         )
-        .await
-        {
+        .await;
+        // A shutdown during the connection is a clean exit, not a failure to log
+        // or back off from.
+        if shutdown.is_cancelled() {
+            break;
+        }
+        match outcome {
             Ok(()) => info!("attach stream closed by gateway; reconnecting"),
             Err(e) => {
                 warn!(error = %e, backoff_secs = backoff.as_secs(), "attach failed; retrying");
             }
         }
-        tokio::time::sleep(backoff).await;
+        tokio::select! {
+            biased;
+            () = shutdown.cancelled() => break,
+            () = tokio::time::sleep(backoff) => {}
+        }
         backoff = (backoff * 2).min(MAX_BACKOFF);
     }
+
+    info!("shutdown signal received; stopping runners");
+    supervisor.shutdown(SHUTDOWN_GRACE).await;
+    Ok(())
 }
 
 /// One connect + stream lifetime. Returns `Ok(())` on a clean close. Resets
@@ -102,6 +125,13 @@ pub async fn run(
 /// connection-scoped heartbeats are sent directly, while runner lifecycle
 /// events are forwarded from the shared egress queue. Inbound orders are routed
 /// to the persistent `supervisor`.
+#[allow(
+    clippy::too_many_arguments,
+    reason = "one connection's lifecycle genuinely needs all of: endpoint config, \
+              credential, the persistent supervisor, the cross-reconnect egress queue \
+              and its pending slot, the mutable backoff, advertised capabilities, and \
+              the shutdown token"
+)]
 async fn connect_and_serve(
     config: &AgentConfig,
     credential: &Credential,
@@ -110,6 +140,7 @@ async fn connect_and_serve(
     pending: &mut Option<AttachRequest>,
     backoff: &mut Duration,
     capabilities: &[Capability],
+    shutdown: &CancellationToken,
 ) -> Result<()> {
     let channel = config
         .endpoint()?
@@ -155,6 +186,7 @@ async fn connect_and_serve(
 
     let outcome = loop {
         tokio::select! {
+            () = shutdown.cancelled() => break Ok(()),
             event = egress_rx.recv() => match event {
                 Some(msg) => {
                     if let Err(err) = req_tx.send(msg).await {

--- a/fleet/arcbox-fleet-agent/src/config.rs
+++ b/fleet/arcbox-fleet-agent/src/config.rs
@@ -14,13 +14,20 @@ pub const DEFAULT_GATEWAY: &str = "https://fleet.arcbox.dev";
 
 const ENV_GATEWAY: &str = "ARCBOX_FLEET_GATEWAY";
 const ENV_RUNNER_DIR: &str = "ARCBOX_FLEET_RUNNER_DIR";
-const ENV_MAX_CONCURRENT: &str = "ARCBOX_FLEET_MAX_CONCURRENT";
+const ENV_LOAD_CEILING: &str = "ARCBOX_FLEET_LOAD_CEILING";
+const ENV_MEM_FLOOR_MIB: &str = "ARCBOX_FLEET_MEM_FLOOR_MIB";
 const ENV_DATA_DIR: &str = "ARCBOX_FLEET_DATA_DIR";
 const ENV_DOCKER: &str = "ARCBOX_FLEET_DOCKER";
 const ENV_RUNNER_IMAGE: &str = "ARCBOX_FLEET_RUNNER_IMAGE";
 
-const DEFAULT_MAX_CONCURRENT: usize = 2;
+/// Reject an offer when 1-minute load average per core exceeds this.
+const DEFAULT_LOAD_CEILING: f64 = 0.9;
+/// Reject an offer when available memory is below this many MiB.
+const DEFAULT_MEM_FLOOR_MIB: u64 = 2048;
 const DEFAULT_RUNNER_IMAGE: &str = "ghcr.io/actions/actions-runner:latest";
+
+/// Wire-protocol version this agent speaks; the gateway rejects a mismatch.
+pub const PROTOCOL_VERSION: u32 = 1;
 
 /// Whether Docker-based Linux job execution is enabled.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -37,8 +44,7 @@ pub enum DockerMode {
 #[derive(Debug, Clone)]
 pub struct DockerConfig {
     pub mode: DockerMode,
-    /// Container image used for Linux runner jobs when the platform sends no
-    /// image (empty `ProvisionRunner.image`).
+    /// Container image used for Linux runner jobs.
     pub runner_image: String,
 }
 
@@ -50,8 +56,10 @@ pub struct AgentConfig {
     /// Directory holding the pre-installed GitHub Actions runner (`run.sh`/`run.cmd`).
     /// `None` until set; required only by the `run` command.
     pub runner_dir: Option<PathBuf>,
-    /// Maximum number of concurrently executing runner jobs.
-    pub max_concurrent: usize,
+    /// Reject an offer when 1-minute load average per core exceeds this.
+    pub load_ceiling: f64,
+    /// Reject an offer when available memory (MiB) is below this.
+    pub mem_floor_mib: u64,
     /// Agent data directory (credentials, logs). Defaults to `~/.arcbox/fleet`.
     pub data_dir: PathBuf,
     /// Docker runtime configuration for Linux jobs.
@@ -65,17 +73,17 @@ impl AgentConfig {
 
         let runner_dir = std::env::var_os(ENV_RUNNER_DIR).map(PathBuf::from);
 
-        let max_concurrent = match std::env::var(ENV_MAX_CONCURRENT) {
-            Ok(v) => {
-                let n: usize = v
-                    .parse()
-                    .with_context(|| format!("{ENV_MAX_CONCURRENT} must be a positive integer"))?;
-                if n == 0 {
-                    anyhow::bail!("{ENV_MAX_CONCURRENT} must be a positive integer, got 0");
-                }
-                n
-            }
-            Err(_) => DEFAULT_MAX_CONCURRENT,
+        let load_ceiling = match std::env::var(ENV_LOAD_CEILING) {
+            Ok(v) => v
+                .parse()
+                .with_context(|| format!("{ENV_LOAD_CEILING} must be a number"))?,
+            Err(_) => DEFAULT_LOAD_CEILING,
+        };
+        let mem_floor_mib = match std::env::var(ENV_MEM_FLOOR_MIB) {
+            Ok(v) => v
+                .parse()
+                .with_context(|| format!("{ENV_MEM_FLOOR_MIB} must be a non-negative integer"))?,
+            Err(_) => DEFAULT_MEM_FLOOR_MIB,
         };
 
         let data_dir = match std::env::var_os(ENV_DATA_DIR) {
@@ -97,7 +105,8 @@ impl AgentConfig {
         Ok(Self {
             gateway,
             runner_dir,
-            max_concurrent,
+            load_ceiling,
+            mem_floor_mib,
             data_dir,
             docker: DockerConfig {
                 mode: docker_mode,

--- a/fleet/arcbox-fleet-agent/src/config.rs
+++ b/fleet/arcbox-fleet-agent/src/config.rs
@@ -74,9 +74,15 @@ impl AgentConfig {
         let runner_dir = std::env::var_os(ENV_RUNNER_DIR).map(PathBuf::from);
 
         let load_ceiling = match std::env::var(ENV_LOAD_CEILING) {
-            Ok(v) => v
-                .parse()
-                .with_context(|| format!("{ENV_LOAD_CEILING} must be a number"))?,
+            Ok(v) => {
+                let n: f64 = v
+                    .parse()
+                    .with_context(|| format!("{ENV_LOAD_CEILING} must be a positive number"))?;
+                if n <= 0.0 {
+                    anyhow::bail!("{ENV_LOAD_CEILING} must be a positive number, got {n}");
+                }
+                n
+            }
             Err(_) => DEFAULT_LOAD_CEILING,
         };
         let mem_floor_mib = match std::env::var(ENV_MEM_FLOOR_MIB) {

--- a/fleet/arcbox-fleet-agent/src/config.rs
+++ b/fleet/arcbox-fleet-agent/src/config.rs
@@ -19,6 +19,7 @@ const ENV_MEM_FLOOR_MIB: &str = "ARCBOX_FLEET_MEM_FLOOR_MIB";
 const ENV_DATA_DIR: &str = "ARCBOX_FLEET_DATA_DIR";
 const ENV_DOCKER: &str = "ARCBOX_FLEET_DOCKER";
 const ENV_RUNNER_IMAGE: &str = "ARCBOX_FLEET_RUNNER_IMAGE";
+const ENV_CREDENTIAL_STORE: &str = "ARCBOX_FLEET_CREDENTIAL_STORE";
 
 /// Reject an offer when 1-minute load average per core exceeds this.
 const DEFAULT_LOAD_CEILING: f64 = 0.9;
@@ -38,6 +39,19 @@ pub enum DockerMode {
     Enabled,
     /// Never use Docker, even if available.
     Disabled,
+}
+
+/// Where the long-lived machine credential is persisted.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CredentialMode {
+    /// OS keychain on macOS (login Keychain) and Windows (Credential Manager);
+    /// the owner-only data-dir file on Linux. On macOS the agent must run in the
+    /// user's session, where the login Keychain is unlocked.
+    Auto,
+    /// Force the OS keychain. Supported on macOS and Windows; errors on Linux.
+    Keyring,
+    /// Force the data-dir file (`0600` on Unix).
+    File,
 }
 
 /// Docker-specific configuration for running Linux jobs in containers.
@@ -64,6 +78,8 @@ pub struct AgentConfig {
     pub data_dir: PathBuf,
     /// Docker runtime configuration for Linux jobs.
     pub docker: DockerConfig,
+    /// Where the machine credential is persisted (OS keychain vs file).
+    pub credential_store: CredentialMode,
 }
 
 impl AgentConfig {
@@ -108,6 +124,17 @@ impl AgentConfig {
         let runner_image =
             std::env::var(ENV_RUNNER_IMAGE).unwrap_or_else(|_| DEFAULT_RUNNER_IMAGE.to_string());
 
+        let credential_store = match std::env::var(ENV_CREDENTIAL_STORE).as_deref() {
+            Ok("keyring") => CredentialMode::Keyring,
+            Ok("file") => CredentialMode::File,
+            Ok("auto") | Err(_) => CredentialMode::Auto,
+            Ok(other) => {
+                anyhow::bail!(
+                    "{ENV_CREDENTIAL_STORE} must be 'auto', 'keyring', or 'file', got '{other}'"
+                )
+            }
+        };
+
         Ok(Self {
             gateway,
             runner_dir,
@@ -118,6 +145,7 @@ impl AgentConfig {
                 mode: docker_mode,
                 runner_image,
             },
+            credential_store,
         })
     }
 

--- a/fleet/arcbox-fleet-agent/src/config.rs
+++ b/fleet/arcbox-fleet-agent/src/config.rs
@@ -134,6 +134,13 @@ impl AgentConfig {
                 )
             }
         };
+        #[cfg(not(any(target_os = "macos", target_os = "windows")))]
+        if credential_store == CredentialMode::Keyring {
+            anyhow::bail!(
+                "{ENV_CREDENTIAL_STORE}=keyring is only supported on macOS and Windows; \
+                 use 'file' (the default on Linux)"
+            );
+        }
 
         Ok(Self {
             gateway,

--- a/fleet/arcbox-fleet-agent/src/config.rs
+++ b/fleet/arcbox-fleet-agent/src/config.rs
@@ -90,15 +90,7 @@ impl AgentConfig {
         let runner_dir = std::env::var_os(ENV_RUNNER_DIR).map(PathBuf::from);
 
         let load_ceiling = match std::env::var(ENV_LOAD_CEILING) {
-            Ok(v) => {
-                let n: f64 = v
-                    .parse()
-                    .with_context(|| format!("{ENV_LOAD_CEILING} must be a positive number"))?;
-                if n <= 0.0 {
-                    anyhow::bail!("{ENV_LOAD_CEILING} must be a positive number, got {n}");
-                }
-                n
-            }
+            Ok(v) => parse_load_ceiling(&v)?,
             Err(_) => DEFAULT_LOAD_CEILING,
         };
         let mem_floor_mib = match std::env::var(ENV_MEM_FLOOR_MIB) {
@@ -176,8 +168,39 @@ impl AgentConfig {
     }
 }
 
+/// Parse `ARCBOX_FLEET_LOAD_CEILING`: a positive, finite load-per-core bound.
+/// Non-finite values must be rejected here: every admission comparison against
+/// `NaN` is false, which would silently disable the load gate, and `inf` never
+/// rejects — a misconfiguration should fail startup, not neuter admission.
+fn parse_load_ceiling(v: &str) -> Result<f64> {
+    let n: f64 = v
+        .parse()
+        .with_context(|| format!("{ENV_LOAD_CEILING} must be a positive finite number"))?;
+    if !(n.is_finite() && n > 0.0) {
+        anyhow::bail!("{ENV_LOAD_CEILING} must be a positive finite number, got {n}");
+    }
+    Ok(n)
+}
+
 /// `~/.arcbox/fleet`, resolved from the user's home directory.
 fn default_data_dir() -> Result<PathBuf> {
     let home = dirs::home_dir().context("could not determine home directory")?;
     Ok(home.join(".arcbox").join("fleet"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    #[expect(
+        clippy::float_cmp,
+        reason = "1.5 parses exactly; no arithmetic involved"
+    )]
+    fn load_ceiling_requires_positive_finite() {
+        assert_eq!(parse_load_ceiling("1.5").unwrap(), 1.5);
+        for bad in ["0", "-1.5", "NaN", "inf", "-inf", "nonsense"] {
+            assert!(parse_load_ceiling(bad).is_err(), "accepted {bad}");
+        }
+    }
 }

--- a/fleet/arcbox-fleet-agent/src/credentials.rs
+++ b/fleet/arcbox-fleet-agent/src/credentials.rs
@@ -39,28 +39,17 @@ impl CredentialStore {
     /// Select a backend from `mode` and the platform.
     ///
     /// `Auto` uses the OS keychain on macOS/Windows and the `path` file
-    /// elsewhere; `Keyring` forces the keychain (and errors where none exists);
-    /// `File` forces the file.
-    pub fn new(mode: CredentialMode, path: PathBuf) -> Result<Self> {
-        let use_keyring = match mode {
-            CredentialMode::Keyring => true,
-            CredentialMode::File => false,
-            CredentialMode::Auto => cfg!(any(target_os = "macos", target_os = "windows")),
-        };
-        if use_keyring {
-            #[cfg(any(target_os = "macos", target_os = "windows"))]
-            {
-                return Ok(Self::Keyring(KeyringStore));
-            }
-            #[cfg(not(any(target_os = "macos", target_os = "windows")))]
-            {
-                anyhow::bail!(
-                    "ARCBOX_FLEET_CREDENTIAL_STORE=keyring is only supported on macOS and \
-                     Windows; use 'file' (the default on Linux)"
-                );
-            }
+    /// elsewhere; `Keyring` forces the keychain; `File` forces the file. `mode`
+    /// is validated against the platform when parsed from the environment, so
+    /// `Keyring` never reaches here on a platform without a keychain.
+    pub fn new(mode: CredentialMode, path: PathBuf) -> Self {
+        #[cfg(any(target_os = "macos", target_os = "windows"))]
+        if matches!(mode, CredentialMode::Keyring | CredentialMode::Auto) {
+            return Self::Keyring(KeyringStore);
         }
-        Ok(Self::File(FileStore { path }))
+        #[cfg(not(any(target_os = "macos", target_os = "windows")))]
+        let _ = mode;
+        Self::File(FileStore { path })
     }
 
     /// Load the stored credential, or `None` if the host has not enrolled yet.
@@ -201,7 +190,7 @@ mod tests {
 
         let dir = std::env::temp_dir().join(format!("fleet-cred-{}", std::process::id()));
         let path = dir.join("credentials.json");
-        let store = CredentialStore::new(CredentialMode::File, path.clone()).unwrap();
+        let store = CredentialStore::new(CredentialMode::File, path.clone());
         assert!(store.load().unwrap().is_none());
 
         let cred = Credential {

--- a/fleet/arcbox-fleet-agent/src/credentials.rs
+++ b/fleet/arcbox-fleet-agent/src/credentials.rs
@@ -1,16 +1,23 @@
 //! Persistence of the long-lived machine credential.
 //!
-//! The credential is written once at enrollment and read on every `run`. On
-//! Unix the file is locked down to `0600`. Other platforms are unsupported:
-//! without an equivalent owner-only ACL the agent refuses to persist the
-//! long-lived machine token rather than write it at default permissions.
+//! The credential is written once at enrollment and read on every `run`. The
+//! backend is chosen by [`CredentialMode`]: the OS keychain on macOS (login
+//! Keychain) and Windows (Credential Manager), or an owner-only (`0600`) file on
+//! Linux. The keychain item is access-controlled to this binary by the OS, so a
+//! same-user process can't read it without a prompt — a boundary the file lacks.
+//! The macOS login Keychain is unlocked by the user's login, so the agent must
+//! run in that session; Linux has no keychain backend that fits a headless,
+//! reboot-persistent agent, so it uses the file (encryption at rest there is the
+//! deployment's job, via LUKS). See [`CredentialStore::new`].
 
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
 
-/// The machine identity returned by `Enroll`, persisted to disk.
+use crate::config::CredentialMode;
+
+/// The machine identity returned by `Enroll`, persisted by the agent.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Credential {
     /// Prefixed machine id (`fltm_...`).
@@ -19,19 +26,69 @@ pub struct Credential {
     pub machine_token: String,
 }
 
-/// Reads and writes [`Credential`] at a fixed path.
-pub struct CredentialStore {
-    path: PathBuf,
+/// Reads and writes the [`Credential`] via the platform-appropriate backend.
+pub enum CredentialStore {
+    /// Owner-only JSON file in the data directory.
+    File(FileStore),
+    /// OS keychain: the login Keychain on macOS, Credential Manager on Windows.
+    #[cfg(any(target_os = "macos", target_os = "windows"))]
+    Keyring(KeyringStore),
 }
 
 impl CredentialStore {
-    /// Create a store backed by `path` (typically `<data_dir>/credentials.json`).
-    pub fn new(path: impl Into<PathBuf>) -> Self {
-        Self { path: path.into() }
+    /// Select a backend from `mode` and the platform.
+    ///
+    /// `Auto` uses the OS keychain on macOS/Windows and the `path` file
+    /// elsewhere; `Keyring` forces the keychain (and errors where none exists);
+    /// `File` forces the file.
+    pub fn new(mode: CredentialMode, path: PathBuf) -> Result<Self> {
+        let use_keyring = match mode {
+            CredentialMode::Keyring => true,
+            CredentialMode::File => false,
+            CredentialMode::Auto => cfg!(any(target_os = "macos", target_os = "windows")),
+        };
+        if use_keyring {
+            #[cfg(any(target_os = "macos", target_os = "windows"))]
+            {
+                return Ok(Self::Keyring(KeyringStore));
+            }
+            #[cfg(not(any(target_os = "macos", target_os = "windows")))]
+            {
+                anyhow::bail!(
+                    "ARCBOX_FLEET_CREDENTIAL_STORE=keyring is only supported on macOS and \
+                     Windows; use 'file' (the default on Linux)"
+                );
+            }
+        }
+        Ok(Self::File(FileStore { path }))
     }
 
     /// Load the stored credential, or `None` if the host has not enrolled yet.
     pub fn load(&self) -> Result<Option<Credential>> {
+        match self {
+            Self::File(store) => store.load(),
+            #[cfg(any(target_os = "macos", target_os = "windows"))]
+            Self::Keyring(store) => store.load(),
+        }
+    }
+
+    /// Persist the credential.
+    pub fn store(&self, cred: &Credential) -> Result<()> {
+        match self {
+            Self::File(store) => store.store(cred),
+            #[cfg(any(target_os = "macos", target_os = "windows"))]
+            Self::Keyring(store) => store.store(cred),
+        }
+    }
+}
+
+/// Stores the credential as an owner-only JSON file at a fixed path.
+pub struct FileStore {
+    path: PathBuf,
+}
+
+impl FileStore {
+    fn load(&self) -> Result<Option<Credential>> {
         match std::fs::read(&self.path) {
             Ok(bytes) => {
                 let cred = serde_json::from_slice(&bytes)
@@ -43,9 +100,7 @@ impl CredentialStore {
         }
     }
 
-    /// Persist the credential, creating the parent directory and restricting
-    /// permissions to the owner.
-    pub fn store(&self, cred: &Credential) -> Result<()> {
+    fn store(&self, cred: &Credential) -> Result<()> {
         if let Some(parent) = self.path.parent() {
             std::fs::create_dir_all(parent)
                 .with_context(|| format!("creating {}", parent.display()))?;
@@ -66,7 +121,7 @@ impl CredentialStore {
 
 /// Write `bytes` to `path`, owner-only (`0600`) from creation on Unix.
 #[cfg(unix)]
-fn write_private(path: &Path, bytes: &[u8]) -> Result<()> {
+fn write_private(path: &std::path::Path, bytes: &[u8]) -> Result<()> {
     use std::io::Write;
     use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
 
@@ -86,31 +141,67 @@ fn write_private(path: &Path, bytes: &[u8]) -> Result<()> {
         .with_context(|| format!("writing {}", path.display()))
 }
 
-/// Refuse to persist the machine token on platforms without owner-only file
-/// permissions. Windows ACL hardening (a protected, owner-only DACL) is not yet
-/// implemented, and writing the long-lived token at the default ACL would leave
-/// it readable by other local accounts — so credential storage is Unix-only for
-/// now.
+/// Refuse to persist the machine token via a file on platforms without
+/// owner-only file permissions. On Windows the secure path is the OS keychain
+/// (`ARCBOX_FLEET_CREDENTIAL_STORE=auto`, the default there); the file backend
+/// has no ACL hardening, so writing the long-lived token at the default ACL
+/// would leave it readable by other local accounts.
 #[cfg(not(unix))]
-fn write_private(_path: &Path, _bytes: &[u8]) -> Result<()> {
+fn write_private(_path: &std::path::Path, _bytes: &[u8]) -> Result<()> {
     anyhow::bail!(
-        "Fleet agent credential storage is only supported on Unix; Windows ACL \
-         hardening is not yet implemented"
+        "file credential storage is not hardened on this platform; use the OS \
+         keychain (ARCBOX_FLEET_CREDENTIAL_STORE=auto)"
     )
+}
+
+/// Stores the credential as a single JSON blob in the OS keychain.
+#[cfg(any(target_os = "macos", target_os = "windows"))]
+pub struct KeyringStore;
+
+#[cfg(any(target_os = "macos", target_os = "windows"))]
+impl KeyringStore {
+    /// Keychain service and account under which the credential blob is stored.
+    const SERVICE: &'static str = "dev.arcbox.fleet-agent";
+    const ACCOUNT: &'static str = "machine-credential";
+
+    fn entry() -> Result<keyring::Entry> {
+        keyring::Entry::new(Self::SERVICE, Self::ACCOUNT).context("opening OS keychain entry")
+    }
+
+    fn load(&self) -> Result<Option<Credential>> {
+        match Self::entry()?.get_password() {
+            Ok(json) => {
+                let cred =
+                    serde_json::from_str(&json).context("malformed credential in OS keychain")?;
+                Ok(Some(cred))
+            }
+            Err(keyring::Error::NoEntry) => Ok(None),
+            Err(e) => Err(e).context("reading credential from OS keychain"),
+        }
+    }
+
+    fn store(&self, cred: &Credential) -> Result<()> {
+        let json = serde_json::to_string(cred).context("serializing credential")?;
+        Self::entry()?
+            .set_password(&json)
+            .context("writing credential to OS keychain")
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    // Storage is Unix-only (owner-only `0600`); other platforms refuse to write.
+    // The file backend is the default (and only) store on Linux, where the test
+    // suite runs; the keychain backends are exercised on macOS/Windows builds.
     #[cfg(unix)]
     #[test]
-    fn round_trips_credential() {
+    fn file_store_round_trips_at_0600() {
         use std::os::unix::fs::PermissionsExt;
 
         let dir = std::env::temp_dir().join(format!("fleet-cred-{}", std::process::id()));
-        let store = CredentialStore::new(dir.join("credentials.json"));
+        let path = dir.join("credentials.json");
+        let store = CredentialStore::new(CredentialMode::File, path.clone()).unwrap();
         assert!(store.load().unwrap().is_none());
 
         let cred = Credential {
@@ -123,7 +214,7 @@ mod tests {
         assert_eq!(loaded.machine_id, cred.machine_id);
         assert_eq!(loaded.machine_token, cred.machine_token);
 
-        let mode = std::fs::metadata(store.path).unwrap().permissions().mode();
+        let mode = std::fs::metadata(&path).unwrap().permissions().mode();
         assert_eq!(mode & 0o777, 0o600);
 
         let _ = std::fs::remove_dir_all(dir);

--- a/fleet/arcbox-fleet-agent/src/credentials.rs
+++ b/fleet/arcbox-fleet-agent/src/credentials.rs
@@ -42,13 +42,21 @@ impl CredentialStore {
     /// elsewhere; `Keyring` forces the keychain; `File` forces the file. `mode`
     /// is validated against the platform when parsed from the environment, so
     /// `Keyring` never reaches here on a platform without a keychain.
-    pub fn new(mode: CredentialMode, path: PathBuf) -> Self {
+    ///
+    /// `gateway` scopes the credential to the environment it was enrolled
+    /// against: the keychain keys its entry by gateway URI, so credentials for
+    /// different gateways (production, staging, local e2e) coexist instead of
+    /// silently overwriting each other. The file backend is scoped by `path`
+    /// (per data dir) instead.
+    pub fn new(mode: CredentialMode, path: PathBuf, gateway: &str) -> Self {
         #[cfg(any(target_os = "macos", target_os = "windows"))]
         if matches!(mode, CredentialMode::Keyring | CredentialMode::Auto) {
-            return Self::Keyring(KeyringStore);
+            return Self::Keyring(KeyringStore {
+                account: gateway.to_owned(),
+            });
         }
         #[cfg(not(any(target_os = "macos", target_os = "windows")))]
-        let _ = mode;
+        let _ = (mode, gateway);
         Self::File(FileStore { path })
     }
 
@@ -143,22 +151,26 @@ fn write_private(_path: &std::path::Path, _bytes: &[u8]) -> Result<()> {
     )
 }
 
-/// Stores the credential as a single JSON blob in the OS keychain.
+/// Stores the credential as a single JSON blob in the OS keychain, one entry
+/// per gateway (the account is the gateway URI), so enrolling against another
+/// environment never clobbers this one's credential.
 #[cfg(any(target_os = "macos", target_os = "windows"))]
-pub struct KeyringStore;
+pub struct KeyringStore {
+    /// Keychain account: the gateway URI this credential enrolls against.
+    account: String,
+}
 
 #[cfg(any(target_os = "macos", target_os = "windows"))]
 impl KeyringStore {
-    /// Keychain service and account under which the credential blob is stored.
+    /// Keychain service under which every credential entry is stored.
     const SERVICE: &'static str = "dev.arcbox.fleet-agent";
-    const ACCOUNT: &'static str = "machine-credential";
 
-    fn entry() -> Result<keyring::Entry> {
-        keyring::Entry::new(Self::SERVICE, Self::ACCOUNT).context("opening OS keychain entry")
+    fn entry(&self) -> Result<keyring::Entry> {
+        keyring::Entry::new(Self::SERVICE, &self.account).context("opening OS keychain entry")
     }
 
     fn load(&self) -> Result<Option<Credential>> {
-        match Self::entry()?.get_password() {
+        match self.entry()?.get_password() {
             Ok(json) => {
                 let cred =
                     serde_json::from_str(&json).context("malformed credential in OS keychain")?;
@@ -171,7 +183,7 @@ impl KeyringStore {
 
     fn store(&self, cred: &Credential) -> Result<()> {
         let json = serde_json::to_string(cred).context("serializing credential")?;
-        Self::entry()?
+        self.entry()?
             .set_password(&json)
             .context("writing credential to OS keychain")
     }
@@ -190,7 +202,11 @@ mod tests {
 
         let dir = std::env::temp_dir().join(format!("fleet-cred-{}", std::process::id()));
         let path = dir.join("credentials.json");
-        let store = CredentialStore::new(CredentialMode::File, path.clone());
+        let store = CredentialStore::new(
+            CredentialMode::File,
+            path.clone(),
+            "https://fleet.arcbox.dev",
+        );
         assert!(store.load().unwrap().is_none());
 
         let cred = Credential {

--- a/fleet/arcbox-fleet-agent/src/docker.rs
+++ b/fleet/arcbox-fleet-agent/src/docker.rs
@@ -99,6 +99,43 @@ fn arcbox_socket_path() -> Option<String> {
     })
 }
 
+/// Connect to a Docker-compatible runtime and verify it answers a ping.
+///
+/// On macOS, prefers ArcBox's own socket and falls back to the system default
+/// if ArcBox is absent or its socket is unresponsive (the ping is what proves
+/// reachability — building the client does no I/O). On other platforms it uses
+/// the system default directly.
+async fn connect() -> Result<Docker> {
+    if let Some(addr) = arcbox_socket_path() {
+        match connect_arcbox(&addr).await {
+            Ok(client) => return Ok(client),
+            Err(e) => {
+                warn!(error = %e, "ArcBox runtime unavailable; falling back to local Docker");
+            }
+        }
+    }
+    let client = Docker::connect_with_local_defaults().context("connecting to Docker runtime")?;
+    client
+        .ping()
+        .await
+        .context("Docker-compatible runtime is not reachable (ping failed)")?;
+    Ok(client)
+}
+
+/// Connect to ArcBox's socket and confirm it responds to a ping.
+///
+/// A short timeout keeps a present-but-hung socket from stalling startup before
+/// the local-Docker fallback kicks in — a live socket answers a ping promptly.
+async fn connect_arcbox(addr: &str) -> Result<Docker> {
+    let client = Docker::connect_with_unix(addr, 15, bollard::API_DEFAULT_VERSION)
+        .with_context(|| format!("connecting to ArcBox runtime at {addr}"))?;
+    client
+        .ping()
+        .await
+        .with_context(|| format!("ArcBox runtime at {addr} is not reachable (ping failed)"))?;
+    Ok(client)
+}
+
 /// Linux arches this host could serve, before verifying they can be pulled.
 ///
 /// The native arch always, plus amd64 on Apple Silicon macOS, where ArcBox's
@@ -116,9 +153,10 @@ impl DockerRunner {
     /// Connect to the Docker-compatible runtime and prove it works by pulling
     /// the default runner image for each candidate arch.
     ///
-    /// On macOS, connects to ArcBox's own socket (`~/.arcbox/docker.sock`); on
-    /// other platforms the system default (e.g. `/var/run/docker.sock` on
-    /// Linux, named pipe on Windows).
+    /// On macOS, prefers ArcBox's own socket (`~/.arcbox/docker.sock`) and falls
+    /// back to the system default (Docker Desktop, Colima, …) when ArcBox is
+    /// absent or unresponsive. On other platforms it uses the system default
+    /// directly (e.g. `/var/run/docker.sock` on Linux, named pipe on Windows).
     ///
     /// The pull is the readiness check: an arch is advertised only if its image
     /// pulls, so a host that cannot realize `linux/amd64` (no working emulation)
@@ -126,16 +164,7 @@ impl DockerRunner {
     /// pulls; otherwise this returns an error and the caller proceeds without it
     /// (`Auto`) or fails startup (`Enabled`).
     pub async fn new(default_image: String) -> Result<Self> {
-        let client = if let Some(addr) = arcbox_socket_path() {
-            Docker::connect_with_unix(&addr, 120, bollard::API_DEFAULT_VERSION)
-                .with_context(|| format!("connecting to ArcBox runtime at {addr}"))?
-        } else {
-            Docker::connect_with_local_defaults().context("connecting to Docker runtime")?
-        };
-        client
-            .ping()
-            .await
-            .context("Docker-compatible runtime is not reachable (ping failed)")?;
+        let client = connect().await?;
 
         let mut linux_arches = Vec::new();
         for arch in candidate_arches() {

--- a/fleet/arcbox-fleet-agent/src/docker.rs
+++ b/fleet/arcbox-fleet-agent/src/docker.rs
@@ -26,9 +26,10 @@ pub struct RunSpec<'a> {
 }
 
 /// A container that has been created and started. Held by the caller while the
-/// job runs; [`wait`](RunningContainer::wait) drives it to completion, and a
-/// drop before then (e.g. `CancelRunner` aborting the task) kills and removes it
-/// via the embedded [`ContainerGuard`].
+/// job runs: [`wait`](Self::wait) observes the exit, then [`remove`](Self::remove)
+/// or [`cancel`](Self::cancel) tears the container down — both awaited, so the
+/// caller's bookkeeping settles only after the container is actually gone. The
+/// embedded [`ContainerGuard`] is a panic safety net, not the teardown path.
 pub struct RunningContainer {
     client: Docker,
     id: String,
@@ -36,14 +37,14 @@ pub struct RunningContainer {
 }
 
 impl RunningContainer {
-    /// Block until the container exits, then remove it. The agent reports no
-    /// outcome upstream (the GitHub webhook is authoritative); the outcome here
-    /// is for logging only.
-    pub async fn wait(self) -> Result<DockerOutcome> {
-        let Self { client, id, guard } = self;
-        let wait = client
+    /// Block until the container exits and return its exit code. No cleanup —
+    /// follow with [`remove`](Self::remove). The agent reports no outcome
+    /// upstream (the GitHub webhook is authoritative); the code is for logging.
+    pub async fn wait(&self) -> Result<i64> {
+        let wait = self
+            .client
             .wait_container(
-                &id,
+                &self.id,
                 Some(WaitContainerOptions {
                     condition: "not-running".to_owned(),
                 }),
@@ -51,9 +52,14 @@ impl RunningContainer {
             .next()
             .await
             .context("container wait stream ended unexpectedly")?
-            .with_context(|| format!("waiting on container {id}"))?;
+            .with_context(|| format!("waiting on container {}", self.id))?;
+        Ok(wait.status_code)
+    }
 
-        let exit_code = wait.status_code;
+    /// Remove the (exited) container, awaited. Failures are logged, not
+    /// propagated: the job itself already concluded.
+    pub async fn remove(self) {
+        let Self { client, id, guard } = self;
         guard.defuse();
         let options = RemoveContainerOptions {
             force: true,
@@ -62,18 +68,19 @@ impl RunningContainer {
         if let Err(e) = client.remove_container(&id, Some(options)).await {
             warn!(container = %id, error = %e, "failed to remove container");
         }
-
-        Ok(DockerOutcome {
-            success: exit_code == 0,
-            detail: format!("container exited with code {exit_code}"),
-        })
     }
-}
 
-/// Terminal outcome of a containerized job.
-pub struct DockerOutcome {
-    pub success: bool,
-    pub detail: String,
+    /// Kill and remove the container, awaited — the cancellation/shutdown
+    /// teardown. Once this returns the container is gone (or its removal
+    /// failed loudly), so a shutdown that awaits it leaves no orphan behind.
+    pub async fn cancel(self) {
+        // The container may have exited on its own in the cancel race; a failed
+        // kill is expected then, and the forced remove below handles both cases.
+        if let Err(e) = self.client.kill_container(&self.id, None).await {
+            debug!(container = %self.id, error = %e, "kill on cancel failed (may have exited)");
+        }
+        self.remove().await;
+    }
 }
 
 /// Wraps the Docker Engine API for running GitHub Actions jobs in containers.
@@ -84,6 +91,12 @@ pub struct DockerRunner {
     default_image: String,
     /// Linux arches verified pullable at startup, advertised as capacity pools.
     linux_arches: Vec<String>,
+}
+
+/// Deterministic per-job container name, so redeliveries and interrupted
+/// startups can always find (and remove) whatever an earlier attempt created.
+fn container_name(job_id: &str) -> String {
+    format!("arcbox-{job_id}")
 }
 
 /// ArcBox's Docker-compatible socket path on macOS (`~/.arcbox/docker.sock`).
@@ -202,21 +215,12 @@ impl DockerRunner {
 
         Self::pull_image(&self.client, &self.default_image, &platform).await?;
 
-        let container_name = format!("arcbox-{}", spec.job_id);
+        let container_name = container_name(spec.job_id);
 
         // The name is deterministic per job, so a redelivery after a crash that
         // left an orphan would otherwise collide on create. Remove any leftover
         // first (remove-before-bind); a missing container is the normal case.
-        let _ = self
-            .client
-            .remove_container(
-                &container_name,
-                Some(RemoveContainerOptions {
-                    force: true,
-                    ..Default::default()
-                }),
-            )
-            .await;
+        self.remove_job_container(spec.job_id).await;
 
         let config = ContainerCreateBody {
             image: Some(self.default_image.clone()),
@@ -257,6 +261,23 @@ impl DockerRunner {
         })
     }
 
+    /// Force-remove the container named for `job_id`, if any — awaited and
+    /// idempotent. Used as remove-before-bind ahead of a create, and as the
+    /// cleanup when a cancellation interrupts [`start`](Self::start) mid-flight
+    /// (the deterministic name reaches whatever the dropped start created).
+    pub async fn remove_job_container(&self, job_id: &str) {
+        let _ = self
+            .client
+            .remove_container(
+                &container_name(job_id),
+                Some(RemoveContainerOptions {
+                    force: true,
+                    ..Default::default()
+                }),
+            )
+            .await;
+    }
+
     /// Pull an image for a specific platform.
     async fn pull_image(client: &Docker, image: &str, platform: &str) -> Result<()> {
         debug!(image, platform, "pulling image");
@@ -274,11 +295,14 @@ impl DockerRunner {
     }
 }
 
-/// Kills and removes a container on drop — the cancellation safety net.
+/// Kills and removes a container on drop — the panic safety net.
 ///
-/// On normal completion the caller calls [`defuse`](Self::defuse) and handles
-/// cleanup explicitly (where errors can be logged). On task abort, the guard
-/// spawns a fire-and-forget cleanup task.
+/// Every deliberate exit ([`RunningContainer::remove`]/[`cancel`]) defuses the
+/// guard and awaits the teardown itself, so this drop path only fires when the
+/// runner task dies without reaching one — a panic, or the future dropped
+/// without cancellation. The spawned cleanup is fire-and-forget by necessity
+/// (drop cannot await); it must never be the path a correctness guarantee
+/// rides on.
 struct ContainerGuard {
     client: Docker,
     container_id: String,

--- a/fleet/arcbox-fleet-agent/src/docker.rs
+++ b/fleet/arcbox-fleet-agent/src/docker.rs
@@ -19,13 +19,55 @@ use crate::host;
 pub struct RunSpec<'a> {
     /// Job identifier, used as the container name suffix.
     pub job_id: &'a str,
-    /// Resolved container image (never empty — caller must fall back to the
-    /// default before constructing this).
-    pub image: &'a str,
     /// Base64-encoded JIT runner config, passed through to `run.sh`.
     pub encoded_jit_config: &'a str,
     /// Target CPU architecture (`arm64` or `amd64`).
     pub arch: &'a str,
+}
+
+/// A container that has been created and started. Held by the caller while the
+/// job runs; [`wait`](RunningContainer::wait) drives it to completion, and a
+/// drop before then (e.g. `CancelRunner` aborting the task) kills and removes it
+/// via the embedded [`ContainerGuard`].
+pub struct RunningContainer {
+    client: Docker,
+    id: String,
+    guard: ContainerGuard,
+}
+
+impl RunningContainer {
+    /// Block until the container exits, then remove it. The agent reports no
+    /// outcome upstream (the GitHub webhook is authoritative); the outcome here
+    /// is for logging only.
+    pub async fn wait(self) -> Result<DockerOutcome> {
+        let Self { client, id, guard } = self;
+        let wait = client
+            .wait_container(
+                &id,
+                Some(WaitContainerOptions {
+                    condition: "not-running".to_owned(),
+                }),
+            )
+            .next()
+            .await
+            .context("container wait stream ended unexpectedly")?
+            .with_context(|| format!("waiting on container {id}"))?;
+
+        let exit_code = wait.status_code;
+        guard.defuse();
+        let options = RemoveContainerOptions {
+            force: true,
+            ..Default::default()
+        };
+        if let Err(e) = client.remove_container(&id, Some(options)).await {
+            warn!(container = %id, error = %e, "failed to remove container");
+        }
+
+        Ok(DockerOutcome {
+            success: exit_code == 0,
+            detail: format!("container exited with code {exit_code}"),
+        })
+    }
 }
 
 /// Terminal outcome of a containerized job.
@@ -120,24 +162,16 @@ impl DockerRunner {
         self.linux_arches.clone()
     }
 
-    /// Resolve the image for a job: prefer the platform-supplied value, fall
-    /// back to the configured default.
-    pub fn resolve_image<'a>(&'a self, platform_image: &'a str) -> &'a str {
-        if platform_image.is_empty() {
-            &self.default_image
-        } else {
-            platform_image
-        }
-    }
-
-    /// Run a job inside a container. Returns the terminal outcome.
+    /// Create and start a container for `spec`, returning a handle to await.
     ///
-    /// If the future is canceled (e.g. `CancelRunner` aborting the task), the
-    /// [`ContainerGuard`] kills and removes the container on drop.
-    pub async fn run_job(&self, spec: RunSpec<'_>) -> Result<DockerOutcome> {
+    /// Returning `Ok` means the container is running — the caller can then
+    /// accept the offer. Any failure up to here (image pull, create, start) is
+    /// an error so the caller rejects and the platform re-offers. A failure
+    /// after the guard is armed kills and removes the container on drop.
+    pub async fn start(&self, spec: RunSpec<'_>) -> Result<RunningContainer> {
         let platform = format!("linux/{}", spec.arch);
 
-        Self::pull_image(&self.client, spec.image, &platform).await?;
+        Self::pull_image(&self.client, &self.default_image, &platform).await?;
 
         let container_name = format!("arcbox-{}", spec.job_id);
 
@@ -156,7 +190,7 @@ impl DockerRunner {
             .await;
 
         let config = ContainerCreateBody {
-            image: Some(spec.image.to_owned()),
+            image: Some(self.default_image.clone()),
             cmd: Some(vec![
                 "./run.sh".to_owned(),
                 "--jitconfig".to_owned(),
@@ -187,26 +221,10 @@ impl DockerRunner {
             .with_context(|| format!("starting container {id}"))?;
         debug!(job_id = spec.job_id, container = %id, "container started");
 
-        let wait = self
-            .client
-            .wait_container(
-                &id,
-                Some(WaitContainerOptions {
-                    condition: "not-running".to_owned(),
-                }),
-            )
-            .next()
-            .await
-            .context("container wait stream ended unexpectedly")?
-            .with_context(|| format!("waiting on container {id}"))?;
-
-        let exit_code = wait.status_code;
-        guard.defuse();
-        self.cleanup_container(&id).await;
-
-        Ok(DockerOutcome {
-            success: exit_code == 0,
-            detail: format!("container exited with code {exit_code}"),
+        Ok(RunningContainer {
+            client: self.client.clone(),
+            id,
+            guard,
         })
     }
 
@@ -224,17 +242,6 @@ impl DockerRunner {
         }
         info!(image, platform, "image ready");
         Ok(())
-    }
-
-    /// Best-effort container removal.
-    async fn cleanup_container(&self, id: &str) {
-        let options = RemoveContainerOptions {
-            force: true,
-            ..Default::default()
-        };
-        if let Err(e) = self.client.remove_container(id, Some(options)).await {
-            warn!(container = %id, error = %e, "failed to remove container");
-        }
     }
 }
 

--- a/fleet/arcbox-fleet-agent/src/enroll.rs
+++ b/fleet/arcbox-fleet-agent/src/enroll.rs
@@ -43,7 +43,7 @@ pub async fn enroll(
         machine_id: response.machine_id,
         machine_token: response.machine_token,
     };
-    CredentialStore::new(config.credentials_path()).store(&credential)?;
+    CredentialStore::new(config.credential_store, config.credentials_path())?.store(&credential)?;
     info!(machine_id = %credential.machine_id, "enrolled");
     Ok(credential)
 }

--- a/fleet/arcbox-fleet-agent/src/enroll.rs
+++ b/fleet/arcbox-fleet-agent/src/enroll.rs
@@ -43,7 +43,7 @@ pub async fn enroll(
         machine_id: response.machine_id,
         machine_token: response.machine_token,
     };
-    CredentialStore::new(config.credential_store, config.credentials_path())?.store(&credential)?;
+    CredentialStore::new(config.credential_store, config.credentials_path()).store(&credential)?;
     info!(machine_id = %credential.machine_id, "enrolled");
     Ok(credential)
 }

--- a/fleet/arcbox-fleet-agent/src/enroll.rs
+++ b/fleet/arcbox-fleet-agent/src/enroll.rs
@@ -43,7 +43,12 @@ pub async fn enroll(
         machine_id: response.machine_id,
         machine_token: response.machine_token,
     };
-    CredentialStore::new(config.credential_store, config.credentials_path()).store(&credential)?;
+    CredentialStore::new(
+        config.credential_store,
+        config.credentials_path(),
+        &config.gateway,
+    )
+    .store(&credential)?;
     info!(machine_id = %credential.machine_id, "enrolled");
     Ok(credential)
 }

--- a/fleet/arcbox-fleet-agent/src/enroll.rs
+++ b/fleet/arcbox-fleet-agent/src/enroll.rs
@@ -2,10 +2,10 @@
 
 use anyhow::{Context, Result};
 use arcbox_fleet_proto::v1::fleet_gateway_service_client::FleetGatewayServiceClient;
-use arcbox_fleet_proto::v1::{EnrollRequest, RuntimeCapacity};
+use arcbox_fleet_proto::v1::{Capability, EnrollRequest};
 use tracing::info;
 
-use crate::config::AgentConfig;
+use crate::config::{AgentConfig, PROTOCOL_VERSION};
 use crate::credentials::{Credential, CredentialStore};
 use crate::host;
 
@@ -13,7 +13,7 @@ use crate::host;
 pub async fn enroll(
     config: &AgentConfig,
     token: String,
-    capacities: Vec<RuntimeCapacity>,
+    capabilities: Vec<Capability>,
 ) -> Result<Credential> {
     let channel = config
         .endpoint()?
@@ -28,8 +28,9 @@ pub async fn enroll(
         host_arch: host::host_arch(),
         cpu_cores: host::cpu_cores(),
         mem_mib: host::mem_mib(),
-        capacities,
+        capabilities,
         host_info_json: host::host_info_json(),
+        protocol_version: PROTOCOL_VERSION,
     };
 
     let response = client

--- a/fleet/arcbox-fleet-agent/src/host.rs
+++ b/fleet/arcbox-fleet-agent/src/host.rs
@@ -1,6 +1,6 @@
 //! Host facts reported to the gateway at enrollment and in heartbeats.
 
-use arcbox_fleet_proto::v1::RuntimeCapacity;
+use arcbox_fleet_proto::v1::{Backend, Capability, HostTelemetry};
 
 /// Map Rust's `target_os` to the gateway's lowercase `RunnerOs` naming.
 pub fn map_os(os: &str) -> &str {
@@ -60,75 +60,65 @@ pub fn host_info_json() -> String {
     info.to_string()
 }
 
-/// Number of containers the host can run concurrently, derived from memory:
-/// one slot per 4 GiB of RAM, at least one. Docker-served Linux pools share
-/// this budget (see [`capacities`]).
-pub fn docker_budget() -> usize {
-    const MIB_PER_SLOT: u64 = 4096;
-    (mem_mib() / MIB_PER_SLOT).max(1) as usize
+/// Live host utilization for the heartbeat — a placement ranking hint for the
+/// server and the input to this agent's own admission decision. Load average is
+/// 0 on platforms that don't report it (e.g. Windows), which simply makes the
+/// load gate a no-op there.
+pub fn telemetry() -> HostTelemetry {
+    let mut sys = sysinfo::System::new();
+    sys.refresh_memory();
+    HostTelemetry {
+        load_avg_1m: sysinfo::System::load_average().one,
+        cpu_count: cpu_cores(),
+        mem_total_mib: sys.total_memory() / 1024 / 1024,
+        mem_available_mib: sys.available_memory() / 1024 / 1024,
+    }
 }
 
-/// Build the capacity pools to advertise. The gateway reserves each
-/// `(os, arch)` pool independently, so this list is also the agent's admission
-/// contract: every advertised pool must be one the agent can actually serve, at
-/// a cap it will actually honor.
+/// Build the capabilities this agent advertises: which `(os, arch)` it can serve
+/// and the backend serving each. There are no capacity numbers — whether the
+/// host can take another job is decided per offer from live [`telemetry`].
 ///
-/// - **Docker-served Linux pools.** `docker_arches` is the set of Linux arches
-///   Docker can run (empty when Docker is absent). Each is advertised at the
-///   full `docker_budget`. On Apple Silicon the arm64 (native) and amd64
-///   (Rosetta-emulated) pools are alternative execution modes on one Docker
-///   host, so each may use the whole budget when the other is idle.
-/// - **Host-runner pool.** The native `(os, arch)` served by the pre-installed
-///   runner, capped at `host_max_concurrent`. Omitted when no runner directory
-///   is configured (nothing to run it), or when Linux jobs are already
-///   Docker-served on this host (a Linux host with Docker).
-pub fn capacities(
-    host_max_concurrent: usize,
-    runner_dir_present: bool,
-    docker_arches: &[String],
-    docker_budget: usize,
-) -> Vec<RuntimeCapacity> {
-    build_pools(
-        &host_os(),
-        &host_arch(),
-        host_max_concurrent,
-        runner_dir_present,
-        docker_arches,
-        docker_budget,
-    )
+/// - **Docker-served Linux capabilities.** `docker_arches` is the set of Linux
+///   arches Docker can run (empty when Docker is absent), each backed by
+///   `docker`. On Apple Silicon that is arm64 (native) plus amd64 (Rosetta).
+/// - **Host-runner capability.** The native `(os, arch)` served by the
+///   pre-installed runner, backed by `host_runner`. Omitted when no runner
+///   directory is configured, or when Linux jobs are already Docker-served on
+///   this host (a Linux host with Docker). macOS is `host_runner` today; the
+///   `vm` backend arrives with VM isolation.
+pub fn capabilities(runner_dir_present: bool, docker_arches: &[String]) -> Vec<Capability> {
+    build_capabilities(&host_os(), &host_arch(), runner_dir_present, docker_arches)
 }
 
-/// Platform-independent core of [`capacities`], taking the native `(os, arch)`
+/// Platform-independent core of [`capabilities`], taking the native `(os, arch)`
 /// explicitly so it can be exercised for every platform in tests.
-fn build_pools(
+fn build_capabilities(
     native_os: &str,
     native_arch: &str,
-    host_max_concurrent: usize,
     runner_dir_present: bool,
     docker_arches: &[String],
-    docker_budget: usize,
-) -> Vec<RuntimeCapacity> {
-    let mut pools = Vec::new();
+) -> Vec<Capability> {
+    let mut caps = Vec::new();
 
-    let docker_cap = i32::try_from(docker_budget).unwrap_or(i32::MAX);
     for arch in docker_arches {
-        pools.push(RuntimeCapacity {
+        caps.push(Capability {
             os: "linux".to_owned(),
             arch: arch.clone(),
-            max_concurrent: docker_cap,
+            backed_by: Backend::Docker as i32,
         });
     }
 
-    let host_pool_is_docker_served = native_os == "linux" && !docker_arches.is_empty();
-    if runner_dir_present && !host_pool_is_docker_served {
-        pools.push(RuntimeCapacity {
+    let host_served_by_docker = native_os == "linux" && !docker_arches.is_empty();
+    if runner_dir_present && !host_served_by_docker {
+        caps.push(Capability {
             os: native_os.to_owned(),
             arch: native_arch.to_owned(),
-            max_concurrent: i32::try_from(host_max_concurrent).unwrap_or(i32::MAX),
+            backed_by: Backend::HostRunner as i32,
         });
     }
 
-    pools
+    caps
 }
 
 #[cfg(test)]
@@ -143,42 +133,48 @@ mod tests {
         assert_eq!(map_arch("x86_64"), "amd64");
     }
 
-    fn triple(c: &RuntimeCapacity) -> (&str, &str, i32) {
-        (c.os.as_str(), c.arch.as_str(), c.max_concurrent)
+    fn triple(c: &Capability) -> (&str, &str, i32) {
+        (c.os.as_str(), c.arch.as_str(), c.backed_by)
     }
 
     #[test]
-    fn build_pools_host_only_without_docker() {
-        let pools = build_pools("darwin", "arm64", 4, true, &[], 0);
-        assert_eq!(pools.len(), 1);
-        assert_eq!(triple(&pools[0]), ("darwin", "arm64", 4));
+    fn host_only_without_docker() {
+        let caps = build_capabilities("darwin", "arm64", true, &[]);
+        assert_eq!(caps.len(), 1);
+        assert_eq!(
+            triple(&caps[0]),
+            ("darwin", "arm64", Backend::HostRunner as i32)
+        );
     }
 
     #[test]
-    fn build_pools_macos_adds_docker_linux_pools_at_full_budget() {
+    fn macos_adds_docker_linux_capabilities() {
         let arches = vec!["arm64".to_owned(), "amd64".to_owned()];
-        let pools = build_pools("darwin", "arm64", 2, true, &arches, 4);
-        // Each docker linux pool gets the full budget, plus the darwin host pool.
-        assert_eq!(pools.len(), 3);
-        assert_eq!(triple(&pools[0]), ("linux", "arm64", 4));
-        assert_eq!(triple(&pools[1]), ("linux", "amd64", 4));
-        assert_eq!(triple(&pools[2]), ("darwin", "arm64", 2));
+        let caps = build_capabilities("darwin", "arm64", true, &arches);
+        // Two docker linux capabilities plus the darwin host-runner one.
+        assert_eq!(caps.len(), 3);
+        assert_eq!(triple(&caps[0]), ("linux", "arm64", Backend::Docker as i32));
+        assert_eq!(triple(&caps[1]), ("linux", "amd64", Backend::Docker as i32));
+        assert_eq!(
+            triple(&caps[2]),
+            ("darwin", "arm64", Backend::HostRunner as i32)
+        );
     }
 
     #[test]
-    fn build_pools_linux_host_pool_is_docker_served() {
-        // On a Linux host with Docker the native pool IS the docker linux pool,
-        // capped by the docker budget — no separate host-runner pool is added.
-        let pools = build_pools("linux", "amd64", 2, true, &["amd64".to_owned()], 4);
-        assert_eq!(pools.len(), 1);
-        assert_eq!(triple(&pools[0]), ("linux", "amd64", 4));
+    fn linux_host_capability_is_docker_served() {
+        // On a Linux host with Docker the native capability IS the docker linux
+        // one — no separate host-runner capability is added.
+        let caps = build_capabilities("linux", "amd64", true, &["amd64".to_owned()]);
+        assert_eq!(caps.len(), 1);
+        assert_eq!(triple(&caps[0]), ("linux", "amd64", Backend::Docker as i32));
     }
 
     #[test]
-    fn build_pools_omits_host_pool_without_runner_dir() {
-        // Docker-only macOS: no runner dir means no darwin pool is advertised.
-        let pools = build_pools("darwin", "arm64", 2, false, &["arm64".to_owned()], 3);
-        assert_eq!(pools.len(), 1);
-        assert_eq!(triple(&pools[0]), ("linux", "arm64", 3));
+    fn omits_host_capability_without_runner_dir() {
+        // Docker-only macOS: no runner dir means no darwin capability.
+        let caps = build_capabilities("darwin", "arm64", false, &["arm64".to_owned()]);
+        assert_eq!(caps.len(), 1);
+        assert_eq!(triple(&caps[0]), ("linux", "arm64", Backend::Docker as i32));
     }
 }

--- a/fleet/arcbox-fleet-agent/src/main.rs
+++ b/fleet/arcbox-fleet-agent/src/main.rs
@@ -98,11 +98,14 @@ async fn run(command: Command, config: AgentConfig) -> Result<()> {
         Command::Run => {
             let docker = init_docker(&config).await?;
             let capabilities = capabilities(&config, docker.as_ref());
-            let credential = CredentialStore::new(config.credentials_path())
-                .load()?
-                .context(
-                    "no credential found — run `arcbox-fleet-agent enroll --token-file …` first",
-                )?;
+            let credential = CredentialStore::new(
+                config.credential_store,
+                config.credentials_path(),
+            )?
+            .load()?
+            .context(
+                "no credential found — run `arcbox-fleet-agent enroll --token-file …` first",
+            )?;
             info!(machine_id = %credential.machine_id, "starting fleet agent");
 
             // Cancelled on the first termination signal; `attach::run` then

--- a/fleet/arcbox-fleet-agent/src/main.rs
+++ b/fleet/arcbox-fleet-agent/src/main.rs
@@ -6,8 +6,10 @@
 //! available; other jobs run via the pre-installed runner
 //! (`run.sh --jitconfig …`).
 //!
-//! Configuration is environment-driven (`ARCBOX_FLEET_*`); the only CLI
-//! argument is the one-shot enrollment token.
+//! Configuration is environment-driven (`ARCBOX_FLEET_*`). The `enroll`
+//! subcommand reads the fleet join token from a file (`--token-file`) or stdin
+//! by default; `--token` is accepted for convenience but discouraged, as it
+//! leaks the token through the process argument list and shell history.
 
 mod attach;
 mod config;
@@ -17,10 +19,13 @@ mod enroll;
 mod host;
 mod runner;
 
+use std::path::PathBuf;
+
 use anyhow::{Context, Result};
 use arcbox_fleet_proto::v1::Capability;
 use arcbox_logging::LogConfig;
 use clap::{Parser, Subcommand};
+use tokio_util::sync::CancellationToken;
 use tracing::{info, warn};
 
 use crate::config::{AgentConfig, DockerMode};
@@ -37,11 +42,21 @@ struct Cli {
 #[derive(Debug, Subcommand)]
 enum Command {
     /// Exchange an enrollment token for the machine credential and persist it.
+    ///
+    /// The token is a multi-use fleet join token (valid until it expires or is
+    /// rotated). Provide it via `--token-file`, on stdin, or — discouraged —
+    /// `--token`.
     Enroll {
-        /// Fleet enrollment token issued by the control plane (a multi-use
-        /// join token valid until it expires or is rotated).
-        #[arg(long)]
-        token: String,
+        /// File holding the enrollment token (recommended). Keeps the token out
+        /// of the process argument list, shell history, and service logs.
+        #[arg(long, value_name = "PATH")]
+        token_file: Option<PathBuf>,
+
+        /// Enrollment token passed directly. Convenient but insecure: it leaks
+        /// via the process argument list and shell history. Prefer
+        /// `--token-file`, or pipe the token on stdin.
+        #[arg(long, conflicts_with = "token_file")]
+        token: Option<String>,
     },
     /// Attach to the gateway and run dispatched jobs until terminated.
     Run,
@@ -69,7 +84,8 @@ fn main() -> Result<()> {
 
 async fn run(command: Command, config: AgentConfig) -> Result<()> {
     match command {
-        Command::Enroll { token } => {
+        Command::Enroll { token_file, token } => {
+            let token = resolve_enrollment_token(token_file, token)?;
             // Enrollment is pure credential exchange — it never needs Docker, so
             // an operator can enroll before the runtime is up. The capabilities
             // sent here are an initial hint, replaced wholesale by the first
@@ -84,11 +100,84 @@ async fn run(command: Command, config: AgentConfig) -> Result<()> {
             let capabilities = capabilities(&config, docker.as_ref());
             let credential = CredentialStore::new(config.credentials_path())
                 .load()?
-                .context("no credential found — run `arcbox-fleet-agent enroll --token …` first")?;
+                .context(
+                    "no credential found — run `arcbox-fleet-agent enroll --token-file …` first",
+                )?;
             info!(machine_id = %credential.machine_id, "starting fleet agent");
-            attach::run(config, credential, docker, capabilities).await
+
+            // Cancelled on the first termination signal; `attach::run` then
+            // stops accepting work and tears down in-flight runners.
+            let shutdown = CancellationToken::new();
+            let signal_token = shutdown.clone();
+            tokio::spawn(async move {
+                shutdown_signal().await;
+                info!("termination signal received; draining runners");
+                signal_token.cancel();
+            });
+
+            attach::run(config, credential, docker, capabilities, shutdown).await
         }
     }
+}
+
+/// Resolve when the process receives a termination signal: Ctrl-C on any
+/// platform, or SIGTERM on Unix (e.g. a service-manager stop). If a listener
+/// cannot be installed, that signal simply never fires rather than aborting
+/// startup.
+async fn shutdown_signal() {
+    let ctrl_c = async {
+        if let Err(e) = tokio::signal::ctrl_c().await {
+            warn!(error = %e, "failed to listen for Ctrl-C; ignoring");
+            std::future::pending::<()>().await;
+        }
+    };
+
+    #[cfg(unix)]
+    let terminate = async {
+        use tokio::signal::unix::{SignalKind, signal};
+        match signal(SignalKind::terminate()) {
+            Ok(mut term) => {
+                term.recv().await;
+            }
+            Err(e) => {
+                warn!(error = %e, "failed to listen for SIGTERM; ignoring");
+                std::future::pending::<()>().await;
+            }
+        }
+    };
+
+    #[cfg(not(unix))]
+    let terminate = std::future::pending::<()>();
+
+    tokio::select! {
+        () = ctrl_c => {}
+        () = terminate => {}
+    }
+}
+
+/// Resolve the enrollment token from its chosen source: a file, an explicit
+/// `--token`, or stdin when neither is given (the two flags are mutually
+/// exclusive). Surrounding whitespace — a trailing newline from a file or
+/// `echo` — is trimmed.
+fn resolve_enrollment_token(token_file: Option<PathBuf>, token: Option<String>) -> Result<String> {
+    let raw = match (token_file, token) {
+        (Some(path), _) => std::fs::read_to_string(&path)
+            .with_context(|| format!("reading enrollment token from {}", path.display()))?,
+        (None, Some(token)) => token,
+        (None, None) => {
+            use std::io::Read;
+            let mut buf = String::new();
+            std::io::stdin()
+                .read_to_string(&mut buf)
+                .context("reading enrollment token from stdin")?;
+            buf
+        }
+    };
+    let token = raw.trim().to_owned();
+    if token.is_empty() {
+        anyhow::bail!("enrollment token is empty");
+    }
+    Ok(token)
 }
 
 /// Build the capabilities this agent advertises: the native host-runner
@@ -114,5 +203,31 @@ async fn init_docker(config: &AgentConfig) -> Result<Option<DockerRunner>> {
                 Ok(None)
             }
         },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn direct_token_is_trimmed() {
+        let token = resolve_enrollment_token(None, Some("  flt_join_abc\n".to_owned())).unwrap();
+        assert_eq!(token, "flt_join_abc");
+    }
+
+    #[test]
+    fn blank_token_is_rejected() {
+        assert!(resolve_enrollment_token(None, Some("   \n".to_owned())).is_err());
+    }
+
+    #[test]
+    fn token_file_takes_precedence_and_is_trimmed() {
+        let path = std::env::temp_dir().join(format!("fleet-tok-{}", std::process::id()));
+        std::fs::write(&path, "flt_from_file\n").unwrap();
+        let token =
+            resolve_enrollment_token(Some(path.clone()), Some("ignored".to_owned())).unwrap();
+        assert_eq!(token, "flt_from_file");
+        let _ = std::fs::remove_file(path);
     }
 }

--- a/fleet/arcbox-fleet-agent/src/main.rs
+++ b/fleet/arcbox-fleet-agent/src/main.rs
@@ -6,10 +6,8 @@
 //! available; other jobs run via the pre-installed runner
 //! (`run.sh --jitconfig …`).
 //!
-//! Configuration is environment-driven (`ARCBOX_FLEET_*`). The `enroll`
-//! subcommand reads the fleet join token from a file (`--token-file`) or stdin
-//! by default; `--token` is accepted for convenience but discouraged, as it
-//! leaks the token through the process argument list and shell history.
+//! Configuration is environment-driven (`ARCBOX_FLEET_*`); the only CLI
+//! argument is the one-shot enrollment token.
 
 mod attach;
 mod config;
@@ -19,13 +17,10 @@ mod enroll;
 mod host;
 mod runner;
 
-use std::path::PathBuf;
-
 use anyhow::{Context, Result};
-use arcbox_fleet_proto::v1::RuntimeCapacity;
+use arcbox_fleet_proto::v1::Capability;
 use arcbox_logging::LogConfig;
 use clap::{Parser, Subcommand};
-use tokio_util::sync::CancellationToken;
 use tracing::{info, warn};
 
 use crate::config::{AgentConfig, DockerMode};
@@ -42,21 +37,11 @@ struct Cli {
 #[derive(Debug, Subcommand)]
 enum Command {
     /// Exchange an enrollment token for the machine credential and persist it.
-    ///
-    /// The token is a multi-use fleet join token (valid until it expires or is
-    /// rotated). Provide it via `--token-file`, on stdin, or — discouraged —
-    /// `--token`.
     Enroll {
-        /// File holding the enrollment token (recommended). Keeps the token out
-        /// of the process argument list, shell history, and service logs.
-        #[arg(long, value_name = "PATH")]
-        token_file: Option<PathBuf>,
-
-        /// Enrollment token passed directly. Convenient but insecure: it leaks
-        /// via the process argument list and shell history. Prefer
-        /// `--token-file`, or pipe the token on stdin.
-        #[arg(long, conflicts_with = "token_file")]
-        token: Option<String>,
+        /// Fleet enrollment token issued by the control plane (a multi-use
+        /// join token valid until it expires or is rotated).
+        #[arg(long)]
+        token: String,
     },
     /// Attach to the gateway and run dispatched jobs until terminated.
     Run,
@@ -84,118 +69,34 @@ fn main() -> Result<()> {
 
 async fn run(command: Command, config: AgentConfig) -> Result<()> {
     match command {
-        Command::Enroll { token_file, token } => {
-            let token = resolve_enrollment_token(token_file, token)?;
+        Command::Enroll { token } => {
             // Enrollment is pure credential exchange — it never needs Docker, so
-            // an operator can enroll before the runtime is up. The capacities
+            // an operator can enroll before the runtime is up. The capabilities
             // sent here are an initial hint, replaced wholesale by the first
             // heartbeat once the agent attaches, so we advertise what we know
             // without probing the runtime.
-            let pools = capacity_pools(&config, None);
-            enroll::enroll(&config, token, pools).await?;
+            let capabilities = capabilities(&config, None);
+            enroll::enroll(&config, token, capabilities).await?;
             Ok(())
         }
         Command::Run => {
             let docker = init_docker(&config).await?;
-            let pools = capacity_pools(&config, docker.as_ref());
+            let capabilities = capabilities(&config, docker.as_ref());
             let credential = CredentialStore::new(config.credentials_path())
                 .load()?
-                .context(
-                    "no credential found — run `arcbox-fleet-agent enroll --token-file …` first",
-                )?;
+                .context("no credential found — run `arcbox-fleet-agent enroll --token …` first")?;
             info!(machine_id = %credential.machine_id, "starting fleet agent");
-
-            // Cancelled on the first termination signal; `attach::run` then
-            // stops accepting work and tears down in-flight runners.
-            let shutdown = CancellationToken::new();
-            let signal_token = shutdown.clone();
-            tokio::spawn(async move {
-                shutdown_signal().await;
-                info!("termination signal received; draining runners");
-                signal_token.cancel();
-            });
-
-            attach::run(config, credential, docker, pools, shutdown).await
+            attach::run(config, credential, docker, capabilities).await
         }
     }
 }
 
-/// Resolve when the process receives a termination signal: Ctrl-C on any
-/// platform, or SIGTERM on Unix (e.g. a service-manager stop). If a listener
-/// cannot be installed, that signal simply never fires rather than aborting
-/// startup.
-async fn shutdown_signal() {
-    let ctrl_c = async {
-        if let Err(e) = tokio::signal::ctrl_c().await {
-            warn!(error = %e, "failed to listen for Ctrl-C; ignoring");
-            std::future::pending::<()>().await;
-        }
-    };
-
-    #[cfg(unix)]
-    let terminate = async {
-        use tokio::signal::unix::{SignalKind, signal};
-        match signal(SignalKind::terminate()) {
-            Ok(mut term) => {
-                term.recv().await;
-            }
-            Err(e) => {
-                warn!(error = %e, "failed to listen for SIGTERM; ignoring");
-                std::future::pending::<()>().await;
-            }
-        }
-    };
-
-    #[cfg(not(unix))]
-    let terminate = std::future::pending::<()>();
-
-    tokio::select! {
-        () = ctrl_c => {}
-        () = terminate => {}
-    }
-}
-
-/// Resolve the enrollment token from its chosen source: a file, an explicit
-/// `--token`, or stdin when neither is given (the two flags are mutually
-/// exclusive). Surrounding whitespace — a trailing newline from a file or
-/// `echo` — is trimmed.
-fn resolve_enrollment_token(token_file: Option<PathBuf>, token: Option<String>) -> Result<String> {
-    let raw = match (token_file, token) {
-        (Some(path), _) => std::fs::read_to_string(&path)
-            .with_context(|| format!("reading enrollment token from {}", path.display()))?,
-        (None, Some(token)) => token,
-        (None, None) => {
-            use std::io::Read;
-            let mut buf = String::new();
-            std::io::stdin()
-                .read_to_string(&mut buf)
-                .context("reading enrollment token from stdin")?;
-            buf
-        }
-    };
-    let token = raw.trim().to_owned();
-    if token.is_empty() {
-        anyhow::bail!("enrollment token is empty");
-    }
-    Ok(token)
-}
-
-/// Build the capacity pools this agent advertises and admits against: the
-/// host-runner pool (if a runner directory is set) plus any Docker-served Linux
-/// pools, the latter sharing a resource-derived budget.
-fn capacity_pools(config: &AgentConfig, docker: Option<&DockerRunner>) -> Vec<RuntimeCapacity> {
+/// Build the capabilities this agent advertises: the native host-runner
+/// capability (if a runner directory is set) plus any Docker-served Linux
+/// capabilities. Capacity is decided per offer from live telemetry, not here.
+fn capabilities(config: &AgentConfig, docker: Option<&DockerRunner>) -> Vec<Capability> {
     let docker_arches = docker.map(DockerRunner::linux_arches).unwrap_or_default();
-    let docker_budget = if docker_arches.is_empty() {
-        0
-    } else {
-        host::docker_budget()
-    };
-    host::capacities(
-        config.max_concurrent,
-        config.runner_dir.is_some(),
-        &docker_arches,
-        docker_budget,
-    )
+    host::capabilities(config.runner_dir.is_some(), &docker_arches)
 }
 
 /// Probe Docker availability according to the configured [`DockerMode`].
@@ -209,35 +110,9 @@ async fn init_docker(config: &AgentConfig) -> Result<Option<DockerRunner>> {
         DockerMode::Auto => match DockerRunner::new(config.docker.runner_image.clone()).await {
             Ok(runner) => Ok(Some(runner)),
             Err(e) => {
-                warn!(error = %e, "docker not available; linux pools will not be advertised");
+                warn!(error = %e, "docker not available; linux capabilities will not be advertised");
                 Ok(None)
             }
         },
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn direct_token_is_trimmed() {
-        let token = resolve_enrollment_token(None, Some("  flt_join_abc\n".to_owned())).unwrap();
-        assert_eq!(token, "flt_join_abc");
-    }
-
-    #[test]
-    fn blank_token_is_rejected() {
-        assert!(resolve_enrollment_token(None, Some("   \n".to_owned())).is_err());
-    }
-
-    #[test]
-    fn token_file_takes_precedence_and_is_trimmed() {
-        let path = std::env::temp_dir().join(format!("fleet-tok-{}", std::process::id()));
-        std::fs::write(&path, "flt_from_file\n").unwrap();
-        let token =
-            resolve_enrollment_token(Some(path.clone()), Some("ignored".to_owned())).unwrap();
-        assert_eq!(token, "flt_from_file");
-        let _ = std::fs::remove_file(path);
     }
 }

--- a/fleet/arcbox-fleet-agent/src/main.rs
+++ b/fleet/arcbox-fleet-agent/src/main.rs
@@ -101,6 +101,7 @@ async fn run(command: Command, config: AgentConfig) -> Result<()> {
             let credential = CredentialStore::new(
                 config.credential_store,
                 config.credentials_path(),
+                &config.gateway,
             )
             .load()?
             .context(

--- a/fleet/arcbox-fleet-agent/src/main.rs
+++ b/fleet/arcbox-fleet-agent/src/main.rs
@@ -101,7 +101,7 @@ async fn run(command: Command, config: AgentConfig) -> Result<()> {
             let credential = CredentialStore::new(
                 config.credential_store,
                 config.credentials_path(),
-            )?
+            )
             .load()?
             .context(
                 "no credential found — run `arcbox-fleet-agent enroll --token-file …` first",

--- a/fleet/arcbox-fleet-agent/src/runner.rs
+++ b/fleet/arcbox-fleet-agent/src/runner.rs
@@ -82,6 +82,23 @@ struct Inner {
     draining: std::sync::atomic::AtomicBool,
 }
 
+/// Clears a job's bookkeeping (`in_flight`, `cancels`) when dropped. Held by the
+/// runner task so release happens on every exit — normal completion, early
+/// return, abort, or panic. Without it a panicking task would leak the job ID in
+/// `in_flight` forever, and re-offers would be mis-classified as duplicates and
+/// re-accepted with no runner behind them.
+struct ReleaseGuard {
+    inner: Arc<Inner>,
+    job_id: String,
+}
+
+impl Drop for ReleaseGuard {
+    fn drop(&mut self) {
+        self.inner.in_flight.remove(&self.job_id);
+        self.inner.cancels.remove(&self.job_id);
+    }
+}
+
 impl RunnerSupervisor {
     /// Create a supervisor that emits verdicts on `events`. `capabilities` is the
     /// same set advertised to the gateway, so routing and advertisement agree.
@@ -136,7 +153,15 @@ impl RunnerSupervisor {
                 // flight before the spawned task starts the runner.
                 self.inner.in_flight.insert(job_id.clone(), ());
                 let sup = self.clone();
-                let handle = tokio::spawn(async move { sup.run_job(order, backend, token).await });
+                let handle = tokio::spawn(async move {
+                    // The guard releases the job on any task exit, including a
+                    // panic, so the ID never leaks in `in_flight`.
+                    let _release = ReleaseGuard {
+                        inner: sup.inner.clone(),
+                        job_id: order.job_id.clone(),
+                    };
+                    sup.run_job(order, backend, token).await;
+                });
                 self.inner.cancels.insert(job_id, handle.abort_handle());
             }
         }
@@ -208,7 +233,6 @@ impl RunnerSupervisor {
             Backend::Vm | Backend::Unspecified => {
                 self.reject(&job_id, &token, "backend not supported by this agent")
                     .await;
-                self.release(&job_id);
             }
         }
     }
@@ -218,7 +242,6 @@ impl RunnerSupervisor {
         let Some(runner_dir) = &self.inner.runner_dir else {
             self.reject(job_id, token, "no host runner directory configured")
                 .await;
-            self.release(job_id);
             return;
         };
 
@@ -228,7 +251,6 @@ impl RunnerSupervisor {
             Err(e) => {
                 self.reject(job_id, token, &format!("failed to spawn runner: {e}"))
                     .await;
-                self.release(job_id);
                 return;
             }
         };
@@ -241,7 +263,6 @@ impl RunnerSupervisor {
             Ok(status) => info!(job_id, success = status.success(), "runner exited"),
             Err(e) => warn!(job_id, error = %e, "waiting on runner failed"),
         }
-        self.release(job_id);
     }
 
     /// Run a job inside a Docker container.
@@ -266,7 +287,6 @@ impl RunnerSupervisor {
             Err(e) => {
                 self.reject(job_id, token, &format!("failed to start container: {e}"))
                     .await;
-                self.release(job_id);
                 return;
             }
         };
@@ -281,13 +301,6 @@ impl RunnerSupervisor {
             }
             Err(e) => warn!(job_id, error = %e, "waiting on container failed"),
         }
-        self.release(job_id);
-    }
-
-    /// Drop bookkeeping for a job.
-    fn release(&self, job_id: &str) {
-        self.inner.in_flight.remove(job_id);
-        self.inner.cancels.remove(job_id);
     }
 
     /// Accept an offer (the runner has started).

--- a/fleet/arcbox-fleet-agent/src/runner.rs
+++ b/fleet/arcbox-fleet-agent/src/runner.rs
@@ -133,16 +133,26 @@ impl RunnerSupervisor {
         }
     }
 
-    /// Decide on an offer and answer it. A redelivered offer for a running job
-    /// is re-accepted (idempotent, echoing the new token); otherwise it is
+    /// Decide on an offer and answer it. A redelivered offer for a job started
+    /// here is re-accepted (idempotent, echoing the new token); otherwise it is
     /// accepted (and a runner started) or rejected.
     pub fn handle_provision(&self, order: ProvisionRunner) {
         let job_id = order.job_id.clone();
         let token = order.offer_token.clone();
+        // The exact same offer redelivered (a gateway/worker replay before its
+        // dispatch was journaled): the verdict is already recorded and the
+        // resend loop is delivering it — answering again would only overwrite
+        // that pending verdict.
+        if self.inner.outstanding.contains_key(&token) {
+            info!(job_id, "offer replayed; verdict already pending");
+            return;
+        }
         match self.admit(&job_id, &order.os, &order.arch, &host::telemetry()) {
             Admission::Duplicate => {
-                // At-least-once delivery: a re-offer of a running job must never
-                // start a second runner, but must still resolve this offer.
+                // At-least-once delivery: a re-offer of a job started here must
+                // never start a second runner, but must still resolve this
+                // offer — with the new token, since each offer has its own
+                // awakeable and the old one is dead.
                 info!(job_id, "duplicate offer; re-accepting");
                 self.accept(&job_id, &token);
             }
@@ -172,10 +182,14 @@ impl RunnerSupervisor {
     /// Decide whether to run `job_id`. `Duplicate` takes precedence so a
     /// redelivery is never a fresh runner. Then drain, then capability routing,
     /// then live headroom (load per core and free memory). The check/insert gap
-    /// in [`Self::handle_provision`] is safe: the attach loop dispatches offers
-    /// one at a time with no `.await` between this check and the reservation.
+    /// in [`Self::handle_provision`] is safe: dispatch is synchronous and the
+    /// attach loop delivers offers one at a time.
     fn admit(&self, job_id: &str, os: &str, arch: &str, telemetry: &HostTelemetry) -> Admission {
-        if self.inner.in_flight.contains_key(job_id) {
+        // Started here and still settling counts as a duplicate too: a runner
+        // can finish (releasing `in_flight`) while its accept is still unacked,
+        // and a re-offer of that job must replay "started here" — not admit a
+        // fresh runner for a job whose single-use JIT config is already spent.
+        if self.inner.in_flight.contains_key(job_id) || self.has_unacked_accept(job_id) {
             return Admission::Duplicate;
         }
         if self
@@ -203,6 +217,16 @@ impl RunnerSupervisor {
             ));
         }
         Admission::Accept(backend)
+    }
+
+    /// Whether an accepted verdict for `job_id` is still awaiting its ack — the
+    /// window between the runner exiting and the gateway settling the accept.
+    /// A linear scan: `outstanding` only holds verdicts the gateway hasn't
+    /// settled yet, so it is empty in steady state.
+    fn has_unacked_accept(&self, job_id: &str) -> bool {
+        self.inner.outstanding.iter().any(|entry| {
+            matches!(entry.value(), attach_request::Msg::RunnerAccepted(a) if a.job_id == job_id)
+        })
     }
 
     /// Cancel an in-flight job. Signals `run_job`, which tears down the runner —
@@ -619,6 +643,49 @@ mod tests {
             }
         }
         assert!(sup.inner.outstanding.contains_key("tok2"));
+    }
+
+    #[tokio::test]
+    async fn replayed_offer_token_is_not_answered_twice() {
+        let (sup, mut rx) = supervisor_with_rx(8);
+        sup.reject("rjob_a", "tok1", "busy");
+        rx.try_recv().expect("initial verdict");
+
+        // The same offer redelivered verbatim: the pending verdict stands and
+        // no fresh admission (which might now accept) overwrites it.
+        sup.handle_provision(ProvisionRunner {
+            job_id: "rjob_a".to_owned(),
+            os: "darwin".to_owned(),
+            arch: "arm64".to_owned(),
+            encoded_jit_config: String::new(),
+            offer_token: "tok1".to_owned(),
+        });
+        assert!(rx.try_recv().is_err());
+        assert!(matches!(
+            sup.inner.outstanding.get("tok1").map(|e| e.value().clone()),
+            Some(attach_request::Msg::RunnerRejected(_))
+        ));
+        assert!(!sup.inner.in_flight.contains_key("rjob_a"));
+    }
+
+    #[tokio::test]
+    async fn unacked_accept_makes_a_reoffer_duplicate() {
+        let (sup, _rx) = supervisor_with_rx(8);
+        // The runner started and exited (no longer in flight), but the accept
+        // has not been acked: a re-offer must replay "started here" under its
+        // new token, not admit a fresh runner.
+        sup.accept("rjob_a", "tok1");
+        assert_eq!(
+            sup.admit("rjob_a", "darwin", "arm64", &idle()),
+            Admission::Duplicate
+        );
+
+        // Once the gateway settles the accept, the job is genuinely done here.
+        sup.handle_ack("tok1");
+        assert_eq!(
+            sup.admit("rjob_a", "darwin", "arm64", &idle()),
+            Admission::Accept(Backend::HostRunner)
+        );
     }
 
     #[tokio::test]

--- a/fleet/arcbox-fleet-agent/src/runner.rs
+++ b/fleet/arcbox-fleet-agent/src/runner.rs
@@ -1,97 +1,87 @@
-//! Runner supervision: start a runner per `ProvisionRunner`, track in-flight
-//! jobs per `(os, arch)` capacity pool, and report terminal state back over the
-//! stream.
+//! Runner supervision: the agent is the admission authority. On each offer it
+//! decides — against live host state — whether to run the job, starts the
+//! runner, and answers the gateway with **accept** (the runner started) or
+//! **reject** (try another host). It reports no terminal event; the GitHub
+//! webhook is the authoritative outcome.
 //!
-//! Linux jobs run inside a Docker container for isolation (using
-//! `ProvisionRunner.image`); all other jobs run directly on the host via the
-//! pre-installed runner. Admission gates each pool against the cap the agent
-//! advertised for it, so the gateway's per-pool reservations and the agent's
-//! local capacity never disagree.
+//! Backend is chosen from the agent's own advertised capabilities: Linux jobs a
+//! Docker capability serves run in a container (isolation); a `host_runner`
+//! capability runs via the pre-installed runner. Capacity is never a number —
+//! admission gates on live load and free memory, so a busy host simply rejects
+//! and the platform re-offers elsewhere.
 
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
-use std::time::Duration;
 
 use arcbox_fleet_proto::v1::{
-    AttachRequest, ProvisionRunner, RunnerAccepted, RunnerFailed, RunnerFinished, RunnerStarted,
-    RuntimeCapacity, attach_request,
+    AttachRequest, Backend, Capability, HostTelemetry, ProvisionRunner, RunnerAccepted,
+    RunnerRejected, attach_request,
 };
-use command_group::AsyncCommandGroup;
 use dashmap::DashMap;
-use tokio::sync::{mpsc, oneshot};
+use tokio::sync::mpsc;
+use tokio::task::AbortHandle;
 use tracing::{info, warn};
 
 use crate::docker::{DockerRunner, RunSpec};
+use crate::host;
 
-/// An `(os, arch)` capacity pool, mirroring the gateway's reservation key.
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-struct Pool {
-    os: String,
-    arch: String,
-}
-
-/// Outcome of the admission check for an incoming `ProvisionRunner`.
+/// Outcome of the admission decision for an incoming offer.
 #[derive(Debug, PartialEq, Eq)]
 enum Admission {
-    /// Accept the job and start a runner.
-    Accept,
-    /// The job is already in flight; ignore the redelivered order.
+    /// Run the job via this backend.
+    Accept(Backend),
+    /// The job is already running here; re-accept idempotently, don't restart.
     Duplicate,
-    /// The host is draining and rejects new work.
-    Draining,
-    /// The job's `(os, arch)` pool is at its concurrency cap.
-    AtCapacity,
-    /// No advertised pool serves the job's `(os, arch)`.
-    Unservable,
+    /// Decline the offer; `reason` is echoed back for debuggability.
+    Reject(String),
 }
 
-/// Spawns and tracks runner processes, emitting lifecycle events to the gateway.
+/// Spawns and tracks runner processes, answering each offer with accept/reject.
 #[derive(Clone)]
 pub struct RunnerSupervisor {
     inner: Arc<Inner>,
 }
 
 struct Inner {
-    /// Outbound channel to the gateway (runner lifecycle events).
+    /// Outbound channel to the gateway (offer verdicts).
     events: mpsc::Sender<AttachRequest>,
-    /// In-flight jobs mapped to the pool each occupies; drives per-pool capacity.
-    in_flight: DashMap<String, Pool>,
-    /// Cancel signals for in-flight jobs. Firing one makes the job's `run_job`
-    /// kill the runner's whole process group; see [`RunnerSupervisor::handle_cancel`].
-    cancels: DashMap<String, oneshot::Sender<()>>,
+    /// Jobs currently running here — for duplicate detection and release.
+    in_flight: DashMap<String, ()>,
+    /// Abort handles for in-flight jobs, for `CancelRunner`.
+    cancels: DashMap<String, AbortHandle>,
     /// Directory holding the installed runner (`run.sh` / `run.cmd`).
     /// `None` when only Docker-based execution is configured.
     runner_dir: Option<PathBuf>,
     /// Docker runtime for Linux jobs, if available.
     docker: Option<DockerRunner>,
-    /// Advertised capacity per `(os, arch)` pool. Admission gates each pool
-    /// against its own cap, mirroring the gateway's per-pool reservation.
-    pools: HashMap<Pool, i32>,
+    /// The backend serving each advertised `(os, arch)` — the routing table.
+    backends: HashMap<(String, String), Backend>,
+    /// Reject an offer when 1-minute load per core exceeds this.
+    load_ceiling: f64,
+    /// Reject an offer when available memory (MiB) is below this.
+    mem_floor_mib: u64,
     /// Set once `Drain` is received; no new jobs are accepted.
     draining: std::sync::atomic::AtomicBool,
 }
 
 impl RunnerSupervisor {
-    /// Create a supervisor that emits events on `events`. `pools` is the
-    /// advertised capacity set — the same list reported to the gateway, so
-    /// admission and advertisement can never disagree.
+    /// Create a supervisor that emits verdicts on `events`. `capabilities` is the
+    /// same set advertised to the gateway, so routing and advertisement agree.
     pub fn new(
         events: mpsc::Sender<AttachRequest>,
         runner_dir: Option<PathBuf>,
         docker: Option<DockerRunner>,
-        pools: Vec<RuntimeCapacity>,
+        capabilities: Vec<Capability>,
+        load_ceiling: f64,
+        mem_floor_mib: u64,
     ) -> Self {
-        let pools = pools
+        let backends = capabilities
             .into_iter()
-            .map(|c| {
-                (
-                    Pool {
-                        os: c.os,
-                        arch: c.arch,
-                    },
-                    c.max_concurrent,
-                )
+            .filter_map(|c| {
+                Backend::try_from(c.backed_by)
+                    .ok()
+                    .map(|b| ((c.os, c.arch), b))
             })
             .collect();
         Self {
@@ -101,71 +91,45 @@ impl RunnerSupervisor {
                 cancels: DashMap::new(),
                 runner_dir,
                 docker,
-                pools,
+                backends,
+                load_ceiling,
+                mem_floor_mib,
                 draining: std::sync::atomic::AtomicBool::new(false),
             }),
         }
     }
 
-    /// Start a runner for `order`. A redelivered order for a job already in
-    /// flight is ignored; otherwise the job is rejected if draining or at
-    /// capacity.
+    /// Decide on an offer and answer it. A redelivered offer for a running job
+    /// is re-accepted (idempotent, echoing the new token); otherwise it is
+    /// accepted (and a runner started) or rejected.
     pub async fn handle_provision(&self, order: ProvisionRunner) {
         let job_id = order.job_id.clone();
-        let pool = Pool {
-            os: order.os.clone(),
-            arch: order.arch.clone(),
-        };
-
-        match self.admit(&job_id, &pool) {
+        let token = order.offer_token.clone();
+        match self.admit(&job_id, &order.os, &order.arch, &host::telemetry()) {
             Admission::Duplicate => {
-                // The gateway's dispatch is at-least-once, so a redelivered
-                // order for a running job must be a no-op — never a second
-                // runner process for the same job.
-                info!(job_id, "duplicate provision ignored");
-                return;
+                // At-least-once delivery: a re-offer of a running job must never
+                // start a second runner, but must still resolve this offer.
+                info!(job_id, "duplicate offer; re-accepting");
+                self.accept(&job_id, &token).await;
             }
-            Admission::Draining => {
-                self.fail(&job_id, "host is draining").await;
-                return;
+            Admission::Reject(reason) => self.reject(&job_id, &token, &reason).await,
+            Admission::Accept(backend) => {
+                // Reserve synchronously so a follow-up offer sees the job in
+                // flight before the spawned task starts the runner.
+                self.inner.in_flight.insert(job_id.clone(), ());
+                let sup = self.clone();
+                let handle = tokio::spawn(async move { sup.run_job(order, backend, token).await });
+                self.inner.cancels.insert(job_id, handle.abort_handle());
             }
-            Admission::AtCapacity => {
-                self.fail(&job_id, "host at capacity").await;
-                return;
-            }
-            Admission::Unservable => {
-                self.fail(
-                    &job_id,
-                    &format!("no capacity pool for {}/{}", order.os, order.arch),
-                )
-                .await;
-                return;
-            }
-            Admission::Accept => {}
         }
-
-        // Reserve the slot synchronously so a follow-up dispatch sees it.
-        self.inner.in_flight.insert(job_id.clone(), pool);
-
-        // Cancellation is cooperative: `run_job` owns the runner process group
-        // and tears it down on this signal, so `CancelRunner` never orphans the
-        // runner's child processes (a task abort would kill only the immediate
-        // `run.sh`/`cmd` child, not the runner and job it spawns).
-        let (cancel_tx, cancel_rx) = oneshot::channel();
-        self.inner.cancels.insert(job_id, cancel_tx);
-        let sup = self.clone();
-        tokio::spawn(async move { sup.run_job(order, cancel_rx).await });
     }
 
-    /// Decide whether to start a runner for `job_id` in `pool`. `Duplicate`
-    /// takes precedence over the host-state checks: a redelivery of an
-    /// already-running job is a no-op regardless. Capacity is gated per pool —
-    /// each `(os, arch)` against its own advertised cap — so the agent admits
-    /// exactly what the gateway reserves. The `contains`/`insert` gap back in
-    /// [`Self::handle_provision`] is safe because the attach loop dispatches
-    /// orders one at a time, with no `.await` between this check and the
-    /// reservation.
-    fn admit(&self, job_id: &str, pool: &Pool) -> Admission {
+    /// Decide whether to run `job_id`. `Duplicate` takes precedence so a
+    /// redelivery is never a fresh runner. Then drain, then capability routing,
+    /// then live headroom (load per core and free memory). The check/insert gap
+    /// in [`Self::handle_provision`] is safe: the attach loop dispatches offers
+    /// one at a time with no `.await` between this check and the reservation.
+    fn admit(&self, job_id: &str, os: &str, arch: &str, telemetry: &HostTelemetry) -> Admission {
         if self.inner.in_flight.contains_key(job_id) {
             return Admission::Duplicate;
         }
@@ -174,34 +138,35 @@ impl RunnerSupervisor {
             .draining
             .load(std::sync::atomic::Ordering::Relaxed)
         {
-            return Admission::Draining;
+            return Admission::Reject("host is draining".to_owned());
         }
-        let Some(&cap) = self.inner.pools.get(pool) else {
-            return Admission::Unservable;
+        let Some(&backend) = self.inner.backends.get(&(os.to_owned(), arch.to_owned())) else {
+            return Admission::Reject(format!("no capability for {os}/{arch}"));
         };
-        if self.active_in(pool) >= cap.max(0) as usize {
-            return Admission::AtCapacity;
+        let load_per_core = if telemetry.cpu_count > 0 {
+            telemetry.load_avg_1m / f64::from(telemetry.cpu_count)
+        } else {
+            telemetry.load_avg_1m
+        };
+        if load_per_core > self.inner.load_ceiling {
+            return Admission::Reject(format!("load too high ({load_per_core:.2}/core)"));
         }
-        Admission::Accept
+        if telemetry.mem_available_mib < self.inner.mem_floor_mib {
+            return Admission::Reject(format!(
+                "low memory ({} MiB free)",
+                telemetry.mem_available_mib
+            ));
+        }
+        Admission::Accept(backend)
     }
 
-    /// Count jobs currently occupying `pool`.
-    fn active_in(&self, pool: &Pool) -> usize {
-        self.inner
-            .in_flight
-            .iter()
-            .filter(|entry| entry.value() == pool)
-            .count()
-    }
-
-    /// Cancel an in-flight job. Signals `run_job`, which tears down the runner
-    /// (process group for host jobs, container for Docker jobs) and releases the
-    /// slot — the slot is dropped there, not here, so local capacity tracks the
-    /// real process lifetime.
+    /// Cancel an in-flight job: aborting the task drops the child (kill-on-drop)
+    /// or the container (guard-on-drop).
     pub fn handle_cancel(&self, job_id: &str) {
-        if let Some((_, cancel)) = self.inner.cancels.remove(job_id) {
-            let _ = cancel.send(());
-            warn!(job_id, "runner cancel requested");
+        if let Some((_, handle)) = self.inner.cancels.remove(job_id) {
+            handle.abort();
+            self.inner.in_flight.remove(job_id);
+            warn!(job_id, "runner canceled");
         }
     }
 
@@ -210,193 +175,124 @@ impl RunnerSupervisor {
         self.inner
             .draining
             .store(true, std::sync::atomic::Ordering::Relaxed);
-        info!("draining: no new runners will be accepted");
+        info!("draining: no new offers will be accepted");
     }
 
-    /// Begin graceful shutdown: stop accepting offers, cancel every in-flight
-    /// job (each `run_job` tears down its runner — process group for host jobs,
-    /// container for Docker jobs), and wait — bounded by `grace` — for the jobs
-    /// to release their slots.
-    ///
-    /// Terminal events are emitted best-effort: the attach stream may already be
-    /// torn down, but the gateway reclaims capacity when it observes the dropped
-    /// connection, so a runner that cannot flush its event is not stranded. The
-    /// real guarantee here is that no runner process group or container is left
-    /// orphaned.
-    pub async fn shutdown(&self, grace: Duration) {
-        self.handle_drain();
-        // `cancels` is a subset of `in_flight`, so firing every cancel signals a
-        // teardown for each running job; jobs already mid-cancel keep tearing
-        // down and are covered by the wait below.
-        let jobs: Vec<String> = self
-            .inner
-            .cancels
-            .iter()
-            .map(|entry| entry.key().clone())
-            .collect();
-        for job_id in &jobs {
-            self.handle_cancel(job_id);
-        }
-        if self.inner.in_flight.is_empty() {
-            return;
-        }
-        info!(jobs = jobs.len(), "shutdown: waiting for runners to stop");
-        let drained = async {
-            while !self.inner.in_flight.is_empty() {
-                tokio::time::sleep(Duration::from_millis(100)).await;
-            }
-        };
-        if tokio::time::timeout(grace, drained).await.is_err() {
-            warn!(
-                remaining = self.inner.in_flight.len(),
-                "shutdown grace elapsed; some runners may still be terminating"
-            );
-        }
-    }
-
-    /// Drive one runner job end to end, emitting accept/start/terminal events.
-    ///
-    /// Linux jobs are routed through Docker when available (for isolation);
-    /// all other jobs run directly on the host via the pre-installed runner.
-    async fn run_job(&self, order: ProvisionRunner, cancel_rx: oneshot::Receiver<()>) {
+    /// Start the runner for an accepted offer, then accept once it is actually
+    /// running. A failure to start rejects instead, so the platform re-offers.
+    async fn run_job(&self, order: ProvisionRunner, backend: Backend, token: String) {
         let job_id = order.job_id.clone();
-        self.send(attach_request::Msg::RunnerAccepted(RunnerAccepted {
-            job_id: job_id.clone(),
-        }))
-        .await;
-
-        let use_docker = order.os == "linux" && self.inner.docker.is_some();
-
-        if use_docker {
-            self.run_docker_job(&job_id, &order, cancel_rx).await;
-        } else {
-            self.run_host_job(&job_id, &order, cancel_rx).await;
+        match backend {
+            Backend::Docker => self.run_docker_job(&job_id, &order, &token).await,
+            Backend::HostRunner => self.run_host_job(&job_id, &order, &token).await,
+            // We never advertise these, so admit() never routes to them; reject
+            // defensively rather than panic if one ever slips through.
+            Backend::Vm | Backend::Unspecified => {
+                self.reject(&job_id, &token, "backend not supported by this agent")
+                    .await;
+                self.release(&job_id);
+            }
         }
     }
 
-    /// Run a job directly on the host via the pre-installed runner. The runner is
-    /// spawned as a process group so cancellation can take down `run.sh` and
-    /// every process it spawned, not just the immediate child.
-    async fn run_host_job(
-        &self,
-        job_id: &str,
-        order: &ProvisionRunner,
-        mut cancel_rx: oneshot::Receiver<()>,
-    ) {
-        let runner_dir = match &self.inner.runner_dir {
-            Some(dir) => dir,
-            None => {
-                self.fail(job_id, "no host runner directory configured")
-                    .await;
-                return;
-            }
+    /// Run a job directly on the host via the pre-installed runner.
+    async fn run_host_job(&self, job_id: &str, order: &ProvisionRunner, token: &str) {
+        let Some(runner_dir) = &self.inner.runner_dir else {
+            self.reject(job_id, token, "no host runner directory configured")
+                .await;
+            self.release(job_id);
+            return;
         };
 
         let mut command = runner_command(runner_dir, &order.encoded_jit_config);
-        let mut child = match command.group_spawn() {
+        let mut child = match command.kill_on_drop(true).spawn() {
             Ok(child) => child,
             Err(e) => {
-                self.fail(job_id, &format!("failed to spawn runner: {e}"))
+                self.reject(job_id, token, &format!("failed to spawn runner: {e}"))
                     .await;
+                self.release(job_id);
                 return;
             }
         };
 
-        self.send(attach_request::Msg::RunnerStarted(RunnerStarted {
-            job_id: job_id.to_owned(),
-        }))
-        .await;
+        // The runner is running: accept the offer.
+        self.accept(job_id, token).await;
         info!(job_id, "runner started (host)");
 
-        tokio::select! {
-            result = child.wait() => match result {
-                Ok(status) => {
-                    self.send(attach_request::Msg::RunnerFinished(RunnerFinished {
-                        job_id: job_id.to_owned(),
-                        success: status.success(),
-                        detail: format!("exit status: {status}"),
-                    }))
-                    .await;
-                    info!(job_id, success = status.success(), "runner finished");
-                    self.release(job_id);
-                }
-                Err(e) => self.fail(job_id, &format!("waiting on runner: {e}")).await,
-            },
-            // CancelRunner: SIGKILL the whole process group (run.sh and the
-            // runner/job processes it spawned) and reap it, then report terminal.
-            _ = &mut cancel_rx => {
-                if let Err(e) = child.kill().await {
-                    warn!(job_id, error = %e, "killing runner process group failed");
-                }
-                self.fail(job_id, "canceled by gateway").await;
-            }
+        match child.wait().await {
+            Ok(status) => info!(job_id, success = status.success(), "runner exited"),
+            Err(e) => warn!(job_id, error = %e, "waiting on runner failed"),
         }
+        self.release(job_id);
     }
 
-    /// Run a job inside a Docker container. On cancellation the in-flight
-    /// container future is dropped, and its `ContainerGuard` kills and removes
-    /// the container.
-    async fn run_docker_job(
-        &self,
-        job_id: &str,
-        order: &ProvisionRunner,
-        mut cancel_rx: oneshot::Receiver<()>,
-    ) {
-        let docker = self.inner.docker.as_ref().expect("checked by caller");
-        let image = docker.resolve_image(&order.image);
+    /// Run a job inside a Docker container.
+    async fn run_docker_job(&self, job_id: &str, order: &ProvisionRunner, token: &str) {
+        // Invariant: a Docker-backed capability is only advertised when Docker
+        // is present, so admit() routes here only with `docker` set.
+        let docker = self
+            .inner
+            .docker
+            .as_ref()
+            .expect("docker backend implies a docker runtime");
 
-        self.send(attach_request::Msg::RunnerStarted(RunnerStarted {
-            job_id: job_id.to_owned(),
-        }))
-        .await;
-        info!(job_id, image, arch = %order.arch, "runner started (docker)");
-
-        let run = docker.run_job(RunSpec {
-            job_id,
-            image,
-            encoded_jit_config: &order.encoded_jit_config,
-            arch: &order.arch,
-        });
-        tokio::select! {
-            result = run => match result {
-                Ok(outcome) => {
-                    self.send(attach_request::Msg::RunnerFinished(RunnerFinished {
-                        job_id: job_id.to_owned(),
-                        success: outcome.success,
-                        detail: outcome.detail.clone(),
-                    }))
+        let running = match docker
+            .start(RunSpec {
+                job_id,
+                encoded_jit_config: &order.encoded_jit_config,
+                arch: &order.arch,
+            })
+            .await
+        {
+            Ok(running) => running,
+            Err(e) => {
+                self.reject(job_id, token, &format!("failed to start container: {e}"))
                     .await;
-                    info!(job_id, success = outcome.success, detail = %outcome.detail, "runner finished");
-                    self.release(job_id);
-                }
-                Err(e) => self.fail(job_id, &format!("docker runner: {e}")).await,
-            },
-            // CancelRunner: dropping `run` drops the container guard, which kills
-            // and removes the container.
-            _ = &mut cancel_rx => {
-                self.fail(job_id, "canceled by gateway").await;
+                self.release(job_id);
+                return;
             }
+        };
+
+        // The container is running: accept the offer.
+        self.accept(job_id, token).await;
+        info!(job_id, arch = %order.arch, "runner started (docker)");
+
+        match running.wait().await {
+            Ok(outcome) => {
+                info!(job_id, success = outcome.success, detail = %outcome.detail, "runner exited");
+            }
+            Err(e) => warn!(job_id, error = %e, "waiting on container failed"),
         }
+        self.release(job_id);
     }
 
-    /// Drop bookkeeping for a job, releasing its capacity slot.
+    /// Drop bookkeeping for a job.
     fn release(&self, job_id: &str) {
         self.inner.in_flight.remove(job_id);
         self.inner.cancels.remove(job_id);
     }
 
-    /// Emit a `RunnerFailed` and release the slot.
-    async fn fail(&self, job_id: &str, reason: &str) {
-        warn!(job_id, reason, "runner failed");
-        self.send(attach_request::Msg::RunnerFailed(RunnerFailed {
-            job_id: job_id.to_string(),
-            reason: reason.to_string(),
+    /// Accept an offer (the runner has started).
+    async fn accept(&self, job_id: &str, token: &str) {
+        self.send(attach_request::Msg::RunnerAccepted(RunnerAccepted {
+            job_id: job_id.to_owned(),
+            offer_token: token.to_owned(),
         }))
         .await;
-        self.release(job_id);
     }
 
-    /// Send a runner event, awaiting channel capacity.
+    /// Reject an offer with a reason.
+    async fn reject(&self, job_id: &str, token: &str, reason: &str) {
+        info!(job_id, reason, "offer rejected");
+        self.send(attach_request::Msg::RunnerRejected(RunnerRejected {
+            job_id: job_id.to_owned(),
+            offer_token: token.to_owned(),
+            reason: reason.to_owned(),
+        }))
+        .await;
+    }
+
+    /// Send a verdict, awaiting channel capacity.
     async fn send(&self, msg: attach_request::Msg) {
         if self
             .inner
@@ -436,123 +332,93 @@ fn runner_command(runner_dir: &Path, encoded_jit_config: &str) -> tokio::process
 mod tests {
     use super::*;
 
-    fn cap(os: &str, arch: &str, max: i32) -> RuntimeCapacity {
-        RuntimeCapacity {
+    fn capability(os: &str, arch: &str, backend: Backend) -> Capability {
+        Capability {
             os: os.to_owned(),
             arch: arch.to_owned(),
-            max_concurrent: max,
+            backed_by: backend as i32,
         }
     }
 
-    fn pool(os: &str, arch: &str) -> Pool {
-        Pool {
-            os: os.to_owned(),
-            arch: arch.to_owned(),
+    fn telemetry(load_avg_1m: f64, mem_available_mib: u64) -> HostTelemetry {
+        HostTelemetry {
+            load_avg_1m,
+            cpu_count: 8,
+            mem_total_mib: 16384,
+            mem_available_mib,
         }
     }
 
-    fn supervisor(pools: Vec<RuntimeCapacity>) -> RunnerSupervisor {
+    fn supervisor(capabilities: Vec<Capability>) -> RunnerSupervisor {
         let (events, _rx) = mpsc::channel(1);
-        RunnerSupervisor::new(events, Some(PathBuf::from("/nonexistent")), None, pools)
+        RunnerSupervisor::new(
+            events,
+            Some(PathBuf::from("/nonexistent")),
+            None,
+            capabilities,
+            0.9,
+            2048,
+        )
+    }
+
+    // Idle host: plenty of headroom.
+    fn idle() -> HostTelemetry {
+        telemetry(0.5, 8192)
     }
 
     #[test]
-    fn admits_until_pool_capacity_then_rejects() {
-        let sup = supervisor(vec![cap("darwin", "arm64", 2)]);
-        let p = pool("darwin", "arm64");
-        assert_eq!(sup.admit("rjob_a", &p), Admission::Accept);
-
-        sup.inner.in_flight.insert("rjob_a".to_string(), p.clone());
-        // A redelivery of a running job is a duplicate, never a fresh slot.
-        assert_eq!(sup.admit("rjob_a", &p), Admission::Duplicate);
-        assert_eq!(sup.admit("rjob_b", &p), Admission::Accept);
-
-        sup.inner.in_flight.insert("rjob_b".to_string(), p.clone());
-        assert_eq!(sup.admit("rjob_c", &p), Admission::AtCapacity);
-    }
-
-    #[test]
-    fn pools_have_independent_capacity() {
-        let sup = supervisor(vec![cap("darwin", "arm64", 1), cap("linux", "amd64", 1)]);
-        let darwin = pool("darwin", "arm64");
-        let linux = pool("linux", "amd64");
-
-        sup.inner
-            .in_flight
-            .insert("rjob_a".to_string(), darwin.clone());
-        // The darwin pool is full...
-        assert_eq!(sup.admit("rjob_b", &darwin), Admission::AtCapacity);
-        // ...but the linux pool is unaffected.
-        assert_eq!(sup.admit("rjob_c", &linux), Admission::Accept);
-    }
-
-    #[test]
-    fn unadvertised_pool_is_unservable() {
-        let sup = supervisor(vec![cap("darwin", "arm64", 2)]);
+    fn accepts_when_servable_with_headroom() {
+        let sup = supervisor(vec![capability("darwin", "arm64", Backend::HostRunner)]);
         assert_eq!(
-            sup.admit("rjob_a", &pool("linux", "amd64")),
-            Admission::Unservable
+            sup.admit("rjob_a", "darwin", "arm64", &idle()),
+            Admission::Accept(Backend::HostRunner)
         );
     }
 
     #[test]
-    fn duplicate_takes_precedence_over_drain_and_capacity() {
-        let sup = supervisor(vec![cap("darwin", "arm64", 1)]);
-        let p = pool("darwin", "arm64");
-        sup.inner.in_flight.insert("rjob_a".to_string(), p.clone());
+    fn rejects_unservable_os_arch() {
+        let sup = supervisor(vec![capability("darwin", "arm64", Backend::HostRunner)]);
+        assert!(matches!(
+            sup.admit("rjob_a", "linux", "amd64", &idle()),
+            Admission::Reject(_)
+        ));
+    }
+
+    #[test]
+    fn duplicate_takes_precedence_over_drain() {
+        let sup = supervisor(vec![capability("darwin", "arm64", Backend::HostRunner)]);
+        sup.inner.in_flight.insert("rjob_a".to_owned(), ());
         sup.inner
             .draining
             .store(true, std::sync::atomic::Ordering::Relaxed);
-
-        // Already running, host draining and at capacity: still a duplicate.
-        assert_eq!(sup.admit("rjob_a", &p), Admission::Duplicate);
-        // A different job while draining is rejected for draining.
-        assert_eq!(sup.admit("rjob_b", &p), Admission::Draining);
-    }
-
-    /// Register an in-flight job with a cancel signal, mirroring what
-    /// `handle_provision` sets up before spawning `run_job`.
-    fn register_in_flight(sup: &RunnerSupervisor, job_id: &str) -> oneshot::Receiver<()> {
-        let (cancel_tx, cancel_rx) = oneshot::channel();
-        sup.inner
-            .in_flight
-            .insert(job_id.to_string(), pool("darwin", "arm64"));
-        sup.inner.cancels.insert(job_id.to_string(), cancel_tx);
-        cancel_rx
-    }
-
-    #[tokio::test]
-    async fn shutdown_drains_cancels_and_waits_for_release() {
-        let sup = supervisor(vec![cap("darwin", "arm64", 4)]);
-        let cancel_rx = register_in_flight(&sup, "rjob_a");
-
-        // Stand in for `run_job`: release the slot once the cancel signal fires.
-        let inner = sup.inner.clone();
-        tokio::spawn(async move {
-            let _ = cancel_rx.await;
-            inner.in_flight.remove("rjob_a");
-            inner.cancels.remove("rjob_a");
-        });
-
-        sup.shutdown(Duration::from_secs(5)).await;
-
-        assert!(
-            sup.inner
-                .draining
-                .load(std::sync::atomic::Ordering::Relaxed)
+        assert_eq!(
+            sup.admit("rjob_a", "darwin", "arm64", &idle()),
+            Admission::Duplicate
         );
-        assert!(sup.inner.in_flight.is_empty());
+        // A different job while draining is rejected.
+        assert!(matches!(
+            sup.admit("rjob_b", "darwin", "arm64", &idle()),
+            Admission::Reject(_)
+        ));
     }
 
-    #[tokio::test]
-    async fn shutdown_returns_after_grace_when_a_job_will_not_release() {
-        let sup = supervisor(vec![cap("darwin", "arm64", 4)]);
-        // Hold the receiver so the cancel send succeeds, but never release the
-        // slot — shutdown must give up after the grace rather than hang.
-        let _cancel_rx = register_in_flight(&sup, "rjob_a");
-
-        sup.shutdown(Duration::from_millis(250)).await;
-
-        assert!(!sup.inner.in_flight.is_empty());
+    #[test]
+    fn rejects_when_load_or_memory_over_budget() {
+        let sup = supervisor(vec![capability("linux", "amd64", Backend::Docker)]);
+        // load 16 over 8 cores = 2.0/core > 0.9 ceiling.
+        assert!(matches!(
+            sup.admit("rjob_a", "linux", "amd64", &telemetry(16.0, 8192)),
+            Admission::Reject(_)
+        ));
+        // 1 GiB free < 2 GiB floor.
+        assert!(matches!(
+            sup.admit("rjob_b", "linux", "amd64", &telemetry(0.1, 1024)),
+            Admission::Reject(_)
+        ));
+        // Routes to the docker backend when healthy.
+        assert_eq!(
+            sup.admit("rjob_c", "linux", "amd64", &idle()),
+            Admission::Accept(Backend::Docker)
+        );
     }
 }

--- a/fleet/arcbox-fleet-agent/src/runner.rs
+++ b/fleet/arcbox-fleet-agent/src/runner.rs
@@ -27,18 +27,6 @@ use tracing::{info, warn};
 use crate::docker::{DockerRunner, RunSpec};
 use crate::host;
 
-/// Give up resending a verdict after this many attempts (~5 min at the
-/// attach-loop resend interval), so a verdict whose awakeable no longer exists
-/// (job long concluded, workflow retention expired) cannot resend forever.
-const VERDICT_MAX_RESENDS: u32 = 30;
-
-/// A verdict sent to the gateway but not yet acknowledged. Held until an
-/// `OfferVerdictAck` arrives and resent meanwhile; `attempts` bounds the resends.
-struct Outstanding {
-    msg: attach_request::Msg,
-    attempts: u32,
-}
-
 /// Outcome of the admission decision for an incoming offer.
 #[derive(Debug, PartialEq, Eq)]
 enum Admission {
@@ -61,9 +49,13 @@ struct Inner {
     events: mpsc::Sender<AttachRequest>,
     /// Verdicts sent but not yet acknowledged by the gateway, keyed by
     /// `offer_token`. Resent until an `OfferVerdictAck` arrives so a gateway
-    /// crash-after-read cannot lose the verdict; the gateway resolves the
-    /// awakeable idempotently, so resends are safe.
-    outstanding: DashMap<String, Outstanding>,
+    /// crash-after-read cannot lose the verdict. There is no local expiry: the
+    /// gateway acks every settled verdict — durably handed off (resolution is
+    /// idempotent, so resends are safe) or provably obsolete — so only a
+    /// transiently unreachable gateway leaves an entry here, and resending
+    /// through that is exactly the recovery we want. Growth is bounded because
+    /// offers originate from the same parked workflows the acks come from.
+    outstanding: DashMap<String, attach_request::Msg>,
     /// Jobs currently running here — for duplicate detection and release.
     in_flight: DashMap<String, ()>,
     /// Cancel signals for in-flight jobs. Firing one makes the job's `run_job`
@@ -140,7 +132,7 @@ impl RunnerSupervisor {
     /// Decide on an offer and answer it. A redelivered offer for a running job
     /// is re-accepted (idempotent, echoing the new token); otherwise it is
     /// accepted (and a runner started) or rejected.
-    pub async fn handle_provision(&self, order: ProvisionRunner) {
+    pub fn handle_provision(&self, order: ProvisionRunner) {
         let job_id = order.job_id.clone();
         let token = order.offer_token.clone();
         match self.admit(&job_id, &order.os, &order.arch, &host::telemetry()) {
@@ -148,9 +140,9 @@ impl RunnerSupervisor {
                 // At-least-once delivery: a re-offer of a running job must never
                 // start a second runner, but must still resolve this offer.
                 info!(job_id, "duplicate offer; re-accepting");
-                self.accept(&job_id, &token).await;
+                self.accept(&job_id, &token);
             }
-            Admission::Reject(reason) => self.reject(&job_id, &token, &reason).await,
+            Admission::Reject(reason) => self.reject(&job_id, &token, &reason),
             Admission::Accept(backend) => {
                 // Reserve synchronously so a follow-up offer sees the job in
                 // flight before the spawned task starts the runner.
@@ -284,8 +276,7 @@ impl RunnerSupervisor {
             // We never advertise these, so admit() never routes to them; reject
             // defensively rather than panic if one ever slips through.
             Backend::Vm | Backend::Unspecified => {
-                self.reject(&job_id, &token, "backend not supported by this agent")
-                    .await;
+                self.reject(&job_id, &token, "backend not supported by this agent");
             }
         }
     }
@@ -301,8 +292,7 @@ impl RunnerSupervisor {
         mut cancel_rx: oneshot::Receiver<()>,
     ) {
         let Some(runner_dir) = &self.inner.runner_dir else {
-            self.reject(job_id, token, "no host runner directory configured")
-                .await;
+            self.reject(job_id, token, "no host runner directory configured");
             return;
         };
 
@@ -310,14 +300,13 @@ impl RunnerSupervisor {
         let mut child = match command.group_spawn() {
             Ok(child) => child,
             Err(e) => {
-                self.reject(job_id, token, &format!("failed to spawn runner: {e}"))
-                    .await;
+                self.reject(job_id, token, &format!("failed to spawn runner: {e}"));
                 return;
             }
         };
 
         // The runner is running: accept the offer.
-        self.accept(job_id, token).await;
+        self.accept(job_id, token);
         info!(job_id, "runner started (host)");
 
         tokio::select! {
@@ -363,14 +352,13 @@ impl RunnerSupervisor {
         {
             Ok(running) => running,
             Err(e) => {
-                self.reject(job_id, token, &format!("failed to start container: {e}"))
-                    .await;
+                self.reject(job_id, token, &format!("failed to start container: {e}"));
                 return;
             }
         };
 
         // The container is running: accept the offer.
-        self.accept(job_id, token).await;
+        self.accept(job_id, token);
         info!(job_id, arch = %order.arch, "runner started (docker)");
 
         tokio::select! {
@@ -389,19 +377,18 @@ impl RunnerSupervisor {
     }
 
     /// Accept an offer (the runner has started).
-    async fn accept(&self, job_id: &str, token: &str) {
+    fn accept(&self, job_id: &str, token: &str) {
         self.send_verdict(
             token,
             attach_request::Msg::RunnerAccepted(RunnerAccepted {
                 job_id: job_id.to_owned(),
                 offer_token: token.to_owned(),
             }),
-        )
-        .await;
+        );
     }
 
     /// Reject an offer with a reason.
-    async fn reject(&self, job_id: &str, token: &str, reason: &str) {
+    fn reject(&self, job_id: &str, token: &str, reason: &str) {
         info!(job_id, reason, "offer rejected");
         self.send_verdict(
             token,
@@ -410,56 +397,33 @@ impl RunnerSupervisor {
                 offer_token: token.to_owned(),
                 reason: reason.to_owned(),
             }),
-        )
-        .await;
-    }
-
-    /// Record a verdict as outstanding (resent until acked) and send it once now.
-    async fn send_verdict(&self, token: &str, msg: attach_request::Msg) {
-        self.inner.outstanding.insert(
-            token.to_owned(),
-            Outstanding {
-                msg: msg.clone(),
-                attempts: 0,
-            },
         );
-        self.send(msg).await;
     }
 
-    /// Stop resending the verdict the gateway just acknowledged.
+    /// Record a verdict as outstanding (resent until acked) and try to send it
+    /// now. Never blocks: the `outstanding` entry is the source of truth for
+    /// delivery, so a full egress buffer just means the resend tick delivers
+    /// instead — runner supervision must not stall on verdict transport.
+    fn send_verdict(&self, token: &str, msg: attach_request::Msg) {
+        self.inner.outstanding.insert(token.to_owned(), msg.clone());
+        let _ = self.inner.events.try_send(AttachRequest { msg: Some(msg) });
+    }
+
+    /// Stop resending the verdict the gateway just settled (delivered to the
+    /// workflow, or found obsolete).
     pub fn handle_ack(&self, offer_token: &str) {
         self.inner.outstanding.remove(offer_token);
     }
 
-    /// Resend every still-unacked verdict onto the egress queue, bounded by
-    /// [`VERDICT_MAX_RESENDS`]. Non-blocking (`try_send`): a full buffer or a
-    /// momentarily detached stream just retries on the next tick. Driven by the
-    /// attach loop's resend ticker and, implicitly, every reconnect.
+    /// Resend every still-unacked verdict onto the egress queue. Non-blocking
+    /// (`try_send`): a full buffer or a momentarily detached stream just retries
+    /// on the next tick. Driven by the attach loop's resend ticker and,
+    /// implicitly, every reconnect.
     pub fn resend_outstanding(&self) {
-        self.inner.outstanding.retain(|token, entry| {
-            if entry.attempts >= VERDICT_MAX_RESENDS {
-                warn!(offer_token = %token, "giving up on unacknowledged verdict");
-                return false;
-            }
-            entry.attempts += 1;
-            // Ignore send errors: outstanding stays, the next tick retries.
+        for entry in &self.inner.outstanding {
             let _ = self.inner.events.try_send(AttachRequest {
-                msg: Some(entry.msg.clone()),
+                msg: Some(entry.value().clone()),
             });
-            true
-        });
-    }
-
-    /// Send a verdict, awaiting channel capacity.
-    async fn send(&self, msg: attach_request::Msg) {
-        if self
-            .inner
-            .events
-            .send(AttachRequest { msg: Some(msg) })
-            .await
-            .is_err()
-        {
-            warn!("event channel closed; gateway stream is reconnecting");
         }
     }
 }
@@ -596,7 +560,7 @@ mod tests {
     #[tokio::test]
     async fn verdict_tracked_and_acked() {
         let (sup, mut rx) = supervisor_with_rx(8);
-        sup.accept("rjob_a", "tok1").await;
+        sup.accept("rjob_a", "tok1");
         assert!(sup.inner.outstanding.contains_key("tok1"));
         assert!(matches!(
             rx.try_recv().expect("verdict emitted").msg,
@@ -611,27 +575,36 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn resend_reemits_unacked_verdict() {
+    async fn resend_reemits_unacked_verdict_until_acked() {
         let (sup, mut rx) = supervisor_with_rx(8);
-        sup.reject("rjob_b", "tok2", "busy").await;
+        sup.reject("rjob_b", "tok2", "busy");
         rx.try_recv().expect("initial verdict");
 
-        sup.resend_outstanding();
-        match rx.try_recv().expect("resend emitted").msg {
-            Some(attach_request::Msg::RunnerRejected(r)) => assert_eq!(r.offer_token, "tok2"),
-            other => panic!("unexpected message: {other:?}"),
+        // No local expiry: every tick re-emits until the gateway acks.
+        for _ in 0..3 {
+            sup.resend_outstanding();
+            match rx.try_recv().expect("resend emitted").msg {
+                Some(attach_request::Msg::RunnerRejected(r)) => assert_eq!(r.offer_token, "tok2"),
+                other => panic!("unexpected message: {other:?}"),
+            }
         }
+        assert!(sup.inner.outstanding.contains_key("tok2"));
     }
 
     #[tokio::test]
-    async fn resend_gives_up_after_cap() {
-        let (sup, _rx) = supervisor_with_rx(256);
-        sup.accept("rjob_c", "tok3").await;
-        // One resend per attempt up to the cap, then the entry is dropped.
-        for _ in 0..=VERDICT_MAX_RESENDS {
-            sup.resend_outstanding();
-        }
-        assert!(!sup.inner.outstanding.contains_key("tok3"));
+    async fn verdict_survives_full_egress_buffer() {
+        // Capacity 1: the initial send fills the buffer, further sends drop.
+        let (sup, mut rx) = supervisor_with_rx(1);
+        sup.accept("rjob_a", "tok1");
+        sup.accept("rjob_b", "tok2");
+
+        // Both verdicts stay outstanding regardless of delivery; once the
+        // buffer drains, the resend tick delivers the one that didn't fit.
+        assert!(sup.inner.outstanding.contains_key("tok1"));
+        assert!(sup.inner.outstanding.contains_key("tok2"));
+        rx.try_recv().expect("first verdict delivered");
+        sup.resend_outstanding();
+        rx.try_recv().expect("second verdict delivered by resend");
     }
 
     /// Register an in-flight job with a cancel signal, mirroring what

--- a/fleet/arcbox-fleet-agent/src/runner.rs
+++ b/fleet/arcbox-fleet-agent/src/runner.rs
@@ -13,14 +13,15 @@
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
+use std::time::Duration;
 
 use arcbox_fleet_proto::v1::{
     AttachRequest, Backend, Capability, HostTelemetry, ProvisionRunner, RunnerAccepted,
     RunnerRejected, attach_request,
 };
+use command_group::AsyncCommandGroup;
 use dashmap::DashMap;
-use tokio::sync::mpsc;
-use tokio::task::AbortHandle;
+use tokio::sync::{mpsc, oneshot};
 use tracing::{info, warn};
 
 use crate::docker::{DockerRunner, RunSpec};
@@ -65,8 +66,10 @@ struct Inner {
     outstanding: DashMap<String, Outstanding>,
     /// Jobs currently running here — for duplicate detection and release.
     in_flight: DashMap<String, ()>,
-    /// Abort handles for in-flight jobs, for `CancelRunner`.
-    cancels: DashMap<String, AbortHandle>,
+    /// Cancel signals for in-flight jobs. Firing one makes the job's `run_job`
+    /// kill the runner's whole process group (host) or drop the container guard
+    /// (Docker); see [`RunnerSupervisor::handle_cancel`].
+    cancels: DashMap<String, oneshot::Sender<()>>,
     /// Directory holding the installed runner (`run.sh` / `run.cmd`).
     /// `None` when only Docker-based execution is configured.
     runner_dir: Option<PathBuf>,
@@ -152,17 +155,21 @@ impl RunnerSupervisor {
                 // Reserve synchronously so a follow-up offer sees the job in
                 // flight before the spawned task starts the runner.
                 self.inner.in_flight.insert(job_id.clone(), ());
+                // Cooperative cancel: `run_job` owns the runner and tears down
+                // its whole process group (host) or container (Docker) on this
+                // signal, so `CancelRunner` never orphans the runner's children.
+                let (cancel_tx, cancel_rx) = oneshot::channel();
+                self.inner.cancels.insert(job_id, cancel_tx);
                 let sup = self.clone();
-                let handle = tokio::spawn(async move {
+                tokio::spawn(async move {
                     // The guard releases the job on any task exit, including a
                     // panic, so the ID never leaks in `in_flight`.
                     let _release = ReleaseGuard {
                         inner: sup.inner.clone(),
                         job_id: order.job_id.clone(),
                     };
-                    sup.run_job(order, backend, token).await;
+                    sup.run_job(order, backend, token, cancel_rx).await;
                 });
-                self.inner.cancels.insert(job_id, handle.abort_handle());
             }
         }
     }
@@ -203,13 +210,14 @@ impl RunnerSupervisor {
         Admission::Accept(backend)
     }
 
-    /// Cancel an in-flight job: aborting the task drops the child (kill-on-drop)
-    /// or the container (guard-on-drop).
+    /// Cancel an in-flight job. Signals `run_job`, which tears down the runner —
+    /// the whole process group for a host job, or the container for a Docker job
+    /// — and releases the slot via its `ReleaseGuard`, so local state tracks the
+    /// real runner lifetime rather than a fire-and-forget abort.
     pub fn handle_cancel(&self, job_id: &str) {
-        if let Some((_, handle)) = self.inner.cancels.remove(job_id) {
-            handle.abort();
-            self.inner.in_flight.remove(job_id);
-            warn!(job_id, "runner canceled");
+        if let Some((_, cancel)) = self.inner.cancels.remove(job_id) {
+            let _ = cancel.send(());
+            warn!(job_id, "runner cancel requested");
         }
     }
 
@@ -221,13 +229,58 @@ impl RunnerSupervisor {
         info!("draining: no new offers will be accepted");
     }
 
+    /// Begin graceful shutdown: stop accepting offers, cancel every in-flight
+    /// job (each `run_job` tears down its runner — process group for host jobs,
+    /// container for Docker jobs), and wait — bounded by `grace` — for the jobs
+    /// to release their slots. The guarantee is that no runner process group or
+    /// container is left orphaned when the agent exits.
+    pub async fn shutdown(&self, grace: Duration) {
+        self.handle_drain();
+        // `cancels` is a subset of `in_flight`, so firing every cancel signals a
+        // teardown for each running job; jobs already mid-cancel keep tearing
+        // down and are covered by the wait below.
+        let jobs: Vec<String> = self
+            .inner
+            .cancels
+            .iter()
+            .map(|entry| entry.key().clone())
+            .collect();
+        for job_id in &jobs {
+            self.handle_cancel(job_id);
+        }
+        if self.inner.in_flight.is_empty() {
+            return;
+        }
+        info!(jobs = jobs.len(), "shutdown: waiting for runners to stop");
+        let drained = async {
+            while !self.inner.in_flight.is_empty() {
+                tokio::time::sleep(Duration::from_millis(100)).await;
+            }
+        };
+        if tokio::time::timeout(grace, drained).await.is_err() {
+            warn!(
+                remaining = self.inner.in_flight.len(),
+                "shutdown grace elapsed; some runners may still be terminating"
+            );
+        }
+    }
+
     /// Start the runner for an accepted offer, then accept once it is actually
     /// running. A failure to start rejects instead, so the platform re-offers.
-    async fn run_job(&self, order: ProvisionRunner, backend: Backend, token: String) {
+    async fn run_job(
+        &self,
+        order: ProvisionRunner,
+        backend: Backend,
+        token: String,
+        cancel_rx: oneshot::Receiver<()>,
+    ) {
         let job_id = order.job_id.clone();
         match backend {
-            Backend::Docker => self.run_docker_job(&job_id, &order, &token).await,
-            Backend::HostRunner => self.run_host_job(&job_id, &order, &token).await,
+            Backend::Docker => {
+                self.run_docker_job(&job_id, &order, &token, cancel_rx)
+                    .await;
+            }
+            Backend::HostRunner => self.run_host_job(&job_id, &order, &token, cancel_rx).await,
             // We never advertise these, so admit() never routes to them; reject
             // defensively rather than panic if one ever slips through.
             Backend::Vm | Backend::Unspecified => {
@@ -237,8 +290,16 @@ impl RunnerSupervisor {
         }
     }
 
-    /// Run a job directly on the host via the pre-installed runner.
-    async fn run_host_job(&self, job_id: &str, order: &ProvisionRunner, token: &str) {
+    /// Run a job directly on the host via the pre-installed runner. The runner is
+    /// spawned as a process group so cancellation tears down `run.sh` and every
+    /// process it spawned, not just the immediate child.
+    async fn run_host_job(
+        &self,
+        job_id: &str,
+        order: &ProvisionRunner,
+        token: &str,
+        mut cancel_rx: oneshot::Receiver<()>,
+    ) {
         let Some(runner_dir) = &self.inner.runner_dir else {
             self.reject(job_id, token, "no host runner directory configured")
                 .await;
@@ -246,7 +307,7 @@ impl RunnerSupervisor {
         };
 
         let mut command = runner_command(runner_dir, &order.encoded_jit_config);
-        let mut child = match command.kill_on_drop(true).spawn() {
+        let mut child = match command.group_spawn() {
             Ok(child) => child,
             Err(e) => {
                 self.reject(job_id, token, &format!("failed to spawn runner: {e}"))
@@ -259,14 +320,31 @@ impl RunnerSupervisor {
         self.accept(job_id, token).await;
         info!(job_id, "runner started (host)");
 
-        match child.wait().await {
-            Ok(status) => info!(job_id, success = status.success(), "runner exited"),
-            Err(e) => warn!(job_id, error = %e, "waiting on runner failed"),
+        tokio::select! {
+            result = child.wait() => match result {
+                Ok(status) => info!(job_id, success = status.success(), "runner exited"),
+                Err(e) => warn!(job_id, error = %e, "waiting on runner failed"),
+            },
+            // CancelRunner: SIGKILL the whole process group and reap it.
+            _ = &mut cancel_rx => {
+                if let Err(e) = child.kill().await {
+                    warn!(job_id, error = %e, "killing runner process group failed");
+                }
+                info!(job_id, "runner canceled");
+            }
         }
     }
 
-    /// Run a job inside a Docker container.
-    async fn run_docker_job(&self, job_id: &str, order: &ProvisionRunner, token: &str) {
+    /// Run a job inside a Docker container. On cancellation the in-flight
+    /// container future is dropped, and its `ContainerGuard` kills and removes
+    /// the container.
+    async fn run_docker_job(
+        &self,
+        job_id: &str,
+        order: &ProvisionRunner,
+        token: &str,
+        mut cancel_rx: oneshot::Receiver<()>,
+    ) {
         // Invariant: a Docker-backed capability is only advertised when Docker
         // is present, so admit() routes here only with `docker` set.
         let docker = self
@@ -295,11 +373,18 @@ impl RunnerSupervisor {
         self.accept(job_id, token).await;
         info!(job_id, arch = %order.arch, "runner started (docker)");
 
-        match running.wait().await {
-            Ok(outcome) => {
-                info!(job_id, success = outcome.success, detail = %outcome.detail, "runner exited");
+        tokio::select! {
+            result = running.wait() => match result {
+                Ok(outcome) => {
+                    info!(job_id, success = outcome.success, detail = %outcome.detail, "runner exited");
+                }
+                Err(e) => warn!(job_id, error = %e, "waiting on container failed"),
+            },
+            // CancelRunner: dropping the wait future drops the container guard,
+            // which kills and removes the container.
+            _ = &mut cancel_rx => {
+                info!(job_id, "runner canceled");
             }
-            Err(e) => warn!(job_id, error = %e, "waiting on container failed"),
         }
     }
 
@@ -547,5 +632,49 @@ mod tests {
             sup.resend_outstanding();
         }
         assert!(!sup.inner.outstanding.contains_key("tok3"));
+    }
+
+    /// Register an in-flight job with a cancel signal, mirroring what
+    /// `handle_provision` sets up before spawning `run_job`.
+    fn register_in_flight(sup: &RunnerSupervisor, job_id: &str) -> oneshot::Receiver<()> {
+        let (cancel_tx, cancel_rx) = oneshot::channel();
+        sup.inner.in_flight.insert(job_id.to_owned(), ());
+        sup.inner.cancels.insert(job_id.to_owned(), cancel_tx);
+        cancel_rx
+    }
+
+    #[tokio::test]
+    async fn shutdown_drains_cancels_and_waits_for_release() {
+        let sup = supervisor(vec![capability("darwin", "arm64", Backend::HostRunner)]);
+        let cancel_rx = register_in_flight(&sup, "rjob_a");
+
+        // Stand in for `run_job`: release the slot once the cancel signal fires.
+        let inner = sup.inner.clone();
+        tokio::spawn(async move {
+            let _ = cancel_rx.await;
+            inner.in_flight.remove("rjob_a");
+            inner.cancels.remove("rjob_a");
+        });
+
+        sup.shutdown(Duration::from_secs(5)).await;
+
+        assert!(
+            sup.inner
+                .draining
+                .load(std::sync::atomic::Ordering::Relaxed)
+        );
+        assert!(sup.inner.in_flight.is_empty());
+    }
+
+    #[tokio::test]
+    async fn shutdown_returns_after_grace_when_a_job_will_not_release() {
+        let sup = supervisor(vec![capability("darwin", "arm64", Backend::HostRunner)]);
+        // Hold the receiver so the cancel send succeeds, but never release the
+        // slot — shutdown must give up after the grace rather than hang.
+        let _cancel_rx = register_in_flight(&sup, "rjob_a");
+
+        sup.shutdown(Duration::from_millis(250)).await;
+
+        assert!(!sup.inner.in_flight.is_empty());
     }
 }

--- a/fleet/arcbox-fleet-agent/src/runner.rs
+++ b/fleet/arcbox-fleet-agent/src/runner.rs
@@ -21,7 +21,8 @@ use arcbox_fleet_proto::v1::{
 };
 use command_group::AsyncCommandGroup;
 use dashmap::DashMap;
-use tokio::sync::{mpsc, oneshot};
+use tokio::sync::mpsc;
+use tokio_util::sync::CancellationToken;
 use tracing::{info, warn};
 
 use crate::docker::{DockerRunner, RunSpec};
@@ -56,12 +57,14 @@ struct Inner {
     /// through that is exactly the recovery we want. Growth is bounded because
     /// offers originate from the same parked workflows the acks come from.
     outstanding: DashMap<String, attach_request::Msg>,
-    /// Jobs currently running here — for duplicate detection and release.
-    in_flight: DashMap<String, ()>,
-    /// Cancel signals for in-flight jobs. Firing one makes the job's `run_job`
-    /// kill the runner's whole process group (host) or drop the container guard
-    /// (Docker); see [`RunnerSupervisor::handle_cancel`].
-    cancels: DashMap<String, oneshot::Sender<()>>,
+    /// Jobs currently running here, each with its cancellation token — one map
+    /// for duplicate detection, cancel delivery, and release. Cancelling a token
+    /// makes the job's `run_job` tear down the runner — the whole process group
+    /// (host) or the container (Docker) — awaited, before the entry is released.
+    /// The token is level-triggered, so a cancel that lands while the runner is
+    /// still starting is observed at the next cancellation point rather than
+    /// lost; see [`RunnerSupervisor::handle_cancel`].
+    in_flight: DashMap<String, CancellationToken>,
     /// Directory holding the installed runner (`run.sh` / `run.cmd`).
     /// `None` when only Docker-based execution is configured.
     runner_dir: Option<PathBuf>,
@@ -77,11 +80,14 @@ struct Inner {
     draining: std::sync::atomic::AtomicBool,
 }
 
-/// Clears a job's bookkeeping (`in_flight`, `cancels`) when dropped. Held by the
-/// runner task so release happens on every exit — normal completion, early
-/// return, abort, or panic. Without it a panicking task would leak the job ID in
+/// Clears a job's `in_flight` entry when dropped. Held by the runner task so
+/// release happens on every exit — normal completion, early return, awaited
+/// teardown, or panic. Without it a panicking task would leak the job ID in
 /// `in_flight` forever, and re-offers would be mis-classified as duplicates and
-/// re-accepted with no runner behind them.
+/// re-accepted with no runner behind them. Because teardown is awaited inside
+/// the task, the entry disappears only once the runner is actually gone —
+/// which is what lets [`RunnerSupervisor::shutdown`] poll `in_flight` as its
+/// orphan-free condition.
 struct ReleaseGuard {
     inner: Arc<Inner>,
     job_id: String,
@@ -90,7 +96,6 @@ struct ReleaseGuard {
 impl Drop for ReleaseGuard {
     fn drop(&mut self) {
         self.inner.in_flight.remove(&self.job_id);
-        self.inner.cancels.remove(&self.job_id);
     }
 }
 
@@ -118,7 +123,6 @@ impl RunnerSupervisor {
                 events,
                 outstanding: DashMap::new(),
                 in_flight: DashMap::new(),
-                cancels: DashMap::new(),
                 runner_dir,
                 docker,
                 backends,
@@ -145,13 +149,12 @@ impl RunnerSupervisor {
             Admission::Reject(reason) => self.reject(&job_id, &token, &reason),
             Admission::Accept(backend) => {
                 // Reserve synchronously so a follow-up offer sees the job in
-                // flight before the spawned task starts the runner.
-                self.inner.in_flight.insert(job_id.clone(), ());
-                // Cooperative cancel: `run_job` owns the runner and tears down
-                // its whole process group (host) or container (Docker) on this
-                // signal, so `CancelRunner` never orphans the runner's children.
-                let (cancel_tx, cancel_rx) = oneshot::channel();
-                self.inner.cancels.insert(job_id, cancel_tx);
+                // flight before the spawned task starts the runner. The token
+                // travels with the entry: cancelling it makes `run_job` tear
+                // down the runner — process group (host) or container (Docker),
+                // awaited — so `CancelRunner` never orphans the runner's work.
+                let cancel = CancellationToken::new();
+                self.inner.in_flight.insert(job_id, cancel.clone());
                 let sup = self.clone();
                 tokio::spawn(async move {
                     // The guard releases the job on any task exit, including a
@@ -160,7 +163,7 @@ impl RunnerSupervisor {
                         inner: sup.inner.clone(),
                         job_id: order.job_id.clone(),
                     };
-                    sup.run_job(order, backend, token, cancel_rx).await;
+                    sup.run_job(order, backend, token, cancel).await;
                 });
             }
         }
@@ -204,11 +207,13 @@ impl RunnerSupervisor {
 
     /// Cancel an in-flight job. Signals `run_job`, which tears down the runner —
     /// the whole process group for a host job, or the container for a Docker job
-    /// — and releases the slot via its `ReleaseGuard`, so local state tracks the
-    /// real runner lifetime rather than a fire-and-forget abort.
+    /// — awaited, then releases the slot via its `ReleaseGuard`, so local state
+    /// tracks the real runner lifetime rather than a fire-and-forget abort. The
+    /// entry stays until that release: cancellation is a state the job observes,
+    /// not an event that can race past it.
     pub fn handle_cancel(&self, job_id: &str) {
-        if let Some((_, cancel)) = self.inner.cancels.remove(job_id) {
-            let _ = cancel.send(());
+        if let Some(entry) = self.inner.in_flight.get(job_id) {
+            entry.value().cancel();
             warn!(job_id, "runner cancel requested");
         }
     }
@@ -228,22 +233,18 @@ impl RunnerSupervisor {
     /// container is left orphaned when the agent exits.
     pub async fn shutdown(&self, grace: Duration) {
         self.handle_drain();
-        // `cancels` is a subset of `in_flight`, so firing every cancel signals a
-        // teardown for each running job; jobs already mid-cancel keep tearing
-        // down and are covered by the wait below.
-        let jobs: Vec<String> = self
-            .inner
-            .cancels
-            .iter()
-            .map(|entry| entry.key().clone())
-            .collect();
-        for job_id in &jobs {
-            self.handle_cancel(job_id);
+        // Cancelling is idempotent, so jobs already mid-cancel just keep
+        // tearing down and are covered by the wait below.
+        for entry in &self.inner.in_flight {
+            entry.value().cancel();
         }
         if self.inner.in_flight.is_empty() {
             return;
         }
-        info!(jobs = jobs.len(), "shutdown: waiting for runners to stop");
+        info!(
+            jobs = self.inner.in_flight.len(),
+            "shutdown: waiting for runners to stop"
+        );
         let drained = async {
             while !self.inner.in_flight.is_empty() {
                 tokio::time::sleep(Duration::from_millis(100)).await;
@@ -264,15 +265,12 @@ impl RunnerSupervisor {
         order: ProvisionRunner,
         backend: Backend,
         token: String,
-        cancel_rx: oneshot::Receiver<()>,
+        cancel: CancellationToken,
     ) {
         let job_id = order.job_id.clone();
         match backend {
-            Backend::Docker => {
-                self.run_docker_job(&job_id, &order, &token, cancel_rx)
-                    .await;
-            }
-            Backend::HostRunner => self.run_host_job(&job_id, &order, &token, cancel_rx).await,
+            Backend::Docker => self.run_docker_job(&job_id, &order, &token, cancel).await,
+            Backend::HostRunner => self.run_host_job(&job_id, &order, &token, cancel).await,
             // We never advertise these, so admit() never routes to them; reject
             // defensively rather than panic if one ever slips through.
             Backend::Vm | Backend::Unspecified => {
@@ -289,7 +287,7 @@ impl RunnerSupervisor {
         job_id: &str,
         order: &ProvisionRunner,
         token: &str,
-        mut cancel_rx: oneshot::Receiver<()>,
+        cancel: CancellationToken,
     ) {
         let Some(runner_dir) = &self.inner.runner_dir else {
             self.reject(job_id, token, "no host runner directory configured");
@@ -314,8 +312,10 @@ impl RunnerSupervisor {
                 Ok(status) => info!(job_id, success = status.success(), "runner exited"),
                 Err(e) => warn!(job_id, error = %e, "waiting on runner failed"),
             },
-            // CancelRunner: SIGKILL the whole process group and reap it.
-            _ = &mut cancel_rx => {
+            // CancelRunner: SIGKILL the whole process group and reap it. The
+            // token is level-triggered, so a cancel that fired while the runner
+            // was being spawned is observed here immediately.
+            () = cancel.cancelled() => {
                 if let Err(e) = child.kill().await {
                     warn!(job_id, error = %e, "killing runner process group failed");
                 }
@@ -324,15 +324,16 @@ impl RunnerSupervisor {
         }
     }
 
-    /// Run a job inside a Docker container. On cancellation the in-flight
-    /// container future is dropped, and its `ContainerGuard` kills and removes
-    /// the container.
+    /// Run a job inside a Docker container. Cancellation is observed at every
+    /// stage — during startup (image pull / create / start) and while the
+    /// container runs — and the teardown is awaited, so by the time this
+    /// returns (releasing `in_flight`) no container is left behind.
     async fn run_docker_job(
         &self,
         job_id: &str,
         order: &ProvisionRunner,
         token: &str,
-        mut cancel_rx: oneshot::Receiver<()>,
+        cancel: CancellationToken,
     ) {
         // Invariant: a Docker-backed capability is only advertised when Docker
         // is present, so admit() routes here only with `docker` set.
@@ -342,17 +343,34 @@ impl RunnerSupervisor {
             .as_ref()
             .expect("docker backend implies a docker runtime");
 
-        let running = match docker
-            .start(RunSpec {
+        // Startup is cancellation-aware: a slow image pull must not make the
+        // agent deaf to CancelRunner and then accept a job the platform has
+        // already concluded.
+        let started = {
+            let start = std::pin::pin!(docker.start(RunSpec {
                 job_id,
                 encoded_jit_config: &order.encoded_jit_config,
                 arch: &order.arch,
-            })
-            .await
-        {
-            Ok(running) => running,
-            Err(e) => {
+            }));
+            tokio::select! {
+                result = start => Some(result),
+                () = cancel.cancelled() => None,
+            }
+        };
+        let running = match started {
+            Some(Ok(running)) => running,
+            Some(Err(e)) => {
                 self.reject(job_id, token, &format!("failed to start container: {e}"));
+                return;
+            }
+            None => {
+                // Canceled mid-startup. A cancel follows the job concluding on
+                // the platform, so no verdict is owed — its awakeable is
+                // abandoned. Dropping `start` stopped the startup; the awaited
+                // remove reaches whatever it had created by then (the name is
+                // deterministic), so nothing is orphaned.
+                docker.remove_job_container(job_id).await;
+                info!(job_id, "runner canceled during startup");
                 return;
             }
         };
@@ -361,16 +379,26 @@ impl RunnerSupervisor {
         self.accept(job_id, token);
         info!(job_id, arch = %order.arch, "runner started (docker)");
 
-        tokio::select! {
-            result = running.wait() => match result {
-                Ok(outcome) => {
-                    info!(job_id, success = outcome.success, detail = %outcome.detail, "runner exited");
-                }
-                Err(e) => warn!(job_id, error = %e, "waiting on container failed"),
-            },
-            // CancelRunner: dropping the wait future drops the container guard,
-            // which kills and removes the container.
-            _ = &mut cancel_rx => {
+        let exited = {
+            let wait = std::pin::pin!(running.wait());
+            tokio::select! {
+                result = wait => Some(result),
+                () = cancel.cancelled() => None,
+            }
+        };
+        match exited {
+            Some(Ok(exit_code)) => {
+                info!(job_id, exit_code, "runner exited");
+                running.remove().await;
+            }
+            Some(Err(e)) => {
+                warn!(job_id, error = %e, "waiting on container failed");
+                running.remove().await;
+            }
+            // CancelRunner: kill and remove the container, awaited, so the
+            // in-flight slot outlives the container — never the reverse.
+            None => {
+                running.cancel().await;
                 info!(job_id, "runner canceled");
             }
         }
@@ -509,7 +537,9 @@ mod tests {
     #[test]
     fn duplicate_takes_precedence_over_drain() {
         let sup = supervisor(vec![capability("darwin", "arm64", Backend::HostRunner)]);
-        sup.inner.in_flight.insert("rjob_a".to_owned(), ());
+        sup.inner
+            .in_flight
+            .insert("rjob_a".to_owned(), CancellationToken::new());
         sup.inner
             .draining
             .store(true, std::sync::atomic::Ordering::Relaxed);
@@ -607,26 +637,39 @@ mod tests {
         rx.try_recv().expect("second verdict delivered by resend");
     }
 
-    /// Register an in-flight job with a cancel signal, mirroring what
+    /// Register an in-flight job with its cancel token, mirroring what
     /// `handle_provision` sets up before spawning `run_job`.
-    fn register_in_flight(sup: &RunnerSupervisor, job_id: &str) -> oneshot::Receiver<()> {
-        let (cancel_tx, cancel_rx) = oneshot::channel();
-        sup.inner.in_flight.insert(job_id.to_owned(), ());
-        sup.inner.cancels.insert(job_id.to_owned(), cancel_tx);
-        cancel_rx
+    fn register_in_flight(sup: &RunnerSupervisor, job_id: &str) -> CancellationToken {
+        let cancel = CancellationToken::new();
+        sup.inner
+            .in_flight
+            .insert(job_id.to_owned(), cancel.clone());
+        cancel
+    }
+
+    #[tokio::test]
+    async fn cancel_signals_token_and_keeps_entry_until_release() {
+        let sup = supervisor(vec![capability("darwin", "arm64", Backend::HostRunner)]);
+        let cancel = register_in_flight(&sup, "rjob_a");
+
+        sup.handle_cancel("rjob_a");
+
+        assert!(cancel.is_cancelled());
+        // The entry stays until the runner task's ReleaseGuard drops it, so
+        // shutdown keeps waiting for the awaited teardown to finish.
+        assert!(sup.inner.in_flight.contains_key("rjob_a"));
     }
 
     #[tokio::test]
     async fn shutdown_drains_cancels_and_waits_for_release() {
         let sup = supervisor(vec![capability("darwin", "arm64", Backend::HostRunner)]);
-        let cancel_rx = register_in_flight(&sup, "rjob_a");
+        let cancel = register_in_flight(&sup, "rjob_a");
 
         // Stand in for `run_job`: release the slot once the cancel signal fires.
         let inner = sup.inner.clone();
         tokio::spawn(async move {
-            let _ = cancel_rx.await;
+            cancel.cancelled().await;
             inner.in_flight.remove("rjob_a");
-            inner.cancels.remove("rjob_a");
         });
 
         sup.shutdown(Duration::from_secs(5)).await;
@@ -642,9 +685,9 @@ mod tests {
     #[tokio::test]
     async fn shutdown_returns_after_grace_when_a_job_will_not_release() {
         let sup = supervisor(vec![capability("darwin", "arm64", Backend::HostRunner)]);
-        // Hold the receiver so the cancel send succeeds, but never release the
-        // slot — shutdown must give up after the grace rather than hang.
-        let _cancel_rx = register_in_flight(&sup, "rjob_a");
+        // Cancel is signalled but the slot is never released — shutdown must
+        // give up after the grace rather than hang.
+        let _cancel = register_in_flight(&sup, "rjob_a");
 
         sup.shutdown(Duration::from_millis(250)).await;
 

--- a/fleet/arcbox-fleet-agent/src/runner.rs
+++ b/fleet/arcbox-fleet-agent/src/runner.rs
@@ -26,6 +26,18 @@ use tracing::{info, warn};
 use crate::docker::{DockerRunner, RunSpec};
 use crate::host;
 
+/// Give up resending a verdict after this many attempts (~5 min at the
+/// attach-loop resend interval), so a verdict whose awakeable no longer exists
+/// (job long concluded, workflow retention expired) cannot resend forever.
+const VERDICT_MAX_RESENDS: u32 = 30;
+
+/// A verdict sent to the gateway but not yet acknowledged. Held until an
+/// `OfferVerdictAck` arrives and resent meanwhile; `attempts` bounds the resends.
+struct Outstanding {
+    msg: attach_request::Msg,
+    attempts: u32,
+}
+
 /// Outcome of the admission decision for an incoming offer.
 #[derive(Debug, PartialEq, Eq)]
 enum Admission {
@@ -46,6 +58,11 @@ pub struct RunnerSupervisor {
 struct Inner {
     /// Outbound channel to the gateway (offer verdicts).
     events: mpsc::Sender<AttachRequest>,
+    /// Verdicts sent but not yet acknowledged by the gateway, keyed by
+    /// `offer_token`. Resent until an `OfferVerdictAck` arrives so a gateway
+    /// crash-after-read cannot lose the verdict; the gateway resolves the
+    /// awakeable idempotently, so resends are safe.
+    outstanding: DashMap<String, Outstanding>,
     /// Jobs currently running here — for duplicate detection and release.
     in_flight: DashMap<String, ()>,
     /// Abort handles for in-flight jobs, for `CancelRunner`.
@@ -87,6 +104,7 @@ impl RunnerSupervisor {
         Self {
             inner: Arc::new(Inner {
                 events,
+                outstanding: DashMap::new(),
                 in_flight: DashMap::new(),
                 cancels: DashMap::new(),
                 runner_dir,
@@ -274,22 +292,64 @@ impl RunnerSupervisor {
 
     /// Accept an offer (the runner has started).
     async fn accept(&self, job_id: &str, token: &str) {
-        self.send(attach_request::Msg::RunnerAccepted(RunnerAccepted {
-            job_id: job_id.to_owned(),
-            offer_token: token.to_owned(),
-        }))
+        self.send_verdict(
+            token,
+            attach_request::Msg::RunnerAccepted(RunnerAccepted {
+                job_id: job_id.to_owned(),
+                offer_token: token.to_owned(),
+            }),
+        )
         .await;
     }
 
     /// Reject an offer with a reason.
     async fn reject(&self, job_id: &str, token: &str, reason: &str) {
         info!(job_id, reason, "offer rejected");
-        self.send(attach_request::Msg::RunnerRejected(RunnerRejected {
-            job_id: job_id.to_owned(),
-            offer_token: token.to_owned(),
-            reason: reason.to_owned(),
-        }))
+        self.send_verdict(
+            token,
+            attach_request::Msg::RunnerRejected(RunnerRejected {
+                job_id: job_id.to_owned(),
+                offer_token: token.to_owned(),
+                reason: reason.to_owned(),
+            }),
+        )
         .await;
+    }
+
+    /// Record a verdict as outstanding (resent until acked) and send it once now.
+    async fn send_verdict(&self, token: &str, msg: attach_request::Msg) {
+        self.inner.outstanding.insert(
+            token.to_owned(),
+            Outstanding {
+                msg: msg.clone(),
+                attempts: 0,
+            },
+        );
+        self.send(msg).await;
+    }
+
+    /// Stop resending the verdict the gateway just acknowledged.
+    pub fn handle_ack(&self, offer_token: &str) {
+        self.inner.outstanding.remove(offer_token);
+    }
+
+    /// Resend every still-unacked verdict onto the egress queue, bounded by
+    /// [`VERDICT_MAX_RESENDS`]. Non-blocking (`try_send`): a full buffer or a
+    /// momentarily detached stream just retries on the next tick. Driven by the
+    /// attach loop's resend ticker and, implicitly, every reconnect.
+    pub fn resend_outstanding(&self) {
+        self.inner.outstanding.retain(|token, entry| {
+            if entry.attempts >= VERDICT_MAX_RESENDS {
+                warn!(offer_token = %token, "giving up on unacknowledged verdict");
+                return false;
+            }
+            entry.attempts += 1;
+            // Ignore send errors: outstanding stays, the next tick retries.
+            let _ = self.inner.events.try_send(AttachRequest {
+                msg: Some(entry.msg.clone()),
+            });
+            true
+        });
     }
 
     /// Send a verdict, awaiting channel capacity.
@@ -420,5 +480,59 @@ mod tests {
             sup.admit("rjob_c", "linux", "amd64", &idle()),
             Admission::Accept(Backend::Docker)
         );
+    }
+
+    fn supervisor_with_rx(capacity: usize) -> (RunnerSupervisor, mpsc::Receiver<AttachRequest>) {
+        let (events, rx) = mpsc::channel(capacity);
+        let sup = RunnerSupervisor::new(
+            events,
+            Some(PathBuf::from("/nonexistent")),
+            None,
+            vec![capability("darwin", "arm64", Backend::HostRunner)],
+            0.9,
+            2048,
+        );
+        (sup, rx)
+    }
+
+    #[tokio::test]
+    async fn verdict_tracked_and_acked() {
+        let (sup, mut rx) = supervisor_with_rx(8);
+        sup.accept("rjob_a", "tok1").await;
+        assert!(sup.inner.outstanding.contains_key("tok1"));
+        assert!(matches!(
+            rx.try_recv().expect("verdict emitted").msg,
+            Some(attach_request::Msg::RunnerAccepted(_))
+        ));
+
+        // The ack stops tracking, so a later resend emits nothing for it.
+        sup.handle_ack("tok1");
+        assert!(!sup.inner.outstanding.contains_key("tok1"));
+        sup.resend_outstanding();
+        assert!(rx.try_recv().is_err());
+    }
+
+    #[tokio::test]
+    async fn resend_reemits_unacked_verdict() {
+        let (sup, mut rx) = supervisor_with_rx(8);
+        sup.reject("rjob_b", "tok2", "busy").await;
+        rx.try_recv().expect("initial verdict");
+
+        sup.resend_outstanding();
+        match rx.try_recv().expect("resend emitted").msg {
+            Some(attach_request::Msg::RunnerRejected(r)) => assert_eq!(r.offer_token, "tok2"),
+            other => panic!("unexpected message: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn resend_gives_up_after_cap() {
+        let (sup, _rx) = supervisor_with_rx(256);
+        sup.accept("rjob_c", "tok3").await;
+        // One resend per attempt up to the cap, then the entry is dropped.
+        for _ in 0..=VERDICT_MAX_RESENDS {
+            sup.resend_outstanding();
+        }
+        assert!(!sup.inner.outstanding.contains_key("tok3"));
     }
 }

--- a/fleet/arcbox-fleet-proto/proto/arcbox/fleet/v1/fleet.proto
+++ b/fleet/arcbox-fleet-proto/proto/arcbox/fleet/v1/fleet.proto
@@ -111,7 +111,17 @@ message AttachResponse {
     ProvisionRunner provision_runner = 1;
     CancelRunner cancel = 2;
     Drain drain = 3;
+    OfferVerdictAck offer_verdict_ack = 4;
   }
+}
+
+// Acknowledges that the gateway durably handed off the agent's offer verdict
+// (RunnerAccepted/RunnerRejected) to the workflow. Until it arrives, the agent
+// resends the same verdict so a gateway crash-after-read cannot lose it; the
+// echoed token lets the agent match the ack to the verdict it is retrying.
+message OfferVerdictAck {
+  // Opaque correlation token from the offer, echoed back from the verdict.
+  string offer_token = 1;
 }
 
 // Offer to run one job. The agent maps (os, arch) to a backend via its own

--- a/fleet/arcbox-fleet-proto/proto/arcbox/fleet/v1/fleet.proto
+++ b/fleet/arcbox-fleet-proto/proto/arcbox/fleet/v1/fleet.proto
@@ -115,8 +115,10 @@ message AttachResponse {
   }
 }
 
-// Acknowledges that the gateway durably handed off the agent's offer verdict
-// (RunnerAccepted/RunnerRejected) to the workflow. Until it arrives, the agent
+// Tells the agent to stop resending an offer verdict
+// (RunnerAccepted/RunnerRejected): the gateway either durably handed it off to
+// the workflow or found the offer obsolete (its workflow already moved on or
+// expired) — resending can achieve nothing more. Until it arrives, the agent
 // resends the same verdict so a gateway crash-after-read cannot lose it; the
 // echoed token lets the agent match the ack to the verdict it is retrying.
 message OfferVerdictAck {

--- a/fleet/arcbox-fleet-proto/proto/arcbox/fleet/v1/fleet.proto
+++ b/fleet/arcbox-fleet-proto/proto/arcbox/fleet/v1/fleet.proto
@@ -25,10 +25,12 @@ message EnrollRequest {
   string host_arch = 3;
   uint32 cpu_cores = 4;
   uint64 mem_mib = 5;
-  // Capacity pools the host serves, e.g. darwin/arm64 max 2 + linux/arm64.
-  repeated RuntimeCapacity capacities = 6;
+  // What the host can serve, e.g. darwin/arm64 via vm + linux/arm64 via docker.
+  repeated Capability capabilities = 6;
   // Free-form host facts as JSON (macOS version, chip, ...).
   string host_info_json = 7;
+  // Wire-protocol version the agent speaks; the gateway rejects unsupported.
+  uint32 protocol_version = 8;
 }
 
 message EnrollResponse {
@@ -39,51 +41,69 @@ message EnrollResponse {
   string machine_token = 2;
 }
 
-// One (os, arch) capacity pool of a host.
-message RuntimeCapacity {
+// What execution backend serves a capability. Routing only — capacity is the
+// agent's runtime decision, never a number on the wire.
+enum Backend {
+  BACKEND_UNSPECIFIED = 0;
+  BACKEND_HOST_RUNNER = 1;
+  BACKEND_DOCKER = 2;
+  BACKEND_VM = 3;
+}
+
+// One (os, arch) a host can serve, and how that execution is backed. The agent
+// decides per-offer whether it can run one more right now; the server never
+// reserves against a count.
+message Capability {
   // `darwin` | `linux` | `windows` (lowercase RunnerOs).
   string os = 1;
   // `arm64` | `amd64` (lowercase RunnerArch).
   string arch = 2;
-  int32 max_concurrent = 3;
+  Backend backed_by = 3;
+}
+
+// Live host utilization, reported each heartbeat. A ranking hint for placement
+// only — never an admission gate.
+message HostTelemetry {
+  double load_avg_1m = 1;
+  uint32 cpu_count = 2;
+  uint64 mem_total_mib = 3;
+  uint64 mem_available_mib = 4;
 }
 
 message AttachRequest {
   oneof msg {
     Heartbeat heartbeat = 1;
     RunnerAccepted runner_accepted = 2;
-    RunnerStarted runner_started = 3;
-    RunnerFinished runner_finished = 4;
-    RunnerFailed runner_failed = 5;
+    RunnerRejected runner_rejected = 3;
   }
 }
 
-// Periodic capacity + liveness report. Capacity pools are declarative: the
-// reported set replaces what is stored.
+// Periodic capability + liveness report. The reported capability set is
+// declarative — it replaces what is stored, so losing a backend (e.g. Docker
+// dies) simply drops the capabilities it served.
 message Heartbeat {
-  repeated RuntimeCapacity capacities = 1;
+  repeated Capability capabilities = 1;
   string host_info_json = 2;
+  HostTelemetry telemetry = 3;
 }
 
+// The agent admitted the offer and has started the runner. Echoes the offer
+// token so the workflow's awakeable resolves to this verdict; the job moves to
+// Running and the authoritative outcome then comes from the GitHub webhook.
 message RunnerAccepted {
   // Prefixed runner job id (`rjob_...`), echoing ProvisionRunner.
   string job_id = 1;
+  // Opaque correlation token from the offer.
+  string offer_token = 2;
 }
 
-message RunnerStarted {
+// The agent declined the offer and started nothing (busy, at the macOS-VM cap,
+// backend unhealthy, image unpullable, draining). The workflow re-offers to the
+// next candidate; once candidates are exhausted the job fails fast.
+message RunnerRejected {
   string job_id = 1;
-}
-
-message RunnerFinished {
-  string job_id = 1;
-  bool success = 2;
-  // Human-readable detail (exit status, GitHub conclusion, ...).
-  string detail = 3;
-}
-
-message RunnerFailed {
-  string job_id = 1;
-  string reason = 2;
+  string offer_token = 2;
+  string reason = 3;
 }
 
 message AttachResponse {
@@ -94,17 +114,16 @@ message AttachResponse {
   }
 }
 
-// Order to start one JIT runner for one job.
+// Offer to run one job. The agent maps (os, arch) to a backend via its own
+// advertised capabilities; the backend is not named here.
 message ProvisionRunner {
   string job_id = 1;
   string os = 2;
   string arch = 3;
   // Single-use GitHub JIT runner config (base64), passed through verbatim.
   string encoded_jit_config = 4;
-  // Base image for the guest; empty means the fleet default.
-  string image = 5;
-  uint32 cpus = 6;
-  uint64 mem_mib = 7;
+  // Opaque correlation token the agent echoes in RunnerAccepted/RunnerRejected.
+  string offer_token = 5;
 }
 
 // Stop a runner before it picks up work (job canceled on GitHub).

--- a/fleet/arcbox-fleet-proto/src/lib.rs
+++ b/fleet/arcbox-fleet-proto/src/lib.rs
@@ -5,6 +5,10 @@
 //! is intentionally absent — it lives in the platform's unpublished module.
 
 /// Fleet gateway protocol (`arcbox.fleet.v1` package).
+// `tonic_build` turns the `.proto` message comments into Rust doc comments;
+// some first paragraphs exceed Clippy's length limit. This is generated code
+// whose wording is owned by the proto, so the doc-style lint doesn't apply.
+#[allow(clippy::too_long_first_doc_paragraph)]
 pub mod v1 {
     tonic::include_proto!("arcbox.fleet.v1");
 }


### PR DESCRIPTION
Client half of the RUN-23 fleet protocol redesign. Pairs with the platform PR (`arcboxlabs/platform#100`); both repos move to `protocol_version = 1` together.

Stacked on #328 (`feat/fleet-docker`) — retarget to `master` once #328 merges.

## What changed

The agent is now the **admission authority** under the new offer/reject protocol; the server holds no capacity model.

- **proto** re-vendored: `Capability(os, arch, backed_by)` + `HostTelemetry`; `ProvisionRunner` carries an `offer_token`; `AttachRequest` is `Heartbeat`/`RunnerAccepted`/`RunnerRejected`; `EnrollRequest` carries `protocol_version`.
- **host**: advertise capabilities (`host_runner` / `docker` per `(os, arch)`; darwin is `host_runner` until the VM backend lands) and report live telemetry (load-avg, cpu, total/available memory).
- **runner**: per-offer admission — draining / capability routing / live load + memory headroom; a redelivered offer for a running job is an idempotent accept. **Starts the runner, then accepts**; any failure up to start → reject so the platform re-offers. Backend chosen by capability lookup (the `if os == "linux"` inference is gone). No terminal events — the GitHub webhook is authoritative.
- **docker**: split run into `start` + `RunningContainer::wait`, so accept is sent only once the container is actually running; dropped the image override.
- **config**: dropped `ARCBOX_FLEET_MAX_CONCURRENT`; added `ARCBOX_FLEET_LOAD_CEILING` (0.9) + `ARCBOX_FLEET_MEM_FLOOR_MIB` (2048) + `PROTOCOL_VERSION = 1`; attach sends the version handshake.

## Verification

Fleet-scoped gate passes: `cargo clippy -p arcbox-fleet-agent -p arcbox-fleet-proto --all-targets -- -D warnings`, `cargo fmt --check`, `cargo test -p arcbox-fleet-agent` (10/10). (Workspace clippy can't run on Linux — macOS-only crates need `cc1obj`.)

**Fleet E2E (no mocks) — ✅ PASSED on the dev box (2026-06-26).** This agent, built and run natively on the box against the new gateway (platform `protocol_version = 1`):

enroll (version handshake) → attach (advertises `linux/amd64` `docker`, reports telemetry) → on a real `runs-on: [self-hosted, linux, X64]` job: gateway offer → `docker.start` → `RunnerAccepted` resolved the workflow's per-offer awakeable → the runner executed the job inside the actions-runner container → GitHub `workflow_job=completed` drove the terminal state. Job completed **success** end-to-end; output confirmed execution on the fleet. (The reject/re-offer path remains covered by `runner.rs` unit tests, not forced live.)

## Still pending

- [ ] Retarget to `master` after #328 merges.
- [x] The vendored `fleet.proto` is a **manual copy** (pre-publish). After the platform proto publishes to the BSR, run `make fleet-proto-sync` to replace it with the canonical module.
