### PR TITLE
fix(xtask): use non-colliding xtask-kit package

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,9 @@ jobs:
       - name: Check formatting
         run: cargo fmt --check
 
+      - name: Smoke test cargo xtask alias
+        run: cargo xtask --help
+
       - name: Run clippy
         run: cargo clippy --workspace --exclude arcbox-agent -- -D warnings
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -95,7 +95,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -106,7 +106,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1561,7 +1561,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1653,7 +1653,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2439,7 +2439,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2870,7 +2870,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3864,7 +3864,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4336,7 +4336,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4483,10 +4483,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5430,7 +5430,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5876,18 +5876,6 @@ checksum = "32ac00cd3f8ec9c1d33fb3e7958a82df6989c42d747bd326c822b1d625283547"
 
 [[package]]
 name = "xtask"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88cce62643054f9be2d5ab39194e56eff4b7c99613d0d23090daa4517eb77777"
-dependencies = [
- "anyhow",
- "plist",
- "sha2",
- "xshell",
-]
-
-[[package]]
-name = "xtask"
 version = "0.4.13"
 dependencies = [
  "anyhow",
@@ -5901,7 +5889,19 @@ dependencies = [
  "tar",
  "toml_edit 0.25.12+spec-1.1.0",
  "xshell",
- "xtask 0.1.3",
+ "xtask-kit",
+]
+
+[[package]]
+name = "xtask-kit"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43f625fca4bd17471d87a0b7f94142d314281e8c5347c5fe6e9d475f4d421e42"
+dependencies = [
+ "anyhow",
+ "plist",
+ "sha2",
+ "xshell",
 ]
 
 [[package]]

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -19,7 +19,7 @@ sha2.workspace = true
 tar = "0.4.46"
 toml_edit = "0.25.12"
 xshell = "0.2.7"
-xtask-kit = { version = "0.1.3", package = "xtask", features = ["apple", "github-actions"] }
+xtask-kit = { version = "0.1.4", features = ["apple", "github-actions"] }
 
 [lints]
 workspace = true


### PR DESCRIPTION
## Summary
- publish and consume the new crates.io package name `xtask-kit@0.1.4`
- keep the workspace package named `xtask` and keep the `cargo xtask` alias unchanged
- remove the dependency rename from `package = "xtask"`, so Cargo no longer sees two packages named `xtask`
- add a CI smoke test for `cargo xtask --help` so this alias path is covered

Fixes ABX-389

## Verification
- `cargo xtask --help` reaches the rust-version gate instead of the previous ambiguous package error on this machine (rustc 1.95.0; repo requires 1.96)
- `cargo run --package xtask --ignore-rust-version -- --help`
- `cargo fmt --check`
- `cargo check -p xtask --ignore-rust-version`
- `cargo clippy -p xtask --ignore-rust-version -- -D warnings`
