### PR TITLE
observability: close boot-flow gaps (G1, G3, G4, G5, G8)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -196,6 +196,7 @@ dependencies = [
  "arcbox-constants",
  "arcbox-dns",
  "arcbox-ext4",
+ "arcbox-logging",
  "arcbox-protocol",
  "arcbox-vm",
  "async-trait",

--- a/app/arcbox-core/src/agent_client.rs
+++ b/app/arcbox-core/src/agent_client.rs
@@ -525,6 +525,7 @@ impl AgentClient {
         mut self,
         start_runtime_if_needed: bool,
         timeout: Duration,
+        trace_id: &str,
     ) -> Result<ReadinessEvent> {
         if !self.connected {
             self.connect().await?;
@@ -535,7 +536,7 @@ impl AgentClient {
             timeout_ms: u32::try_from(timeout.as_millis()).unwrap_or(u32::MAX),
         };
         let payload = req.encode_to_vec();
-        let buf = Self::build_message(MessageType::WatchReadinessRequest, "", &payload);
+        let buf = Self::build_message(MessageType::WatchReadinessRequest, trace_id, &payload);
 
         match &mut self.transport {
             AgentTransport::Async(t) => {
@@ -596,13 +597,14 @@ impl AgentClient {
         mut self,
         start_runtime_if_needed: bool,
         timeout: Duration,
+        trace_id: &str,
     ) -> Result<ReadinessEvent> {
         let req = WatchReadinessRequest {
             start_runtime_if_needed,
             timeout_ms: u32::try_from(timeout.as_millis()).unwrap_or(u32::MAX),
         };
         let payload = req.encode_to_vec();
-        let buf = Self::build_message(MessageType::WatchReadinessRequest, "", &payload);
+        let buf = Self::build_message(MessageType::WatchReadinessRequest, trace_id, &payload);
 
         let AgentTransport::Blocking(t) = &mut self.transport else {
             return Err(CoreError::Machine(

--- a/app/arcbox-core/src/container_backend/guest_docker.rs
+++ b/app/arcbox-core/src/container_backend/guest_docker.rs
@@ -37,7 +37,11 @@ impl GuestDockerBackend {
         let timeout = Duration::from_millis(self.config.startup_timeout_ms);
         let agent = self.machine_manager.connect_agent(self.machine_name)?;
 
-        match agent.watch_readiness(true, timeout).await {
+        // Correlate with the triggering Docker API request via its trace id.
+        match agent
+            .watch_readiness(true, timeout, &crate::trace::current_trace_id())
+            .await
+        {
             Ok(event) if Kind::try_from(event.kind) == Ok(Kind::RuntimeReady) => {
                 validate_reported_vsock_endpoint(&event.endpoint, port)?;
                 tracing::debug!(port, "guest docker runtime is ready");

--- a/app/arcbox-core/src/vm_lifecycle/boot.rs
+++ b/app/arcbox-core/src/vm_lifecycle/boot.rs
@@ -180,8 +180,17 @@ impl LifecycleShared {
             });
         }
 
+        // Time the fresh boot (VM start -> agent ready) so the boot latency is
+        // one greppable structured event against the <1.5s cold / <500ms warm
+        // targets. `boot` only runs on a fresh start, so no boot is ever
+        // double-counted.
+        let boot_start = std::time::Instant::now();
         self.start_with_retries(timeout).await?;
         self.wait_for_agent(timeout).await?;
+        tracing::info!(
+            boot_ms = boot_start.elapsed().as_millis() as u64,
+            "guest boot ready"
+        );
         self.sync_guest_clock().await;
 
         // Reset recovery counters on a fully successful boot.

--- a/app/arcbox-core/src/vm_lifecycle/boot.rs
+++ b/app/arcbox-core/src/vm_lifecycle/boot.rs
@@ -482,7 +482,10 @@ impl LifecycleShared {
 
     /// Waits for the agent to become ready.
     async fn wait_for_agent(&self, timeout: Duration) -> Result<()> {
-        tracing::debug!("Waiting for agent to become ready...");
+        // Per-boot correlation id: stamped on every readiness RPC so the host's
+        // wait logs and the guest's RPC-dispatch logs can be matched for one boot.
+        let boot_id = uuid::Uuid::new_v4().to_string();
+        tracing::debug!(boot_id = %boot_id, "Waiting for agent to become ready...");
 
         enum AgentProbe {
             Ready,
@@ -491,6 +494,7 @@ impl LifecycleShared {
 
         let mm = Arc::clone(&self.machine_manager);
         let machine_name = self.machine_name.clone();
+        let boot_id_blocking = boot_id.clone();
 
         // Run the entire probe loop on a blocking thread. On macOS HV backend,
         // the agent transport is AF_UNIX socketpair → BlockingVsockTransport.
@@ -555,7 +559,7 @@ impl LifecycleShared {
                         if remaining.is_zero() {
                             return Err(agent_timeout_error(last_readiness_err.as_deref()));
                         }
-                        match agent.watch_readiness_blocking(false, remaining) {
+                        match agent.watch_readiness_blocking(false, remaining, &boot_id_blocking) {
                             Ok(_) => return Ok(AgentProbe::Ready),
                             Err(e) => {
                                 tracing::debug!("agent not ready yet: {e}");
@@ -636,7 +640,7 @@ impl LifecycleShared {
                     if remaining.is_zero() {
                         return Err(agent_timeout_error(last_readiness_err.as_deref()));
                     }
-                    match agent.watch_readiness(false, remaining).await {
+                    match agent.watch_readiness(false, remaining, &boot_id).await {
                         Ok(_) => break,
                         Err(e) => {
                             tracing::debug!("agent not ready yet: {e}");
@@ -649,7 +653,7 @@ impl LifecycleShared {
         }
 
         // Back on async context — do async follow-up work.
-        tracing::info!("Agent is ready");
+        tracing::info!(boot_id = %boot_id, "Agent is ready");
         self.health_monitor.record_success();
         #[cfg(target_os = "macos")]
         {

--- a/guest/arcbox-agent/Cargo.toml
+++ b/guest/arcbox-agent/Cargo.toml
@@ -43,6 +43,7 @@ arcbox-dns = { workspace = true }
 wait-timeout = "0.2.1"
 oci2rootfs = { version = "0.2.1", default-features = false }
 arcbox-ext4 = "0.1.2"
+arcbox-logging.workspace = true
 
 # vsock and arcbox-vm are Linux-only
 [target.'cfg(target_os = "linux")'.dependencies]

--- a/guest/arcbox-agent/src/agent/linux/runtime.rs
+++ b/guest/arcbox-agent/src/agent/linux/runtime.rs
@@ -583,47 +583,43 @@ pub(super) fn daemon_log_file(name: &str) -> Stdio {
     let arcbox_path = format!("{}/{}.log", log_dir, name);
     let tmp_log_path = format!("/tmp/{}.log", name);
 
+    let open_append = |path: &str| {
+        std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(path)
+    };
+
     // Prefer the VirtioFS share so the host can read the log; warn loudly on each
     // degradation so a virtiofs failure doesn't silently hide service logs.
-    let arcbox_available = Path::new("/arcbox").exists();
-    let primary = if arcbox_available {
+    if Path::new("/arcbox").exists() {
         let _ = std::fs::create_dir_all(&log_dir);
-        &arcbox_path
+        match open_append(&arcbox_path) {
+            Ok(f) => return f.into(),
+            Err(e) => {
+                tracing::warn!(
+                    service = name,
+                    error = %e,
+                    "failed to open {arcbox_path} for {name} logs; falling back to {tmp_log_path}"
+                );
+            }
+        }
     } else {
         tracing::warn!(
             service = name,
             "/arcbox VirtioFS share not mounted; {name} logs go to {tmp_log_path} (guest-local, not visible from the host)"
         );
-        &tmp_log_path
-    };
+    }
 
-    match std::fs::OpenOptions::new()
-        .create(true)
-        .append(true)
-        .open(primary)
-    {
+    match open_append(&tmp_log_path) {
         Ok(f) => f.into(),
         Err(e) => {
-            tracing::warn!(
+            tracing::error!(
                 service = name,
                 error = %e,
-                "failed to open {primary} for {name} logs; falling back to {tmp_log_path}"
+                "failed to open {tmp_log_path} for {name} logs; discarding to /dev/null"
             );
-            match std::fs::OpenOptions::new()
-                .create(true)
-                .append(true)
-                .open(&tmp_log_path)
-            {
-                Ok(f) => f.into(),
-                Err(e2) => {
-                    tracing::error!(
-                        service = name,
-                        error = %e2,
-                        "failed to open {tmp_log_path} for {name} logs; discarding to /dev/null"
-                    );
-                    Stdio::null()
-                }
-            }
+            Stdio::null()
         }
     }
 }

--- a/guest/arcbox-agent/src/agent/linux/runtime.rs
+++ b/guest/arcbox-agent/src/agent/linux/runtime.rs
@@ -583,32 +583,46 @@ pub(super) fn daemon_log_file(name: &str) -> Stdio {
     let arcbox_path = format!("{}/{}.log", log_dir, name);
     let tmp_log_path = format!("/tmp/{}.log", name);
 
-    // Ensure the log directory exists inside the VirtioFS share.
-    if Path::new("/arcbox").exists() {
+    // Prefer the VirtioFS share so the host can read the log; warn loudly on each
+    // degradation so a virtiofs failure doesn't silently hide service logs.
+    let arcbox_available = Path::new("/arcbox").exists();
+    let primary = if arcbox_available {
         let _ = std::fs::create_dir_all(&log_dir);
-    }
-
-    let log_path = if Path::new("/arcbox").exists() {
         &arcbox_path
     } else {
+        tracing::warn!(
+            service = name,
+            "/arcbox VirtioFS share not mounted; {name} logs go to {tmp_log_path} (guest-local, not visible from the host)"
+        );
         &tmp_log_path
     };
 
     match std::fs::OpenOptions::new()
         .create(true)
         .append(true)
-        .open(log_path)
+        .open(primary)
     {
         Ok(f) => f.into(),
-        Err(_) => {
-            // Fallback to /tmp/ if /arcbox/log/ write fails.
+        Err(e) => {
+            tracing::warn!(
+                service = name,
+                error = %e,
+                "failed to open {primary} for {name} logs; falling back to {tmp_log_path}"
+            );
             match std::fs::OpenOptions::new()
                 .create(true)
                 .append(true)
                 .open(&tmp_log_path)
             {
                 Ok(f) => f.into(),
-                Err(_) => Stdio::null(),
+                Err(e2) => {
+                    tracing::error!(
+                        service = name,
+                        error = %e2,
+                        "failed to open {tmp_log_path} for {name} logs; discarding to /dev/null"
+                    );
+                    Stdio::null()
+                }
             }
         }
     }

--- a/guest/arcbox-agent/src/main.rs
+++ b/guest/arcbox-agent/src/main.rs
@@ -52,6 +52,11 @@ mod dns;
 mod dns_server;
 mod docker_events;
 
+/// Max bytes for `agent.log` before it rotates (matches the daemon's 10 MiB).
+const AGENT_LOG_MAX_BYTES: u64 = 10 * 1024 * 1024;
+/// Number of rotated `agent.log.N` files to retain (matches the daemon).
+const AGENT_LOG_MAX_FILES: usize = 5;
+
 /// Startup mode selected from the process arguments.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum Mode {
@@ -91,7 +96,15 @@ async fn main() -> Result<()> {
     let _log_guard = if std::path::Path::new("/arcbox").exists() {
         match std::fs::create_dir_all(&log_dir) {
             Ok(()) => {
-                let file_appender = tracing_appender::rolling::never(&log_dir, "agent.log");
+                // Size-based rotation (10 MiB x 5) reusing the daemon's writer:
+                // keeps the active file named `agent.log` (so `abctl logs
+                // --component agent` still finds it) while bounding growth.
+                let log_path = std::path::Path::new(&log_dir).join("agent.log");
+                let file_appender = arcbox_logging::SizeRotatingWriter::new(
+                    log_path,
+                    AGENT_LOG_MAX_BYTES,
+                    AGENT_LOG_MAX_FILES,
+                );
                 let (non_blocking, guard) = tracing_appender::non_blocking(file_appender);
                 tracing_subscriber::registry()
                     .with(

--- a/virt/arcbox-virtio-console/src/device.rs
+++ b/virt/arcbox-virtio-console/src/device.rs
@@ -58,6 +58,43 @@ impl ConsolePort {
             output_buffer: VecDeque::with_capacity(4096),
         }
     }
+
+    /// Drains all complete (newline-terminated) lines from `output_buffer`,
+    /// returning them trimmed. Bytes after the last newline stay buffered.
+    fn take_complete_lines(&mut self) -> Vec<String> {
+        let mut lines = Vec::new();
+        while let Some(pos) = self.output_buffer.iter().position(|&b| b == b'\n') {
+            let line: Vec<u8> = self.output_buffer.drain(..=pos).collect();
+            if let Ok(s) = std::str::from_utf8(&line) {
+                lines.push(s.trim_end().to_string());
+            }
+        }
+        lines
+    }
+
+    /// Drains everything, including a final line with no trailing newline — e.g.
+    /// a kernel panic or a crash's dying line that would otherwise be lost when
+    /// the device is reset or dropped. Empty trailing fragments are skipped.
+    fn take_all_lines(&mut self) -> Vec<String> {
+        let mut lines = self.take_complete_lines();
+        if !self.output_buffer.is_empty() {
+            let rest: Vec<u8> = self.output_buffer.drain(..).collect();
+            if let Ok(s) = std::str::from_utf8(&rest) {
+                let trimmed = s.trim_end();
+                if !trimmed.is_empty() {
+                    lines.push(trimmed.to_string());
+                }
+            }
+        }
+        lines
+    }
+}
+
+/// Emits captured guest console lines to the host `guest_console` log target.
+fn emit_console_lines(lines: Vec<String>) {
+    for line in lines {
+        tracing::info!(target: "guest_console", "{line}");
+    }
 }
 
 /// `VirtIO` console device.
@@ -405,7 +442,9 @@ impl VirtioDevice for VirtioConsole {
         for port in &mut self.ports {
             port.open = false;
             port.input_buffer.clear();
-            port.output_buffer.clear();
+            // Flush any final partial line (e.g. a panic message with no trailing
+            // newline) before discarding the buffer, so the dying line isn't lost.
+            emit_console_lines(port.take_all_lines());
         }
     }
 
@@ -466,13 +505,10 @@ impl VirtioDevice for VirtioConsole {
                 }
                 if let Some(port) = self.ports.first_mut() {
                     port.output_buffer.extend(data.iter().copied());
-                    // Flush on newline.
-                    while let Some(pos) = port.output_buffer.iter().position(|&b| b == b'\n') {
-                        let line: Vec<u8> = port.output_buffer.drain(..=pos).collect();
-                        if let Ok(s) = std::str::from_utf8(&line) {
-                            tracing::info!(target: "guest_console", "{}", s.trim_end());
-                        }
-                    }
+                    // Emit complete (newline-terminated) lines; any trailing
+                    // partial stays buffered for the next batch (or is flushed
+                    // on reset/drop).
+                    emit_console_lines(port.take_complete_lines());
                 }
                 total_len += desc.len;
             }
@@ -481,6 +517,16 @@ impl VirtioDevice for VirtioConsole {
 
         queue.push_used_batch(&completions);
         Ok(completions)
+    }
+}
+
+impl Drop for VirtioConsole {
+    fn drop(&mut self) {
+        // Capture any final partial line buffered on each port (a panic/crash
+        // message that never got a trailing newline) before teardown loses it.
+        for port in &mut self.ports {
+            emit_console_lines(port.take_all_lines());
+        }
     }
 }
 
@@ -690,5 +736,32 @@ mod tests {
         // Input fully consumed; a second call is a no-op (no fresh avail entries).
         assert_eq!(console.rx_available(), 0);
         assert!(!console.process_rx_queue(&mut mem, &qc).unwrap());
+    }
+
+    #[test]
+    fn take_complete_lines_leaves_trailing_partial_buffered() {
+        let mut port = ConsolePort::new(0);
+        port.output_buffer
+            .extend(b"first\nsecond\npartial no newline");
+
+        // Only the newline-terminated lines come out; the partial stays buffered.
+        assert_eq!(port.take_complete_lines(), vec!["first", "second"]);
+        assert!(!port.output_buffer.is_empty());
+    }
+
+    #[test]
+    fn take_all_lines_flushes_the_dying_partial_line() {
+        let mut port = ConsolePort::new(0);
+        // A panic message that never got a trailing newline before teardown.
+        port.output_buffer
+            .extend(b"Kernel panic - not syncing: Attempted to kill init");
+
+        // take_complete_lines would drop it (no newline); take_all_lines keeps it.
+        let lines = port.take_all_lines();
+        assert_eq!(
+            lines,
+            vec!["Kernel panic - not syncing: Attempted to kill init"]
+        );
+        assert!(port.output_buffer.is_empty());
     }
 }


### PR DESCRIPTION
Follow-up to the boot-flow observability review. Closes the actionable gaps for diagnosing a stuck/failed cold boot. Gap numbering matches the review (G1–G8).

## Implemented

- **G1 — VirtioConsole dropped the un-newlined dying line** (`virt/arcbox-virtio-console`). `reset()`/teardown `clear()`ed the buffer, silently discarding a line without a trailing `\n` — exactly the line you want on a crash (a kernel panic, the agent's last message). Extract `take_complete_lines` (hot path) + `take_all_lines` (also emits the trailing partial); flush on `reset()` and in a new `Drop` impl. Unit-tested. (298ac76)
- **G3 — service logs fell off the host-visible share silently** (`guest/arcbox-agent`). `daemon_log_file` redirected containerd/dockerd logs to guest-local `/tmp`/`/dev/null` when `/arcbox` VirtioFS was unavailable, with no signal. Each degradation is now loud (warn/error). (4a9ac5b)
- **G5 — `agent.log` grew without bound**. Reuse `arcbox_logging::SizeRotatingWriter` (the daemon's writer, 10 MiB x 5) instead of `tracing_appender::rolling::never`. Size-based + keeps the active file named `agent.log` so `abctl logs --component agent` is unaffected — tracing-appender's native rolling is time-based and renames the file, which would break the CLI. (e52861f)
- **G8 — no single boot-latency marker**. On a fresh boot, emit a structured `boot_ms=<n> "guest boot ready"` event (VM start → agent ready) against the <1.5s/<500ms targets. (013c6e2)
- **G4 — empty trace_id on boot RPCs**. `watch_readiness`/`_blocking` now take a `trace_id`; `wait_for_agent` stamps a per-boot UUID on every readiness attempt and the "Agent is ready" line, and the runtime-readiness path passes the live Docker-request trace id. Host wait-logs ↔ guest dispatch-logs now correlate per boot. (c5a6a66)

## Deferred (with rationale)

| Gap | Status |
|-----|--------|
| G2 hvc1 agent log DEBUG | ⏭️ moot on HV — no real `/dev/hvc1`; agent stderr already reaches hvc0 → `guest_console` at INFO |
| G6 `wait_for_agent` only awaits AgentReady | ⏭️ design nuance, not an observability hole (runtime readiness is observable via `EnsureRuntime`/`GetRuntimeStatus`) |
| G7 DaxStats not exported | ⏭️ `dax_stats` lives on the raw `Vmm`, not `machine_manager` — disproportionate plumbing for a niche counter |

## Tests
`cargo test -p arcbox-virtio-console` (34, +2 new) and `-p arcbox-core` (62) green; `cargo fmt --all --check` clean; agent changes verified on `aarch64-unknown-linux-musl`.