### PR TITLE
ci(release): sync shipped issues to Linear Releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -308,3 +308,29 @@ jobs:
           files: |
             ${{ steps.tarball.outputs.tarball }}
             ${{ steps.tarball.outputs.tarball }}.sha256
+
+  # ==========================================================================
+  # Sync shipped issues to Linear Releases (continuous pipeline)
+  #
+  # Runs after the binaries are published, so each Linear release records what
+  # actually shipped to Homebrew/CLI users — not just what merged. Issues are
+  # associated by scanning commits since the previous Linear release for PR
+  # references (#NNN, which Linear resolves to their linked issues) and ABX-123
+  # identifiers. Requires the LINEAR_ACCESS_KEY secret (this pipeline's access
+  # key, generated in Linear → Settings → Releases; not a personal API key).
+  # ==========================================================================
+  linear-release:
+    name: Sync Linear Release
+    needs: [version, package-and-release]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # full history required for commit-range scanning
+
+      - uses: linear/linear-release-action@v0
+        with:
+          access_key: ${{ secrets.LINEAR_ACCESS_KEY }}
+          version: ${{ needs.version.outputs.version }}
+          links: https://github.com/${{ github.repository }}/releases/tag/${{ needs.version.outputs.version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -323,6 +323,8 @@ jobs:
     name: Sync Linear Release
     needs: [version, package-and-release]
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
## What

Adds a `linear-release` job to `release.yml` that syncs each published version to a **Linear Release** ([docs](https://linear.app/docs/releases)). It runs after `package-and-release`, so a release in Linear records what actually shipped to Homebrew/CLI users — not just what merged.

Uses [`linear/linear-release-action`](https://github.com/linear/linear-release-action). Continuous pipeline model: each version tag → one completed Linear release. Issues are associated by scanning commits since the previous release for:
- PR refs `(#NNN)` in squash subjects → Linear resolves these to their linked issues
- explicit `ABX-123` identifiers (magic-word footers like `Closes ABX-123`, or `[ABX-123]` subject prefixes)

## Required setup before this runs

1. **Linear → Settings → Releases**: create a continuous pipeline (e.g. `ArcBox Core`), owner = ArcBox team.
2. Generate its **pipeline access key** and add it as the repo secret **`LINEAR_ACCESS_KEY`** (Settings → Secrets and variables → Actions). This is a pipeline key, *not* a personal API key.
3. (Optional) In Linear, add a status automation: *on release completion → move associated issues to Done*.

Until the secret exists the job fails fast with "access_key input is required" — no other jobs are affected (it's a leaf job).

## Notes / caveats

- **Coverage depends on commit history.** Today most commits land directly on `master` without a PR number or issue key, so they won't associate. Changes that go through a Linear-linked PR (squash subject keeps the default `(#NNN)`) will. To raise coverage, route more work through PRs or add a `Closes ABX-123` footer to commits.
- **First run** uses a fallback baseline and may sweep a large history range into one release. Consider watching the first run, or flip `dry_run: true` on the action for one run to preview before going live.