### PR TITLE
fix(release): add crate descriptions to unblock crates.io publish

### DIFF
--- a/tests/e2e/Cargo.toml
+++ b/tests/e2e/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "arcbox-e2e"
+publish = false
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true

--- a/tests/e2e/Cargo.toml
+++ b/tests/e2e/Cargo.toml
@@ -6,6 +6,7 @@ rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 authors.workspace = true
+description = "End-to-end integration tests for the ArcBox container and VM runtime"
 
 [dependencies]
 anyhow.workspace = true

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "xtask"
+publish = false
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -6,6 +6,7 @@ rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 authors.workspace = true
+description = "Cargo xtask build-automation tasks for the ArcBox workspace"
 
 [dependencies]
 anyhow.workspace = true


### PR DESCRIPTION
## Problem

The **Release Build → Publish crates to crates.io** job has failed on *every* release since 0.4.9 (0.4.9–0.4.14, all red). crates.io rejects `arcbox-e2e`:

```
error: failed to publish arcbox-e2e v0.4.14 to registry at https://crates.io
Caused by: 400 Bad Request: missing or empty metadata fields: description
```

`cargo publish --workspace` uploads in dependency order and aborts on the first failure, so it never gets past `arcbox-e2e` (6th, alphabetically). `xtask` has the same missing-`description` gap and would fail next.

## Fix

Give `arcbox-e2e` and `xtask` a `description`, matching every other published workspace member. These are the only two publishable crates missing it.

## Heads-up

Because the publish has always died at `arcbox-e2e`, the crates *after* it (the app binaries, VM/virtio family, etc.) have never actually been pushed. With this fix, the next release's coordinated `cargo publish --workspace` will publish the **full workspace to crates.io for the first time** — which is the workflow's stated intent ("one coordinated publish of the whole workspace"), but it's an irreversible first-time mass publish. If that's *not* wanted for some members (test/tooling/binaries), the alternative is `publish = false` / `--exclude` on those instead — say the word and I'll switch to that.

Pre-existing issue, unrelated to any specific feature; surfaced right after the #346 merge cut 0.4.14.