### PR TITLE
fix(hv): deliver virtio-mmio/PL011 SPIs as level-triggered, not edge

### DIFF
--- a/virt/arcbox-vmm/src/irq/chip.rs
+++ b/virt/arcbox-vmm/src/irq/chip.rs
@@ -9,6 +9,27 @@ use super::{
     MAX_IRQS, TriggerMode,
 };
 
+/// First GICv3 SPI INTID. INTIDs 0–31 are SGIs/PPIs; 32+ are SPIs.
+const SPI_BASE: Irq = 32;
+
+/// Default trigger mode for an IRQ with no explicit `IrqConfig`.
+///
+/// On this GICv3/ARM64 platform every SPI we expose (virtio-mmio devices and
+/// the PL011 UART) is declared `IRQ_TYPE_LEVEL_HIGH` in the guest device tree,
+/// so an SPI must be driven as level-triggered: the line is held asserted
+/// until the guest clears the device's `interrupt_status`, and the device
+/// then deasserts it. Treating an SPI as edge (a momentary assert/deassert
+/// pulse) violates that contract — with the Apple GIC it leaves the line in a
+/// state the guest re-takes endlessly, producing an interrupt storm that wedges
+/// early boot (ABX-386). SGIs/PPIs (< 32) remain edge.
+const fn default_trigger_mode(irq: Irq) -> TriggerMode {
+    if irq >= SPI_BASE {
+        TriggerMode::Level
+    } else {
+        TriggerMode::Edge
+    }
+}
+
 /// IRQ chip abstraction.
 ///
 /// Manages interrupt routing, delivery, and coalescing.
@@ -241,7 +262,7 @@ impl IrqChip {
         let config = configs.get(&irq);
         let trigger_mode = match config {
             Some(c) => c.trigger_mode,
-            None => TriggerMode::Edge,
+            None => default_trigger_mode(irq),
         };
         drop(configs);
 
@@ -300,7 +321,7 @@ impl IrqChip {
         let config = configs.get(&irq);
         let (gsi, trigger_mode) = match config {
             Some(c) => (c.gsi, c.trigger_mode),
-            None => (irq % MAX_GSIS, TriggerMode::Edge),
+            None => (irq % MAX_GSIS, default_trigger_mode(irq)),
         };
         drop(configs);
 
@@ -360,9 +381,11 @@ impl IrqChip {
                 tracing::trace!("deassert_irq called on edge-triggered IRQ {}", irq);
                 return Ok(());
             }
-            None => {
-                return Ok(());
-            }
+            // No explicit config: SPIs default to level (see
+            // `default_trigger_mode`), so honor the deassert; sub-32 lines stay
+            // edge and have nothing to lower.
+            None if default_trigger_mode(irq) == TriggerMode::Level => irq % MAX_GSIS,
+            None => return Ok(()),
         };
         drop(configs);
 
@@ -549,6 +572,62 @@ mod tests {
 
         let recorded = events.lock().unwrap_or_else(|e| e.into_inner());
         assert_eq!(recorded.as_slice(), &[(5, true), (5, false)]);
+    }
+
+    #[test]
+    fn unconfigured_spi_defaults_to_level() {
+        // ABX-386: a virtio-mmio SPI (>= 32) with no explicit IrqConfig — the
+        // shape the custom HV path produces — must be delivered level-triggered
+        // (single assert, held until an explicit deassert), not as an edge
+        // pulse. An edge pulse on a line the guest treats as level produces an
+        // interrupt storm that wedges cold boot.
+        let chip = Arc::new(IrqChip::new().unwrap());
+        let events = Arc::new(Mutex::new(Vec::new()));
+        let events_clone = Arc::clone(&events);
+        let callback: IrqTriggerCallback = Box::new(move |gsi, level| {
+            events_clone
+                .lock()
+                .unwrap_or_else(|e| e.into_inner())
+                .push((gsi, level));
+            Ok(())
+        });
+        chip.set_trigger_callback(Arc::new(callback));
+
+        let spi: Irq = 48; // VIRTIO_IRQ_BASE — never configured on the HV path.
+        chip.trigger_irq(spi).unwrap();
+        chip.deassert_irq(spi).unwrap();
+
+        let recorded = events.lock().unwrap_or_else(|e| e.into_inner());
+        // Level: assert held, then a real deassert — never an assert/deassert
+        // pulse from the trigger alone.
+        assert_eq!(
+            recorded.as_slice(),
+            &[(spi % MAX_GSIS, true), (spi % MAX_GSIS, false)]
+        );
+    }
+
+    #[test]
+    fn unconfigured_legacy_irq_stays_edge() {
+        // Sub-32 lines (SGIs/PPIs) keep edge semantics: a single trigger is a
+        // self-clearing assert/deassert pulse, and deassert is a no-op.
+        let chip = Arc::new(IrqChip::new().unwrap());
+        let events = Arc::new(Mutex::new(Vec::new()));
+        let events_clone = Arc::clone(&events);
+        let callback: IrqTriggerCallback = Box::new(move |gsi, level| {
+            events_clone
+                .lock()
+                .unwrap_or_else(|e| e.into_inner())
+                .push((gsi, level));
+            Ok(())
+        });
+        chip.set_trigger_callback(Arc::new(callback));
+
+        let legacy: Irq = 7;
+        chip.trigger_irq(legacy).unwrap();
+        chip.deassert_irq(legacy).unwrap(); // no-op for edge
+
+        let recorded = events.lock().unwrap_or_else(|e| e.into_inner());
+        assert_eq!(recorded.as_slice(), &[(7, true), (7, false)]);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes a root cause of the flaky HV (Hypervisor.framework) cold-boot stall (ABX-386): **virtio-mmio / PL011 SPIs were delivered edge-triggered while the guest services them as level-triggered.**

The custom HV path assigns virtio-mmio device INTIDs as `VIRTIO_IRQ_BASE(48) + index` (`darwin_hv/mod.rs`) and never registers them with the `IrqChip` (whose `next_irq` starts at 32; only the generic `register_mmio_device` path calls `allocate_level_irq()`). So those INTIDs have no `IrqConfig`, `deliver_irq`/`deassert_irq` fell through to the `None => Edge` default, and each device completion was delivered as a momentary `set_spi(true); set_spi(false)` **edge pulse**. But the HV FDT (`darwin_hv/setup.rs`) declares every virtio SPI `IRQ_TYPE_LEVEL_HIGH`, so the guest configures and services them as **level** interrupts. Edge-on-level leaves the Apple GIC line in a state the guest re-takes endlessly — an interrupt storm (observed on virtio-rng's `InterruptACK`, `0xc003064`) that intermittently wedges early `/sbin/init` before the agent ever logs.

## Fix

Default unconfigured SPIs (INTID ≥ 32) to level-triggered and honor the deassert for them; SGIs/PPIs (< 32) stay edge. Minimal and contained to `irq/chip.rs`.

## Evidence

Root-caused with a deterministic in-process repro (extended `examples/hv_boot_test.rs` to `vcpu_count == host cores` + real rootfs + real agent) and host-side probes of the guest↔GIC path. At the wedge: all request virtqueues drained (`avail == used`), completions delivered and not suppressed, every vCPU blocked in `hv_vcpu_run` (`wfi=0`, ~0% CPU) — i.e. **not** a virtqueue-notification/EVENT_IDX problem, disproving the prior investigation's theory on mechanism.

**Clean A/B at `vcpu_count == host cores`, identical conditions: edge baseline 0/10 → level fix 3/10 boots reach agent readiness.**

## Not fully fixed

Necessary but not sufficient at full vCPU count (3/10; boot is highly timing-sensitive). The residual is a separate lost-wakeup race — WFI/WFE don't trap on this backend so the guest idles inside `hv_vcpu_run`, and only the net-RX worker calls `hv_vcpus_exit`, not the blk/generic device IRQ paths. Pinning it is gated on guest-side visibility (ABX-388). Full analysis in the ABX-386 comment thread.

## Test plan

- `cargo fmt` / `cargo clippy -D warnings` / `cargo test -p arcbox-vmm irq` green
- New regression tests: `unconfigured_spi_defaults_to_level`, `unconfigured_legacy_irq_stays_edge`
- Manual: HV cold boot at `vcpu_count == host cores` (0/10 → 3/10 vs edge baseline)

Refs ABX-386.
