### PR TITLE
chore(assets): fix 0.6.1 manifest SHA to match published build

### DIFF
--- a/assets.lock
+++ b/assets.lock
@@ -13,7 +13,7 @@
 [boot]
 version = "0.6.1"
 cdn = "https://boot.arcboxcdn.com"
-manifest_sha256 = "6945c6c612c7e021ee709f7e50aeedc39ad3cefaf53c6a30b0aaac1919ac49d5"
+manifest_sha256 = "20c6a934cbba0d2b304efdc99af02eae2b9da72a9bfe2c825fb209023d4bd8d7"
 
 [[tools]]
 name = "docker"


### PR DESCRIPTION
Master pins the 0.6.1 boot manifest SHA as `6945c6c6…`, but the published 0.6.1 manifest (the rcS-init-fail-fast rebuild) is `20c6a934…`. As a result, **any source build off master fails boot-asset verification and cannot start a VM** (`manifest SHA256 mismatch: expected 6945…, got 20c6…`). Installed Homebrew binaries are unaffected (they carry their own matching pin).

Re-pin `manifest_sha256` to the published `20c6…`. Verified: with this pin a freshly built + Developer-ID-signed daemon boots the System VM to ready and serves the Docker API (dockerd 27.5.1, kernel `6.12.11-arcbox`).

One-line, no code changes. Unblocks #346 (and any other source build) once merged.