### PR TITLE
feat(fleet): local gRPC control-plane API on agent.sock — lifecycle, live state, settings (RUN-35)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,28 +59,6 @@ jobs:
       - name: Install Protobuf compiler
         run: brew install protobuf
 
-      - name: Set up buf
-        uses: bufbuild/buf-setup-action@v1
-        with:
-          github_token: ${{ github.token }}
-
-      # The desktop and agent ship/self-update independently, so the
-      # control-plane wire contract must only ever change additively. Fail any
-      # PR that breaks it against the base branch. Self-bootstrapping: inert
-      # until the proto first lands on the base branch, so it never blocks the
-      # PR that introduces it.
-      - name: Check control-plane proto for breaking changes
-        if: github.event_name == 'pull_request'
-        run: |
-          base="${{ github.base_ref }}"
-          module=fleet/arcbox-fleet-control-proto
-          git fetch --depth=1 origin "$base"
-          if git cat-file -e "FETCH_HEAD:$module/buf.yaml" 2>/dev/null; then
-            buf breaking "$module" --against ".git#ref=FETCH_HEAD,subdir=$module"
-          else
-            echo "control-plane proto not yet on '$base'; breaking check inactive"
-          fi
-
       - name: Cache cargo
         uses: actions/cache@v4
         with:
@@ -123,3 +101,36 @@ jobs:
 
       - name: Smoke test arcbox helper
         run: ./target/debug/arcbox-helper --help
+
+  # Pure proto-contract analysis — no Rust toolchain, no build. Runs in
+  # parallel with `ci` on a cheap Linux runner. The desktop and agent
+  # ship/self-update independently, so the control-plane wire contract must
+  # only ever change additively; fail any PR that breaks it against the base
+  # branch. PR-only, since "breaking against the branch being merged into" is
+  # only defined for a PR.
+  proto-compat:
+    name: Control-plane proto compatibility
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up buf
+        uses: bufbuild/buf-setup-action@v1
+        with:
+          github_token: ${{ github.token }}
+
+      # Self-bootstrapping: inert until the proto first lands on the base
+      # branch, so it never blocks the PR that introduces it.
+      - name: Check for breaking changes
+        run: |
+          base="${{ github.base_ref }}"
+          module=fleet/arcbox-fleet-control-proto
+          git fetch --depth=1 origin "$base"
+          if git cat-file -e "FETCH_HEAD:$module/buf.yaml" 2>/dev/null; then
+            buf breaking "$module" --against ".git#ref=FETCH_HEAD,subdir=$module"
+          else
+            echo "control-plane proto not yet on '$base'; breaking check inactive"
+          fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,28 @@ jobs:
       - name: Install Protobuf compiler
         run: brew install protobuf
 
+      - name: Set up buf
+        uses: bufbuild/buf-setup-action@v1
+        with:
+          github_token: ${{ github.token }}
+
+      # The desktop and agent ship/self-update independently, so the
+      # control-plane wire contract must only ever change additively. Fail any
+      # PR that breaks it against the base branch. Self-bootstrapping: inert
+      # until the proto first lands on the base branch, so it never blocks the
+      # PR that introduces it.
+      - name: Check control-plane proto for breaking changes
+        if: github.event_name == 'pull_request'
+        run: |
+          base="${{ github.base_ref }}"
+          module=fleet/arcbox-fleet-control-proto
+          git fetch --depth=1 origin "$base"
+          if git cat-file -e "FETCH_HEAD:$module/buf.yaml" 2>/dev/null; then
+            buf breaking "$module" --against ".git#ref=FETCH_HEAD,subdir=$module"
+          else
+            echo "control-plane proto not yet on '$base'; breaking check inactive"
+          fi
+
       - name: Cache cargo
         uses: actions/cache@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [master, develop]
 
+# Every job only reads the repo; nothing here writes back through the API.
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -510,6 +510,7 @@ dependencies = [
  "arcbox-fleet-control-proto",
  "arcbox-fleet-proto",
  "arcbox-logging",
+ "async-stream",
  "bollard",
  "clap",
  "command-group",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -528,6 +528,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "arcbox-fleet-control-proto"
+version = "0.4.17"
+dependencies = [
+ "prost",
+ "tonic",
+ "tonic-build",
+]
+
+[[package]]
 name = "arcbox-fleet-proto"
 version = "0.4.17"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -507,6 +507,7 @@ name = "arcbox-fleet-agent"
 version = "0.4.17"
 dependencies = [
  "anyhow",
+ "arcbox-fleet-control-proto",
  "arcbox-fleet-proto",
  "arcbox-logging",
  "bollard",
@@ -515,6 +516,7 @@ dependencies = [
  "dashmap",
  "dirs",
  "hostname",
+ "hyper-util",
  "keyring",
  "prost",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,6 +79,7 @@ members = [
     # Fleet (cross-platform runner agent, MIT OR Apache-2.0)
     # ============================================
     "fleet/arcbox-fleet-proto",
+    "fleet/arcbox-fleet-control-proto",
     "fleet/arcbox-fleet-agent",
 ]
 
@@ -246,6 +247,7 @@ arcbox-protocol = { version = "0.4.17", path = "rpc/arcbox-protocol" } # x-relea
 arcbox-grpc = { version = "0.4.17", path = "rpc/arcbox-grpc" } # x-release-please-version
 arcbox-transport = { version = "0.4.17", path = "rpc/arcbox-transport" } # x-release-please-version
 arcbox-fleet-proto = { version = "0.4.17", path = "fleet/arcbox-fleet-proto" } # x-release-please-version
+arcbox-fleet-control-proto = { version = "0.4.17", path = "fleet/arcbox-fleet-control-proto" } # x-release-please-version
 arcbox-docker = { version = "0.4.17", path = "app/arcbox-docker" } # x-release-please-version
 arcbox-helper = { version = "0.4.17", path = "app/arcbox-helper" } # x-release-please-version
 arcbox-core = { version = "0.4.17", path = "app/arcbox-core" } # x-release-please-version

--- a/fleet/arcbox-fleet-agent/Cargo.toml
+++ b/fleet/arcbox-fleet-agent/Cargo.toml
@@ -15,6 +15,7 @@ path = "src/main.rs"
 
 [dependencies]
 arcbox-fleet-proto = { workspace = true }
+arcbox-fleet-control-proto = { workspace = true }
 arcbox-logging = { workspace = true }
 
 tonic = { workspace = true, features = ["tls", "tls-webpki-roots"] }
@@ -35,6 +36,7 @@ sysinfo = { workspace = true }
 command-group = { version = "5.0.1", features = ["with-tokio"] }
 tokio-util = "0.7.18"
 bollard = "0.21.0"
+hyper-util = "0.1"
 
 [lints]
 workspace = true

--- a/fleet/arcbox-fleet-agent/Cargo.toml
+++ b/fleet/arcbox-fleet-agent/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "arcbox-fleet-agent"
 publish = false
-description = "Cross-platform Fleet runner agent: enrolls, attaches to the gateway, and runs GitHub Actions jobs"
+description = "Fleet runner agent (macOS, Linux): enrolls, attaches to the gateway, and runs GitHub Actions jobs"
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
@@ -42,5 +42,5 @@ hyper-util = "0.1"
 [lints]
 workspace = true
 
-[target.'cfg(any(target_os = "macos", target_os = "windows"))'.dependencies]
+[target.'cfg(target_os = "macos")'.dependencies]
 keyring = "4"

--- a/fleet/arcbox-fleet-agent/Cargo.toml
+++ b/fleet/arcbox-fleet-agent/Cargo.toml
@@ -23,6 +23,7 @@ prost = { workspace = true }
 
 tokio = { workspace = true }
 tokio-stream = { workspace = true }
+async-stream = { workspace = true }
 
 tracing = { workspace = true }
 clap = { workspace = true }

--- a/fleet/arcbox-fleet-agent/src/attach.rs
+++ b/fleet/arcbox-fleet-agent/src/attach.rs
@@ -365,7 +365,7 @@ mod tests {
         PersistedSettings {
             load_ceiling: 0.9,
             mem_floor_mib: 2048,
-            runner_image: "img".to_owned(),
+            linux_runner_image: "img".to_owned(),
             gateway: "https://fleet.arcbox.dev".to_owned(),
             docker_mode: DockerMode::Disabled,
             runner_script: None,
@@ -400,7 +400,7 @@ mod tests {
             data_dir: std::env::temp_dir(),
             docker: crate::config::DockerConfig {
                 mode: DockerMode::Disabled,
-                runner_image: "img".to_owned(),
+                linux_runner_image: "img".to_owned(),
             },
             credential_store: crate::config::CredentialMode::File,
         }

--- a/fleet/arcbox-fleet-agent/src/attach.rs
+++ b/fleet/arcbox-fleet-agent/src/attach.rs
@@ -114,7 +114,7 @@ pub async fn run(
     // attachment, exiting when `shutdown` fires. Tied to the attachment rather
     // than the process because `AgentSupervisor::attach` spawns a fresh `run`
     // per enrollment — a process-lifetime task here would leak one per
-    // disconnect/re-enroll cycle.
+    // unenroll/re-enroll cycle.
     let resend = spawn_verdict_resend(supervisor.clone(), shutdown.clone());
 
     while !shutdown.is_cancelled() {
@@ -198,10 +198,10 @@ async fn connect_and_serve(
     // The connect + Attach-RPC handshake can block indefinitely — no connect
     // timeout is configured on the tonic `Endpoint` — and, unlike the
     // message loop below, has no cancellation awareness of its own. Without
-    // this race, a reconnect attempt straddling a `disconnect()` could
-    // complete the handshake and write `Attached` after `disconnect()`
+    // this race, a reconnect attempt straddling an `unenroll()` could
+    // complete the handshake and write `Attached` after `unenroll()`
     // already wrote `Unenrolled`, with nothing to undo it (see
-    // `AgentSupervisor::disconnect`'s doc). `req_rx` moves into the connect
+    // `AgentSupervisor::unenroll`'s doc). `req_rx` moves into the connect
     // future and is dropped with it if cancellation wins; `req_tx` stays
     // available in this outer scope for the rest of the connection.
     let connect = async {
@@ -300,7 +300,7 @@ fn dispatch(supervisor: &RunnerSupervisor, msg: Option<attach_response::Msg>) {
 /// Periodically resend verdicts still awaiting an `OfferVerdictAck`, until the
 /// gateway settles them (delivered to the workflow, or found obsolete).
 /// Attachment-scoped: it spans reconnects within one attachment and exits when
-/// `shutdown` fires, so it's reaped on disconnect instead of outliving the
+/// `shutdown` fires, so it's reaped on unenroll instead of outliving the
 /// attachment that spawned it. The supervisor holds the egress sender, so
 /// resends route through the same outbound path as fresh verdicts.
 fn spawn_verdict_resend(
@@ -373,7 +373,7 @@ mod tests {
     }
 
     /// The verdict-resend loop is attachment-scoped: cancelling the shutdown
-    /// token must reap it. Otherwise every disconnect/re-enroll cycle would
+    /// token must reap it. Otherwise every unenroll/re-enroll cycle would
     /// leak a task holding a supervisor clone (DashMaps, egress sender, Docker
     /// handle) for the life of the process.
     #[tokio::test]
@@ -416,7 +416,7 @@ mod tests {
     /// The connect + Attach-RPC handshake has no cancellation awareness of
     /// its own (see this fn's own doc in the non-test code above) — without
     /// racing it against `shutdown`, a reconnect attempt could complete the
-    /// handshake and write `Attached` after a `disconnect()` already wrote
+    /// handshake and write `Attached` after an `unenroll()` already wrote
     /// `Unenrolled`. Cancelling before this call even starts must bail out
     /// immediately, attempting no connect at all and touching no state.
     #[tokio::test]

--- a/fleet/arcbox-fleet-agent/src/attach.rs
+++ b/fleet/arcbox-fleet-agent/src/attach.rs
@@ -72,11 +72,9 @@ pub fn spawn_supervisor(
     let (egress_tx, egress_rx) = mpsc::channel::<AttachRequest>(OUTBOUND_CAPACITY);
     let supervisor = RunnerSupervisor::new(
         egress_tx,
-        config.runner_dir.clone(),
+        config.runner_script.clone(),
         docker,
         capabilities,
-        config.load_ceiling,
-        config.mem_floor_mib,
         state,
     );
 
@@ -183,15 +181,15 @@ async fn connect_and_serve(
     shutdown: &CancellationToken,
     state: &AgentState,
 ) -> Result<()> {
-    // A credential enrolled via the local control-plane's `Enroll` may carry
-    // a gateway override; the CLI's `enroll` subcommand never sets one, so
-    // this falls back to the configured default.
-    let gateway = credential
-        .control_plane
-        .as_deref()
-        .unwrap_or(&config.gateway);
+    // The desired (`target`) gateway, not `config.gateway` directly —
+    // `AgentSupervisor` seeds it from config and `UpdateSettings` can move
+    // it from there. Re-read on every attempt so a change takes effect on
+    // whatever reconnect happens next, without this loop ever being forced
+    // to one; `current` only moves to match once this actually succeeds,
+    // below.
+    let gateway = state.gateway_target();
     let channel = config
-        .endpoint_for(gateway)?
+        .endpoint_for(&gateway)?
         .connect()
         .await
         .with_context(|| format!("connecting to {gateway}"))?;
@@ -221,6 +219,7 @@ async fn connect_and_serve(
         .into_inner();
     *backoff = INITIAL_BACKOFF;
     state.set_enrollment(control_proto::Enrollment::Attached, &credential.machine_id);
+    state.set_gateway_current(&gateway);
     info!("attached to gateway");
 
     // Re-send the event stranded by the previous connection before anything else.

--- a/fleet/arcbox-fleet-agent/src/attach.rs
+++ b/fleet/arcbox-fleet-agent/src/attach.rs
@@ -41,29 +41,24 @@ const PROTOCOL_VERSION_HEADER: &str = "x-arcbox-protocol-version";
 /// generous ceiling rather than an expected wait.
 const SHUTDOWN_GRACE: Duration = Duration::from_secs(15);
 
-/// Connect and serve the attach stream, reconnecting on any failure until
-/// `shutdown` fires, then stop runners cleanly.
+/// Build the [`RunnerSupervisor`] and its egress queue, and start the
+/// process-scoped verdict-resend loop.
 ///
-/// The supervisor and the egress queue carrying runner lifecycle events are
-/// built once and reused across reconnects, so in-flight jobs survive a dropped
-/// connection and their verdicts reach the next live stream. On shutdown the
-/// loop exits and hands off to [`RunnerSupervisor::shutdown`], which tears down
-/// any in-flight runners.
-pub async fn run(
-    config: AgentConfig,
-    credential: Credential,
+/// Split from [`run`] so a caller — the local control-plane's
+/// `AgentSupervisor` — can hold the returned `RunnerSupervisor` handle for
+/// `Drain`/`Resume`/`GetStatus` while [`run`] drives the reconnect loop in
+/// its own task.
+pub fn spawn_supervisor(
+    config: &AgentConfig,
     docker: Option<docker::DockerRunner>,
     capabilities: Vec<Capability>,
-    shutdown: CancellationToken,
-) -> Result<()> {
-    let runner_dir = config.runner_dir.clone();
-
-    let (egress_tx, mut egress_rx) = mpsc::channel::<AttachRequest>(OUTBOUND_CAPACITY);
+) -> (RunnerSupervisor, mpsc::Receiver<AttachRequest>) {
+    let (egress_tx, egress_rx) = mpsc::channel::<AttachRequest>(OUTBOUND_CAPACITY);
     let supervisor = RunnerSupervisor::new(
         egress_tx,
-        runner_dir,
+        config.runner_dir.clone(),
         docker,
-        capabilities.clone(),
+        capabilities,
         config.load_ceiling,
         config.mem_floor_mib,
     );
@@ -74,6 +69,25 @@ pub async fn run(
     // live. Detached for the agent's lifetime; the agent never shuts down here.
     spawn_verdict_resend(supervisor.clone());
 
+    (supervisor, egress_rx)
+}
+
+/// Connect and serve the attach stream, reconnecting on any failure until
+/// `shutdown` fires, then stop runners cleanly.
+///
+/// `supervisor` and `egress_rx` come from [`spawn_supervisor`] and are reused
+/// across reconnects, so in-flight jobs survive a dropped connection and
+/// their verdicts reach the next live stream. On shutdown the loop exits and
+/// hands off to [`RunnerSupervisor::shutdown`], which tears down any
+/// in-flight runners.
+pub async fn run(
+    config: AgentConfig,
+    credential: Credential,
+    supervisor: RunnerSupervisor,
+    mut egress_rx: mpsc::Receiver<AttachRequest>,
+    capabilities: Vec<Capability>,
+    shutdown: CancellationToken,
+) -> Result<()> {
     let mut backoff = INITIAL_BACKOFF;
     // An event pulled from the egress queue but not yet delivered when the
     // connection dropped; re-sent first on the next connection so a terminal
@@ -142,11 +156,18 @@ async fn connect_and_serve(
     capabilities: &[Capability],
     shutdown: &CancellationToken,
 ) -> Result<()> {
+    // A credential enrolled via the local control-plane's `Enroll` may carry
+    // a gateway override; the CLI's `enroll` subcommand never sets one, so
+    // this falls back to the configured default.
+    let gateway = credential
+        .control_plane
+        .as_deref()
+        .unwrap_or(&config.gateway);
     let channel = config
-        .endpoint()?
+        .endpoint_for(gateway)?
         .connect()
         .await
-        .with_context(|| format!("connecting to {}", config.gateway))?;
+        .with_context(|| format!("connecting to {gateway}"))?;
     let mut client = FleetGatewayServiceClient::new(channel);
 
     let (req_tx, req_rx) = mpsc::channel::<AttachRequest>(OUTBOUND_CAPACITY);

--- a/fleet/arcbox-fleet-agent/src/attach.rs
+++ b/fleet/arcbox-fleet-agent/src/attach.rs
@@ -193,35 +193,51 @@ async fn connect_and_serve(
     // to one; `current` only moves to match once this actually succeeds,
     // below.
     let gateway = state.gateway_target();
-    let channel = config
-        .endpoint_for(&gateway)?
-        .connect()
-        .await
-        .with_context(|| format!("connecting to {gateway}"))?;
-    let mut client = FleetGatewayServiceClient::new(channel);
-
     let (req_tx, req_rx) = mpsc::channel::<AttachRequest>(OUTBOUND_CAPACITY);
 
-    let mut request = Request::new(ReceiverStream::new(req_rx));
-    let token: MetadataValue<_> = credential
-        .machine_token
-        .parse()
-        .context("machine token is not a valid metadata value")?;
-    request.metadata_mut().insert(MACHINE_TOKEN_HEADER, token);
-    // Protocol-version handshake: the gateway rejects an unsupported version.
-    let version: MetadataValue<_> = PROTOCOL_VERSION
-        .to_string()
-        .parse()
-        .expect("protocol version is a valid metadata value");
-    request
-        .metadata_mut()
-        .insert(PROTOCOL_VERSION_HEADER, version);
+    // The connect + Attach-RPC handshake can block indefinitely — no connect
+    // timeout is configured on the tonic `Endpoint` — and, unlike the
+    // message loop below, has no cancellation awareness of its own. Without
+    // this race, a reconnect attempt straddling a `disconnect()` could
+    // complete the handshake and write `Attached` after `disconnect()`
+    // already wrote `Unenrolled`, with nothing to undo it (see
+    // `AgentSupervisor::disconnect`'s doc). `req_rx` moves into the connect
+    // future and is dropped with it if cancellation wins; `req_tx` stays
+    // available in this outer scope for the rest of the connection.
+    let connect = async {
+        let channel = config
+            .endpoint_for(&gateway)?
+            .connect()
+            .await
+            .with_context(|| format!("connecting to {gateway}"))?;
+        let mut client = FleetGatewayServiceClient::new(channel);
 
-    let mut inbound = client
-        .attach(request)
-        .await
-        .context("Attach RPC failed")?
-        .into_inner();
+        let mut request = Request::new(ReceiverStream::new(req_rx));
+        let token: MetadataValue<_> = credential
+            .machine_token
+            .parse()
+            .context("machine token is not a valid metadata value")?;
+        request.metadata_mut().insert(MACHINE_TOKEN_HEADER, token);
+        // Protocol-version handshake: the gateway rejects an unsupported version.
+        let version: MetadataValue<_> = PROTOCOL_VERSION
+            .to_string()
+            .parse()
+            .expect("protocol version is a valid metadata value");
+        request
+            .metadata_mut()
+            .insert(PROTOCOL_VERSION_HEADER, version);
+
+        client
+            .attach(request)
+            .await
+            .context("Attach RPC failed")
+            .map(|response| response.into_inner())
+    };
+    let mut inbound = tokio::select! {
+        biased;
+        () = shutdown.cancelled() => return Ok(()),
+        result = connect => result?,
+    };
     *backoff = INITIAL_BACKOFF;
     state.set_enrollment(control_proto::Enrollment::Attached, &credential.machine_id);
     state.set_gateway_current(&gateway);
@@ -373,5 +389,73 @@ mod tests {
             .await
             .expect("resend task must exit promptly once shutdown is cancelled")
             .expect("resend task must not panic");
+    }
+
+    fn config() -> AgentConfig {
+        AgentConfig {
+            gateway: "http://127.0.0.1:1".to_owned(),
+            runner_script: None,
+            load_ceiling: 0.9,
+            mem_floor_mib: 2048,
+            data_dir: std::env::temp_dir(),
+            docker: crate::config::DockerConfig {
+                mode: DockerMode::Disabled,
+                runner_image: "img".to_owned(),
+            },
+            credential_store: crate::config::CredentialMode::File,
+        }
+    }
+
+    fn credential() -> Credential {
+        Credential {
+            machine_id: "fltm_test".to_owned(),
+            machine_token: "secret".to_owned(),
+        }
+    }
+
+    /// The connect + Attach-RPC handshake has no cancellation awareness of
+    /// its own (see this fn's own doc in the non-test code above) — without
+    /// racing it against `shutdown`, a reconnect attempt could complete the
+    /// handshake and write `Attached` after a `disconnect()` already wrote
+    /// `Unenrolled`. Cancelling before this call even starts must bail out
+    /// immediately, attempting no connect at all and touching no state.
+    #[tokio::test]
+    async fn connect_and_serve_bails_out_immediately_when_already_cancelled() {
+        let state = AgentState::new(&seed());
+        let (events, _rx) = mpsc::channel(1);
+        let supervisor =
+            RunnerSupervisor::new(events, None, None, Vec::new(), AgentState::new(&seed()));
+        let (_egress_tx, mut egress_rx) = mpsc::channel::<AttachRequest>(1);
+        let mut pending = None;
+        let mut backoff = INITIAL_BACKOFF;
+        let shutdown = CancellationToken::new();
+        shutdown.cancel();
+
+        let config = config();
+        let credential = credential();
+
+        let result = tokio::time::timeout(
+            Duration::from_secs(1),
+            connect_and_serve(
+                &config,
+                &credential,
+                &supervisor,
+                &mut egress_rx,
+                &mut pending,
+                &mut backoff,
+                &[],
+                &shutdown,
+                &state,
+            ),
+        )
+        .await
+        .expect("must return promptly once already cancelled, not attempt a connect");
+
+        assert!(result.is_ok());
+        assert_eq!(
+            state.current().enrollment,
+            control_proto::Enrollment::Unenrolled as i32,
+            "must never have written Attaching/Attached"
+        );
     }
 }

--- a/fleet/arcbox-fleet-agent/src/attach.rs
+++ b/fleet/arcbox-fleet-agent/src/attach.rs
@@ -236,11 +236,12 @@ async fn connect_and_serve(
     state: &AgentState,
 ) -> Result<()> {
     // The desired (`target`) gateway, not `config.gateway` directly —
-    // `AgentSupervisor` seeds it from config and `UpdateSettings` can move
-    // it from there. Re-read on every attempt so a change takes effect on
-    // whatever reconnect happens next, without this loop ever being forced
-    // to one; `current` only moves to match once this actually succeeds,
-    // below.
+    // `AgentSupervisor` seeds it from config, and an `Enroll` gateway
+    // override can have moved it from there. It cannot move while this
+    // attachment lives (`UpdateSettings` refuses gateway changes whenever a
+    // credential exists), so the per-attempt re-read is for freshness of
+    // the enrolled value, not to chase a live retarget; `current` only
+    // moves to match once this actually succeeds, below.
     let gateway = state.gateway_target();
     let (req_tx, req_rx) = mpsc::channel::<AttachRequest>(OUTBOUND_CAPACITY);
 

--- a/fleet/arcbox-fleet-agent/src/attach.rs
+++ b/fleet/arcbox-fleet-agent/src/attach.rs
@@ -56,8 +56,9 @@ fn telemetry_to_control(t: &HostTelemetry) -> control_proto::HostTelemetry {
     }
 }
 
-/// Build the [`RunnerSupervisor`] and its egress queue, and start the
-/// process-scoped verdict-resend loop.
+/// Build the [`RunnerSupervisor`] and its egress queue. The verdict-resend
+/// loop is started by [`run`] instead, so it shares the attachment's shutdown
+/// token and is reaped with it.
 ///
 /// Split from [`run`] so a caller — the local control-plane's
 /// `AgentSupervisor` — can hold the returned `RunnerSupervisor` handle for
@@ -77,13 +78,6 @@ pub fn spawn_supervisor(
         capabilities,
         state,
     );
-
-    // Process-scoped: resend unacked verdicts across reconnects. Re-emitted
-    // verdicts ride the same egress queue, so the reconnect-survival machinery
-    // below (egress forwarding + `pending`) delivers them to whichever stream is
-    // live. Detached for the agent's lifetime; the agent never shuts down here.
-    spawn_verdict_resend(supervisor.clone());
-
     (supervisor, egress_rx)
 }
 
@@ -115,6 +109,13 @@ pub async fn run(
     // connection dropped; re-sent first on the next connection so a terminal
     // event is never lost to a closed stream.
     let mut pending: Option<AttachRequest> = None;
+
+    // Attachment-scoped: resend unacked verdicts across reconnects within this
+    // attachment, exiting when `shutdown` fires. Tied to the attachment rather
+    // than the process because `AgentSupervisor::attach` spawns a fresh `run`
+    // per enrollment — a process-lifetime task here would leak one per
+    // disconnect/re-enroll cycle.
+    let resend = spawn_verdict_resend(supervisor.clone(), shutdown.clone());
 
     while !shutdown.is_cancelled() {
         state.set_enrollment(control_proto::Enrollment::Attaching, &credential.machine_id);
@@ -151,6 +152,10 @@ pub async fn run(
 
     info!("shutdown signal received; stopping runners");
     supervisor.shutdown(SHUTDOWN_GRACE).await;
+    // The loop only exits once `shutdown` is cancelled, so the resend task has
+    // already broken out of its own loop; await it so it's fully reaped before
+    // this attachment's task returns.
+    let _ = resend.await;
     Ok(())
 }
 
@@ -278,17 +283,25 @@ fn dispatch(supervisor: &RunnerSupervisor, msg: Option<attach_response::Msg>) {
 
 /// Periodically resend verdicts still awaiting an `OfferVerdictAck`, until the
 /// gateway settles them (delivered to the workflow, or found obsolete).
-/// Process-scoped so it spans reconnects; the supervisor holds the egress
-/// sender, so resends route through the same outbound path as fresh verdicts.
-fn spawn_verdict_resend(supervisor: RunnerSupervisor) -> tokio::task::JoinHandle<()> {
+/// Attachment-scoped: it spans reconnects within one attachment and exits when
+/// `shutdown` fires, so it's reaped on disconnect instead of outliving the
+/// attachment that spawned it. The supervisor holds the egress sender, so
+/// resends route through the same outbound path as fresh verdicts.
+fn spawn_verdict_resend(
+    supervisor: RunnerSupervisor,
+    shutdown: CancellationToken,
+) -> tokio::task::JoinHandle<()> {
     tokio::spawn(async move {
         let mut ticker = tokio::time::interval(VERDICT_RESEND_INTERVAL);
         // Skip the immediate first tick: a verdict just sent has not had time to
         // be acked, so there is nothing to resend yet.
         ticker.tick().await;
         loop {
-            ticker.tick().await;
-            supervisor.resend_outstanding();
+            tokio::select! {
+                biased;
+                () = shutdown.cancelled() => break,
+                _ = ticker.tick() => supervisor.resend_outstanding(),
+            }
         }
     })
 }
@@ -324,4 +337,41 @@ fn spawn_heartbeat(
             }
         }
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::DockerMode;
+    use crate::settings::PersistedSettings;
+
+    fn seed() -> PersistedSettings {
+        PersistedSettings {
+            load_ceiling: 0.9,
+            mem_floor_mib: 2048,
+            runner_image: "img".to_owned(),
+            gateway: "https://fleet.arcbox.dev".to_owned(),
+            docker_mode: DockerMode::Disabled,
+            runner_script: None,
+        }
+    }
+
+    /// The verdict-resend loop is attachment-scoped: cancelling the shutdown
+    /// token must reap it. Otherwise every disconnect/re-enroll cycle would
+    /// leak a task holding a supervisor clone (DashMaps, egress sender, Docker
+    /// handle) for the life of the process.
+    #[tokio::test]
+    async fn verdict_resend_task_exits_when_shutdown_fires() {
+        let (events, _rx) = mpsc::channel(1);
+        let supervisor =
+            RunnerSupervisor::new(events, None, None, Vec::new(), AgentState::new(&seed()));
+        let shutdown = CancellationToken::new();
+        let handle = spawn_verdict_resend(supervisor, shutdown.clone());
+
+        shutdown.cancel();
+        tokio::time::timeout(Duration::from_secs(1), handle)
+            .await
+            .expect("resend task must exit promptly once shutdown is cancelled")
+            .expect("resend task must not panic");
+    }
 }

--- a/fleet/arcbox-fleet-agent/src/attach.rs
+++ b/fleet/arcbox-fleet-agent/src/attach.rs
@@ -9,9 +9,10 @@
 use std::time::Duration;
 
 use anyhow::{Context, Result};
+use arcbox_fleet_control_proto::v1 as control_proto;
 use arcbox_fleet_proto::v1::fleet_gateway_service_client::FleetGatewayServiceClient;
 use arcbox_fleet_proto::v1::{
-    AttachRequest, Capability, Heartbeat, attach_request, attach_response,
+    AttachRequest, Capability, Heartbeat, HostTelemetry, attach_request, attach_response,
 };
 use tokio::sync::mpsc;
 use tokio_stream::wrappers::ReceiverStream;
@@ -25,6 +26,7 @@ use crate::credentials::Credential;
 use crate::docker;
 use crate::host;
 use crate::runner::RunnerSupervisor;
+use crate::state::AgentState;
 
 const HEARTBEAT_INTERVAL: Duration = Duration::from_secs(15);
 /// How often to resend verdicts still awaiting an `OfferVerdictAck`. Comfortably
@@ -41,6 +43,19 @@ const PROTOCOL_VERSION_HEADER: &str = "x-arcbox-protocol-version";
 /// generous ceiling rather than an expected wait.
 const SHUTDOWN_GRACE: Duration = Duration::from_secs(15);
 
+/// Convert a gateway-facing telemetry reading into its control-plane
+/// counterpart. A plain function, not `From`: both `HostTelemetry` types
+/// are generated in other crates, so Rust's orphan rule blocks implementing
+/// a foreign trait for two foreign types here.
+fn telemetry_to_control(t: &HostTelemetry) -> control_proto::HostTelemetry {
+    control_proto::HostTelemetry {
+        load_avg_1m: t.load_avg_1m,
+        cpu_count: t.cpu_count,
+        mem_total_mib: t.mem_total_mib,
+        mem_available_mib: t.mem_available_mib,
+    }
+}
+
 /// Build the [`RunnerSupervisor`] and its egress queue, and start the
 /// process-scoped verdict-resend loop.
 ///
@@ -52,6 +67,7 @@ pub fn spawn_supervisor(
     config: &AgentConfig,
     docker: Option<docker::DockerRunner>,
     capabilities: Vec<Capability>,
+    state: AgentState,
 ) -> (RunnerSupervisor, mpsc::Receiver<AttachRequest>) {
     let (egress_tx, egress_rx) = mpsc::channel::<AttachRequest>(OUTBOUND_CAPACITY);
     let supervisor = RunnerSupervisor::new(
@@ -61,6 +77,7 @@ pub fn spawn_supervisor(
         capabilities,
         config.load_ceiling,
         config.mem_floor_mib,
+        state,
     );
 
     // Process-scoped: resend unacked verdicts across reconnects. Re-emitted
@@ -80,6 +97,12 @@ pub fn spawn_supervisor(
 /// their verdicts reach the next live stream. On shutdown the loop exits and
 /// hands off to [`RunnerSupervisor::shutdown`], which tears down any
 /// in-flight runners.
+#[allow(
+    clippy::too_many_arguments,
+    reason = "the reconnect loop genuinely needs all of: endpoint config, credential, the \
+              persistent supervisor, the cross-reconnect egress queue, advertised \
+              capabilities, the shutdown token, and the observable state handle"
+)]
 pub async fn run(
     config: AgentConfig,
     credential: Credential,
@@ -87,6 +110,7 @@ pub async fn run(
     mut egress_rx: mpsc::Receiver<AttachRequest>,
     capabilities: Vec<Capability>,
     shutdown: CancellationToken,
+    state: AgentState,
 ) -> Result<()> {
     let mut backoff = INITIAL_BACKOFF;
     // An event pulled from the egress queue but not yet delivered when the
@@ -95,6 +119,7 @@ pub async fn run(
     let mut pending: Option<AttachRequest> = None;
 
     while !shutdown.is_cancelled() {
+        state.set_enrollment(control_proto::Enrollment::Attaching, &credential.machine_id);
         let outcome = connect_and_serve(
             &config,
             &credential,
@@ -104,6 +129,7 @@ pub async fn run(
             &mut backoff,
             &capabilities,
             &shutdown,
+            &state,
         )
         .await;
         // A shutdown during the connection is a clean exit, not a failure to log
@@ -143,8 +169,8 @@ pub async fn run(
     clippy::too_many_arguments,
     reason = "one connection's lifecycle genuinely needs all of: endpoint config, \
               credential, the persistent supervisor, the cross-reconnect egress queue \
-              and its pending slot, the mutable backoff, advertised capabilities, and \
-              the shutdown token"
+              and its pending slot, the mutable backoff, advertised capabilities, the \
+              shutdown token, and the observable state handle"
 )]
 async fn connect_and_serve(
     config: &AgentConfig,
@@ -155,6 +181,7 @@ async fn connect_and_serve(
     backoff: &mut Duration,
     capabilities: &[Capability],
     shutdown: &CancellationToken,
+    state: &AgentState,
 ) -> Result<()> {
     // A credential enrolled via the local control-plane's `Enroll` may carry
     // a gateway override; the CLI's `enroll` subcommand never sets one, so
@@ -193,6 +220,7 @@ async fn connect_and_serve(
         .context("Attach RPC failed")?
         .into_inner();
     *backoff = INITIAL_BACKOFF;
+    state.set_enrollment(control_proto::Enrollment::Attached, &credential.machine_id);
     info!("attached to gateway");
 
     // Re-send the event stranded by the previous connection before anything else.
@@ -203,7 +231,7 @@ async fn connect_and_serve(
         }
     }
 
-    let heartbeat = spawn_heartbeat(req_tx.clone(), capabilities.to_vec());
+    let heartbeat = spawn_heartbeat(req_tx.clone(), capabilities.to_vec(), state.clone());
 
     let outcome = loop {
         tokio::select! {
@@ -275,15 +303,18 @@ fn spawn_verdict_resend(supervisor: RunnerSupervisor) -> tokio::task::JoinHandle
 fn spawn_heartbeat(
     outbound: mpsc::Sender<AttachRequest>,
     capabilities: Vec<Capability>,
+    state: AgentState,
 ) -> tokio::task::JoinHandle<()> {
     tokio::spawn(async move {
         let mut ticker = tokio::time::interval(HEARTBEAT_INTERVAL);
         loop {
             ticker.tick().await;
+            let telemetry = host::telemetry();
+            state.set_telemetry(telemetry_to_control(&telemetry));
             let msg = attach_request::Msg::Heartbeat(Heartbeat {
                 capabilities: capabilities.clone(),
                 host_info_json: host::host_info_json(),
-                telemetry: Some(host::telemetry()),
+                telemetry: Some(telemetry),
             });
             if outbound
                 .send(AttachRequest { msg: Some(msg) })

--- a/fleet/arcbox-fleet-agent/src/attach.rs
+++ b/fleet/arcbox-fleet-agent/src/attach.rs
@@ -377,6 +377,7 @@ mod tests {
             gateway: "https://fleet.arcbox.dev".to_owned(),
             docker_mode: DockerMode::Disabled,
             runner_script: None,
+            participate: true,
         }
     }
 

--- a/fleet/arcbox-fleet-agent/src/attach.rs
+++ b/fleet/arcbox-fleet-agent/src/attach.rs
@@ -43,6 +43,26 @@ const PROTOCOL_VERSION_HEADER: &str = "x-arcbox-protocol-version";
 /// generous ceiling rather than an expected wait.
 const SHUTDOWN_GRACE: Duration = Duration::from_secs(15);
 
+/// Wrap `message` with the machine-credential and protocol-version metadata
+/// every authenticated gateway RPC carries (`Attach` here,
+/// `enroll::unenroll`'s `Unenroll`).
+pub fn authenticated_request<T>(message: T, machine_token: &str) -> Result<Request<T>> {
+    let mut request = Request::new(message);
+    let token: MetadataValue<_> = machine_token
+        .parse()
+        .context("machine token is not a valid metadata value")?;
+    request.metadata_mut().insert(MACHINE_TOKEN_HEADER, token);
+    // Protocol-version handshake: the gateway rejects an unsupported version.
+    let version: MetadataValue<_> = PROTOCOL_VERSION
+        .to_string()
+        .parse()
+        .expect("protocol version is a valid metadata value");
+    request
+        .metadata_mut()
+        .insert(PROTOCOL_VERSION_HEADER, version);
+    Ok(request)
+}
+
 /// Convert a gateway-facing telemetry reading into its control-plane
 /// counterpart. A plain function, not `From`: both `HostTelemetry` types
 /// are generated in other crates, so Rust's orphan rule blocks implementing
@@ -212,20 +232,8 @@ async fn connect_and_serve(
             .with_context(|| format!("connecting to {gateway}"))?;
         let mut client = FleetGatewayServiceClient::new(channel);
 
-        let mut request = Request::new(ReceiverStream::new(req_rx));
-        let token: MetadataValue<_> = credential
-            .machine_token
-            .parse()
-            .context("machine token is not a valid metadata value")?;
-        request.metadata_mut().insert(MACHINE_TOKEN_HEADER, token);
-        // Protocol-version handshake: the gateway rejects an unsupported version.
-        let version: MetadataValue<_> = PROTOCOL_VERSION
-            .to_string()
-            .parse()
-            .expect("protocol version is a valid metadata value");
-        request
-            .metadata_mut()
-            .insert(PROTOCOL_VERSION_HEADER, version);
+        let request =
+            authenticated_request(ReceiverStream::new(req_rx), &credential.machine_token)?;
 
         client
             .attach(request)

--- a/fleet/arcbox-fleet-agent/src/attach.rs
+++ b/fleet/arcbox-fleet-agent/src/attach.rs
@@ -63,6 +63,19 @@ pub fn authenticated_request<T>(message: T, machine_token: &str) -> Result<Reque
     Ok(request)
 }
 
+/// Whether the error chain contains an `UNAUTHENTICATED` gRPC status — the
+/// gateway's definitive "this credential is revoked" (a RUN-40
+/// decommission), surfaced either by the Attach handshake or as a
+/// mid-stream eviction item. Transport failures are not `Status` values,
+/// so an unreachable gateway never matches.
+fn is_unauthenticated(error: &anyhow::Error) -> bool {
+    error.chain().any(|cause| {
+        cause
+            .downcast_ref::<tonic::Status>()
+            .is_some_and(|status| status.code() == tonic::Code::Unauthenticated)
+    })
+}
+
 /// Convert a gateway-facing telemetry reading into its control-plane
 /// counterpart. A plain function, not `From`: both `HostTelemetry` types
 /// are generated in other crates, so Rust's orphan rule blocks implementing
@@ -158,6 +171,22 @@ pub async fn run(
         }
         match outcome {
             Ok(()) => info!("attach stream closed by gateway; reconnecting"),
+            Err(e) if is_unauthenticated(&e) => {
+                // The gateway definitively rejected the credential — the
+                // machine was decommissioned server-side (RUN-40), whether
+                // at the handshake or as a mid-stream eviction. Retrying can
+                // never succeed; park visibly instead, keeping the
+                // credential on disk until an operator unenrolls, so a
+                // server-side auth regression can never make agents wipe
+                // their own credentials.
+                warn!("gateway rejected the machine credential; parked until an explicit unenroll");
+                state.set_enrollment(
+                    control_proto::Enrollment::CredentialRejected,
+                    &credential.machine_id,
+                );
+                shutdown.cancelled().await;
+                break;
+            }
             Err(e) => {
                 warn!(error = %e, backoff_secs = backoff.as_secs(), "attach failed; retrying");
             }
@@ -379,6 +408,114 @@ mod tests {
             runner_script: None,
             participate: true,
         }
+    }
+
+    /// A gateway that rejects every call with `UNAUTHENTICATED` — what a
+    /// decommissioned machine's revoked credential meets (RUN-40).
+    struct RejectingGateway;
+
+    #[tonic::async_trait]
+    impl arcbox_fleet_proto::v1::fleet_gateway_service_server::FleetGatewayService
+        for RejectingGateway
+    {
+        async fn enroll(
+            &self,
+            _: Request<arcbox_fleet_proto::v1::EnrollRequest>,
+        ) -> Result<tonic::Response<arcbox_fleet_proto::v1::EnrollResponse>, tonic::Status>
+        {
+            Err(tonic::Status::unauthenticated("machine decommissioned"))
+        }
+
+        type AttachStream = tokio_stream::wrappers::ReceiverStream<
+            Result<arcbox_fleet_proto::v1::AttachResponse, tonic::Status>,
+        >;
+
+        async fn attach(
+            &self,
+            _: Request<tonic::Streaming<AttachRequest>>,
+        ) -> Result<tonic::Response<Self::AttachStream>, tonic::Status> {
+            Err(tonic::Status::unauthenticated("machine decommissioned"))
+        }
+
+        async fn unenroll(
+            &self,
+            _: Request<arcbox_fleet_proto::v1::UnenrollRequest>,
+        ) -> Result<tonic::Response<arcbox_fleet_proto::v1::UnenrollResponse>, tonic::Status>
+        {
+            Err(tonic::Status::unauthenticated("machine decommissioned"))
+        }
+    }
+
+    /// A revoked credential parks the attach loop: `CREDENTIAL_REJECTED` is
+    /// observable, no reconnect attempts follow, and the loop still exits
+    /// cleanly on shutdown (so unenroll's teardown works from parked).
+    #[tokio::test]
+    async fn attach_parks_visibly_when_the_gateway_rejects_the_credential() {
+        use arcbox_fleet_proto::v1::fleet_gateway_service_server::FleetGatewayServiceServer;
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let gateway = format!("http://{}", listener.local_addr().unwrap());
+        tokio::spawn(
+            tonic::transport::Server::builder()
+                .add_service(FleetGatewayServiceServer::new(RejectingGateway))
+                .serve_with_incoming(tokio_stream::wrappers::TcpListenerStream::new(listener)),
+        );
+
+        let state = AgentState::new(&PersistedSettings {
+            gateway: gateway.clone(),
+            ..seed()
+        });
+        let config = AgentConfig {
+            gateway,
+            runner_script: None,
+            load_ceiling: 0.9,
+            mem_floor_mib: 2048,
+            data_dir: std::env::temp_dir(),
+            docker: crate::config::DockerConfig {
+                mode: DockerMode::Disabled,
+                linux_runner_image: "img".to_owned(),
+            },
+            credential_store: crate::config::CredentialMode::File,
+        };
+        let credential = Credential {
+            machine_id: "fltm_parked".to_owned(),
+            machine_token: "flt_revoked".to_owned(),
+        };
+        let (supervisor, egress_rx) = spawn_supervisor(&config, None, Vec::new(), state.clone());
+        let shutdown = CancellationToken::new();
+        let run = tokio::spawn(run(
+            config,
+            credential,
+            supervisor,
+            egress_rx,
+            Vec::new(),
+            shutdown.clone(),
+            state.clone(),
+        ));
+
+        // The loop must reach the parked state rather than retry-looping.
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+        loop {
+            let snapshot = state.current();
+            if snapshot.enrollment == control_proto::Enrollment::CredentialRejected as i32 {
+                assert_eq!(snapshot.machine_id, "fltm_parked");
+                break;
+            }
+            assert!(
+                tokio::time::Instant::now() < deadline,
+                "never parked on the rejected credential"
+            );
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+        // Parked is not exited: the task is still alive, waiting on shutdown.
+        assert!(!run.is_finished());
+
+        shutdown.cancel();
+        tokio::time::timeout(Duration::from_secs(5), run)
+            .await
+            .expect("parked loop exits on shutdown")
+            .expect("attach task must not panic")
+            .expect("clean exit");
     }
 
     /// The verdict-resend loop is attachment-scoped: cancelling the shutdown

--- a/fleet/arcbox-fleet-agent/src/attach.rs
+++ b/fleet/arcbox-fleet-agent/src/attach.rs
@@ -331,6 +331,10 @@ fn dispatch(supervisor: &RunnerSupervisor, msg: Option<attach_response::Msg>) {
         Some(attach_response::Msg::OfferVerdictAck(ack)) => {
             supervisor.handle_ack(&ack.offer_token);
         }
+        // No-op the gateway acks each heartbeat with, purely so a proxy in
+        // front of the gateway (e.g. Cloudflare) sees server->client traffic
+        // and never idle-times-out the stream.
+        Some(attach_response::Msg::Keepalive(_)) => {}
         None => {}
     }
 }

--- a/fleet/arcbox-fleet-agent/src/config.rs
+++ b/fleet/arcbox-fleet-agent/src/config.rs
@@ -19,14 +19,14 @@ const ENV_LOAD_CEILING: &str = "ARCBOX_FLEET_LOAD_CEILING";
 const ENV_MEM_FLOOR_MIB: &str = "ARCBOX_FLEET_MEM_FLOOR_MIB";
 const ENV_DATA_DIR: &str = "ARCBOX_FLEET_DATA_DIR";
 const ENV_DOCKER: &str = "ARCBOX_FLEET_DOCKER";
-const ENV_RUNNER_IMAGE: &str = "ARCBOX_FLEET_RUNNER_IMAGE";
+const ENV_LINUX_RUNNER_IMAGE: &str = "ARCBOX_FLEET_LINUX_RUNNER_IMAGE";
 const ENV_CREDENTIAL_STORE: &str = "ARCBOX_FLEET_CREDENTIAL_STORE";
 
 /// Reject an offer when 1-minute load average per core exceeds this.
 const DEFAULT_LOAD_CEILING: f64 = 0.9;
 /// Reject an offer when available memory is below this many MiB.
 const DEFAULT_MEM_FLOOR_MIB: u64 = 2048;
-const DEFAULT_RUNNER_IMAGE: &str = "ghcr.io/actions/actions-runner:latest";
+const DEFAULT_LINUX_RUNNER_IMAGE: &str = "ghcr.io/actions/actions-runner:latest";
 
 /// Wire-protocol version this agent speaks; the gateway rejects a mismatch.
 pub const PROTOCOL_VERSION: u32 = 1;
@@ -60,7 +60,7 @@ pub enum CredentialMode {
 pub struct DockerConfig {
     pub mode: DockerMode,
     /// Container image used for Linux runner jobs.
-    pub runner_image: String,
+    pub linux_runner_image: String,
 }
 
 /// Resolved agent configuration.
@@ -115,8 +115,8 @@ impl AgentConfig {
                 anyhow::bail!("{ENV_DOCKER} must be 'auto', 'true', or 'false', got '{other}'")
             }
         };
-        let runner_image =
-            std::env::var(ENV_RUNNER_IMAGE).unwrap_or_else(|_| DEFAULT_RUNNER_IMAGE.to_string());
+        let linux_runner_image = std::env::var(ENV_LINUX_RUNNER_IMAGE)
+            .unwrap_or_else(|_| DEFAULT_LINUX_RUNNER_IMAGE.to_string());
 
         let credential_store = match std::env::var(ENV_CREDENTIAL_STORE).as_deref() {
             Ok("keyring") => CredentialMode::Keyring,
@@ -144,7 +144,7 @@ impl AgentConfig {
             data_dir,
             docker: DockerConfig {
                 mode: docker_mode,
-                runner_image,
+                linux_runner_image,
             },
             credential_store,
         })

--- a/fleet/arcbox-fleet-agent/src/config.rs
+++ b/fleet/arcbox-fleet-agent/src/config.rs
@@ -153,12 +153,20 @@ impl AgentConfig {
         self.data_dir.join("credentials.json")
     }
 
-    /// Build a gateway [`Endpoint`], enabling TLS for `https` URIs.
-    pub fn endpoint(&self) -> Result<Endpoint> {
-        let endpoint = Endpoint::from_shared(self.gateway.clone())
-            .with_context(|| format!("invalid gateway URI: {}", self.gateway))?;
+    /// Path to the local control-plane Unix socket.
+    pub fn control_socket_path(&self) -> PathBuf {
+        self.data_dir.join("agent.sock")
+    }
 
-        if self.gateway.starts_with("https://") {
+    /// Build a gateway [`Endpoint`] for an arbitrary `gateway` URI, enabling
+    /// TLS for `https` URIs. Used to connect against a credential's
+    /// per-enrollment `control_plane` override instead of the configured
+    /// default (see [`crate::credentials::Credential::control_plane`]).
+    pub fn endpoint_for(&self, gateway: &str) -> Result<Endpoint> {
+        let endpoint = Endpoint::from_shared(gateway.to_owned())
+            .with_context(|| format!("invalid gateway URI: {gateway}"))?;
+
+        if gateway.starts_with("https://") {
             // Bundled webpki roots keep trust uniform across macOS/Linux/Windows.
             return endpoint
                 .tls_config(ClientTlsConfig::new().with_webpki_roots())

--- a/fleet/arcbox-fleet-agent/src/config.rs
+++ b/fleet/arcbox-fleet-agent/src/config.rs
@@ -45,11 +45,11 @@ pub enum DockerMode {
 /// Where the long-lived machine credential is persisted.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CredentialMode {
-    /// OS keychain on macOS (login Keychain) and Windows (Credential Manager);
-    /// the owner-only data-dir file on Linux. On macOS the agent must run in the
-    /// user's session, where the login Keychain is unlocked.
+    /// OS keychain (login Keychain) on macOS; the owner-only data-dir file on
+    /// Linux. On macOS the agent must run in the user's session, where the
+    /// login Keychain is unlocked.
     Auto,
-    /// Force the OS keychain. Supported on macOS and Windows; errors on Linux.
+    /// Force the OS keychain. Supported on macOS only; errors on Linux.
     Keyring,
     /// Force the data-dir file (`0600` on Unix).
     File,
@@ -69,8 +69,8 @@ pub struct AgentConfig {
     /// Gateway endpoint URI (scheme selects transport: `https` → TLS, `http` → h2c).
     pub gateway: String,
     /// Direct path to the pre-installed GitHub Actions runner's entry point
-    /// (`run.sh` on Unix, `run.cmd` on Windows) — not its containing
-    /// directory. `None` until set; required only by the `run` command.
+    /// (`run.sh`) — not its containing directory. `None` until set; required
+    /// only by the `run` command.
     pub runner_script: Option<PathBuf>,
     /// Reject an offer when 1-minute load average per core exceeds this.
     pub load_ceiling: f64,
@@ -128,10 +128,10 @@ impl AgentConfig {
                 )
             }
         };
-        #[cfg(not(any(target_os = "macos", target_os = "windows")))]
+        #[cfg(not(target_os = "macos"))]
         if credential_store == CredentialMode::Keyring {
             anyhow::bail!(
-                "{ENV_CREDENTIAL_STORE}=keyring is only supported on macOS and Windows; \
+                "{ENV_CREDENTIAL_STORE}=keyring is only supported on macOS; \
                  use 'file' (the default on Linux)"
             );
         }
@@ -174,7 +174,7 @@ impl AgentConfig {
             .with_context(|| format!("invalid gateway URI: {gateway}"))?;
 
         if gateway.starts_with("https://") {
-            // Bundled webpki roots keep trust uniform across macOS/Linux/Windows.
+            // Bundled webpki roots keep trust uniform across macOS/Linux.
             return endpoint
                 .tls_config(ClientTlsConfig::new().with_webpki_roots())
                 .context("failed to configure TLS");

--- a/fleet/arcbox-fleet-agent/src/config.rs
+++ b/fleet/arcbox-fleet-agent/src/config.rs
@@ -167,8 +167,8 @@ impl AgentConfig {
 
     /// Build a gateway [`Endpoint`] for an arbitrary `gateway` URI, enabling
     /// TLS for `https` URIs. Used to connect against the persisted
-    /// settings' current `gateway`, which may override this config's
-    /// default (see [`crate::state::AgentState::gateway_current`]).
+    /// settings' target `gateway`, which may override this config's
+    /// default (see [`crate::state::AgentState::gateway_target`]).
     pub fn endpoint_for(&self, gateway: &str) -> Result<Endpoint> {
         let endpoint = Endpoint::from_shared(gateway.to_owned())
             .with_context(|| format!("invalid gateway URI: {gateway}"))?;

--- a/fleet/arcbox-fleet-agent/src/config.rs
+++ b/fleet/arcbox-fleet-agent/src/config.rs
@@ -6,6 +6,7 @@
 use std::path::PathBuf;
 
 use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
 use tonic::transport::{ClientTlsConfig, Endpoint};
 
 /// Production gateway endpoint. Overridable via `ARCBOX_FLEET_GATEWAY` for
@@ -13,7 +14,7 @@ use tonic::transport::{ClientTlsConfig, Endpoint};
 pub const DEFAULT_GATEWAY: &str = "https://fleet.arcbox.dev";
 
 const ENV_GATEWAY: &str = "ARCBOX_FLEET_GATEWAY";
-const ENV_RUNNER_DIR: &str = "ARCBOX_FLEET_RUNNER_DIR";
+const ENV_RUNNER_SCRIPT: &str = "ARCBOX_FLEET_RUNNER_SCRIPT";
 const ENV_LOAD_CEILING: &str = "ARCBOX_FLEET_LOAD_CEILING";
 const ENV_MEM_FLOOR_MIB: &str = "ARCBOX_FLEET_MEM_FLOOR_MIB";
 const ENV_DATA_DIR: &str = "ARCBOX_FLEET_DATA_DIR";
@@ -31,7 +32,7 @@ const DEFAULT_RUNNER_IMAGE: &str = "ghcr.io/actions/actions-runner:latest";
 pub const PROTOCOL_VERSION: u32 = 1;
 
 /// Whether Docker-based Linux job execution is enabled.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum DockerMode {
     /// Probe the Docker socket at startup; proceed without Docker if unavailable.
     Auto,
@@ -67,9 +68,10 @@ pub struct DockerConfig {
 pub struct AgentConfig {
     /// Gateway endpoint URI (scheme selects transport: `https` → TLS, `http` → h2c).
     pub gateway: String,
-    /// Directory holding the pre-installed GitHub Actions runner (`run.sh`/`run.cmd`).
-    /// `None` until set; required only by the `run` command.
-    pub runner_dir: Option<PathBuf>,
+    /// Direct path to the pre-installed GitHub Actions runner's entry point
+    /// (`run.sh` on Unix, `run.cmd` on Windows) — not its containing
+    /// directory. `None` until set; required only by the `run` command.
+    pub runner_script: Option<PathBuf>,
     /// Reject an offer when 1-minute load average per core exceeds this.
     pub load_ceiling: f64,
     /// Reject an offer when available memory (MiB) is below this.
@@ -87,7 +89,7 @@ impl AgentConfig {
     pub fn from_env() -> Result<Self> {
         let gateway = std::env::var(ENV_GATEWAY).unwrap_or_else(|_| DEFAULT_GATEWAY.to_string());
 
-        let runner_dir = std::env::var_os(ENV_RUNNER_DIR).map(PathBuf::from);
+        let runner_script = std::env::var_os(ENV_RUNNER_SCRIPT).map(PathBuf::from);
 
         let load_ceiling = match std::env::var(ENV_LOAD_CEILING) {
             Ok(v) => parse_load_ceiling(&v)?,
@@ -136,7 +138,7 @@ impl AgentConfig {
 
         Ok(Self {
             gateway,
-            runner_dir,
+            runner_script,
             load_ceiling,
             mem_floor_mib,
             data_dir,
@@ -158,10 +160,15 @@ impl AgentConfig {
         self.data_dir.join("agent.sock")
     }
 
+    /// Path to the persisted, live-settable configuration.
+    pub fn settings_path(&self) -> PathBuf {
+        self.data_dir.join("settings.json")
+    }
+
     /// Build a gateway [`Endpoint`] for an arbitrary `gateway` URI, enabling
-    /// TLS for `https` URIs. Used to connect against a credential's
-    /// per-enrollment `control_plane` override instead of the configured
-    /// default (see [`crate::credentials::Credential::control_plane`]).
+    /// TLS for `https` URIs. Used to connect against the persisted
+    /// settings' current `gateway`, which may override this config's
+    /// default (see [`crate::state::AgentState::gateway_current`]).
     pub fn endpoint_for(&self, gateway: &str) -> Result<Endpoint> {
         let endpoint = Endpoint::from_shared(gateway.to_owned())
             .with_context(|| format!("invalid gateway URI: {gateway}"))?;

--- a/fleet/arcbox-fleet-agent/src/control/client.rs
+++ b/fleet/arcbox-fleet-agent/src/control/client.rs
@@ -1,0 +1,66 @@
+//! Unix-socket gRPC client helper for the `status`/`drain`/`resume`/
+//! `disconnect` CLI subcommands, connecting to the running agent's
+//! `agent.sock`. Mirrors `arcbox-cli`'s `UnixConnector`
+//! (`app/arcbox-cli/src/commands/machine.rs`).
+
+use std::future::Future;
+use std::path::{Path, PathBuf};
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+use anyhow::{Context as _, Result};
+use arcbox_fleet_control_proto::v1::fleet_lifecycle_service_client::FleetLifecycleServiceClient;
+use hyper_util::rt::TokioIo;
+use tokio::net::UnixStream;
+use tonic::codegen::{Service, http::Uri};
+use tonic::transport::{Channel, Endpoint};
+
+use crate::config::AgentConfig;
+
+/// Connect to the running agent's control socket, at `config`'s configured
+/// path (see [`AgentConfig::control_socket_path`]).
+pub async fn connect_default(config: &AgentConfig) -> Result<FleetLifecycleServiceClient<Channel>> {
+    connect(&config.control_socket_path()).await
+}
+
+/// Connect to `socket_path` and return a `FleetLifecycleService` client.
+pub async fn connect(socket_path: &Path) -> Result<FleetLifecycleServiceClient<Channel>> {
+    let channel = Endpoint::from_static("http://[::]:50051")
+        .connect_with_connector(UnixConnector::new(socket_path.to_path_buf()))
+        .await
+        .with_context(|| {
+            format!(
+                "failed to connect to fleet agent control socket at {}",
+                socket_path.display()
+            )
+        })?;
+    Ok(FleetLifecycleServiceClient::new(channel))
+}
+
+struct UnixConnector {
+    socket_path: PathBuf,
+}
+
+impl UnixConnector {
+    fn new(socket_path: PathBuf) -> Self {
+        Self { socket_path }
+    }
+}
+
+impl Service<Uri> for UnixConnector {
+    type Response = TokioIo<UnixStream>;
+    type Error = std::io::Error;
+    type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send>>;
+
+    fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn call(&mut self, _: Uri) -> Self::Future {
+        let socket_path = self.socket_path.clone();
+        Box::pin(async move {
+            let stream = UnixStream::connect(socket_path).await?;
+            Ok(TokioIo::new(stream))
+        })
+    }
+}

--- a/fleet/arcbox-fleet-agent/src/control/client.rs
+++ b/fleet/arcbox-fleet-agent/src/control/client.rs
@@ -1,6 +1,6 @@
 //! Unix-socket gRPC client helper for the `status`/`drain`/`resume`/
-//! `disconnect` CLI subcommands, connecting to the running agent's
-//! `agent.sock`. Mirrors `arcbox-cli`'s `UnixConnector`
+//! `disconnect`/`settings` CLI subcommands, connecting to the running
+//! agent's `agent.sock`. Mirrors `arcbox-cli`'s `UnixConnector`
 //! (`app/arcbox-cli/src/commands/machine.rs`).
 
 use std::future::Future;
@@ -9,7 +9,6 @@ use std::pin::Pin;
 use std::task::{Context, Poll};
 
 use anyhow::{Context as _, Result};
-use arcbox_fleet_control_proto::v1::fleet_lifecycle_service_client::FleetLifecycleServiceClient;
 use hyper_util::rt::TokioIo;
 use tokio::net::UnixStream;
 use tonic::codegen::{Service, http::Uri};
@@ -18,14 +17,16 @@ use tonic::transport::{Channel, Endpoint};
 use crate::config::AgentConfig;
 
 /// Connect to the running agent's control socket, at `config`'s configured
-/// path (see [`AgentConfig::control_socket_path`]).
-pub async fn connect_default(config: &AgentConfig) -> Result<FleetLifecycleServiceClient<Channel>> {
+/// path (see [`AgentConfig::control_socket_path`]). Returns the raw
+/// channel — a single `Channel` can back as many typed service clients as
+/// a caller needs (`FleetLifecycleServiceClient`, `FleetSettingsServiceClient`, ...).
+pub async fn connect_default(config: &AgentConfig) -> Result<Channel> {
     connect(&config.control_socket_path()).await
 }
 
-/// Connect to `socket_path` and return a `FleetLifecycleService` client.
-pub async fn connect(socket_path: &Path) -> Result<FleetLifecycleServiceClient<Channel>> {
-    let channel = Endpoint::from_static("http://[::]:50051")
+/// Connect to `socket_path`, returning the raw channel.
+pub async fn connect(socket_path: &Path) -> Result<Channel> {
+    Endpoint::from_static("http://[::]:50051")
         .connect_with_connector(UnixConnector::new(socket_path.to_path_buf()))
         .await
         .with_context(|| {
@@ -33,8 +34,7 @@ pub async fn connect(socket_path: &Path) -> Result<FleetLifecycleServiceClient<C
                 "failed to connect to fleet agent control socket at {}",
                 socket_path.display()
             )
-        })?;
-    Ok(FleetLifecycleServiceClient::new(channel))
+        })
 }
 
 struct UnixConnector {

--- a/fleet/arcbox-fleet-agent/src/control/client.rs
+++ b/fleet/arcbox-fleet-agent/src/control/client.rs
@@ -1,5 +1,5 @@
 //! Unix-socket gRPC client helper for the `status`/`drain`/`resume`/
-//! `disconnect`/`settings` CLI subcommands, connecting to the running
+//! `unenroll`/`settings` CLI subcommands, connecting to the running
 //! agent's `agent.sock`. Mirrors `arcbox-cli`'s `UnixConnector`
 //! (`app/arcbox-cli/src/commands/machine.rs`).
 

--- a/fleet/arcbox-fleet-agent/src/control/image.rs
+++ b/fleet/arcbox-fleet-agent/src/control/image.rs
@@ -146,6 +146,7 @@ mod tests {
             gateway: "https://fleet.arcbox.dev".to_owned(),
             docker_mode: DockerMode::Disabled,
             runner_script: None,
+            participate: true,
         }
     }
 

--- a/fleet/arcbox-fleet-agent/src/control/image.rs
+++ b/fleet/arcbox-fleet-agent/src/control/image.rs
@@ -1,0 +1,231 @@
+//! `FleetImageService` — converges each image setting's `current` onto its
+//! `target` by fetching and verifying the target artifact through the
+//! runtime that owns it (the Docker socket today; the arcbox-daemon socket
+//! once the macOS VM backend lands), streaming progress. Split from
+//! `FleetSettingsService` so quick state reads/writes never share a service
+//! with RPCs that stream a multi-gigabyte transfer.
+
+use std::pin::Pin;
+use std::sync::Arc;
+
+use arcbox_fleet_control_proto::v1::fleet_image_service_server::FleetImageService as FleetImageServiceTrait;
+use arcbox_fleet_control_proto::v1::{ImageKind, PrepareRequest, PrepareResponse};
+use tokio_stream::Stream;
+use tonic::{Request, Response, Status};
+
+use crate::docker::DockerRunner;
+use crate::state::AgentState;
+
+pub struct ImageService {
+    state: AgentState,
+    /// The process-lifetime Docker handle, if configured. Never stale:
+    /// `docker_mode` changes are restart-scoped (see
+    /// `AgentSupervisor::docker`'s doc).
+    docker: Option<DockerRunner>,
+    /// Serializes preparations. Two racing Prepares would pull concurrently
+    /// and promote in arbitrary order, so the loser gets `ABORTED` instead
+    /// of queueing behind a transfer of unknown length.
+    busy: Arc<tokio::sync::Mutex<()>>,
+}
+
+impl ImageService {
+    pub fn new(state: AgentState, docker: Option<DockerRunner>) -> Self {
+        Self {
+            state,
+            docker,
+            busy: Arc::new(tokio::sync::Mutex::new(())),
+        }
+    }
+}
+
+fn event(kind: ImageKind, detail: &str, stage: &str, fraction: f64) -> PrepareResponse {
+    PrepareResponse {
+        kind: kind as i32,
+        detail: detail.to_owned(),
+        stage: stage.to_owned(),
+        fraction,
+    }
+}
+
+/// Expand the requested kinds: empty prepares every kind this agent
+/// supports. An unrecognized kind (a newer client) is rejected rather than
+/// silently skipped, so "prepare everything I asked for" never quietly
+/// under-delivers. Duplicates collapse to one preparation.
+///
+/// Returns a plain message rather than `Status` — every failure here maps
+/// to the same `INVALID_ARGUMENT` code, so the caller does that one
+/// conversion (the same convention as `control::settings::validate`).
+fn resolve_kinds(raw: &[i32]) -> Result<Vec<ImageKind>, String> {
+    if raw.is_empty() {
+        return Ok(vec![ImageKind::LinuxRunnerImage]);
+    }
+    let mut kinds = raw
+        .iter()
+        .map(|&v| match ImageKind::try_from(v) {
+            Ok(ImageKind::LinuxRunnerImage) => Ok(ImageKind::LinuxRunnerImage),
+            Ok(ImageKind::Unspecified) | Err(_) => Err(format!("unsupported image kind {v}")),
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    kinds.sort_unstable();
+    kinds.dedup();
+    Ok(kinds)
+}
+
+#[tonic::async_trait]
+impl FleetImageServiceTrait for ImageService {
+    type PrepareStream = Pin<Box<dyn Stream<Item = Result<PrepareResponse, Status>> + Send>>;
+
+    async fn prepare(
+        &self,
+        request: Request<PrepareRequest>,
+    ) -> Result<Response<Self::PrepareStream>, Status> {
+        let kinds = resolve_kinds(&request.into_inner().kinds).map_err(Status::invalid_argument)?;
+        let busy = Arc::clone(&self.busy)
+            .try_lock_owned()
+            .map_err(|_| Status::aborted("another prepare is already in progress"))?;
+        let state = self.state.clone();
+        let docker = self.docker.clone();
+
+        // The work runs inside the stream itself, not a detached task, so a
+        // client disconnect drops it mid-pull: no promotion happens, and a
+        // re-run resumes from whatever the runtime already cached.
+        let stream = async_stream::try_stream! {
+            let _busy = busy;
+            for kind in kinds {
+                // `resolve_kinds` admits no other variant.
+                debug_assert_eq!(kind, ImageKind::LinuxRunnerImage);
+                let target = state.linux_runner_image_target();
+                match &docker {
+                    Some(docker) => {
+                        // All-or-nothing: every advertised arch must pull
+                        // before promotion, so a partial-arch image can
+                        // never become current while the full capability
+                        // set is still advertised. Fail-fast on the first
+                        // arch that can't — `current` is left untouched.
+                        for arch in docker.linux_arches() {
+                            let platform = format!("linux/{arch}");
+                            yield event(kind, &platform, "pulling", 0.0);
+                            docker.pull(&target, &arch).await.map_err(|e| {
+                                Status::failed_precondition(format!(
+                                    "linux_runner_image {target} is not pullable for \
+                                     {platform}; current image left unchanged: {e:#}"
+                                ))
+                            })?;
+                            yield event(kind, &platform, "pulling", 1.0);
+                        }
+                    }
+                    // Without Docker no Linux job can dispatch, so there is
+                    // nothing to verify the image against — promote rather
+                    // than leave the setting pending forever on a
+                    // host-runner-only box. (Startup behaves the same way:
+                    // `AgentState::new` seeds current == target, and it is
+                    // `init_docker` that verifies the seed when Docker is on.)
+                    None => yield event(kind, "docker not configured", "skipped", 1.0),
+                }
+                state.set_linux_runner_image_current(&target);
+                yield event(kind, "", "promoted", 1.0);
+            }
+        };
+        Ok(Response::new(Box::pin(stream)))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use tokio_stream::StreamExt;
+
+    use super::*;
+    use crate::config::DockerMode;
+    use crate::settings::PersistedSettings;
+
+    fn seed() -> PersistedSettings {
+        PersistedSettings {
+            load_ceiling: 0.9,
+            mem_floor_mib: 2048,
+            linux_runner_image: "ghcr.io/actions/actions-runner:latest".to_owned(),
+            gateway: "https://fleet.arcbox.dev".to_owned(),
+            docker_mode: DockerMode::Disabled,
+            runner_script: None,
+        }
+    }
+
+    #[test]
+    fn empty_kinds_resolve_to_every_supported_kind() {
+        assert_eq!(
+            resolve_kinds(&[]).unwrap(),
+            vec![ImageKind::LinuxRunnerImage]
+        );
+    }
+
+    #[test]
+    fn duplicate_kinds_collapse() {
+        let raw = [
+            ImageKind::LinuxRunnerImage as i32,
+            ImageKind::LinuxRunnerImage as i32,
+        ];
+        assert_eq!(
+            resolve_kinds(&raw).unwrap(),
+            vec![ImageKind::LinuxRunnerImage]
+        );
+    }
+
+    #[test]
+    fn unknown_and_unspecified_kinds_are_rejected() {
+        for bad in [0, 999] {
+            assert!(resolve_kinds(&[bad]).is_err(), "accepted kind {bad}");
+        }
+    }
+
+    /// The real pull path needs a live Docker daemon (see `docker.rs`, which
+    /// has no unit tests for the same reason); the no-Docker branch is the
+    /// unit-testable half of the promotion contract: nothing to verify
+    /// against, so the target is promoted rather than pending forever.
+    #[tokio::test]
+    async fn prepare_without_docker_promotes_target() {
+        let state = AgentState::new(&seed());
+        state.set_linux_runner_image_target("ghcr.io/acme/runner:v2");
+        let service = ImageService::new(state.clone(), None);
+
+        let mut stream = service
+            .prepare(Request::new(PrepareRequest { kinds: Vec::new() }))
+            .await
+            .expect("Prepare")
+            .into_inner();
+        let mut stages = Vec::new();
+        while let Some(item) = stream.next().await {
+            stages.push(item.expect("event").stage);
+        }
+
+        assert_eq!(stages, ["skipped", "promoted"]);
+        assert_eq!(state.linux_runner_image_current(), "ghcr.io/acme/runner:v2");
+        assert_eq!(
+            state.linux_runner_image_current(),
+            state.linux_runner_image_target()
+        );
+    }
+
+    /// A second Prepare while one is live must be refused, not queued — and
+    /// dropping the live stream (client disconnect) must release the slot.
+    #[tokio::test]
+    async fn concurrent_prepare_is_refused_until_the_first_stream_drops() {
+        let service = ImageService::new(AgentState::new(&seed()), None);
+
+        let held = service
+            .prepare(Request::new(PrepareRequest { kinds: Vec::new() }))
+            .await
+            .expect("first Prepare");
+        let Err(err) = service
+            .prepare(Request::new(PrepareRequest { kinds: Vec::new() }))
+            .await
+        else {
+            panic!("second Prepare while the first is live must be refused");
+        };
+        assert_eq!(err.code(), tonic::Code::Aborted);
+
+        drop(held);
+        service
+            .prepare(Request::new(PrepareRequest { kinds: Vec::new() }))
+            .await
+            .expect("Prepare after the first stream dropped");
+    }
+}

--- a/fleet/arcbox-fleet-agent/src/control/lifecycle.rs
+++ b/fleet/arcbox-fleet-agent/src/control/lifecycle.rs
@@ -5,9 +5,9 @@ use std::sync::Arc;
 
 use arcbox_fleet_control_proto::v1::fleet_lifecycle_service_server::FleetLifecycleService;
 use arcbox_fleet_control_proto::v1::{
-    DisconnectRequest, DisconnectResponse, DrainRequest, DrainResponse, EnrollRequest,
-    EnrollResponse, GetAgentInfoRequest, GetAgentInfoResponse, GetStatusRequest, GetStatusResponse,
-    ResumeRequest, ResumeResponse,
+    DrainRequest, DrainResponse, EnrollRequest, EnrollResponse, GetAgentInfoRequest,
+    GetAgentInfoResponse, GetStatusRequest, GetStatusResponse, ResumeRequest, ResumeResponse,
+    UnenrollRequest, UnenrollResponse,
 };
 use tonic::{Request, Response, Status};
 
@@ -73,12 +73,12 @@ impl FleetLifecycleService for LifecycleService {
         Ok(Response::new(ResumeResponse {}))
     }
 
-    async fn disconnect(
+    async fn unenroll(
         &self,
-        _request: Request<DisconnectRequest>,
-    ) -> Result<Response<DisconnectResponse>, Status> {
-        self.supervisor.disconnect().await?;
-        Ok(Response::new(DisconnectResponse {}))
+        _request: Request<UnenrollRequest>,
+    ) -> Result<Response<UnenrollResponse>, Status> {
+        self.supervisor.unenroll().await?;
+        Ok(Response::new(UnenrollResponse {}))
     }
 
     async fn get_status(

--- a/fleet/arcbox-fleet-agent/src/control/lifecycle.rs
+++ b/fleet/arcbox-fleet-agent/src/control/lifecycle.rs
@@ -1,0 +1,94 @@
+//! `FleetLifecycleService` — the tonic server impl, backed by
+//! [`AgentSupervisor`](super::AgentSupervisor).
+
+use std::sync::Arc;
+
+use arcbox_fleet_control_proto::v1::fleet_lifecycle_service_server::FleetLifecycleService;
+use arcbox_fleet_control_proto::v1::{
+    DisconnectRequest, DisconnectResponse, DrainRequest, DrainResponse, EnrollRequest,
+    EnrollResponse, GetAgentInfoRequest, GetAgentInfoResponse, GetStatusRequest, GetStatusResponse,
+    ResumeRequest, ResumeResponse,
+};
+use tonic::{Request, Response, Status};
+
+use super::AgentSupervisor;
+
+/// Bumped only on breaking control-API changes. Clients call `GetAgentInfo`
+/// and adapt to what it reports rather than gating behavior on an exact
+/// match — the agent and its clients ship and self-update independently.
+const API_VERSION: u32 = 1;
+
+pub struct LifecycleService {
+    supervisor: Arc<AgentSupervisor>,
+}
+
+impl LifecycleService {
+    pub fn new(supervisor: Arc<AgentSupervisor>) -> Self {
+        Self { supervisor }
+    }
+}
+
+#[tonic::async_trait]
+impl FleetLifecycleService for LifecycleService {
+    async fn get_agent_info(
+        &self,
+        _request: Request<GetAgentInfoRequest>,
+    ) -> Result<Response<GetAgentInfoResponse>, Status> {
+        Ok(Response::new(GetAgentInfoResponse {
+            agent_version: env!("CARGO_PKG_VERSION").to_owned(),
+            api_version: API_VERSION,
+            features: Vec::new(),
+        }))
+    }
+
+    async fn enroll(
+        &self,
+        request: Request<EnrollRequest>,
+    ) -> Result<Response<EnrollResponse>, Status> {
+        let req = request.into_inner();
+        if req.enrollment_token.trim().is_empty() {
+            return Err(Status::invalid_argument("enrollment_token is required"));
+        }
+        let control_plane = (!req.control_plane.is_empty()).then_some(req.control_plane.as_str());
+        let machine_id = self
+            .supervisor
+            .enroll(req.enrollment_token, control_plane)
+            .await?;
+        Ok(Response::new(EnrollResponse { machine_id }))
+    }
+
+    async fn drain(
+        &self,
+        _request: Request<DrainRequest>,
+    ) -> Result<Response<DrainResponse>, Status> {
+        self.supervisor.drain().await?;
+        Ok(Response::new(DrainResponse {}))
+    }
+
+    async fn resume(
+        &self,
+        _request: Request<ResumeRequest>,
+    ) -> Result<Response<ResumeResponse>, Status> {
+        self.supervisor.resume().await?;
+        Ok(Response::new(ResumeResponse {}))
+    }
+
+    async fn disconnect(
+        &self,
+        _request: Request<DisconnectRequest>,
+    ) -> Result<Response<DisconnectResponse>, Status> {
+        self.supervisor.disconnect().await?;
+        Ok(Response::new(DisconnectResponse {}))
+    }
+
+    async fn get_status(
+        &self,
+        _request: Request<GetStatusRequest>,
+    ) -> Result<Response<GetStatusResponse>, Status> {
+        let (state, machine_id) = self.supervisor.status().await;
+        Ok(Response::new(GetStatusResponse {
+            state: state as i32,
+            machine_id,
+        }))
+    }
+}

--- a/fleet/arcbox-fleet-agent/src/control/mod.rs
+++ b/fleet/arcbox-fleet-agent/src/control/mod.rs
@@ -150,9 +150,9 @@ async fn join_or_abort(mut task: tokio::task::JoinHandle<Result<()>>, grace: Dur
 }
 
 /// The `Enroll` admission check: only `Unenrolled` may proceed. Applied
-/// twice — before the gateway round-trip and again after re-locking — so
-/// both an already-live attachment and an `Unenroll` that started
-/// mid-round-trip refuse the enrollment.
+/// once, at the start of [`AgentSupervisor::enroll`] — the transition into
+/// [`State::Enrolling`] under the same lock then keeps every concurrent
+/// admission out, including a straggling `Unenroll`.
 ///
 /// Returns a plain message rather than `Status` — every failure here maps
 /// to the same `FAILED_PRECONDITION` code, so the caller does that one
@@ -160,6 +160,7 @@ async fn join_or_abort(mut task: tokio::task::JoinHandle<Result<()>>, grace: Dur
 fn check_enrollable(state: &State) -> Result<(), &'static str> {
     match state {
         State::Unenrolled => Ok(()),
+        State::Enrolling => Err("enroll in progress — retry shortly"),
         State::Unenrolling => Err("unenroll in progress — retry shortly"),
         State::Detaching => Err("detach in progress — retry shortly"),
         State::Detached { .. } => {
@@ -193,6 +194,16 @@ struct Attachment {
 
 enum State {
     Unenrolled,
+    /// An `Enroll` is between the initial admission check and either
+    /// success (transition to [`State::Attached`]) or failure (rollback to
+    /// [`State::Unenrolled`]). Held across the gateway round-trip so
+    /// [`check_enrollable`] refuses a concurrent `Enroll`, and mirrored as
+    /// observable [`Enrollment::Attaching`] on [`AgentState`] so
+    /// `settings::validate` refuses a gateway change during the same
+    /// window — without that mirror, a settings write could move the
+    /// gateway target under our feet and leave the credential (persisted
+    /// under the enrolling gateway's key) unreachable to the next startup.
+    Enrolling,
     /// An `Unenroll` is tearing its attachment down (bounded by
     /// [`TEARDOWN_GRACE`]). `Enroll` is refused while here: an enrollment
     /// that raced into the teardown window would have its observable state
@@ -345,11 +356,51 @@ impl AgentSupervisor {
         token: String,
         control_plane: Option<&str>,
     ) -> Result<String, Status> {
-        check_enrollable(&*self.state.lock().await).map_err(Status::failed_precondition)?;
+        // Enter `Enrolling` under the state lock so `check_enrollable`
+        // refuses every concurrent admission for the whole round-trip, and
+        // mirror the observable state as `Attaching` on `AgentState` so
+        // `settings::validate` refuses a racing gateway change against the
+        // same window. Without the observable write here, a settings-time
+        // gateway move could land between our target read and the credential
+        // persist, splitting the gateway keys of settings.json and the
+        // credential store — the next startup would then miss the credential.
+        {
+            let mut state = self.state.lock().await;
+            check_enrollable(&state).map_err(Status::failed_precondition)?;
+            *state = State::Enrolling;
+            self.agent_state.set_enrollment(Enrollment::Attaching, "");
+        }
 
-        // Resolve the gateway to dial without mutating shared state yet: a
-        // concurrent Enroll may still win the race check below, and a losing
-        // attempt must not leave its gateway override applied or persisted.
+        // Any early return past this point must roll `Enrolling` back to
+        // `Unenrolled` — otherwise the gate stays closed to future enrolls.
+        let outcome = self.finish_enroll(token, control_plane).await;
+        if outcome.is_err() {
+            let mut state = self.state.lock().await;
+            // Only roll back the state we own. `attach()` transitions to
+            // `Attached` (with a real machine_id in `set_enrollment`), so
+            // if we're still `Enrolling`, no one else has advanced the
+            // observable state either.
+            if matches!(*state, State::Enrolling) {
+                *state = State::Unenrolled;
+                self.agent_state.set_enrollment(Enrollment::Unenrolled, "");
+            }
+        }
+        outcome
+    }
+
+    /// Body of [`Self::enroll`] between entering `State::Enrolling` and
+    /// the `Attached` transition. Split out so the caller can roll the
+    /// state back on any `?`-early return uniformly, without repeating the
+    /// cleanup at every fallible site.
+    async fn finish_enroll(
+        &self,
+        token: String,
+        control_plane: Option<&str>,
+    ) -> Result<String, Status> {
+        // Resolve the gateway to dial. Because `Enrolling` is now held and
+        // `settings::validate` refuses gateway changes while enrollment is
+        // live, this value is stable across the round-trip below — the
+        // credential and settings.json will end up under the same key.
         let gateway =
             control_plane.map_or_else(|| self.agent_state.gateway_target(), str::to_owned);
 
@@ -359,19 +410,17 @@ impl AgentSupervisor {
             .map_err(Internal)?;
 
         let mut state = self.state.lock().await;
-        // Lost a race with a concurrent Enroll (or a Unenroll started
-        // mid-round-trip). The credential just fetched is dropped here
-        // without ever being persisted — only the winner, below, writes to
-        // the credential store — so it cannot clobber the winner's
-        // persisted credential.
-        check_enrollable(&state).map_err(Status::failed_precondition)?;
+        // `check_enrollable` refuses `Enrolling`, so nothing else can
+        // transition it while we're away — assert defensively in case a
+        // future path breaks that invariant.
+        debug_assert!(
+            matches!(*state, State::Enrolling),
+            "state left Enrolling behind our back"
+        );
 
-        // Won the race. Persist the credential now, and only now: a losing
-        // concurrent Enroll returned above without writing, so what lands on
-        // disk always matches the attachment started just below — a later
-        // restart reattaches as the same machine. Scoped to the gateway just
-        // enrolled against, which the settings write below makes the target,
-        // so the restart load finds it under the same key.
+        // Scoped to the gateway just enrolled against, which the settings
+        // write below makes the target — so the restart load finds it under
+        // the same key.
         self.credential_store_for(&gateway)
             .store(&credential)
             .map_err(Internal)?;
@@ -417,6 +466,11 @@ impl AgentSupervisor {
             match &*state {
                 State::Unenrolled => {
                     return Err(Status::failed_precondition("not enrolled"));
+                }
+                State::Enrolling => {
+                    return Err(Status::failed_precondition(
+                        "enroll in progress — retry shortly",
+                    ));
                 }
                 State::Unenrolling => {
                     return Err(Status::failed_precondition("unenroll already in progress"));
@@ -591,7 +645,7 @@ impl AgentSupervisor {
                 a.supervisor.handle_drain();
                 Ok(())
             }
-            State::Unenrolled | State::Unenrolling => {
+            State::Unenrolled | State::Enrolling | State::Unenrolling => {
                 Err(Status::failed_precondition("not enrolled"))
             }
             State::Detaching | State::Detached { .. } => Err(Status::failed_precondition(
@@ -607,7 +661,7 @@ impl AgentSupervisor {
                 a.supervisor.resume();
                 Ok(())
             }
-            State::Unenrolled | State::Unenrolling => {
+            State::Unenrolled | State::Enrolling | State::Unenrolling => {
                 Err(Status::failed_precondition("not enrolled"))
             }
             State::Detaching | State::Detached { .. } => Err(Status::failed_precondition(
@@ -646,10 +700,11 @@ impl AgentSupervisor {
             let mut state = self.state.lock().await;
             match std::mem::replace(&mut *state, State::Unenrolled) {
                 State::Attached(a) => Some(a),
-                // During `Unenrolling`/`Detaching` the transition owns the
-                // attachment handle and awaits it itself; `Detached` has no
-                // task at all. Nothing to join.
+                // During `Enrolling`/`Unenrolling`/`Detaching` the transition
+                // owns any handle involved and awaits it itself; `Unenrolled`
+                // and `Detached` have no task at all. Nothing to join.
                 State::Unenrolled
+                | State::Enrolling
                 | State::Unenrolling
                 | State::Detaching
                 | State::Detached { .. } => None,
@@ -943,6 +998,83 @@ mod tests {
             .expect_err("gateway is unreachable");
         assert_ne!(err.code(), tonic::Code::FailedPrecondition, "{err}");
 
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    /// `enroll` must mirror its `State::Enrolling` transition onto
+    /// `agent_state.enrollment = Attaching` before releasing the state
+    /// lock — that mirror is what makes `settings::validate` refuse a
+    /// gateway change while the gateway round-trip is in flight. If the
+    /// round-trip then fails, both the supervisor state and the observable
+    /// enrollment must roll back to `Unenrolled`, or the gate stays closed
+    /// to every future enroll.
+    #[tokio::test]
+    async fn enroll_marks_state_attaching_across_the_gateway_round_trip() {
+        let dir =
+            std::env::temp_dir().join(format!("fleet-enroll-observability-{}", std::process::id()));
+        let agent_state = AgentState::new(&seed());
+        let supervisor = test_supervisor(&dir, agent_state.clone()).await;
+
+        // The gateway seed points at an unreachable local port — connect
+        // stalls long enough for the mid-round-trip assertions below to
+        // observe the transient state.
+        let enroll = {
+            let supervisor = Arc::clone(&supervisor);
+            tokio::spawn(async move { supervisor.enroll("flt_join_test".to_owned(), None).await })
+        };
+        tokio::time::sleep(Duration::from_millis(50)).await;
+
+        assert_eq!(
+            agent_state.current().enrollment,
+            Enrollment::Attaching as i32,
+            "observable state must flip to Attaching before the round-trip yields"
+        );
+        assert!(matches!(*supervisor.state.lock().await, State::Enrolling));
+
+        let err = enroll
+            .await
+            .expect("enroll task")
+            .expect_err("gateway is unreachable");
+        assert_ne!(err.code(), tonic::Code::FailedPrecondition, "{err}");
+
+        // Rollback: both the supervisor state and observable enrollment
+        // must return to Unenrolled so future enrolls can proceed.
+        assert!(matches!(*supervisor.state.lock().await, State::Unenrolled));
+        assert_eq!(
+            agent_state.current().enrollment,
+            Enrollment::Unenrolled as i32
+        );
+
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    /// Two `enroll` RPCs racing against the same supervisor: the second
+    /// must be refused by `State::Enrolling` (not by the round-trip
+    /// re-check that came after it), so its token is never used and its
+    /// credential is never persisted alongside the first one.
+    #[tokio::test]
+    async fn concurrent_enroll_is_refused_by_the_enrolling_gate() {
+        let dir =
+            std::env::temp_dir().join(format!("fleet-enroll-concurrent-{}", std::process::id()));
+        let agent_state = AgentState::new(&seed());
+        let supervisor = test_supervisor(&dir, agent_state).await;
+
+        let first = {
+            let supervisor = Arc::clone(&supervisor);
+            tokio::spawn(async move { supervisor.enroll("flt_join_first".to_owned(), None).await })
+        };
+        tokio::time::sleep(Duration::from_millis(50)).await;
+
+        let err = supervisor
+            .enroll("flt_join_second".to_owned(), None)
+            .await
+            .expect_err("concurrent enroll must be refused");
+        assert_eq!(err.code(), tonic::Code::FailedPrecondition);
+        assert!(err.message().contains("enroll in progress"), "{err}");
+
+        // The first enroll still fails at the unreachable gateway; the
+        // point is that the second one was gated *before* even trying.
+        let _ = first.await.expect("enroll task");
         let _ = std::fs::remove_dir_all(dir);
     }
 

--- a/fleet/arcbox-fleet-agent/src/control/mod.rs
+++ b/fleet/arcbox-fleet-agent/src/control/mod.rs
@@ -2,7 +2,7 @@
 //! (`~/.arcbox/fleet/agent.sock`) that turns the agent's enrollment from a
 //! fixed, credential-required-at-startup process into a state machine the
 //! `arcbox-fleet-agent` CLI and the desktop app can drive — enroll, drain,
-//! resume, disconnect — while it runs. See [`lifecycle`] for the tonic
+//! resume, unenroll — while it runs. See [`lifecycle`] for the tonic
 //! service implementation.
 
 pub mod client;
@@ -60,7 +60,7 @@ impl From<Internal> for Status {
 /// Bind `agent.sock` and serve `FleetLifecycleService` until `shutdown`
 /// fires. Mirrors `arcbox-daemon`'s `services::start_grpc` (remove-before-bind,
 /// then `UnixListener`/`UnixListenerStream`), plus explicit owner-only
-/// permissions: unlike the daemon's socket, this one can enroll/disconnect
+/// permissions: unlike the daemon's socket, this one can enroll/unenroll
 /// the machine, so it must not rely on umask alone. The parent directory
 /// (which also holds the credential file) is made `0700` *before* the bind,
 /// so the socket is unreachable by other users even during the brief window
@@ -110,18 +110,18 @@ pub async fn serve(
         .context("control-plane server error")
 }
 
-/// How long [`AgentSupervisor::disconnect`] waits for the attach task to
+/// How long [`AgentSupervisor::unenroll`] waits for the attach task to
 /// react to cancellation before clearing the credential anyway. The task's
 /// own runner teardown is separately bounded by `attach::run`'s
 /// `SHUTDOWN_GRACE`; this only needs to cover that plus scheduling overhead.
-const DISCONNECT_GRACE: Duration = Duration::from_secs(20);
+const UNENROLL_GRACE: Duration = Duration::from_secs(20);
 
 /// Wait up to `grace` for `task` to finish on its own; if it doesn't, abort
 /// it and wait for that reap too, so `task` is guaranteed stopped by the
 /// time this returns regardless of whether it ever observed its own
-/// cancellation signal. Split out from [`AgentSupervisor::disconnect`] so
+/// cancellation signal. Split out from [`AgentSupervisor::unenroll`] so
 /// the abort-on-timeout behavior can be exercised directly with a short
-/// `grace`, instead of the real [`DISCONNECT_GRACE`].
+/// `grace`, instead of the real [`UNENROLL_GRACE`].
 ///
 /// Polls `&mut task` rather than the owned handle so it survives a timeout:
 /// `tokio::time::timeout` drops its future on `Elapsed`, and dropping a
@@ -132,10 +132,10 @@ const DISCONNECT_GRACE: Duration = Duration::from_secs(20);
 async fn join_or_abort(mut task: tokio::task::JoinHandle<Result<()>>, grace: Duration) {
     match tokio::time::timeout(grace, &mut task).await {
         Ok(Ok(Ok(()))) => {}
-        Ok(Ok(Err(e))) => warn!(error = %e, "attach task exited with an error on disconnect"),
-        Ok(Err(e)) => warn!(error = %e, "attach task panicked on disconnect"),
+        Ok(Ok(Err(e))) => warn!(error = %e, "attach task exited with an error on unenroll"),
+        Ok(Err(e)) => warn!(error = %e, "attach task panicked on unenroll"),
         Err(_) => {
-            warn!("disconnect grace elapsed; aborting attach task");
+            warn!("unenroll grace elapsed; aborting attach task");
             task.abort();
             // Best-effort reap; a `Cancelled` JoinError here is expected.
             let _ = task.await;
@@ -145,7 +145,7 @@ async fn join_or_abort(mut task: tokio::task::JoinHandle<Result<()>>, grace: Dur
 
 /// The `Enroll` admission check: only `Unenrolled` may proceed. Applied
 /// twice — before the gateway round-trip and again after re-locking — so
-/// both an already-live attachment and a `Disconnect` that started
+/// both an already-live attachment and an `Unenroll` that started
 /// mid-round-trip refuse the enrollment.
 ///
 /// Returns a plain message rather than `Status` — every failure here maps
@@ -154,8 +154,8 @@ async fn join_or_abort(mut task: tokio::task::JoinHandle<Result<()>>, grace: Dur
 fn check_enrollable(state: &State) -> Result<(), &'static str> {
     match state {
         State::Unenrolled => Ok(()),
-        State::Disconnecting => Err("disconnect in progress — retry shortly"),
-        State::Attached(_) => Err("already enrolled — disconnect first"),
+        State::Unenrolling => Err("unenroll in progress — retry shortly"),
+        State::Attached(_) => Err("already enrolled — unenroll first"),
     }
 }
 
@@ -166,12 +166,12 @@ fn check_enrollable(state: &State) -> Result<(), &'static str> {
 struct Attachment {
     supervisor: RunnerSupervisor,
     /// Child of [`AgentSupervisor::process_shutdown`]: cancelling it stops
-    /// only this attachment (`Disconnect`); cancelling the parent (process
+    /// only this attachment (`Unenroll`); cancelling the parent (process
     /// shutdown) cascades to it too, so runners still drain on SIGTERM.
     shutdown: CancellationToken,
     task: tokio::task::JoinHandle<Result<()>>,
     /// The gateway this attachment's credential is persisted under (the
-    /// keychain backend keys its entry by gateway URI). `disconnect` clears
+    /// keychain backend keys its entry by gateway URI). `unenroll` clears
     /// exactly this store: reading the live `gateway_target` there instead
     /// would clear the wrong entry if a settings update moved the target
     /// while attached, leaving this credential behind on disk.
@@ -180,12 +180,12 @@ struct Attachment {
 
 enum State {
     Unenrolled,
-    /// A `Disconnect` is tearing its attachment down (bounded by
-    /// [`DISCONNECT_GRACE`]). `Enroll` is refused while here: an enrollment
+    /// A `Unenroll` is tearing its attachment down (bounded by
+    /// [`UNENROLL_GRACE`]). `Enroll` is refused while here: an enrollment
     /// that raced into the teardown window would have its observable state
-    /// stomped by the old task's late writes and by disconnect's own final
+    /// stomped by the old task's late writes and by unenroll's own final
     /// `Unenrolled` re-assert, so the window is closed instead of fenced.
-    Disconnecting,
+    Unenrolling,
     Attached(Attachment),
 }
 
@@ -319,7 +319,7 @@ impl AgentSupervisor {
             .map_err(Internal)?;
 
         let mut state = self.state.lock().await;
-        // Lost a race with a concurrent Enroll (or a Disconnect started
+        // Lost a race with a concurrent Enroll (or a Unenroll started
         // mid-round-trip). The credential just fetched is dropped here
         // without ever being persisted — only the winner, below, writes to
         // the credential store — so it cannot clobber the winner's
@@ -355,24 +355,22 @@ impl AgentSupervisor {
 
     /// Stop attaching and remove the persisted credential. Observably
     /// `Unenrolled` immediately (`GetStatus`/`Watch`); the attach task's own
-    /// teardown finishes in the background, bounded by [`DISCONNECT_GRACE`],
+    /// teardown finishes in the background, bounded by [`UNENROLL_GRACE`],
     /// and `Enroll` is refused until it completes (see
-    /// [`State::Disconnecting`]).
-    pub async fn disconnect(&self) -> Result<(), Status> {
+    /// [`State::Unenrolling`]).
+    pub async fn unenroll(&self) -> Result<(), Status> {
         let attachment = {
             let mut state = self.state.lock().await;
             match &*state {
                 State::Unenrolled => {
                     return Err(Status::failed_precondition("not enrolled"));
                 }
-                State::Disconnecting => {
-                    return Err(Status::failed_precondition(
-                        "disconnect already in progress",
-                    ));
+                State::Unenrolling => {
+                    return Err(Status::failed_precondition("unenroll already in progress"));
                 }
                 State::Attached(_) => {}
             }
-            let State::Attached(attachment) = std::mem::replace(&mut *state, State::Disconnecting)
+            let State::Attached(attachment) = std::mem::replace(&mut *state, State::Unenrolling)
             else {
                 unreachable!("checked above");
             };
@@ -387,10 +385,10 @@ impl AgentSupervisor {
         };
 
         attachment.shutdown.cancel();
-        join_or_abort(attachment.task, DISCONNECT_GRACE).await;
+        join_or_abort(attachment.task, UNENROLL_GRACE).await;
 
         // Authoritative: the task is provably stopped (joined or aborted)
-        // and `Disconnecting` kept every `Enroll` out of the grace window,
+        // and `Unenrolling` kept every `Enroll` out of the grace window,
         // so no live attachment's state can be stomped here and no stale
         // write from the old task survives it.
         {
@@ -415,7 +413,7 @@ impl AgentSupervisor {
                 a.supervisor.handle_drain();
                 Ok(())
             }
-            State::Unenrolled | State::Disconnecting => {
+            State::Unenrolled | State::Unenrolling => {
                 Err(Status::failed_precondition("not enrolled"))
             }
         }
@@ -428,7 +426,7 @@ impl AgentSupervisor {
                 a.supervisor.resume();
                 Ok(())
             }
-            State::Unenrolled | State::Disconnecting => {
+            State::Unenrolled | State::Unenrolling => {
                 Err(Status::failed_precondition("not enrolled"))
             }
         }
@@ -462,9 +460,9 @@ impl AgentSupervisor {
             let mut state = self.state.lock().await;
             match std::mem::replace(&mut *state, State::Unenrolled) {
                 State::Attached(a) => Some(a),
-                // During `Disconnecting` the disconnect call owns the
+                // During `Unenrolling` the unenroll call owns the
                 // attachment handle and awaits it itself; nothing to join.
-                State::Unenrolled | State::Disconnecting => None,
+                State::Unenrolled | State::Unenrolling => None,
             }
         };
         if let Some(a) = attachment {
@@ -509,13 +507,13 @@ mod tests {
         }
     }
 
-    /// While a disconnect is inside its teardown grace, a concurrent
+    /// While a unenroll is inside its teardown grace, a concurrent
     /// `Enroll` must be refused — not succeed and then have its observable
-    /// state stomped by the disconnect's final `Unenrolled` re-assert (or
-    /// by the old task's late writes). Once the disconnect completes, the
+    /// state stomped by the unenroll's final `Unenrolled` re-assert (or
+    /// by the old task's late writes). Once the unenroll completes, the
     /// gate opens again.
     #[tokio::test]
-    async fn enroll_is_refused_during_disconnect_grace() {
+    async fn enroll_is_refused_during_unenroll_grace() {
         let dir = std::env::temp_dir().join(format!("fleet-disc-race-{}", std::process::id()));
         let agent_state = AgentState::new(&seed());
         let supervisor = Arc::new(
@@ -550,9 +548,9 @@ mod tests {
             credential_gateway: "http://127.0.0.1:1".to_owned(),
         });
 
-        let disconnect = {
+        let unenroll = {
             let supervisor = Arc::clone(&supervisor);
-            tokio::spawn(async move { supervisor.disconnect().await })
+            tokio::spawn(async move { supervisor.unenroll().await })
         };
         tokio::time::sleep(Duration::from_millis(50)).await;
 
@@ -560,14 +558,14 @@ mod tests {
         let err = supervisor
             .enroll("flt_join_test".to_owned(), None)
             .await
-            .expect_err("enroll during disconnect grace must be refused");
+            .expect_err("enroll during unenroll grace must be refused");
         assert_eq!(err.code(), tonic::Code::FailedPrecondition);
-        assert!(err.message().contains("disconnect in progress"), "{err}");
+        assert!(err.message().contains("unenroll in progress"), "{err}");
 
-        disconnect
+        unenroll
             .await
-            .expect("disconnect task")
-            .expect("disconnect succeeds");
+            .expect("unenroll task")
+            .expect("unenroll succeeds");
         assert!(matches!(*supervisor.state.lock().await, State::Unenrolled));
 
         // Gate open again: enroll now passes the state check and fails

--- a/fleet/arcbox-fleet-agent/src/control/mod.rs
+++ b/fleet/arcbox-fleet-agent/src/control/mod.rs
@@ -1,0 +1,272 @@
+//! Local control-plane API: a Unix-socket gRPC server
+//! (`~/.arcbox/fleet/agent.sock`) that turns the agent's enrollment from a
+//! fixed, credential-required-at-startup process into a state machine the
+//! `arcbox-fleet-agent` CLI and the desktop app can drive — enroll, drain,
+//! resume, disconnect — while it runs. See [`lifecycle`] for the tonic
+//! service implementation.
+
+pub mod client;
+mod lifecycle;
+
+use std::os::unix::fs::PermissionsExt;
+use std::path::Path;
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::{Context, Result};
+use arcbox_fleet_control_proto::v1::ConnectionState;
+use arcbox_fleet_control_proto::v1::fleet_lifecycle_service_server::FleetLifecycleServiceServer;
+use arcbox_fleet_proto::v1::Capability;
+use tokio::net::UnixListener;
+use tokio::sync::Mutex;
+use tokio_stream::wrappers::UnixListenerStream;
+use tokio_util::sync::CancellationToken;
+use tonic::Status;
+use tonic::transport::Server;
+use tracing::{info, warn};
+
+use crate::config::AgentConfig;
+use crate::credentials::{Credential, CredentialStore};
+use crate::docker::DockerRunner;
+use crate::runner::RunnerSupervisor;
+use crate::{attach, enroll};
+use lifecycle::LifecycleService;
+
+/// Bind `agent.sock` and serve `FleetLifecycleService` until `shutdown`
+/// fires. Mirrors `arcbox-daemon`'s `services::start_grpc` (remove-before-bind,
+/// then `UnixListener`/`UnixListenerStream`), plus an explicit owner-only
+/// permission: unlike the daemon's socket, this one can enroll/disconnect
+/// the machine, so it must not rely on umask alone.
+pub async fn serve(
+    socket_path: &Path,
+    supervisor: Arc<AgentSupervisor>,
+    shutdown: CancellationToken,
+) -> Result<()> {
+    let _ = std::fs::remove_file(socket_path);
+    if let Some(parent) = socket_path.parent() {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("creating {}", parent.display()))?;
+    }
+
+    let listener = UnixListener::bind(socket_path)
+        .with_context(|| format!("binding control socket at {}", socket_path.display()))?;
+    std::fs::set_permissions(socket_path, std::fs::Permissions::from_mode(0o600))
+        .with_context(|| format!("chmod 0600 {}", socket_path.display()))?;
+    let incoming = UnixListenerStream::new(listener);
+
+    info!(socket = %socket_path.display(), "control-plane server listening");
+
+    Server::builder()
+        .add_service(FleetLifecycleServiceServer::new(LifecycleService::new(
+            supervisor,
+        )))
+        .serve_with_incoming_shutdown(incoming, shutdown.cancelled())
+        .await
+        .context("control-plane server error")
+}
+
+/// How long [`AgentSupervisor::disconnect`] waits for the attach task to
+/// react to cancellation before clearing the credential anyway. The task's
+/// own runner teardown is separately bounded by `attach::run`'s
+/// `SHUTDOWN_GRACE`; this only needs to cover that plus scheduling overhead.
+const DISCONNECT_GRACE: Duration = Duration::from_secs(20);
+
+/// A live attachment to the gateway: the credential it authenticated with,
+/// the admission authority in `admit()`, and the handle to stop it.
+struct Attachment {
+    credential: Credential,
+    supervisor: RunnerSupervisor,
+    /// Child of [`AgentSupervisor::process_shutdown`]: cancelling it stops
+    /// only this attachment (`Disconnect`); cancelling the parent (process
+    /// shutdown) cascades to it too, so runners still drain on SIGTERM.
+    shutdown: CancellationToken,
+    task: tokio::task::JoinHandle<Result<()>>,
+}
+
+enum State {
+    Unenrolled,
+    Attached(Attachment),
+}
+
+/// Owns the agent's enrollment state machine.
+///
+/// `Run` no longer requires a credential up front: with none on disk the
+/// agent starts `Unenrolled` and idles until `Enroll` delivers one — the
+/// desktop-managed handoff (RUN-8) — while the CLI's one-shot `enroll`
+/// subcommand still works entirely offline, before this process even starts.
+pub struct AgentSupervisor {
+    config: AgentConfig,
+    docker: Option<DockerRunner>,
+    capabilities: Vec<Capability>,
+    credential_store: CredentialStore,
+    /// Cancelled on process shutdown (SIGTERM/Ctrl-C); every attachment's
+    /// `shutdown` is a child of this token.
+    process_shutdown: CancellationToken,
+    state: Mutex<State>,
+}
+
+impl AgentSupervisor {
+    /// Build the supervisor, immediately attaching if a credential is
+    /// already persisted — the existing headless/farm behavior.
+    pub async fn new(
+        config: AgentConfig,
+        docker: Option<DockerRunner>,
+        capabilities: Vec<Capability>,
+        credential_store: CredentialStore,
+        process_shutdown: CancellationToken,
+    ) -> Result<Self> {
+        let existing = credential_store.load()?;
+        let this = Self {
+            config,
+            docker,
+            capabilities,
+            credential_store,
+            process_shutdown,
+            state: Mutex::new(State::Unenrolled),
+        };
+        if let Some(credential) = existing {
+            info!(machine_id = %credential.machine_id, "starting fleet agent (credential on disk)");
+            *this.state.lock().await = State::Attached(this.attach(credential));
+        }
+        Ok(this)
+    }
+
+    /// Spawn the attach task for `credential` and build its [`Attachment`].
+    fn attach(&self, credential: Credential) -> Attachment {
+        let (supervisor, egress_rx) =
+            attach::spawn_supervisor(&self.config, self.docker.clone(), self.capabilities.clone());
+        let shutdown = self.process_shutdown.child_token();
+        let task = tokio::spawn(attach::run(
+            self.config.clone(),
+            credential.clone(),
+            supervisor.clone(),
+            egress_rx,
+            self.capabilities.clone(),
+            shutdown.clone(),
+        ));
+        Attachment {
+            credential,
+            supervisor,
+            shutdown,
+            task,
+        }
+    }
+
+    /// Exchange `token` for a machine credential and start attaching.
+    /// `control_plane` overrides the configured gateway for this enrollment.
+    pub async fn enroll(
+        &self,
+        token: String,
+        control_plane: Option<&str>,
+    ) -> Result<String, Status> {
+        if matches!(*self.state.lock().await, State::Attached(_)) {
+            return Err(Status::failed_precondition(
+                "already enrolled — disconnect first",
+            ));
+        }
+        // The gateway round-trip must not hold `state` locked.
+        let credential = enroll::enroll(
+            &self.config,
+            token,
+            self.capabilities.clone(),
+            control_plane,
+        )
+        .await
+        .map_err(|e| Status::internal(e.to_string()))?;
+
+        let mut state = self.state.lock().await;
+        if matches!(*state, State::Attached(_)) {
+            // Lost a race with a concurrent Enroll; the credential just
+            // fetched is simply discarded rather than clobbering the winner.
+            return Err(Status::failed_precondition(
+                "already enrolled — disconnect first",
+            ));
+        }
+        let machine_id = credential.machine_id.clone();
+        *state = State::Attached(self.attach(credential));
+        Ok(machine_id)
+    }
+
+    /// Stop attaching and remove the persisted credential. Returns to
+    /// `Unenrolled` immediately (concurrent `GetStatus`/`Drain`/`Resume`
+    /// observe that right away); the attach task's own teardown finishes in
+    /// the background, bounded by [`DISCONNECT_GRACE`].
+    pub async fn disconnect(&self) -> Result<(), Status> {
+        let attachment = {
+            let mut state = self.state.lock().await;
+            if matches!(*state, State::Unenrolled) {
+                return Err(Status::failed_precondition("not enrolled"));
+            }
+            let State::Attached(attachment) = std::mem::replace(&mut *state, State::Unenrolled)
+            else {
+                unreachable!("checked above");
+            };
+            attachment
+        };
+
+        attachment.shutdown.cancel();
+        match tokio::time::timeout(DISCONNECT_GRACE, attachment.task).await {
+            Ok(Ok(Ok(()))) => {}
+            Ok(Ok(Err(e))) => warn!(error = %e, "attach task exited with an error on disconnect"),
+            Ok(Err(e)) => warn!(error = %e, "attach task panicked on disconnect"),
+            Err(_) => warn!("disconnect grace elapsed; clearing credential anyway"),
+        }
+        self.credential_store
+            .clear()
+            .map_err(|e| Status::internal(e.to_string()))
+    }
+
+    /// Stop accepting new offers; in-flight jobs finish normally.
+    pub async fn drain(&self) -> Result<(), Status> {
+        match &*self.state.lock().await {
+            State::Attached(a) => {
+                a.supervisor.handle_drain();
+                Ok(())
+            }
+            State::Unenrolled => Err(Status::failed_precondition("not enrolled")),
+        }
+    }
+
+    /// Resume accepting new offers after [`Self::drain`].
+    pub async fn resume(&self) -> Result<(), Status> {
+        match &*self.state.lock().await {
+            State::Attached(a) => {
+                a.supervisor.resume();
+                Ok(())
+            }
+            State::Unenrolled => Err(Status::failed_precondition("not enrolled")),
+        }
+    }
+
+    /// Current lifecycle state and machine id (empty when unenrolled).
+    pub async fn status(&self) -> (ConnectionState, String) {
+        match &*self.state.lock().await {
+            State::Unenrolled => (ConnectionState::Unenrolled, String::new()),
+            State::Attached(a) if a.supervisor.is_draining() => {
+                (ConnectionState::Draining, a.credential.machine_id.clone())
+            }
+            State::Attached(a) => (ConnectionState::Enrolled, a.credential.machine_id.clone()),
+        }
+    }
+
+    /// Await the current attach task's completion, if one is running.
+    /// Called once, at process shutdown, after [`serve`] has itself stopped
+    /// accepting connections — so the process doesn't exit before runners
+    /// get their shutdown grace.
+    pub async fn join(&self) {
+        let attachment = {
+            let mut state = self.state.lock().await;
+            match std::mem::replace(&mut *state, State::Unenrolled) {
+                State::Attached(a) => Some(a),
+                State::Unenrolled => None,
+            }
+        };
+        if let Some(a) = attachment {
+            match a.task.await {
+                Ok(Ok(())) => {}
+                Ok(Err(e)) => warn!(error = %e, "attach task exited with an error"),
+                Err(e) => warn!(error = %e, "attach task panicked"),
+            }
+        }
+    }
+}

--- a/fleet/arcbox-fleet-agent/src/control/mod.rs
+++ b/fleet/arcbox-fleet-agent/src/control/mod.rs
@@ -59,9 +59,12 @@ impl From<Internal> for Status {
 
 /// Bind `agent.sock` and serve `FleetLifecycleService` until `shutdown`
 /// fires. Mirrors `arcbox-daemon`'s `services::start_grpc` (remove-before-bind,
-/// then `UnixListener`/`UnixListenerStream`), plus an explicit owner-only
-/// permission: unlike the daemon's socket, this one can enroll/disconnect
-/// the machine, so it must not rely on umask alone.
+/// then `UnixListener`/`UnixListenerStream`), plus explicit owner-only
+/// permissions: unlike the daemon's socket, this one can enroll/disconnect
+/// the machine, so it must not rely on umask alone. The parent directory
+/// (which also holds the credential file) is made `0700` *before* the bind,
+/// so the socket is unreachable by other users even during the brief window
+/// between `bind` and its own `0600` chmod.
 pub async fn serve(
     socket_path: &Path,
     supervisor: Arc<AgentSupervisor>,
@@ -73,6 +76,10 @@ pub async fn serve(
     if let Some(parent) = socket_path.parent() {
         std::fs::create_dir_all(parent)
             .with_context(|| format!("creating {}", parent.display()))?;
+        // Unconditional, not just on creation: an existing data dir from an
+        // older or umask-lenient run gets the same traversal barrier.
+        std::fs::set_permissions(parent, std::fs::Permissions::from_mode(0o700))
+            .with_context(|| format!("chmod 0700 {}", parent.display()))?;
     }
 
     let listener = UnixListener::bind(socket_path)
@@ -147,6 +154,12 @@ struct Attachment {
     /// shutdown) cascades to it too, so runners still drain on SIGTERM.
     shutdown: CancellationToken,
     task: tokio::task::JoinHandle<Result<()>>,
+    /// The gateway this attachment's credential is persisted under (the
+    /// keychain backend keys its entry by gateway URI). `disconnect` clears
+    /// exactly this store: reading the live `gateway_target` there instead
+    /// would clear the wrong entry if a settings update moved the target
+    /// while attached, leaving this credential behind on disk.
+    credential_gateway: String,
 }
 
 enum State {
@@ -197,12 +210,11 @@ impl AgentSupervisor {
             agent_state,
             settings_store,
         };
-        let existing = this
-            .credential_store_for(&this.agent_state.gateway_target())
-            .load()?;
+        let gateway = this.agent_state.gateway_target();
+        let existing = this.credential_store_for(&gateway).load()?;
         if let Some(credential) = existing {
             info!(machine_id = %credential.machine_id, "starting fleet agent (credential on disk)");
-            *this.state.lock().await = State::Attached(this.attach(credential));
+            *this.state.lock().await = State::Attached(this.attach(credential, gateway));
         }
         Ok(this)
     }
@@ -230,7 +242,9 @@ impl AgentSupervisor {
     }
 
     /// Spawn the attach task for `credential` and build its [`Attachment`].
-    fn attach(&self, credential: Credential) -> Attachment {
+    /// `credential_gateway` is the store key the credential is persisted
+    /// under (see [`Attachment::credential_gateway`]).
+    fn attach(&self, credential: Credential, credential_gateway: String) -> Attachment {
         self.agent_state
             .set_enrollment(Enrollment::Attaching, &credential.machine_id);
         // A fresh attachment always starts accepting: `Drain` is runtime-only
@@ -258,6 +272,7 @@ impl AgentSupervisor {
             supervisor,
             shutdown,
             task,
+            credential_gateway,
         }
     }
 
@@ -319,7 +334,7 @@ impl AgentSupervisor {
         }
 
         let machine_id = credential.machine_id.clone();
-        *state = State::Attached(self.attach(credential));
+        *state = State::Attached(self.attach(credential, gateway));
         Ok(machine_id)
     }
 
@@ -354,8 +369,11 @@ impl AgentSupervisor {
         // aborted), so this can no longer be raced.
         self.agent_state.set_enrollment(Enrollment::Unenrolled, "");
 
+        // Keyed by the gateway this attachment enrolled against, not the
+        // live `gateway_target`, which a settings update may have moved
+        // while attached (see `Attachment::credential_gateway`).
         Ok(self
-            .credential_store_for(&self.agent_state.gateway_target())
+            .credential_store_for(&attachment.credential_gateway)
             .clear()
             .map_err(Internal)?)
     }

--- a/fleet/arcbox-fleet-agent/src/control/mod.rs
+++ b/fleet/arcbox-fleet-agent/src/control/mod.rs
@@ -114,7 +114,7 @@ pub async fn serve(
 /// react to cancellation before clearing the credential anyway. The task's
 /// own runner teardown is separately bounded by `attach::run`'s
 /// `SHUTDOWN_GRACE`; this only needs to cover that plus scheduling overhead.
-const UNENROLL_GRACE: Duration = Duration::from_secs(20);
+const TEARDOWN_GRACE: Duration = Duration::from_secs(20);
 
 /// Bound on the best-effort gateway `Unenroll` call inside
 /// [`AgentSupervisor::unenroll`]. Generous for a healthy round-trip, but a
@@ -127,7 +127,7 @@ const GATEWAY_UNENROLL_TIMEOUT: Duration = Duration::from_secs(10);
 /// time this returns regardless of whether it ever observed its own
 /// cancellation signal. Split out from [`AgentSupervisor::unenroll`] so
 /// the abort-on-timeout behavior can be exercised directly with a short
-/// `grace`, instead of the real [`UNENROLL_GRACE`].
+/// `grace`, instead of the real [`TEARDOWN_GRACE`].
 ///
 /// Polls `&mut task` rather than the owned handle so it survives a timeout:
 /// `tokio::time::timeout` drops its future on `Elapsed`, and dropping a
@@ -161,6 +161,10 @@ fn check_enrollable(state: &State) -> Result<(), &'static str> {
     match state {
         State::Unenrolled => Ok(()),
         State::Unenrolling => Err("unenroll in progress — retry shortly"),
+        State::Detaching => Err("detach in progress — retry shortly"),
+        State::Detached { .. } => {
+            Err("already enrolled — set participate=true to reattach, or unenroll first")
+        }
         State::Attached(_) => Err("already enrolled — unenroll first"),
     }
 }
@@ -189,12 +193,24 @@ struct Attachment {
 
 enum State {
     Unenrolled,
-    /// A `Unenroll` is tearing its attachment down (bounded by
-    /// [`UNENROLL_GRACE`]). `Enroll` is refused while here: an enrollment
+    /// An `Unenroll` is tearing its attachment down (bounded by
+    /// [`TEARDOWN_GRACE`]). `Enroll` is refused while here: an enrollment
     /// that raced into the teardown window would have its observable state
     /// stomped by the old task's late writes and by unenroll's own final
     /// `Unenrolled` re-assert, so the window is closed instead of fenced.
     Unenrolling,
+    /// The participation reconciler is tearing its attachment down
+    /// (`participate` moved to false). Same gating rationale as
+    /// [`State::Unenrolling`].
+    Detaching,
+    /// Enrolled — the credential is kept for reattaching — but deliberately
+    /// offline: `participate` is false. The machine shows Offline
+    /// server-side.
+    Detached {
+        credential: Credential,
+        /// See [`Attachment::credential_gateway`].
+        credential_gateway: String,
+    },
     Attached(Attachment),
 }
 
@@ -244,8 +260,20 @@ impl AgentSupervisor {
         let gateway = this.agent_state.gateway_target();
         let existing = this.credential_store_for(&gateway).load()?;
         if let Some(credential) = existing {
-            info!(machine_id = %credential.machine_id, "starting fleet agent (credential on disk)");
-            *this.state.lock().await = State::Attached(this.attach(credential, gateway));
+            if this.agent_state.participate_target() {
+                info!(machine_id = %credential.machine_id, "starting fleet agent (credential on disk)");
+                *this.state.lock().await = State::Attached(this.attach(credential, gateway));
+            } else {
+                // An operator's detach must survive a launchd restart — a
+                // silent reattach here would betray it.
+                info!(machine_id = %credential.machine_id, "starting fleet agent detached (participate=false)");
+                this.agent_state
+                    .set_enrollment(Enrollment::Detached, &credential.machine_id);
+                *this.state.lock().await = State::Detached {
+                    credential,
+                    credential_gateway: gateway,
+                };
+            }
         }
         Ok(this)
     }
@@ -278,6 +306,8 @@ impl AgentSupervisor {
     fn attach(&self, credential: Credential, credential_gateway: String) -> Attachment {
         self.agent_state
             .set_enrollment(Enrollment::Attaching, &credential.machine_id);
+        // Attaching realizes participation.
+        self.agent_state.set_participate_current(true);
         // A fresh attachment always starts accepting: `Drain` is runtime-only
         // (never persisted), and the previous attachment's teardown shares this
         // process-lifetime state, so clear any stale draining flag rather than
@@ -346,17 +376,20 @@ impl AgentSupervisor {
             .store(&credential)
             .map_err(Internal)?;
 
-        // Persist an explicit gateway override the same way
-        // `FleetSettingsService.UpdateSettings` persists any other setting.
-        // `attach()` below dials `gateway_target`, so both `current` and
-        // `target` already agree with what happens next.
+        // Enrolling is an explicit act of participation: override a stale
+        // participate=false so the reconciler doesn't immediately detach
+        // the attachment started below. Persisted together with an explicit
+        // gateway override, the same way `UpdateSettings` persists any
+        // other setting; `attach()` below dials `gateway_target`, so both
+        // `current` and `target` already agree with what happens next.
+        self.agent_state.set_participate_target(true);
         if let Some(control_plane) = control_plane {
             self.agent_state.set_gateway_target(control_plane);
             self.agent_state.set_gateway_current(control_plane);
-            self.settings_store
-                .store(&self.agent_state.persisted_settings())
-                .map_err(Internal)?;
         }
+        self.settings_store
+            .store(&self.agent_state.persisted_settings())
+            .map_err(Internal)?;
 
         let machine_id = credential.machine_id.clone();
         *state = State::Attached(self.attach(credential, gateway));
@@ -367,10 +400,19 @@ impl AgentSupervisor {
     /// machine at the gateway (best-effort), and removes the persisted
     /// credential. Observably `Unenrolled` immediately (`GetStatus`/
     /// `Watch`); the attach task's own teardown finishes in the background,
-    /// bounded by [`UNENROLL_GRACE`], and `Enroll` is refused until it
+    /// bounded by [`TEARDOWN_GRACE`], and `Enroll` is refused until it
     /// completes (see [`State::Unenrolling`]).
     pub async fn unenroll(&self) -> Result<(), Status> {
-        let attachment = {
+        // What we are leaving from: a live attachment (needs teardown) or a
+        // detached-but-enrolled state (credential only).
+        enum Leaving {
+            Attached(Attachment),
+            Detached {
+                credential: Credential,
+                credential_gateway: String,
+            },
+        }
+        let leaving = {
             let mut state = self.state.lock().await;
             match &*state {
                 State::Unenrolled => {
@@ -379,12 +421,13 @@ impl AgentSupervisor {
                 State::Unenrolling => {
                     return Err(Status::failed_precondition("unenroll already in progress"));
                 }
-                State::Attached(_) => {}
+                State::Detaching => {
+                    return Err(Status::failed_precondition(
+                        "detach in progress — retry shortly",
+                    ));
+                }
+                State::Attached(_) | State::Detached { .. } => {}
             }
-            let State::Attached(attachment) = std::mem::replace(&mut *state, State::Unenrolling)
-            else {
-                unreachable!("checked above");
-            };
             // Immediate observability: `GetStatus`/`Watch` read only
             // `agent_state`, not the `Mutex<State>`, so without this a
             // concurrent caller would see stale state for the whole grace
@@ -392,16 +435,35 @@ impl AgentSupervisor {
             // other `agent_state` enrollment write happens under it too, so
             // none can interleave here.
             self.agent_state.set_enrollment(Enrollment::Unenrolled, "");
-            attachment
+            match std::mem::replace(&mut *state, State::Unenrolling) {
+                State::Attached(attachment) => Leaving::Attached(attachment),
+                State::Detached {
+                    credential,
+                    credential_gateway,
+                } => Leaving::Detached {
+                    credential,
+                    credential_gateway,
+                },
+                _ => unreachable!("checked above"),
+            }
         };
 
-        attachment.shutdown.cancel();
-        join_or_abort(attachment.task, UNENROLL_GRACE).await;
+        let (credential, credential_gateway) = match leaving {
+            Leaving::Attached(attachment) => {
+                attachment.shutdown.cancel();
+                join_or_abort(attachment.task, TEARDOWN_GRACE).await;
+                (attachment.credential, attachment.credential_gateway)
+            }
+            Leaving::Detached {
+                credential,
+                credential_gateway,
+            } => (credential, credential_gateway),
+        };
 
-        // Authoritative: the task is provably stopped (joined or aborted)
-        // and `Unenrolling` kept every `Enroll` out of the grace window,
-        // so no live attachment's state can be stomped here and no stale
-        // write from the old task survives it.
+        // Authoritative: any attach task is provably stopped (joined or
+        // aborted) and `Unenrolling` kept every `Enroll` out of the grace
+        // window, so no live attachment's state can be stomped here and no
+        // stale write from the old task survives it.
         {
             let mut state = self.state.lock().await;
             *state = State::Unenrolled;
@@ -415,21 +477,17 @@ impl AgentSupervisor {
         // from its side.
         match tokio::time::timeout(
             GATEWAY_UNENROLL_TIMEOUT,
-            enroll::unenroll(
-                &self.config,
-                &attachment.credential_gateway,
-                &attachment.credential.machine_token,
-            ),
+            enroll::unenroll(&self.config, &credential_gateway, &credential.machine_token),
         )
         .await
         {
             Ok(Ok(())) => {}
             Ok(Err(e)) => {
-                warn!(error = %e, gateway = %attachment.credential_gateway,
+                warn!(error = %e, gateway = %credential_gateway,
                       "gateway unenroll failed; clearing the local credential anyway");
             }
             Err(_) => {
-                warn!(gateway = %attachment.credential_gateway,
+                warn!(gateway = %credential_gateway,
                       "gateway unenroll timed out; clearing the local credential anyway");
             }
         }
@@ -438,9 +496,92 @@ impl AgentSupervisor {
         // live `gateway_target`, which a settings update may have moved
         // while attached (see `Attachment::credential_gateway`).
         Ok(self
-            .credential_store_for(&attachment.credential_gateway)
+            .credential_store_for(&credential_gateway)
             .clear()
             .map_err(Internal)?)
+    }
+
+    /// Converge the attachment onto the `participate` target: detach (keep
+    /// the credential) when it moves to false, reattach with the kept
+    /// credential when it moves back to true. One pass; the reconciler task
+    /// re-invokes it on every [`AgentState`] change — including this
+    /// method's own writes, which is what re-checks a target that flipped
+    /// mid-teardown.
+    async fn reconcile_participation(&self) {
+        let target = self.agent_state.participate_target();
+        let mut state = self.state.lock().await;
+        match &*state {
+            State::Attached(_) if !target => {
+                let State::Attached(attachment) = std::mem::replace(&mut *state, State::Detaching)
+                else {
+                    unreachable!("just matched");
+                };
+                let machine_id = attachment.credential.machine_id.clone();
+                // Immediate observability, written under the lock (the same
+                // discipline as `unenroll`).
+                self.agent_state
+                    .set_enrollment(Enrollment::Detached, &machine_id);
+                drop(state);
+
+                attachment.shutdown.cancel();
+                join_or_abort(attachment.task, TEARDOWN_GRACE).await;
+
+                let mut state = self.state.lock().await;
+                *state = State::Detached {
+                    credential: attachment.credential,
+                    credential_gateway: attachment.credential_gateway,
+                };
+                // Authoritative re-assert + realized flag: the task is
+                // provably stopped and `Detaching` kept `Enroll` out.
+                self.agent_state
+                    .set_enrollment(Enrollment::Detached, &machine_id);
+                self.agent_state.set_participate_current(false);
+                info!(machine_id = %machine_id, "detached from the fleet (participate=false)");
+            }
+            State::Detached { .. } if target => {
+                let State::Detached {
+                    credential,
+                    credential_gateway,
+                } = std::mem::replace(&mut *state, State::Unenrolled)
+                else {
+                    unreachable!("just matched");
+                };
+                info!(machine_id = %credential.machine_id, "reattaching (participate=true)");
+                // `attach` is synchronous (it only spawns), so the
+                // transitional `Unenrolled` above is never observable: the
+                // lock is held across both writes.
+                *state = State::Attached(self.attach(credential, credential_gateway));
+            }
+            // Nothing to attach or detach: the wish is trivially realized.
+            State::Unenrolled => self.agent_state.set_participate_current(target),
+            _ => {}
+        }
+    }
+
+    /// Drive [`Self::reconcile_participation`] from the [`AgentState`]
+    /// watch channel until `shutdown` fires. This is what lets
+    /// `FleetSettingsService` stay free of any supervisor dependency:
+    /// settings write the target, the supervisor observes and converges.
+    pub fn spawn_participation_reconciler(
+        self: &Arc<Self>,
+        shutdown: CancellationToken,
+    ) -> tokio::task::JoinHandle<()> {
+        let this = Arc::clone(self);
+        tokio::spawn(async move {
+            let mut rx = this.agent_state.subscribe();
+            loop {
+                this.reconcile_participation().await;
+                tokio::select! {
+                    biased;
+                    () = shutdown.cancelled() => break,
+                    changed = rx.changed() => {
+                        if changed.is_err() {
+                            break;
+                        }
+                    }
+                }
+            }
+        })
     }
 
     /// Stop accepting new offers; in-flight jobs finish normally.
@@ -453,6 +594,9 @@ impl AgentSupervisor {
             State::Unenrolled | State::Unenrolling => {
                 Err(Status::failed_precondition("not enrolled"))
             }
+            State::Detaching | State::Detached { .. } => Err(Status::failed_precondition(
+                "not attached (participate=false)",
+            )),
         }
     }
 
@@ -466,6 +610,9 @@ impl AgentSupervisor {
             State::Unenrolled | State::Unenrolling => {
                 Err(Status::failed_precondition("not enrolled"))
             }
+            State::Detaching | State::Detached { .. } => Err(Status::failed_precondition(
+                "not attached (participate=false)",
+            )),
         }
     }
 
@@ -480,6 +627,7 @@ impl AgentSupervisor {
             Enrollment::try_from(snapshot.enrollment).unwrap_or(Enrollment::Unenrolled);
         let state = match enrollment {
             Enrollment::Unspecified | Enrollment::Unenrolled => ConnectionState::Unenrolled,
+            Enrollment::Detached => ConnectionState::Detached,
             Enrollment::Attaching | Enrollment::Attached if snapshot.draining => {
                 ConnectionState::Draining
             }
@@ -497,9 +645,13 @@ impl AgentSupervisor {
             let mut state = self.state.lock().await;
             match std::mem::replace(&mut *state, State::Unenrolled) {
                 State::Attached(a) => Some(a),
-                // During `Unenrolling` the unenroll call owns the
-                // attachment handle and awaits it itself; nothing to join.
-                State::Unenrolled | State::Unenrolling => None,
+                // During `Unenrolling`/`Detaching` the transition owns the
+                // attachment handle and awaits it itself; `Detached` has no
+                // task at all. Nothing to join.
+                State::Unenrolled
+                | State::Unenrolling
+                | State::Detaching
+                | State::Detached { .. } => None,
             }
         };
         if let Some(a) = attachment {
@@ -526,6 +678,7 @@ mod tests {
             gateway: "http://127.0.0.1:1".to_owned(),
             docker_mode: DockerMode::Disabled,
             runner_script: None,
+            participate: true,
         }
     }
 
@@ -544,7 +697,171 @@ mod tests {
         }
     }
 
-    /// While a unenroll is inside its teardown grace, a concurrent
+    /// Build an unenrolled supervisor over a scratch data dir.
+    async fn test_supervisor(
+        dir: &std::path::Path,
+        agent_state: AgentState,
+    ) -> Arc<AgentSupervisor> {
+        Arc::new(
+            AgentSupervisor::new(
+                test_config(dir.to_path_buf()),
+                None,
+                Vec::new(),
+                CancellationToken::new(),
+                agent_state,
+                SettingsStore::new(dir.join("settings.json")),
+            )
+            .await
+            .expect("no credential on disk, so no attach on startup"),
+        )
+    }
+
+    fn test_credential() -> Credential {
+        Credential {
+            machine_id: "fltm_test".to_owned(),
+            machine_token: "flt_token_test".to_owned(),
+        }
+    }
+
+    /// The reconciler realizes `participate=false` by detaching — the
+    /// credential is kept in the `Detached` state, the enrollment shows
+    /// Detached, and `current` flips false — and realizes `true` again by
+    /// reattaching with that same credential.
+    #[tokio::test]
+    async fn reconciler_detaches_and_reattaches_keeping_the_credential() {
+        let dir = std::env::temp_dir().join(format!("fleet-participate-{}", std::process::id()));
+        let agent_state = AgentState::new(&seed());
+        let supervisor = test_supervisor(&dir, agent_state.clone()).await;
+
+        // Inject a live attachment whose task observes its cancel promptly.
+        let shutdown = supervisor.process_shutdown.child_token();
+        let task_token = shutdown.clone();
+        let task = tokio::spawn(async move {
+            task_token.cancelled().await;
+            Ok(())
+        });
+        let (events, _events_rx) = tokio::sync::mpsc::channel(1);
+        let runner = crate::runner::RunnerSupervisor::new(
+            events,
+            None,
+            None,
+            Vec::new(),
+            agent_state.clone(),
+        );
+        *supervisor.state.lock().await = State::Attached(Attachment {
+            supervisor: runner,
+            shutdown,
+            task,
+            credential: test_credential(),
+            credential_gateway: "http://127.0.0.1:1".to_owned(),
+        });
+
+        agent_state.set_participate_target(false);
+        supervisor.reconcile_participation().await;
+
+        {
+            let state = supervisor.state.lock().await;
+            let State::Detached { credential, .. } = &*state else {
+                panic!("expected Detached after reconciling participate=false");
+            };
+            assert_eq!(credential.machine_id, "fltm_test");
+        }
+        let snapshot = agent_state.current();
+        assert_eq!(snapshot.enrollment, Enrollment::Detached as i32);
+        assert_eq!(snapshot.machine_id, "fltm_test");
+        assert!(!agent_state.settings().participate.unwrap().current);
+
+        agent_state.set_participate_target(true);
+        supervisor.reconcile_participation().await;
+
+        assert!(matches!(
+            &*supervisor.state.lock().await,
+            State::Attached(_)
+        ));
+        assert!(agent_state.settings().participate.unwrap().current);
+        // The fresh attachment starts dialing (the gateway is unreachable in
+        // this test, so it stays Attaching — which is enough to prove the
+        // kept credential was reused).
+        assert_eq!(
+            agent_state.current().enrollment,
+            Enrollment::Attaching as i32
+        );
+
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    /// Unenroll must also work from `Detached` (leave the fleet while
+    /// offline): no task to tear down, straight to the credential clear.
+    #[tokio::test]
+    async fn unenroll_from_detached_clears_the_credential() {
+        let dir = std::env::temp_dir().join(format!("fleet-det-unenroll-{}", std::process::id()));
+        let agent_state = AgentState::new(&seed());
+        let supervisor = test_supervisor(&dir, agent_state.clone()).await;
+
+        let store = supervisor.credential_store_for("http://127.0.0.1:1");
+        store
+            .store(&test_credential())
+            .expect("persist test credential");
+        *supervisor.state.lock().await = State::Detached {
+            credential: test_credential(),
+            credential_gateway: "http://127.0.0.1:1".to_owned(),
+        };
+        agent_state.set_enrollment(Enrollment::Detached, "fltm_test");
+
+        supervisor.unenroll().await.expect("unenroll from detached");
+
+        assert!(matches!(*supervisor.state.lock().await, State::Unenrolled));
+        assert_eq!(
+            agent_state.current().enrollment,
+            Enrollment::Unenrolled as i32
+        );
+        assert!(store.load().expect("store readable").is_none());
+
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    /// A persisted `participate=false` must survive a restart: the agent
+    /// starts detached instead of silently reattaching.
+    #[tokio::test]
+    async fn startup_honors_persisted_participate_false() {
+        let dir = std::env::temp_dir().join(format!("fleet-start-det-{}", std::process::id()));
+        let config = test_config(dir.clone());
+        CredentialStore::new(
+            config.credential_store,
+            config.credentials_path(),
+            "http://127.0.0.1:1",
+        )
+        .store(&test_credential())
+        .expect("persist test credential");
+
+        let agent_state = AgentState::new(&PersistedSettings {
+            participate: false,
+            ..seed()
+        });
+        let supervisor = AgentSupervisor::new(
+            config,
+            None,
+            Vec::new(),
+            CancellationToken::new(),
+            agent_state.clone(),
+            SettingsStore::new(dir.join("settings.json")),
+        )
+        .await
+        .expect("startup with credential");
+
+        assert!(matches!(
+            *supervisor.state.lock().await,
+            State::Detached { .. }
+        ));
+        let snapshot = agent_state.current();
+        assert_eq!(snapshot.enrollment, Enrollment::Detached as i32);
+        assert_eq!(snapshot.machine_id, "fltm_test");
+        assert!(!agent_state.settings().participate.unwrap().current);
+
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    /// While an unenroll is inside its teardown grace, a concurrent
     /// `Enroll` must be refused — not succeed and then have its observable
     /// state stomped by the unenroll's final `Unenrolled` re-assert (or
     /// by the old task's late writes). Once the unenroll completes, the

--- a/fleet/arcbox-fleet-agent/src/control/mod.rs
+++ b/fleet/arcbox-fleet-agent/src/control/mod.rs
@@ -116,6 +116,12 @@ pub async fn serve(
 /// `SHUTDOWN_GRACE`; this only needs to cover that plus scheduling overhead.
 const UNENROLL_GRACE: Duration = Duration::from_secs(20);
 
+/// Bound on the best-effort gateway `Unenroll` call inside
+/// [`AgentSupervisor::unenroll`]. Generous for a healthy round-trip, but a
+/// blackholed gateway (no connect timeout is configured on the endpoint)
+/// must not hang the RPC — the local clear proceeds without the server half.
+const GATEWAY_UNENROLL_TIMEOUT: Duration = Duration::from_secs(10);
+
 /// Wait up to `grace` for `task` to finish on its own; if it doesn't, abort
 /// it and wait for that reap too, so `task` is guaranteed stopped by the
 /// time this returns regardless of whether it ever observed its own
@@ -160,9 +166,9 @@ fn check_enrollable(state: &State) -> Result<(), &'static str> {
 }
 
 /// A live attachment to the gateway: the admission authority in `admit()`
-/// and the handle to stop it. The credential itself isn't retained here —
-/// nothing reads it back once attaching starts; `machine_id` observability
-/// goes through [`AgentState`] instead.
+/// and the handle to stop it. Retains a copy of the credential for
+/// `unenroll`'s server-side revocation call; `machine_id` observability
+/// still goes through [`AgentState`].
 struct Attachment {
     supervisor: RunnerSupervisor,
     /// Child of [`AgentSupervisor::process_shutdown`]: cancelling it stops
@@ -170,11 +176,14 @@ struct Attachment {
     /// shutdown) cascades to it too, so runners still drain on SIGTERM.
     shutdown: CancellationToken,
     task: tokio::task::JoinHandle<Result<()>>,
+    /// The credential this attachment runs with — what `unenroll` presents
+    /// to the gateway to decommission the machine.
+    credential: Credential,
     /// The gateway this attachment's credential is persisted under (the
-    /// keychain backend keys its entry by gateway URI). `unenroll` clears
-    /// exactly this store: reading the live `gateway_target` there instead
-    /// would clear the wrong entry if a settings update moved the target
-    /// while attached, leaving this credential behind on disk.
+    /// keychain backend keys its entry by gateway URI). `unenroll` calls
+    /// and clears exactly this store: reading the live `gateway_target`
+    /// there instead would clear the wrong entry if a settings update moved
+    /// the target while attached, leaving this credential behind on disk.
     credential_gateway: String,
 }
 
@@ -283,7 +292,7 @@ impl AgentSupervisor {
         let shutdown = self.process_shutdown.child_token();
         let task = tokio::spawn(attach::run(
             self.config.clone(),
-            credential,
+            credential.clone(),
             supervisor.clone(),
             egress_rx,
             self.capabilities.clone(),
@@ -294,6 +303,7 @@ impl AgentSupervisor {
             supervisor,
             shutdown,
             task,
+            credential,
             credential_gateway,
         }
     }
@@ -353,11 +363,12 @@ impl AgentSupervisor {
         Ok(machine_id)
     }
 
-    /// Stop attaching and remove the persisted credential. Observably
-    /// `Unenrolled` immediately (`GetStatus`/`Watch`); the attach task's own
-    /// teardown finishes in the background, bounded by [`UNENROLL_GRACE`],
-    /// and `Enroll` is refused until it completes (see
-    /// [`State::Unenrolling`]).
+    /// Leave the fleet — terminal. Stops attaching, decommissions the
+    /// machine at the gateway (best-effort), and removes the persisted
+    /// credential. Observably `Unenrolled` immediately (`GetStatus`/
+    /// `Watch`); the attach task's own teardown finishes in the background,
+    /// bounded by [`UNENROLL_GRACE`], and `Enroll` is refused until it
+    /// completes (see [`State::Unenrolling`]).
     pub async fn unenroll(&self) -> Result<(), Status> {
         let attachment = {
             let mut state = self.state.lock().await;
@@ -395,6 +406,32 @@ impl AgentSupervisor {
             let mut state = self.state.lock().await;
             *state = State::Unenrolled;
             self.agent_state.set_enrollment(Enrollment::Unenrolled, "");
+        }
+
+        // The server half, best-effort and time-bounded: decommission the
+        // machine and revoke the credential at the gateway (RUN-40). An
+        // unreachable gateway must not block leaving — proceed with the
+        // local clear, and the org can decommission the leftover record
+        // from its side.
+        match tokio::time::timeout(
+            GATEWAY_UNENROLL_TIMEOUT,
+            enroll::unenroll(
+                &self.config,
+                &attachment.credential_gateway,
+                &attachment.credential.machine_token,
+            ),
+        )
+        .await
+        {
+            Ok(Ok(())) => {}
+            Ok(Err(e)) => {
+                warn!(error = %e, gateway = %attachment.credential_gateway,
+                      "gateway unenroll failed; clearing the local credential anyway");
+            }
+            Err(_) => {
+                warn!(gateway = %attachment.credential_gateway,
+                      "gateway unenroll timed out; clearing the local credential anyway");
+            }
         }
 
         // Keyed by the gateway this attachment enrolled against, not the
@@ -541,10 +578,20 @@ mod tests {
         let (events, _events_rx) = tokio::sync::mpsc::channel(1);
         let runner =
             crate::runner::RunnerSupervisor::new(events, None, None, Vec::new(), agent_state);
+        // A persisted credential, so the completed unenroll can prove the
+        // local clear happens even though this gateway is unreachable (the
+        // server-side call is best-effort).
+        let credential = Credential {
+            machine_id: "fltm_test".to_owned(),
+            machine_token: "flt_token_test".to_owned(),
+        };
+        let store = supervisor.credential_store_for("http://127.0.0.1:1");
+        store.store(&credential).expect("persist test credential");
         *supervisor.state.lock().await = State::Attached(Attachment {
             supervisor: runner,
             shutdown,
             task,
+            credential,
             credential_gateway: "http://127.0.0.1:1".to_owned(),
         });
 
@@ -567,6 +614,8 @@ mod tests {
             .expect("unenroll task")
             .expect("unenroll succeeds");
         assert!(matches!(*supervisor.state.lock().await, State::Unenrolled));
+        // The unreachable gateway didn't block the terminal local outcome.
+        assert!(store.load().expect("credential store readable").is_none());
 
         // Gate open again: enroll now passes the state check and fails
         // later, at the unreachable gateway — a different error.

--- a/fleet/arcbox-fleet-agent/src/control/mod.rs
+++ b/fleet/arcbox-fleet-agent/src/control/mod.rs
@@ -130,7 +130,6 @@ pub struct AgentSupervisor {
     config: AgentConfig,
     docker: Option<DockerRunner>,
     capabilities: Vec<Capability>,
-    credential_store: CredentialStore,
     /// Cancelled on process shutdown (SIGTERM/Ctrl-C); every attachment's
     /// `shutdown` is a child of this token.
     process_shutdown: CancellationToken,
@@ -151,27 +150,40 @@ impl AgentSupervisor {
         config: AgentConfig,
         docker: Option<DockerRunner>,
         capabilities: Vec<Capability>,
-        credential_store: CredentialStore,
         process_shutdown: CancellationToken,
         agent_state: AgentState,
         settings_store: SettingsStore,
     ) -> Result<Self> {
-        let existing = credential_store.load()?;
         let this = Self {
             config,
             docker,
             capabilities,
-            credential_store,
             process_shutdown,
             state: Mutex::new(State::Unenrolled),
             agent_state,
             settings_store,
         };
+        let existing = this
+            .credential_store_for(&this.agent_state.gateway_target())
+            .load()?;
         if let Some(credential) = existing {
             info!(machine_id = %credential.machine_id, "starting fleet agent (credential on disk)");
             *this.state.lock().await = State::Attached(this.attach(credential));
         }
         Ok(this)
+    }
+
+    /// The credential store scoped to `gateway`. Built per operation rather
+    /// than held: the keychain backend keys its entry by gateway URI, and the
+    /// effective gateway can change over this supervisor's lifetime (an
+    /// `Enroll` `control_plane` override, or a settings update), so a store
+    /// captured at startup could read or clear the wrong entry.
+    fn credential_store_for(&self, gateway: &str) -> CredentialStore {
+        CredentialStore::new(
+            self.config.credential_store,
+            self.config.credentials_path(),
+            gateway,
+        )
     }
 
     /// Spawn the attach task for `credential` and build its [`Attachment`].
@@ -232,17 +244,29 @@ impl AgentSupervisor {
 
         let mut state = self.state.lock().await;
         if matches!(*state, State::Attached(_)) {
-            // Lost a race with a concurrent Enroll; the credential just
-            // fetched is simply discarded rather than clobbering the winner.
+            // Lost a race with a concurrent Enroll. The credential just fetched
+            // is dropped here without ever being persisted — only the winner,
+            // below, writes to the credential store — so it cannot clobber the
+            // winner's persisted credential.
             return Err(Status::failed_precondition(
                 "already enrolled — disconnect first",
             ));
         }
 
-        // Won the race — now, and only now, persist an explicit gateway
-        // override. `attach()` below dials `gateway_target`, so both `current`
-        // and `target` already agree with what happens next, the same way
+        // Won the race. Persist the credential now, and only now: a losing
+        // concurrent Enroll returned above without writing, so what lands on
+        // disk always matches the attachment started just below — a later
+        // restart reattaches as the same machine. Scoped to the gateway just
+        // enrolled against, which the settings write below makes the target,
+        // so the restart load finds it under the same key.
+        self.credential_store_for(&gateway)
+            .store(&credential)
+            .map_err(Internal)?;
+
+        // Persist an explicit gateway override the same way
         // `FleetSettingsService.UpdateSettings` persists any other setting.
+        // `attach()` below dials `gateway_target`, so both `current` and
+        // `target` already agree with what happens next.
         if let Some(control_plane) = control_plane {
             self.agent_state.set_gateway_target(control_plane);
             self.agent_state.set_gateway_current(control_plane);
@@ -281,7 +305,10 @@ impl AgentSupervisor {
             Ok(Err(e)) => warn!(error = %e, "attach task panicked on disconnect"),
             Err(_) => warn!("disconnect grace elapsed; clearing credential anyway"),
         }
-        Ok(self.credential_store.clear().map_err(Internal)?)
+        Ok(self
+            .credential_store_for(&self.agent_state.gateway_target())
+            .clear()
+            .map_err(Internal)?)
     }
 
     /// Stop accepting new offers; in-flight jobs finish normally.

--- a/fleet/arcbox-fleet-agent/src/control/mod.rs
+++ b/fleet/arcbox-fleet-agent/src/control/mod.rs
@@ -6,6 +6,7 @@
 //! service implementation.
 
 pub mod client;
+mod image;
 mod lifecycle;
 mod settings;
 mod watch;
@@ -16,6 +17,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use anyhow::{Context, Result};
+use arcbox_fleet_control_proto::v1::fleet_image_service_server::FleetImageServiceServer;
 use arcbox_fleet_control_proto::v1::fleet_lifecycle_service_server::FleetLifecycleServiceServer;
 use arcbox_fleet_control_proto::v1::fleet_settings_service_server::FleetSettingsServiceServer;
 use arcbox_fleet_control_proto::v1::fleet_state_service_server::FleetStateServiceServer;
@@ -36,6 +38,7 @@ use crate::runner::RunnerSupervisor;
 use crate::settings::SettingsStore;
 use crate::state::AgentState;
 use crate::{attach, enroll};
+use image::ImageService;
 use lifecycle::LifecycleService;
 use settings::SettingsService;
 use watch::WatchService;
@@ -89,9 +92,11 @@ pub async fn serve(
             state.clone(),
         )))
         .add_service(FleetSettingsServiceServer::new(SettingsService::new(
-            state,
+            state.clone(),
             settings_store,
-            docker,
+        )))
+        .add_service(FleetImageServiceServer::new(ImageService::new(
+            state, docker,
         )))
         .serve_with_incoming_shutdown(incoming, shutdown.cancelled())
         .await
@@ -216,10 +221,10 @@ impl AgentSupervisor {
     }
 
     /// A handle to the process-lifetime Docker runtime, if configured — read
-    /// by [`serve`] and passed to `FleetSettingsService` to validate a
-    /// candidate `linux_runner_image` (see `control::settings`). Fixed at
-    /// construction and unaffected by the attach/detach cycle: `docker_mode`
-    /// changes are restart-scoped, so this is never stale.
+    /// by [`serve`] and passed to `FleetImageService` to prepare a candidate
+    /// `linux_runner_image` (see `control::image`). Fixed at construction
+    /// and unaffected by the attach/detach cycle: `docker_mode` changes are
+    /// restart-scoped, so this is never stale.
     fn docker(&self) -> Option<DockerRunner> {
         self.docker.clone()
     }

--- a/fleet/arcbox-fleet-agent/src/control/mod.rs
+++ b/fleet/arcbox-fleet-agent/src/control/mod.rs
@@ -779,6 +779,41 @@ mod tests {
         }
     }
 
+    /// A local TCP endpoint that accepts a gateway connection and holds it
+    /// open without ever speaking gRPC, so an enroll round-trip against it
+    /// blocks in `State::Enrolling` rather than failing fast — which a refused
+    /// port (`127.0.0.1:1`) does too quickly for the mid-round-trip state to
+    /// be observed reliably. Aborting the returned task drops the held sockets,
+    /// failing the in-flight round-trip so the enroll can then roll back.
+    async fn stalling_gateway() -> (String, tokio::task::JoinHandle<()>) {
+        let listener = tokio::net::TcpListener::bind(("127.0.0.1", 0))
+            .await
+            .expect("bind stalling gateway listener");
+        let addr = listener.local_addr().expect("stalling gateway addr");
+        let task = tokio::spawn(async move {
+            if let Ok((sock, _)) = listener.accept().await {
+                // Hold the connection open without ever speaking gRPC; parking
+                // here keeps the round-trip blocked, and dropping `sock` on
+                // task abort closes it so the round-trip fails.
+                let _sock = sock;
+                std::future::pending::<()>().await;
+            }
+        });
+        (format!("http://{addr}"), task)
+    }
+
+    /// Poll until the observable enrollment reaches `Attaching`, bounded so a
+    /// stuck transition fails the test instead of hanging it.
+    async fn wait_for_attaching(agent_state: &AgentState) {
+        tokio::time::timeout(Duration::from_secs(5), async {
+            while agent_state.current().enrollment != Enrollment::Attaching as i32 {
+                tokio::time::sleep(Duration::from_millis(5)).await;
+            }
+        })
+        .await
+        .expect("enroll must flip observable state to Attaching");
+    }
+
     /// The reconciler realizes `participate=false` by detaching — the
     /// credential is kept in the `Detached` state, the enrollment shows
     /// Detached, and `current` flips false — and realizes `true` again by
@@ -1015,14 +1050,18 @@ mod tests {
         let agent_state = AgentState::new(&seed());
         let supervisor = test_supervisor(&dir, agent_state.clone()).await;
 
-        // The gateway seed points at an unreachable local port — connect
-        // stalls long enough for the mid-round-trip assertions below to
-        // observe the transient state.
+        // A stalling gateway keeps the round-trip in flight so the transient
+        // state below is observable; aborting it later fails the round-trip.
+        let (gateway, gateway_task) = stalling_gateway().await;
         let enroll = {
             let supervisor = Arc::clone(&supervisor);
-            tokio::spawn(async move { supervisor.enroll("flt_join_test".to_owned(), None).await })
+            tokio::spawn(async move {
+                supervisor
+                    .enroll("flt_join_test".to_owned(), Some(&gateway))
+                    .await
+            })
         };
-        tokio::time::sleep(Duration::from_millis(50)).await;
+        wait_for_attaching(&agent_state).await;
 
         assert_eq!(
             agent_state.current().enrollment,
@@ -1031,10 +1070,12 @@ mod tests {
         );
         assert!(matches!(*supervisor.state.lock().await, State::Enrolling));
 
+        // Release the stalled round-trip so it fails and the enroll rolls back.
+        gateway_task.abort();
         let err = enroll
             .await
             .expect("enroll task")
-            .expect_err("gateway is unreachable");
+            .expect_err("gateway round-trip fails once released");
         assert_ne!(err.code(), tonic::Code::FailedPrecondition, "{err}");
 
         // Rollback: both the supervisor state and observable enrollment
@@ -1057,13 +1098,20 @@ mod tests {
         let dir =
             std::env::temp_dir().join(format!("fleet-enroll-concurrent-{}", std::process::id()));
         let agent_state = AgentState::new(&seed());
-        let supervisor = test_supervisor(&dir, agent_state).await;
+        let supervisor = test_supervisor(&dir, agent_state.clone()).await;
 
+        // The first enroll stalls at the gateway, holding the enrollment gate
+        // closed for the whole window the second enroll races against.
+        let (gateway, gateway_task) = stalling_gateway().await;
         let first = {
             let supervisor = Arc::clone(&supervisor);
-            tokio::spawn(async move { supervisor.enroll("flt_join_first".to_owned(), None).await })
+            tokio::spawn(async move {
+                supervisor
+                    .enroll("flt_join_first".to_owned(), Some(&gateway))
+                    .await
+            })
         };
-        tokio::time::sleep(Duration::from_millis(50)).await;
+        wait_for_attaching(&agent_state).await;
 
         let err = supervisor
             .enroll("flt_join_second".to_owned(), None)
@@ -1072,8 +1120,9 @@ mod tests {
         assert_eq!(err.code(), tonic::Code::FailedPrecondition);
         assert!(err.message().contains("enroll in progress"), "{err}");
 
-        // The first enroll still fails at the unreachable gateway; the
-        // point is that the second one was gated *before* even trying.
+        // Release the first enroll; the point is that the second one was gated
+        // *before* even trying, not by the round-trip re-check that came after.
+        gateway_task.abort();
         let _ = first.await.expect("enroll task");
         let _ = std::fs::remove_dir_all(dir);
     }

--- a/fleet/arcbox-fleet-agent/src/control/mod.rs
+++ b/fleet/arcbox-fleet-agent/src/control/mod.rs
@@ -164,6 +164,11 @@ impl AgentSupervisor {
     fn attach(&self, credential: Credential) -> Attachment {
         self.agent_state
             .set_enrollment(Enrollment::Attaching, &credential.machine_id);
+        // A fresh attachment always starts accepting: `Drain` is runtime-only
+        // (never persisted), and the previous attachment's teardown shares this
+        // process-lifetime state, so clear any stale draining flag rather than
+        // letting a re-enroll inherit it.
+        self.agent_state.set_draining(false);
         let (supervisor, egress_rx) = attach::spawn_supervisor(
             &self.config,
             self.docker.clone(),
@@ -200,21 +205,11 @@ impl AgentSupervisor {
             ));
         }
 
-        let gateway = if let Some(control_plane) = control_plane {
-            // Enrolling against a specific gateway means dialing it
-            // immediately — `attach()` below does exactly that — so both
-            // `current` and `target` already agree with what happens next,
-            // the same way `FleetSettingsService.UpdateSettings` would
-            // persist any other setting.
-            self.agent_state.set_gateway_target(control_plane);
-            self.agent_state.set_gateway_current(control_plane);
-            self.settings_store
-                .store(&self.agent_state.persisted_settings())
-                .map_err(|e| Status::internal(e.to_string()))?;
-            control_plane.to_owned()
-        } else {
-            self.agent_state.gateway_target()
-        };
+        // Resolve the gateway to dial without mutating shared state yet: a
+        // concurrent Enroll may still win the race check below, and a losing
+        // attempt must not leave its gateway override applied or persisted.
+        let gateway =
+            control_plane.map_or_else(|| self.agent_state.gateway_target(), str::to_owned);
 
         // The gateway round-trip must not hold `state` locked.
         let credential = enroll::enroll(&self.config, token, self.capabilities.clone(), &gateway)
@@ -229,6 +224,19 @@ impl AgentSupervisor {
                 "already enrolled — disconnect first",
             ));
         }
+
+        // Won the race — now, and only now, persist an explicit gateway
+        // override. `attach()` below dials `gateway_target`, so both `current`
+        // and `target` already agree with what happens next, the same way
+        // `FleetSettingsService.UpdateSettings` persists any other setting.
+        if let Some(control_plane) = control_plane {
+            self.agent_state.set_gateway_target(control_plane);
+            self.agent_state.set_gateway_current(control_plane);
+            self.settings_store
+                .store(&self.agent_state.persisted_settings())
+                .map_err(|e| Status::internal(e.to_string()))?;
+        }
+
         let machine_id = credential.machine_id.clone();
         *state = State::Attached(self.attach(credential));
         Ok(machine_id)

--- a/fleet/arcbox-fleet-agent/src/control/mod.rs
+++ b/fleet/arcbox-fleet-agent/src/control/mod.rs
@@ -7,6 +7,7 @@
 
 pub mod client;
 mod lifecycle;
+mod settings;
 mod watch;
 
 use std::os::unix::fs::PermissionsExt;
@@ -16,6 +17,7 @@ use std::time::Duration;
 
 use anyhow::{Context, Result};
 use arcbox_fleet_control_proto::v1::fleet_lifecycle_service_server::FleetLifecycleServiceServer;
+use arcbox_fleet_control_proto::v1::fleet_settings_service_server::FleetSettingsServiceServer;
 use arcbox_fleet_control_proto::v1::fleet_state_service_server::FleetStateServiceServer;
 use arcbox_fleet_control_proto::v1::{ConnectionState, Enrollment};
 use arcbox_fleet_proto::v1::Capability;
@@ -31,9 +33,11 @@ use crate::config::AgentConfig;
 use crate::credentials::{Credential, CredentialStore};
 use crate::docker::DockerRunner;
 use crate::runner::RunnerSupervisor;
+use crate::settings::SettingsStore;
 use crate::state::AgentState;
 use crate::{attach, enroll};
 use lifecycle::LifecycleService;
+use settings::SettingsService;
 use watch::WatchService;
 
 /// Bind `agent.sock` and serve `FleetLifecycleService` until `shutdown`
@@ -45,6 +49,7 @@ pub async fn serve(
     socket_path: &Path,
     supervisor: Arc<AgentSupervisor>,
     state: AgentState,
+    settings_store: SettingsStore,
     shutdown: CancellationToken,
 ) -> Result<()> {
     let _ = std::fs::remove_file(socket_path);
@@ -65,7 +70,13 @@ pub async fn serve(
         .add_service(FleetLifecycleServiceServer::new(LifecycleService::new(
             supervisor,
         )))
-        .add_service(FleetStateServiceServer::new(WatchService::new(state)))
+        .add_service(FleetStateServiceServer::new(WatchService::new(
+            state.clone(),
+        )))
+        .add_service(FleetSettingsServiceServer::new(SettingsService::new(
+            state,
+            settings_store,
+        )))
         .serve_with_incoming_shutdown(incoming, shutdown.cancelled())
         .await
         .context("control-plane server error")
@@ -114,6 +125,9 @@ pub struct AgentSupervisor {
     /// the single source of truth `status()` reads from below, so it never
     /// disagrees with what a `Watch` subscriber sees.
     agent_state: AgentState,
+    /// Persists an `Enroll`-provided gateway override the same way
+    /// `FleetSettingsService.UpdateSettings` persists any other setting.
+    settings_store: SettingsStore,
 }
 
 impl AgentSupervisor {
@@ -126,6 +140,7 @@ impl AgentSupervisor {
         credential_store: CredentialStore,
         process_shutdown: CancellationToken,
         agent_state: AgentState,
+        settings_store: SettingsStore,
     ) -> Result<Self> {
         let existing = credential_store.load()?;
         let this = Self {
@@ -136,6 +151,7 @@ impl AgentSupervisor {
             process_shutdown,
             state: Mutex::new(State::Unenrolled),
             agent_state,
+            settings_store,
         };
         if let Some(credential) = existing {
             info!(machine_id = %credential.machine_id, "starting fleet agent (credential on disk)");
@@ -183,15 +199,27 @@ impl AgentSupervisor {
                 "already enrolled — disconnect first",
             ));
         }
+
+        let gateway = if let Some(control_plane) = control_plane {
+            // Enrolling against a specific gateway means dialing it
+            // immediately — `attach()` below does exactly that — so both
+            // `current` and `target` already agree with what happens next,
+            // the same way `FleetSettingsService.UpdateSettings` would
+            // persist any other setting.
+            self.agent_state.set_gateway_target(control_plane);
+            self.agent_state.set_gateway_current(control_plane);
+            self.settings_store
+                .store(&self.agent_state.persisted_settings())
+                .map_err(|e| Status::internal(e.to_string()))?;
+            control_plane.to_owned()
+        } else {
+            self.agent_state.gateway_target()
+        };
+
         // The gateway round-trip must not hold `state` locked.
-        let credential = enroll::enroll(
-            &self.config,
-            token,
-            self.capabilities.clone(),
-            control_plane,
-        )
-        .await
-        .map_err(|e| Status::internal(e.to_string()))?;
+        let credential = enroll::enroll(&self.config, token, self.capabilities.clone(), &gateway)
+            .await
+            .map_err(|e| Status::internal(e.to_string()))?;
 
         let mut state = self.state.lock().await;
         if matches!(*state, State::Attached(_)) {

--- a/fleet/arcbox-fleet-agent/src/control/mod.rs
+++ b/fleet/arcbox-fleet-agent/src/control/mod.rs
@@ -40,6 +40,20 @@ use lifecycle::LifecycleService;
 use settings::SettingsService;
 use watch::WatchService;
 
+/// Wraps an unexpected internal failure (a disk write, a gateway round-trip,
+/// a keychain clear) so `?` converts it to a tonic `Status` via the `From`
+/// impl below — the repo's error-conversion convention, where a crate-local
+/// type sidesteps the orphan rule that blocks `From<anyhow::Error> for
+/// Status`. Everything wrapped here maps to `INTERNAL`; a site needing a
+/// different code maps it itself.
+struct Internal(anyhow::Error);
+
+impl From<Internal> for Status {
+    fn from(e: Internal) -> Self {
+        Self::internal(e.0.to_string())
+    }
+}
+
 /// Bind `agent.sock` and serve `FleetLifecycleService` until `shutdown`
 /// fires. Mirrors `arcbox-daemon`'s `services::start_grpc` (remove-before-bind,
 /// then `UnixListener`/`UnixListenerStream`), plus an explicit owner-only
@@ -214,7 +228,7 @@ impl AgentSupervisor {
         // The gateway round-trip must not hold `state` locked.
         let credential = enroll::enroll(&self.config, token, self.capabilities.clone(), &gateway)
             .await
-            .map_err(|e| Status::internal(e.to_string()))?;
+            .map_err(Internal)?;
 
         let mut state = self.state.lock().await;
         if matches!(*state, State::Attached(_)) {
@@ -234,7 +248,7 @@ impl AgentSupervisor {
             self.agent_state.set_gateway_current(control_plane);
             self.settings_store
                 .store(&self.agent_state.persisted_settings())
-                .map_err(|e| Status::internal(e.to_string()))?;
+                .map_err(Internal)?;
         }
 
         let machine_id = credential.machine_id.clone();
@@ -267,9 +281,7 @@ impl AgentSupervisor {
             Ok(Err(e)) => warn!(error = %e, "attach task panicked on disconnect"),
             Err(_) => warn!("disconnect grace elapsed; clearing credential anyway"),
         }
-        self.credential_store
-            .clear()
-            .map_err(|e| Status::internal(e.to_string()))
+        Ok(self.credential_store.clear().map_err(Internal)?)
     }
 
     /// Stop accepting new offers; in-flight jobs finish normally.

--- a/fleet/arcbox-fleet-agent/src/control/mod.rs
+++ b/fleet/arcbox-fleet-agent/src/control/mod.rs
@@ -217,7 +217,7 @@ impl AgentSupervisor {
 
     /// A handle to the process-lifetime Docker runtime, if configured — read
     /// by [`serve`] and passed to `FleetSettingsService` to validate a
-    /// candidate `runner_image` (see `control::settings`). Fixed at
+    /// candidate `linux_runner_image` (see `control::settings`). Fixed at
     /// construction and unaffected by the attach/detach cycle: `docker_mode`
     /// changes are restart-scoped, so this is never stale.
     fn docker(&self) -> Option<DockerRunner> {

--- a/fleet/arcbox-fleet-agent/src/control/mod.rs
+++ b/fleet/arcbox-fleet-agent/src/control/mod.rs
@@ -628,6 +628,7 @@ impl AgentSupervisor {
         let state = match enrollment {
             Enrollment::Unspecified | Enrollment::Unenrolled => ConnectionState::Unenrolled,
             Enrollment::Detached => ConnectionState::Detached,
+            Enrollment::CredentialRejected => ConnectionState::CredentialRejected,
             Enrollment::Attaching | Enrollment::Attached if snapshot.draining => {
                 ConnectionState::Draining
             }

--- a/fleet/arcbox-fleet-agent/src/control/mod.rs
+++ b/fleet/arcbox-fleet-agent/src/control/mod.rs
@@ -418,13 +418,6 @@ impl AgentSupervisor {
             "state left Enrolling behind our back"
         );
 
-        // Scoped to the gateway just enrolled against, which the settings
-        // write below makes the target — so the restart load finds it under
-        // the same key.
-        self.credential_store_for(&gateway)
-            .store(&credential)
-            .map_err(Internal)?;
-
         // Enrolling is an explicit act of participation: override a stale
         // participate=false so the reconciler doesn't immediately detach
         // the attachment started below. Persisted together with an explicit
@@ -436,8 +429,24 @@ impl AgentSupervisor {
             self.agent_state.set_gateway_target(control_plane);
             self.agent_state.set_gateway_current(control_plane);
         }
+
+        // Settings before the credential — order matters. On a crash or
+        // failure between these two writes we prefer "settings on the new
+        // gateway, no credential" (next startup loads the new gateway,
+        // finds nothing under the same key, and starts cleanly Unenrolled)
+        // over "credential under the new gateway, settings still on the
+        // old" (next startup reads the old gateway, misses the entry keyed
+        // by the new one on the macOS keychain backend, and the machine
+        // token is orphaned — invisible to `Unenroll`, which also keys by
+        // the settings gateway).
         self.settings_store
             .store(&self.agent_state.persisted_settings())
+            .map_err(Internal)?;
+
+        // Scoped to the gateway just persisted above, so the restart load
+        // finds it under the same key.
+        self.credential_store_for(&gateway)
+            .store(&credential)
             .map_err(Internal)?;
 
         let machine_id = credential.machine_id.clone();

--- a/fleet/arcbox-fleet-agent/src/control/mod.rs
+++ b/fleet/arcbox-fleet-agent/src/control/mod.rs
@@ -80,6 +80,7 @@ pub async fn serve(
 
     info!(socket = %socket_path.display(), "control-plane server listening");
 
+    let docker = supervisor.docker();
     Server::builder()
         .add_service(FleetLifecycleServiceServer::new(LifecycleService::new(
             supervisor,
@@ -90,6 +91,7 @@ pub async fn serve(
         .add_service(FleetSettingsServiceServer::new(SettingsService::new(
             state,
             settings_store,
+            docker,
         )))
         .serve_with_incoming_shutdown(incoming, shutdown.cancelled())
         .await
@@ -211,6 +213,15 @@ impl AgentSupervisor {
             self.config.credentials_path(),
             gateway,
         )
+    }
+
+    /// A handle to the process-lifetime Docker runtime, if configured — read
+    /// by [`serve`] and passed to `FleetSettingsService` to validate a
+    /// candidate `runner_image` (see `control::settings`). Fixed at
+    /// construction and unaffected by the attach/detach cycle: `docker_mode`
+    /// changes are restart-scoped, so this is never stale.
+    fn docker(&self) -> Option<DockerRunner> {
+        self.docker.clone()
     }
 
     /// Spawn the attach task for `credential` and build its [`Attachment`].

--- a/fleet/arcbox-fleet-agent/src/control/mod.rs
+++ b/fleet/arcbox-fleet-agent/src/control/mod.rs
@@ -102,6 +102,33 @@ pub async fn serve(
 /// `SHUTDOWN_GRACE`; this only needs to cover that plus scheduling overhead.
 const DISCONNECT_GRACE: Duration = Duration::from_secs(20);
 
+/// Wait up to `grace` for `task` to finish on its own; if it doesn't, abort
+/// it and wait for that reap too, so `task` is guaranteed stopped by the
+/// time this returns regardless of whether it ever observed its own
+/// cancellation signal. Split out from [`AgentSupervisor::disconnect`] so
+/// the abort-on-timeout behavior can be exercised directly with a short
+/// `grace`, instead of the real [`DISCONNECT_GRACE`].
+///
+/// Polls `&mut task` rather than the owned handle so it survives a timeout:
+/// `tokio::time::timeout` drops its future on `Elapsed`, and dropping a
+/// `JoinHandle` does not abort the task — losing the handle here would leave
+/// it running detached, still holding the old in-memory credential, with
+/// nothing to stop a concurrent `Enroll` from starting a second live
+/// attachment.
+async fn join_or_abort(mut task: tokio::task::JoinHandle<Result<()>>, grace: Duration) {
+    match tokio::time::timeout(grace, &mut task).await {
+        Ok(Ok(Ok(()))) => {}
+        Ok(Ok(Err(e))) => warn!(error = %e, "attach task exited with an error on disconnect"),
+        Ok(Err(e)) => warn!(error = %e, "attach task panicked on disconnect"),
+        Err(_) => {
+            warn!("disconnect grace elapsed; aborting attach task");
+            task.abort();
+            // Best-effort reap; a `Cancelled` JoinError here is expected.
+            let _ = task.await;
+        }
+    }
+}
+
 /// A live attachment to the gateway: the admission authority in `admit()`
 /// and the handle to stop it. The credential itself isn't retained here —
 /// nothing reads it back once attaching starts; `machine_id` observability
@@ -296,15 +323,21 @@ impl AgentSupervisor {
             };
             attachment
         };
+        // Immediate observability: `GetStatus`/`Watch` read only `agent_state`,
+        // not the `Mutex<State>` swapped above, so without this a concurrent
+        // caller would see stale state for the whole grace window below.
+        // Re-asserted after the task is provably stopped, since a reconnect
+        // attempt that straddles this cancel could otherwise briefly clobber
+        // it (mitigated, not fully eliminated, by `connect_and_serve`'s own
+        // cancellation race).
         self.agent_state.set_enrollment(Enrollment::Unenrolled, "");
 
         attachment.shutdown.cancel();
-        match tokio::time::timeout(DISCONNECT_GRACE, attachment.task).await {
-            Ok(Ok(Ok(()))) => {}
-            Ok(Ok(Err(e))) => warn!(error = %e, "attach task exited with an error on disconnect"),
-            Ok(Err(e)) => warn!(error = %e, "attach task panicked on disconnect"),
-            Err(_) => warn!("disconnect grace elapsed; clearing credential anyway"),
-        }
+        join_or_abort(attachment.task, DISCONNECT_GRACE).await;
+        // Authoritative: the task is now provably stopped (joined or
+        // aborted), so this can no longer be raced.
+        self.agent_state.set_enrollment(Enrollment::Unenrolled, "");
+
         Ok(self
             .credential_store_for(&self.agent_state.gateway_target())
             .clear()
@@ -371,5 +404,53 @@ impl AgentSupervisor {
                 Err(e) => warn!(error = %e, "attach task panicked"),
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A task that ignores `shutdown` entirely (never checks it) simulates
+    /// the pathological case `join_or_abort`'s abort branch exists for — a
+    /// reconnect attempt that never observes cancellation. Without the
+    /// abort, this would still be running (and the sender below would
+    /// eventually fire) long after `join_or_abort` returns.
+    #[tokio::test]
+    async fn join_or_abort_stops_a_task_that_ignores_cancellation() {
+        let (never_aborted_tx, never_aborted_rx) = tokio::sync::oneshot::channel::<()>();
+        let task = tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_secs(10)).await;
+            let _ = never_aborted_tx.send(());
+            Ok(())
+        });
+
+        let start = tokio::time::Instant::now();
+        join_or_abort(task, Duration::from_millis(50)).await;
+        assert!(
+            start.elapsed() < Duration::from_secs(5),
+            "must abort rather than wait out the task's own 10s sleep"
+        );
+
+        // The task was aborted mid-sleep, so its sender was dropped without
+        // ever sending — the receiver observes that as an error, not a value.
+        assert!(never_aborted_rx.await.is_err());
+    }
+
+    /// A task that finishes well within `grace` is joined normally; no abort
+    /// needed, and `join_or_abort` doesn't wait out the full grace either.
+    #[tokio::test]
+    async fn join_or_abort_returns_promptly_for_a_task_that_exits_quickly() {
+        let task = tokio::spawn(async {
+            tokio::time::sleep(Duration::from_millis(10)).await;
+            Ok(())
+        });
+
+        let start = tokio::time::Instant::now();
+        join_or_abort(task, Duration::from_secs(20)).await;
+        assert!(
+            start.elapsed() < Duration::from_secs(1),
+            "must return once the task joins, not wait out the full grace"
+        );
     }
 }

--- a/fleet/arcbox-fleet-agent/src/control/mod.rs
+++ b/fleet/arcbox-fleet-agent/src/control/mod.rs
@@ -143,6 +143,22 @@ async fn join_or_abort(mut task: tokio::task::JoinHandle<Result<()>>, grace: Dur
     }
 }
 
+/// The `Enroll` admission check: only `Unenrolled` may proceed. Applied
+/// twice — before the gateway round-trip and again after re-locking — so
+/// both an already-live attachment and a `Disconnect` that started
+/// mid-round-trip refuse the enrollment.
+///
+/// Returns a plain message rather than `Status` — every failure here maps
+/// to the same `FAILED_PRECONDITION` code, so the caller does that one
+/// conversion (the same convention as `control::settings::validate`).
+fn check_enrollable(state: &State) -> Result<(), &'static str> {
+    match state {
+        State::Unenrolled => Ok(()),
+        State::Disconnecting => Err("disconnect in progress — retry shortly"),
+        State::Attached(_) => Err("already enrolled — disconnect first"),
+    }
+}
+
 /// A live attachment to the gateway: the admission authority in `admit()`
 /// and the handle to stop it. The credential itself isn't retained here —
 /// nothing reads it back once attaching starts; `machine_id` observability
@@ -164,6 +180,12 @@ struct Attachment {
 
 enum State {
     Unenrolled,
+    /// A `Disconnect` is tearing its attachment down (bounded by
+    /// [`DISCONNECT_GRACE`]). `Enroll` is refused while here: an enrollment
+    /// that raced into the teardown window would have its observable state
+    /// stomped by the old task's late writes and by disconnect's own final
+    /// `Unenrolled` re-assert, so the window is closed instead of fenced.
+    Disconnecting,
     Attached(Attachment),
 }
 
@@ -283,11 +305,7 @@ impl AgentSupervisor {
         token: String,
         control_plane: Option<&str>,
     ) -> Result<String, Status> {
-        if matches!(*self.state.lock().await, State::Attached(_)) {
-            return Err(Status::failed_precondition(
-                "already enrolled — disconnect first",
-            ));
-        }
+        check_enrollable(&*self.state.lock().await).map_err(Status::failed_precondition)?;
 
         // Resolve the gateway to dial without mutating shared state yet: a
         // concurrent Enroll may still win the race check below, and a losing
@@ -301,15 +319,12 @@ impl AgentSupervisor {
             .map_err(Internal)?;
 
         let mut state = self.state.lock().await;
-        if matches!(*state, State::Attached(_)) {
-            // Lost a race with a concurrent Enroll. The credential just fetched
-            // is dropped here without ever being persisted — only the winner,
-            // below, writes to the credential store — so it cannot clobber the
-            // winner's persisted credential.
-            return Err(Status::failed_precondition(
-                "already enrolled — disconnect first",
-            ));
-        }
+        // Lost a race with a concurrent Enroll (or a Disconnect started
+        // mid-round-trip). The credential just fetched is dropped here
+        // without ever being persisted — only the winner, below, writes to
+        // the credential store — so it cannot clobber the winner's
+        // persisted credential.
+        check_enrollable(&state).map_err(Status::failed_precondition)?;
 
         // Won the race. Persist the credential now, and only now: a losing
         // concurrent Enroll returned above without writing, so what lands on
@@ -338,36 +353,51 @@ impl AgentSupervisor {
         Ok(machine_id)
     }
 
-    /// Stop attaching and remove the persisted credential. Returns to
-    /// `Unenrolled` immediately (concurrent `GetStatus`/`Drain`/`Resume`
-    /// observe that right away); the attach task's own teardown finishes in
-    /// the background, bounded by [`DISCONNECT_GRACE`].
+    /// Stop attaching and remove the persisted credential. Observably
+    /// `Unenrolled` immediately (`GetStatus`/`Watch`); the attach task's own
+    /// teardown finishes in the background, bounded by [`DISCONNECT_GRACE`],
+    /// and `Enroll` is refused until it completes (see
+    /// [`State::Disconnecting`]).
     pub async fn disconnect(&self) -> Result<(), Status> {
         let attachment = {
             let mut state = self.state.lock().await;
-            if matches!(*state, State::Unenrolled) {
-                return Err(Status::failed_precondition("not enrolled"));
+            match &*state {
+                State::Unenrolled => {
+                    return Err(Status::failed_precondition("not enrolled"));
+                }
+                State::Disconnecting => {
+                    return Err(Status::failed_precondition(
+                        "disconnect already in progress",
+                    ));
+                }
+                State::Attached(_) => {}
             }
-            let State::Attached(attachment) = std::mem::replace(&mut *state, State::Unenrolled)
+            let State::Attached(attachment) = std::mem::replace(&mut *state, State::Disconnecting)
             else {
                 unreachable!("checked above");
             };
+            // Immediate observability: `GetStatus`/`Watch` read only
+            // `agent_state`, not the `Mutex<State>`, so without this a
+            // concurrent caller would see stale state for the whole grace
+            // window below. Written while still holding the lock — every
+            // other `agent_state` enrollment write happens under it too, so
+            // none can interleave here.
+            self.agent_state.set_enrollment(Enrollment::Unenrolled, "");
             attachment
         };
-        // Immediate observability: `GetStatus`/`Watch` read only `agent_state`,
-        // not the `Mutex<State>` swapped above, so without this a concurrent
-        // caller would see stale state for the whole grace window below.
-        // Re-asserted after the task is provably stopped, since a reconnect
-        // attempt that straddles this cancel could otherwise briefly clobber
-        // it (mitigated, not fully eliminated, by `connect_and_serve`'s own
-        // cancellation race).
-        self.agent_state.set_enrollment(Enrollment::Unenrolled, "");
 
         attachment.shutdown.cancel();
         join_or_abort(attachment.task, DISCONNECT_GRACE).await;
-        // Authoritative: the task is now provably stopped (joined or
-        // aborted), so this can no longer be raced.
-        self.agent_state.set_enrollment(Enrollment::Unenrolled, "");
+
+        // Authoritative: the task is provably stopped (joined or aborted)
+        // and `Disconnecting` kept every `Enroll` out of the grace window,
+        // so no live attachment's state can be stomped here and no stale
+        // write from the old task survives it.
+        {
+            let mut state = self.state.lock().await;
+            *state = State::Unenrolled;
+            self.agent_state.set_enrollment(Enrollment::Unenrolled, "");
+        }
 
         // Keyed by the gateway this attachment enrolled against, not the
         // live `gateway_target`, which a settings update may have moved
@@ -385,7 +415,9 @@ impl AgentSupervisor {
                 a.supervisor.handle_drain();
                 Ok(())
             }
-            State::Unenrolled => Err(Status::failed_precondition("not enrolled")),
+            State::Unenrolled | State::Disconnecting => {
+                Err(Status::failed_precondition("not enrolled"))
+            }
         }
     }
 
@@ -396,7 +428,9 @@ impl AgentSupervisor {
                 a.supervisor.resume();
                 Ok(())
             }
-            State::Unenrolled => Err(Status::failed_precondition("not enrolled")),
+            State::Unenrolled | State::Disconnecting => {
+                Err(Status::failed_precondition("not enrolled"))
+            }
         }
     }
 
@@ -428,7 +462,9 @@ impl AgentSupervisor {
             let mut state = self.state.lock().await;
             match std::mem::replace(&mut *state, State::Unenrolled) {
                 State::Attached(a) => Some(a),
-                State::Unenrolled => None,
+                // During `Disconnecting` the disconnect call owns the
+                // attachment handle and awaits it itself; nothing to join.
+                State::Unenrolled | State::Disconnecting => None,
             }
         };
         if let Some(a) = attachment {
@@ -444,6 +480,106 @@ impl AgentSupervisor {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::config::{CredentialMode, DockerConfig, DockerMode};
+    use crate::settings::PersistedSettings;
+
+    fn seed() -> PersistedSettings {
+        PersistedSettings {
+            load_ceiling: 0.9,
+            mem_floor_mib: 2048,
+            linux_runner_image: "ghcr.io/actions/actions-runner:latest".to_owned(),
+            gateway: "http://127.0.0.1:1".to_owned(),
+            docker_mode: DockerMode::Disabled,
+            runner_script: None,
+        }
+    }
+
+    fn test_config(data_dir: std::path::PathBuf) -> AgentConfig {
+        AgentConfig {
+            gateway: "http://127.0.0.1:1".to_owned(),
+            runner_script: None,
+            load_ceiling: 0.9,
+            mem_floor_mib: 2048,
+            data_dir,
+            docker: DockerConfig {
+                mode: DockerMode::Disabled,
+                linux_runner_image: "ghcr.io/actions/actions-runner:latest".to_owned(),
+            },
+            credential_store: CredentialMode::File,
+        }
+    }
+
+    /// While a disconnect is inside its teardown grace, a concurrent
+    /// `Enroll` must be refused — not succeed and then have its observable
+    /// state stomped by the disconnect's final `Unenrolled` re-assert (or
+    /// by the old task's late writes). Once the disconnect completes, the
+    /// gate opens again.
+    #[tokio::test]
+    async fn enroll_is_refused_during_disconnect_grace() {
+        let dir = std::env::temp_dir().join(format!("fleet-disc-race-{}", std::process::id()));
+        let agent_state = AgentState::new(&seed());
+        let supervisor = Arc::new(
+            AgentSupervisor::new(
+                test_config(dir.clone()),
+                None,
+                Vec::new(),
+                CancellationToken::new(),
+                agent_state.clone(),
+                SettingsStore::new(dir.join("settings.json")),
+            )
+            .await
+            .expect("no credential on disk, so no attach on startup"),
+        );
+
+        // Inject a live attachment whose task takes a while to observe its
+        // cancel — the teardown grace window the race lives in.
+        let shutdown = supervisor.process_shutdown.child_token();
+        let task_token = shutdown.clone();
+        let task = tokio::spawn(async move {
+            task_token.cancelled().await;
+            tokio::time::sleep(Duration::from_millis(300)).await;
+            Ok(())
+        });
+        let (events, _events_rx) = tokio::sync::mpsc::channel(1);
+        let runner =
+            crate::runner::RunnerSupervisor::new(events, None, None, Vec::new(), agent_state);
+        *supervisor.state.lock().await = State::Attached(Attachment {
+            supervisor: runner,
+            shutdown,
+            task,
+            credential_gateway: "http://127.0.0.1:1".to_owned(),
+        });
+
+        let disconnect = {
+            let supervisor = Arc::clone(&supervisor);
+            tokio::spawn(async move { supervisor.disconnect().await })
+        };
+        tokio::time::sleep(Duration::from_millis(50)).await;
+
+        // Mid-grace: the enrollment gate is closed.
+        let err = supervisor
+            .enroll("flt_join_test".to_owned(), None)
+            .await
+            .expect_err("enroll during disconnect grace must be refused");
+        assert_eq!(err.code(), tonic::Code::FailedPrecondition);
+        assert!(err.message().contains("disconnect in progress"), "{err}");
+
+        disconnect
+            .await
+            .expect("disconnect task")
+            .expect("disconnect succeeds");
+        assert!(matches!(*supervisor.state.lock().await, State::Unenrolled));
+
+        // Gate open again: enroll now passes the state check and fails
+        // later, at the unreachable gateway — a different error.
+        let err = supervisor
+            .enroll("flt_join_test".to_owned(), None)
+            .await
+            .expect_err("gateway is unreachable");
+        assert_ne!(err.code(), tonic::Code::FailedPrecondition, "{err}");
+
+        let _ = std::fs::remove_dir_all(dir);
+    }
 
     /// A task that ignores `shutdown` entirely (never checks it) simulates
     /// the pathological case `join_or_abort`'s abort branch exists for — a

--- a/fleet/arcbox-fleet-agent/src/control/mod.rs
+++ b/fleet/arcbox-fleet-agent/src/control/mod.rs
@@ -7,6 +7,7 @@
 
 pub mod client;
 mod lifecycle;
+mod watch;
 
 use std::os::unix::fs::PermissionsExt;
 use std::path::Path;
@@ -14,8 +15,9 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use anyhow::{Context, Result};
-use arcbox_fleet_control_proto::v1::ConnectionState;
 use arcbox_fleet_control_proto::v1::fleet_lifecycle_service_server::FleetLifecycleServiceServer;
+use arcbox_fleet_control_proto::v1::fleet_state_service_server::FleetStateServiceServer;
+use arcbox_fleet_control_proto::v1::{ConnectionState, Enrollment};
 use arcbox_fleet_proto::v1::Capability;
 use tokio::net::UnixListener;
 use tokio::sync::Mutex;
@@ -29,8 +31,10 @@ use crate::config::AgentConfig;
 use crate::credentials::{Credential, CredentialStore};
 use crate::docker::DockerRunner;
 use crate::runner::RunnerSupervisor;
+use crate::state::AgentState;
 use crate::{attach, enroll};
 use lifecycle::LifecycleService;
+use watch::WatchService;
 
 /// Bind `agent.sock` and serve `FleetLifecycleService` until `shutdown`
 /// fires. Mirrors `arcbox-daemon`'s `services::start_grpc` (remove-before-bind,
@@ -40,6 +44,7 @@ use lifecycle::LifecycleService;
 pub async fn serve(
     socket_path: &Path,
     supervisor: Arc<AgentSupervisor>,
+    state: AgentState,
     shutdown: CancellationToken,
 ) -> Result<()> {
     let _ = std::fs::remove_file(socket_path);
@@ -60,6 +65,7 @@ pub async fn serve(
         .add_service(FleetLifecycleServiceServer::new(LifecycleService::new(
             supervisor,
         )))
+        .add_service(FleetStateServiceServer::new(WatchService::new(state)))
         .serve_with_incoming_shutdown(incoming, shutdown.cancelled())
         .await
         .context("control-plane server error")
@@ -71,10 +77,11 @@ pub async fn serve(
 /// `SHUTDOWN_GRACE`; this only needs to cover that plus scheduling overhead.
 const DISCONNECT_GRACE: Duration = Duration::from_secs(20);
 
-/// A live attachment to the gateway: the credential it authenticated with,
-/// the admission authority in `admit()`, and the handle to stop it.
+/// A live attachment to the gateway: the admission authority in `admit()`
+/// and the handle to stop it. The credential itself isn't retained here —
+/// nothing reads it back once attaching starts; `machine_id` observability
+/// goes through [`AgentState`] instead.
 struct Attachment {
-    credential: Credential,
     supervisor: RunnerSupervisor,
     /// Child of [`AgentSupervisor::process_shutdown`]: cancelling it stops
     /// only this attachment (`Disconnect`); cancelling the parent (process
@@ -103,6 +110,10 @@ pub struct AgentSupervisor {
     /// `shutdown` is a child of this token.
     process_shutdown: CancellationToken,
     state: Mutex<State>,
+    /// Observable state mirrored to `FleetStateService.Watch` subscribers —
+    /// the single source of truth `status()` reads from below, so it never
+    /// disagrees with what a `Watch` subscriber sees.
+    agent_state: AgentState,
 }
 
 impl AgentSupervisor {
@@ -114,6 +125,7 @@ impl AgentSupervisor {
         capabilities: Vec<Capability>,
         credential_store: CredentialStore,
         process_shutdown: CancellationToken,
+        agent_state: AgentState,
     ) -> Result<Self> {
         let existing = credential_store.load()?;
         let this = Self {
@@ -123,6 +135,7 @@ impl AgentSupervisor {
             credential_store,
             process_shutdown,
             state: Mutex::new(State::Unenrolled),
+            agent_state,
         };
         if let Some(credential) = existing {
             info!(machine_id = %credential.machine_id, "starting fleet agent (credential on disk)");
@@ -133,19 +146,25 @@ impl AgentSupervisor {
 
     /// Spawn the attach task for `credential` and build its [`Attachment`].
     fn attach(&self, credential: Credential) -> Attachment {
-        let (supervisor, egress_rx) =
-            attach::spawn_supervisor(&self.config, self.docker.clone(), self.capabilities.clone());
+        self.agent_state
+            .set_enrollment(Enrollment::Attaching, &credential.machine_id);
+        let (supervisor, egress_rx) = attach::spawn_supervisor(
+            &self.config,
+            self.docker.clone(),
+            self.capabilities.clone(),
+            self.agent_state.clone(),
+        );
         let shutdown = self.process_shutdown.child_token();
         let task = tokio::spawn(attach::run(
             self.config.clone(),
-            credential.clone(),
+            credential,
             supervisor.clone(),
             egress_rx,
             self.capabilities.clone(),
             shutdown.clone(),
+            self.agent_state.clone(),
         ));
         Attachment {
-            credential,
             supervisor,
             shutdown,
             task,
@@ -203,6 +222,7 @@ impl AgentSupervisor {
             };
             attachment
         };
+        self.agent_state.set_enrollment(Enrollment::Unenrolled, "");
 
         attachment.shutdown.cancel();
         match tokio::time::timeout(DISCONNECT_GRACE, attachment.task).await {
@@ -238,15 +258,23 @@ impl AgentSupervisor {
         }
     }
 
-    /// Current lifecycle state and machine id (empty when unenrolled).
+    /// Current lifecycle state and machine id (empty when unenrolled),
+    /// derived from [`AgentState`] rather than the resource-holding
+    /// `Mutex<State>` above — the two must agree, and `AgentState` is the
+    /// one `FleetStateService.Watch` subscribers also read, so there is
+    /// exactly one place this can disagree with itself.
     pub async fn status(&self) -> (ConnectionState, String) {
-        match &*self.state.lock().await {
-            State::Unenrolled => (ConnectionState::Unenrolled, String::new()),
-            State::Attached(a) if a.supervisor.is_draining() => {
-                (ConnectionState::Draining, a.credential.machine_id.clone())
+        let snapshot = self.agent_state.current();
+        let enrollment =
+            Enrollment::try_from(snapshot.enrollment).unwrap_or(Enrollment::Unenrolled);
+        let state = match enrollment {
+            Enrollment::Unspecified | Enrollment::Unenrolled => ConnectionState::Unenrolled,
+            Enrollment::Attaching | Enrollment::Attached if snapshot.draining => {
+                ConnectionState::Draining
             }
-            State::Attached(a) => (ConnectionState::Enrolled, a.credential.machine_id.clone()),
-        }
+            Enrollment::Attaching | Enrollment::Attached => ConnectionState::Enrolled,
+        };
+        (state, snapshot.machine_id)
     }
 
     /// Await the current attach task's completion, if one is running.

--- a/fleet/arcbox-fleet-agent/src/control/settings.rs
+++ b/fleet/arcbox-fleet-agent/src/control/settings.rs
@@ -22,7 +22,7 @@ pub struct SettingsService {
     state: AgentState,
     store: SettingsStore,
     /// The process-lifetime Docker handle, if configured — used to validate
-    /// a candidate `runner_image` against currently-advertised arches. Never
+    /// a candidate `linux_runner_image` against currently-advertised arches. Never
     /// stale: `docker_mode` changes are restart-scoped (see
     /// `AgentSupervisor::docker`'s doc).
     docker: Option<DockerRunner>,
@@ -39,13 +39,13 @@ impl SettingsService {
 
     /// If Docker is configured and currently advertising at least one Linux
     /// arch, verify `image` can still be pulled for those arches before
-    /// accepting it — otherwise a bad runner_image swap is only discovered
+    /// accepting it — otherwise a bad linux_runner_image swap is only discovered
     /// later, as avoidable accept-then-reject churn at job dispatch (see
     /// `docker.rs`'s `DockerRunner::new` doc). Rejects only if the new image
     /// serves *none* of the currently-advertised arches, matching this
     /// module's docker_mode/runner_script "leaves nothing servable"
     /// precedent below — a partial mismatch (the new image drops one of
-    /// several arches) is allowed through, since blocking every runner_image
+    /// several arches) is allowed through, since blocking every linux_runner_image
     /// change over one dropped minor arch would be stricter than that
     /// precedent intends.
     async fn validate_runner_image(&self, image: &str) -> Result<(), String> {
@@ -59,7 +59,7 @@ impl SettingsService {
         let still_servable = docker.verify_pullable(image, &served).await;
         if still_servable.is_empty() {
             return Err(format!(
-                "runner_image {image} could not be pulled for any currently-served Linux \
+                "linux_runner_image {image} could not be pulled for any currently-served Linux \
                  architecture ({served:?}); this would leave Docker-backed jobs unable to run"
             ));
         }
@@ -84,7 +84,7 @@ impl FleetSettingsServiceTrait for SettingsService {
     ) -> Result<Response<UpdateSettingsResponse>, Status> {
         let req = request.into_inner();
         validate(&req, &self.state).map_err(Status::invalid_argument)?;
-        if let Some(image) = &req.runner_image {
+        if let Some(image) = &req.linux_runner_image {
             self.validate_runner_image(image)
                 .await
                 .map_err(Status::invalid_argument)?;
@@ -96,8 +96,8 @@ impl FleetSettingsServiceTrait for SettingsService {
         if let Some(v) = req.mem_floor_mib {
             self.state.set_mem_floor_mib(v);
         }
-        if let Some(v) = req.runner_image {
-            self.state.set_runner_image(v);
+        if let Some(v) = req.linux_runner_image {
+            self.state.set_linux_runner_image(v);
         }
         if let Some(v) = &req.gateway {
             self.state.set_gateway_target(v);
@@ -135,9 +135,9 @@ fn validate(req: &UpdateSettingsRequest, state: &AgentState) -> Result<(), Strin
             return Err("load_ceiling must be a positive number".to_owned());
         }
     }
-    if let Some(runner_image) = &req.runner_image {
-        if runner_image.trim().is_empty() {
-            return Err("runner_image must not be empty".to_owned());
+    if let Some(linux_runner_image) = &req.linux_runner_image {
+        if linux_runner_image.trim().is_empty() {
+            return Err("linux_runner_image must not be empty".to_owned());
         }
     }
     if let Some(gateway) = &req.gateway {
@@ -194,7 +194,7 @@ mod tests {
         PersistedSettings {
             load_ceiling: 0.9,
             mem_floor_mib: 2048,
-            runner_image: "ghcr.io/actions/actions-runner:latest".to_owned(),
+            linux_runner_image: "ghcr.io/actions/actions-runner:latest".to_owned(),
             gateway: "https://fleet.arcbox.dev".to_owned(),
             docker_mode: DockerMode::Auto,
             runner_script: None,
@@ -205,7 +205,7 @@ mod tests {
         UpdateSettingsRequest {
             load_ceiling: None,
             mem_floor_mib: None,
-            runner_image: None,
+            linux_runner_image: None,
             gateway: None,
             docker_mode: None,
             runner_script: None,
@@ -301,7 +301,7 @@ mod tests {
 
     /// The pull-check itself needs a live Docker daemon (see `docker.rs`,
     /// which has no unit tests for the same reason), but the "no Docker
-    /// configured" guard is a plain branch and must accept any runner_image
+    /// configured" guard is a plain branch and must accept any linux_runner_image
     /// unconditionally rather than, say, panicking on an absent `DockerRunner`.
     #[tokio::test]
     async fn validate_runner_image_accepts_anything_without_docker() {

--- a/fleet/arcbox-fleet-agent/src/control/settings.rs
+++ b/fleet/arcbox-fleet-agent/src/control/settings.rs
@@ -7,15 +7,14 @@ use std::path::Path;
 
 use arcbox_fleet_control_proto::v1::fleet_settings_service_server::FleetSettingsService as FleetSettingsServiceTrait;
 use arcbox_fleet_control_proto::v1::{
-    self as control_proto, GetSettingsRequest, GetSettingsResponse, UpdateSettingsRequest,
-    UpdateSettingsResponse,
+    GetSettingsRequest, GetSettingsResponse, UpdateSettingsRequest, UpdateSettingsResponse,
 };
 use tonic::transport::Endpoint;
 use tonic::{Request, Response, Status};
 
 use crate::config::DockerMode;
 use crate::settings::SettingsStore;
-use crate::state::AgentState;
+use crate::state::{AgentState, docker_mode_from_wire};
 
 pub struct SettingsService {
     state: AgentState,
@@ -59,10 +58,7 @@ impl FleetSettingsServiceTrait for SettingsService {
             self.state.set_gateway_target(v);
         }
         if let Some(v) = req.docker_mode {
-            let mode: DockerMode = control_proto::DockerMode::try_from(v)
-                .unwrap_or(control_proto::DockerMode::Unspecified)
-                .into();
-            self.state.set_docker_mode_target(mode);
+            self.state.set_docker_mode_target(docker_mode_from_wire(v));
         }
         if let Some(v) = &req.runner_script {
             let path = (!v.is_empty()).then_some(Path::new(v));
@@ -115,11 +111,9 @@ fn validate(req: &UpdateSettingsRequest, state: &AgentState) -> Result<(), Strin
     // (e.g. just load_ceiling) rejected because of it.
     if req.docker_mode.is_some() || req.runner_script.is_some() {
         let persisted = state.persisted_settings();
-        let effective_docker_mode = req.docker_mode.map_or(persisted.docker_mode, |v| {
-            control_proto::DockerMode::try_from(v)
-                .unwrap_or(control_proto::DockerMode::Unspecified)
-                .into()
-        });
+        let effective_docker_mode = req
+            .docker_mode
+            .map_or(persisted.docker_mode, docker_mode_from_wire);
         let effective_runner_script = req.runner_script.clone().unwrap_or_else(|| {
             persisted
                 .runner_script
@@ -146,6 +140,8 @@ fn validate(req: &UpdateSettingsRequest, state: &AgentState) -> Result<(), Strin
 
 #[cfg(test)]
 mod tests {
+    use arcbox_fleet_control_proto::v1 as control_proto;
+
     use super::*;
     use crate::settings::PersistedSettings;
 

--- a/fleet/arcbox-fleet-agent/src/control/settings.rs
+++ b/fleet/arcbox-fleet-agent/src/control/settings.rs
@@ -1,0 +1,260 @@
+//! `FleetSettingsService` — the tonic server impl. Reads/writes
+//! [`AgentState`] directly; no `AgentSupervisor` dependency, since settings
+//! never touch the attach lifecycle (see `state.rs`'s module doc and
+//! RUN-35's design notes: no setting ever forces a reattach).
+
+use std::path::Path;
+
+use arcbox_fleet_control_proto::v1::fleet_settings_service_server::FleetSettingsService as FleetSettingsServiceTrait;
+use arcbox_fleet_control_proto::v1::{
+    self as control_proto, GetSettingsRequest, GetSettingsResponse, UpdateSettingsRequest,
+    UpdateSettingsResponse,
+};
+use tonic::transport::Endpoint;
+use tonic::{Request, Response, Status};
+
+use crate::config::DockerMode;
+use crate::settings::SettingsStore;
+use crate::state::AgentState;
+
+pub struct SettingsService {
+    state: AgentState,
+    store: SettingsStore,
+}
+
+impl SettingsService {
+    pub fn new(state: AgentState, store: SettingsStore) -> Self {
+        Self { state, store }
+    }
+}
+
+#[tonic::async_trait]
+impl FleetSettingsServiceTrait for SettingsService {
+    async fn get_settings(
+        &self,
+        _request: Request<GetSettingsRequest>,
+    ) -> Result<Response<GetSettingsResponse>, Status> {
+        Ok(Response::new(GetSettingsResponse {
+            settings: Some(self.state.settings()),
+        }))
+    }
+
+    async fn update_settings(
+        &self,
+        request: Request<UpdateSettingsRequest>,
+    ) -> Result<Response<UpdateSettingsResponse>, Status> {
+        let req = request.into_inner();
+        validate(&req, &self.state).map_err(Status::invalid_argument)?;
+
+        if let Some(v) = req.load_ceiling {
+            self.state.set_load_ceiling(v);
+        }
+        if let Some(v) = req.mem_floor_mib {
+            self.state.set_mem_floor_mib(v);
+        }
+        if let Some(v) = req.runner_image {
+            self.state.set_runner_image(v);
+        }
+        if let Some(v) = &req.gateway {
+            self.state.set_gateway_target(v);
+        }
+        if let Some(v) = req.docker_mode {
+            let mode: DockerMode = control_proto::DockerMode::try_from(v)
+                .unwrap_or(control_proto::DockerMode::Unspecified)
+                .into();
+            self.state.set_docker_mode_target(mode);
+        }
+        if let Some(v) = &req.runner_script {
+            let path = (!v.is_empty()).then_some(Path::new(v));
+            self.state.set_runner_script_target(path);
+        }
+
+        self.store
+            .store(&self.state.persisted_settings())
+            .map_err(|e| Status::internal(e.to_string()))?;
+
+        Ok(Response::new(UpdateSettingsResponse {
+            settings: Some(self.state.settings()),
+        }))
+    }
+}
+
+/// Per-field validation, then the cross-field docker_mode/runner_script
+/// invariant (see this module's doc and RUN-35's design notes): computed
+/// against the *effective* post-update values — the request's, where
+/// present, else whatever is already persisted as `target`.
+///
+/// Returns a plain message rather than `Status` — every failure here maps
+/// to the same `INVALID_ARGUMENT` code, so the caller does that one
+/// conversion, and `tonic::Status` is large enough that clippy flags
+/// returning it from a plain (non-trait) function.
+fn validate(req: &UpdateSettingsRequest, state: &AgentState) -> Result<(), String> {
+    if let Some(load_ceiling) = req.load_ceiling {
+        if load_ceiling <= 0.0 {
+            return Err("load_ceiling must be a positive number".to_owned());
+        }
+    }
+    if let Some(runner_image) = &req.runner_image {
+        if runner_image.trim().is_empty() {
+            return Err("runner_image must not be empty".to_owned());
+        }
+    }
+    if let Some(gateway) = &req.gateway {
+        Endpoint::from_shared(gateway.clone()).map_err(|e| format!("invalid gateway URI: {e}"))?;
+    }
+    if let Some(runner_script) = &req.runner_script {
+        if !runner_script.is_empty() && !Path::new(runner_script).is_file() {
+            return Err(format!("runner_script {runner_script} does not exist"));
+        }
+    }
+
+    // Only gate this request if it actually touches docker_mode or
+    // runner_script — a host that already has this combination from its
+    // env-derived seed (a legitimate, existing deployment shape; see this
+    // module's doc) must not have every *unrelated* UpdateSettings call
+    // (e.g. just load_ceiling) rejected because of it.
+    if req.docker_mode.is_some() || req.runner_script.is_some() {
+        let persisted = state.persisted_settings();
+        let effective_docker_mode = req.docker_mode.map_or(persisted.docker_mode, |v| {
+            control_proto::DockerMode::try_from(v)
+                .unwrap_or(control_proto::DockerMode::Unspecified)
+                .into()
+        });
+        let effective_runner_script = req.runner_script.clone().unwrap_or_else(|| {
+            persisted
+                .runner_script
+                .as_ref()
+                .map(|p| p.to_string_lossy().into_owned())
+                .unwrap_or_default()
+        });
+        let leaves_nothing_servable = matches!(
+            effective_docker_mode,
+            DockerMode::Auto | DockerMode::Disabled
+        ) && effective_runner_script.is_empty();
+        if leaves_nothing_servable {
+            return Err(
+                "cannot leave docker_mode as auto/disabled with no runner_script configured — \
+                 this would leave the host advertising no capabilities at all; supply \
+                 runner_script in the same request or set docker_mode to enabled"
+                    .to_owned(),
+            );
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::settings::PersistedSettings;
+
+    fn seed() -> PersistedSettings {
+        PersistedSettings {
+            load_ceiling: 0.9,
+            mem_floor_mib: 2048,
+            runner_image: "ghcr.io/actions/actions-runner:latest".to_owned(),
+            gateway: "https://fleet.arcbox.dev".to_owned(),
+            docker_mode: DockerMode::Auto,
+            runner_script: None,
+        }
+    }
+
+    fn request() -> UpdateSettingsRequest {
+        UpdateSettingsRequest {
+            load_ceiling: None,
+            mem_floor_mib: None,
+            runner_image: None,
+            gateway: None,
+            docker_mode: None,
+            runner_script: None,
+        }
+    }
+
+    #[test]
+    fn rejects_docker_disabled_with_no_runner_script() {
+        let state = AgentState::new(&seed());
+        let req = UpdateSettingsRequest {
+            docker_mode: Some(control_proto::DockerMode::Disabled as i32),
+            ..request()
+        };
+        assert!(validate(&req, &state).is_err());
+    }
+
+    #[test]
+    fn accepts_docker_disabled_with_runner_script_in_same_request() {
+        let dir =
+            std::env::temp_dir().join(format!("fleet-settings-validate-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let script = dir.join("run.sh");
+        std::fs::write(&script, "#!/bin/sh\n").unwrap();
+
+        let state = AgentState::new(&seed());
+        let req = UpdateSettingsRequest {
+            docker_mode: Some(control_proto::DockerMode::Disabled as i32),
+            runner_script: Some(script.to_string_lossy().into_owned()),
+            ..request()
+        };
+        assert!(validate(&req, &state).is_ok());
+
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn rejects_nonexistent_runner_script() {
+        let state = AgentState::new(&seed());
+        let req = UpdateSettingsRequest {
+            runner_script: Some("/does/not/exist/run.sh".to_owned()),
+            ..request()
+        };
+        assert!(validate(&req, &state).is_err());
+    }
+
+    #[test]
+    fn unrelated_field_update_succeeds_despite_preexisting_unsafe_combination() {
+        // A host whose env-derived seed already has docker_mode=Disabled and
+        // no runner_script (a legitimate, existing Docker-only deployment)
+        // must not have every future, unrelated UpdateSettings rejected
+        // because of that pre-existing combination.
+        let state = AgentState::new(&crate::settings::PersistedSettings {
+            docker_mode: DockerMode::Disabled,
+            runner_script: None,
+            ..seed()
+        });
+        let req = UpdateSettingsRequest {
+            load_ceiling: Some(0.5),
+            ..request()
+        };
+        assert!(validate(&req, &state).is_ok());
+    }
+
+    #[test]
+    fn accepts_docker_enabled_with_no_runner_script() {
+        let state = AgentState::new(&seed());
+        let req = UpdateSettingsRequest {
+            docker_mode: Some(control_proto::DockerMode::Enabled as i32),
+            ..request()
+        };
+        assert!(validate(&req, &state).is_ok());
+    }
+
+    #[test]
+    fn rejects_non_positive_load_ceiling() {
+        let state = AgentState::new(&seed());
+        let req = UpdateSettingsRequest {
+            load_ceiling: Some(0.0),
+            ..request()
+        };
+        assert!(validate(&req, &state).is_err());
+    }
+
+    #[test]
+    fn rejects_malformed_gateway() {
+        let state = AgentState::new(&seed());
+        let req = UpdateSettingsRequest {
+            gateway: Some("not a uri".to_owned()),
+            ..request()
+        };
+        assert!(validate(&req, &state).is_err());
+    }
+}

--- a/fleet/arcbox-fleet-agent/src/control/settings.rs
+++ b/fleet/arcbox-fleet-agent/src/control/settings.rs
@@ -12,6 +12,7 @@ use arcbox_fleet_control_proto::v1::{
 use tonic::transport::Endpoint;
 use tonic::{Request, Response, Status};
 
+use super::Internal;
 use crate::config::DockerMode;
 use crate::settings::SettingsStore;
 use crate::state::{AgentState, docker_mode_from_wire};
@@ -67,7 +68,7 @@ impl FleetSettingsServiceTrait for SettingsService {
 
         self.store
             .store(&self.state.persisted_settings())
-            .map_err(|e| Status::internal(e.to_string()))?;
+            .map_err(Internal)?;
 
         Ok(Response::new(UpdateSettingsResponse {
             settings: Some(self.state.settings()),

--- a/fleet/arcbox-fleet-agent/src/control/settings.rs
+++ b/fleet/arcbox-fleet-agent/src/control/settings.rs
@@ -14,17 +14,56 @@ use tonic::{Request, Response, Status};
 
 use super::Internal;
 use crate::config::DockerMode;
+use crate::docker::DockerRunner;
 use crate::settings::SettingsStore;
 use crate::state::{AgentState, docker_mode_from_wire};
 
 pub struct SettingsService {
     state: AgentState,
     store: SettingsStore,
+    /// The process-lifetime Docker handle, if configured — used to validate
+    /// a candidate `runner_image` against currently-advertised arches. Never
+    /// stale: `docker_mode` changes are restart-scoped (see
+    /// `AgentSupervisor::docker`'s doc).
+    docker: Option<DockerRunner>,
 }
 
 impl SettingsService {
-    pub fn new(state: AgentState, store: SettingsStore) -> Self {
-        Self { state, store }
+    pub fn new(state: AgentState, store: SettingsStore, docker: Option<DockerRunner>) -> Self {
+        Self {
+            state,
+            store,
+            docker,
+        }
+    }
+
+    /// If Docker is configured and currently advertising at least one Linux
+    /// arch, verify `image` can still be pulled for those arches before
+    /// accepting it — otherwise a bad runner_image swap is only discovered
+    /// later, as avoidable accept-then-reject churn at job dispatch (see
+    /// `docker.rs`'s `DockerRunner::new` doc). Rejects only if the new image
+    /// serves *none* of the currently-advertised arches, matching this
+    /// module's docker_mode/runner_script "leaves nothing servable"
+    /// precedent below — a partial mismatch (the new image drops one of
+    /// several arches) is allowed through, since blocking every runner_image
+    /// change over one dropped minor arch would be stricter than that
+    /// precedent intends.
+    async fn validate_runner_image(&self, image: &str) -> Result<(), String> {
+        let Some(docker) = &self.docker else {
+            return Ok(());
+        };
+        let served = docker.linux_arches();
+        if served.is_empty() {
+            return Ok(());
+        }
+        let still_servable = docker.verify_pullable(image, &served).await;
+        if still_servable.is_empty() {
+            return Err(format!(
+                "runner_image {image} could not be pulled for any currently-served Linux \
+                 architecture ({served:?}); this would leave Docker-backed jobs unable to run"
+            ));
+        }
+        Ok(())
     }
 }
 
@@ -45,6 +84,11 @@ impl FleetSettingsServiceTrait for SettingsService {
     ) -> Result<Response<UpdateSettingsResponse>, Status> {
         let req = request.into_inner();
         validate(&req, &self.state).map_err(Status::invalid_argument)?;
+        if let Some(image) = &req.runner_image {
+            self.validate_runner_image(image)
+                .await
+                .map_err(Status::invalid_argument)?;
+        }
 
         if let Some(v) = req.load_ceiling {
             self.state.set_load_ceiling(v);
@@ -253,5 +297,25 @@ mod tests {
             ..request()
         };
         assert!(validate(&req, &state).is_err());
+    }
+
+    /// The pull-check itself needs a live Docker daemon (see `docker.rs`,
+    /// which has no unit tests for the same reason), but the "no Docker
+    /// configured" guard is a plain branch and must accept any runner_image
+    /// unconditionally rather than, say, panicking on an absent `DockerRunner`.
+    #[tokio::test]
+    async fn validate_runner_image_accepts_anything_without_docker() {
+        let dir = std::env::temp_dir().join(format!("fleet-settings-image-{}", std::process::id()));
+        let service = SettingsService::new(
+            AgentState::new(&seed()),
+            SettingsStore::new(dir.join("settings.json")),
+            None,
+        );
+        assert!(
+            service
+                .validate_runner_image("not-even-a-real-image!!")
+                .await
+                .is_ok()
+        );
     }
 }

--- a/fleet/arcbox-fleet-agent/src/control/settings.rs
+++ b/fleet/arcbox-fleet-agent/src/control/settings.rs
@@ -62,7 +62,19 @@ impl FleetSettingsServiceTrait for SettingsService {
             self.state.set_linux_runner_image_target(v);
         }
         if let Some(v) = &req.gateway {
-            self.state.set_gateway_target(v);
+            // Atomic re-check: `validate` above already refused a gateway
+            // change while enrolled, but a concurrent `Enroll` may have
+            // flipped enrollment to `Attaching` between that read and this
+            // write. `try_set_gateway_target` performs the enrollment check
+            // and the write inside a single `send_modify`, so the two
+            // cannot interleave — the credential and settings.json always
+            // land on the same gateway key.
+            if let Err(observed) = self.state.try_set_gateway_target(v) {
+                return Err(Status::failed_precondition(format!(
+                    "gateway change refused: enrollment is {observed:?} — unenroll first, then \
+                     set the gateway and re-enroll"
+                )));
+            }
         }
         if let Some(v) = req.docker_mode {
             self.state.set_docker_mode_target(docker_mode_from_wire(v));

--- a/fleet/arcbox-fleet-agent/src/control/settings.rs
+++ b/fleet/arcbox-fleet-agent/src/control/settings.rs
@@ -10,7 +10,8 @@ use std::path::Path;
 
 use arcbox_fleet_control_proto::v1::fleet_settings_service_server::FleetSettingsService as FleetSettingsServiceTrait;
 use arcbox_fleet_control_proto::v1::{
-    GetSettingsRequest, GetSettingsResponse, UpdateSettingsRequest, UpdateSettingsResponse,
+    Enrollment, GetSettingsRequest, GetSettingsResponse, UpdateSettingsRequest,
+    UpdateSettingsResponse,
 };
 use tonic::transport::Endpoint;
 use tonic::{Request, Response, Status};
@@ -108,6 +109,22 @@ fn validate(req: &UpdateSettingsRequest, state: &AgentState) -> Result<(), Strin
     }
     if let Some(gateway) = &req.gateway {
         Endpoint::from_shared(gateway.clone()).map_err(|e| format!("invalid gateway URI: {e}"))?;
+        // A credential is bound to the gateway it enrolled against — the
+        // keychain keys its entry by gateway URI, and the machine record
+        // lives in that gateway's database — so moving the target under an
+        // enrollment could only strand it (a startup lookup under the new
+        // key would miss the credential; the old gateway would never see
+        // this machine again). Every enrollment state except Unenrolled
+        // implies a credential on disk.
+        let enrollment =
+            Enrollment::try_from(state.current().enrollment).unwrap_or(Enrollment::Unenrolled);
+        if enrollment != Enrollment::Unenrolled {
+            return Err(
+                "cannot change the gateway while enrolled — unenroll first, then set the \
+                 gateway and re-enroll"
+                    .to_owned(),
+            );
+        }
     }
     if let Some(runner_script) = &req.runner_script {
         if !runner_script.is_empty() && !Path::new(runner_script).is_file() {
@@ -266,6 +283,38 @@ mod tests {
             ..request()
         };
         assert!(validate(&req, &state).is_err());
+    }
+
+    /// The gateway is only settable while unenrolled: every other
+    /// enrollment state implies a credential keyed by the current gateway,
+    /// which a moved target would strand.
+    #[test]
+    fn gateway_change_requires_unenrolled() {
+        let req = UpdateSettingsRequest {
+            gateway: Some("https://other.gateway.test".to_owned()),
+            ..request()
+        };
+
+        let state = AgentState::new(&seed());
+        assert!(validate(&req, &state).is_ok(), "unenrolled may retarget");
+
+        for enrollment in [
+            control_proto::Enrollment::Attaching,
+            control_proto::Enrollment::Attached,
+            control_proto::Enrollment::Detached,
+            control_proto::Enrollment::CredentialRejected,
+        ] {
+            state.set_enrollment(enrollment, "fltm_test");
+            let err = validate(&req, &state).expect_err("credential exists");
+            assert!(err.contains("unenroll first"), "{enrollment:?}: {err}");
+        }
+
+        // Other settings stay updatable regardless of enrollment.
+        let unrelated = UpdateSettingsRequest {
+            load_ceiling: Some(0.5),
+            ..request()
+        };
+        assert!(validate(&unrelated, &state).is_ok());
     }
 
     /// `linux_runner_image` is prepare-scoped: `UpdateSettings` must move

--- a/fleet/arcbox-fleet-agent/src/control/settings.rs
+++ b/fleet/arcbox-fleet-agent/src/control/settings.rs
@@ -1,7 +1,10 @@
 //! `FleetSettingsService` — the tonic server impl. Reads/writes
-//! [`AgentState`] directly; no `AgentSupervisor` dependency, since settings
-//! never touch the attach lifecycle (see `state.rs`'s module doc and
-//! RUN-35's design notes: no setting ever forces a reattach).
+//! [`AgentState`] directly; no `AgentSupervisor` dependency, even for
+//! `participate` — the one setting that deliberately touches the attach
+//! lifecycle. This service only writes its target; the supervisor's
+//! participation reconciler observes the same watch channel and converges
+//! (`AgentSupervisor::spawn_participation_reconciler`), so lifecycle
+//! ownership stays in exactly one place.
 
 use std::path::Path;
 
@@ -66,6 +69,11 @@ impl FleetSettingsServiceTrait for SettingsService {
         if let Some(v) = &req.runner_script {
             let path = (!v.is_empty()).then_some(Path::new(v));
             self.state.set_runner_script_target(path);
+        }
+        // Target only — the supervisor's participation reconciler performs
+        // the detach/reattach and flips `current` when it completes.
+        if let Some(v) = req.participate {
+            self.state.set_participate_target(v);
         }
 
         self.store
@@ -156,6 +164,7 @@ mod tests {
             gateway: "https://fleet.arcbox.dev".to_owned(),
             docker_mode: DockerMode::Auto,
             runner_script: None,
+            participate: true,
         }
     }
 
@@ -167,6 +176,7 @@ mod tests {
             gateway: None,
             docker_mode: None,
             runner_script: None,
+            participate: None,
         }
     }
 
@@ -218,6 +228,7 @@ mod tests {
         let state = AgentState::new(&crate::settings::PersistedSettings {
             docker_mode: DockerMode::Disabled,
             runner_script: None,
+            participate: true,
             ..seed()
         });
         let req = UpdateSettingsRequest {

--- a/fleet/arcbox-fleet-agent/src/control/settings.rs
+++ b/fleet/arcbox-fleet-agent/src/control/settings.rs
@@ -14,56 +14,17 @@ use tonic::{Request, Response, Status};
 
 use super::Internal;
 use crate::config::DockerMode;
-use crate::docker::DockerRunner;
 use crate::settings::SettingsStore;
 use crate::state::{AgentState, docker_mode_from_wire};
 
 pub struct SettingsService {
     state: AgentState,
     store: SettingsStore,
-    /// The process-lifetime Docker handle, if configured — used to validate
-    /// a candidate `linux_runner_image` against currently-advertised arches. Never
-    /// stale: `docker_mode` changes are restart-scoped (see
-    /// `AgentSupervisor::docker`'s doc).
-    docker: Option<DockerRunner>,
 }
 
 impl SettingsService {
-    pub fn new(state: AgentState, store: SettingsStore, docker: Option<DockerRunner>) -> Self {
-        Self {
-            state,
-            store,
-            docker,
-        }
-    }
-
-    /// If Docker is configured and currently advertising at least one Linux
-    /// arch, verify `image` can still be pulled for those arches before
-    /// accepting it — otherwise a bad linux_runner_image swap is only discovered
-    /// later, as avoidable accept-then-reject churn at job dispatch (see
-    /// `docker.rs`'s `DockerRunner::new` doc). Rejects only if the new image
-    /// serves *none* of the currently-advertised arches, matching this
-    /// module's docker_mode/runner_script "leaves nothing servable"
-    /// precedent below — a partial mismatch (the new image drops one of
-    /// several arches) is allowed through, since blocking every linux_runner_image
-    /// change over one dropped minor arch would be stricter than that
-    /// precedent intends.
-    async fn validate_runner_image(&self, image: &str) -> Result<(), String> {
-        let Some(docker) = &self.docker else {
-            return Ok(());
-        };
-        let served = docker.linux_arches();
-        if served.is_empty() {
-            return Ok(());
-        }
-        let still_servable = docker.verify_pullable(image, &served).await;
-        if still_servable.is_empty() {
-            return Err(format!(
-                "linux_runner_image {image} could not be pulled for any currently-served Linux \
-                 architecture ({served:?}); this would leave Docker-backed jobs unable to run"
-            ));
-        }
-        Ok(())
+    pub fn new(state: AgentState, store: SettingsStore) -> Self {
+        Self { state, store }
     }
 }
 
@@ -84,11 +45,6 @@ impl FleetSettingsServiceTrait for SettingsService {
     ) -> Result<Response<UpdateSettingsResponse>, Status> {
         let req = request.into_inner();
         validate(&req, &self.state).map_err(Status::invalid_argument)?;
-        if let Some(image) = &req.linux_runner_image {
-            self.validate_runner_image(image)
-                .await
-                .map_err(Status::invalid_argument)?;
-        }
 
         if let Some(v) = req.load_ceiling {
             self.state.set_load_ceiling(v);
@@ -96,8 +52,10 @@ impl FleetSettingsServiceTrait for SettingsService {
         if let Some(v) = req.mem_floor_mib {
             self.state.set_mem_floor_mib(v);
         }
-        if let Some(v) = req.linux_runner_image {
-            self.state.set_linux_runner_image(v);
+        // Target only — `FleetImageService.Prepare` is what verifies the
+        // image and promotes it to `current`.
+        if let Some(v) = &req.linux_runner_image {
+            self.state.set_linux_runner_image_target(v);
         }
         if let Some(v) = &req.gateway {
             self.state.set_gateway_target(v);
@@ -299,23 +257,29 @@ mod tests {
         assert!(validate(&req, &state).is_err());
     }
 
-    /// The pull-check itself needs a live Docker daemon (see `docker.rs`,
-    /// which has no unit tests for the same reason), but the "no Docker
-    /// configured" guard is a plain branch and must accept any linux_runner_image
-    /// unconditionally rather than, say, panicking on an absent `DockerRunner`.
+    /// `linux_runner_image` is prepare-scoped: `UpdateSettings` must move
+    /// only `target`, leaving `current` (what dispatch actually uses) for
+    /// `FleetImageService.Prepare` to promote after verification.
     #[tokio::test]
-    async fn validate_runner_image_accepts_anything_without_docker() {
+    async fn update_settings_moves_linux_runner_image_target_only() {
         let dir = std::env::temp_dir().join(format!("fleet-settings-image-{}", std::process::id()));
-        let service = SettingsService::new(
-            AgentState::new(&seed()),
-            SettingsStore::new(dir.join("settings.json")),
-            None,
+        let state = AgentState::new(&seed());
+        let service =
+            SettingsService::new(state.clone(), SettingsStore::new(dir.join("settings.json")));
+        service
+            .update_settings(Request::new(UpdateSettingsRequest {
+                linux_runner_image: Some("ghcr.io/acme/runner:v2".to_owned()),
+                ..request()
+            }))
+            .await
+            .expect("UpdateSettings");
+
+        assert_eq!(
+            state.linux_runner_image_current(),
+            "ghcr.io/actions/actions-runner:latest"
         );
-        assert!(
-            service
-                .validate_runner_image("not-even-a-real-image!!")
-                .await
-                .is_ok()
-        );
+        assert_eq!(state.linux_runner_image_target(), "ghcr.io/acme/runner:v2");
+
+        let _ = std::fs::remove_dir_all(dir);
     }
 }

--- a/fleet/arcbox-fleet-agent/src/control/settings.rs
+++ b/fleet/arcbox-fleet-agent/src/control/settings.rs
@@ -50,6 +50,22 @@ impl FleetSettingsServiceTrait for SettingsService {
         let req = request.into_inner();
         validate(&req, &self.state).map_err(Status::invalid_argument)?;
 
+        // Apply the fallible gateway write first so the whole in-memory
+        // phase is all-or-nothing: `try_set_gateway_target` is the only
+        // setter in this method that can refuse (a concurrent `Enroll`
+        // flipped enrollment to `Attaching` between `validate` and here),
+        // and returning after any infallible setter has already written
+        // in-memory state would show up as a partial update on
+        // `Watch`/`GetSettings` while the response says failure and
+        // `settings.json` is never written.
+        if let Some(v) = &req.gateway {
+            if let Err(observed) = self.state.try_set_gateway_target(v) {
+                return Err(Status::failed_precondition(format!(
+                    "gateway change refused: enrollment is {observed:?} — unenroll first, then \
+                     set the gateway and re-enroll"
+                )));
+            }
+        }
         if let Some(v) = req.load_ceiling {
             self.state.set_load_ceiling(v);
         }
@@ -60,21 +76,6 @@ impl FleetSettingsServiceTrait for SettingsService {
         // image and promotes it to `current`.
         if let Some(v) = &req.linux_runner_image {
             self.state.set_linux_runner_image_target(v);
-        }
-        if let Some(v) = &req.gateway {
-            // Atomic re-check: `validate` above already refused a gateway
-            // change while enrolled, but a concurrent `Enroll` may have
-            // flipped enrollment to `Attaching` between that read and this
-            // write. `try_set_gateway_target` performs the enrollment check
-            // and the write inside a single `send_modify`, so the two
-            // cannot interleave — the credential and settings.json always
-            // land on the same gateway key.
-            if let Err(observed) = self.state.try_set_gateway_target(v) {
-                return Err(Status::failed_precondition(format!(
-                    "gateway change refused: enrollment is {observed:?} — unenroll first, then \
-                     set the gateway and re-enroll"
-                )));
-            }
         }
         if let Some(v) = req.docker_mode {
             self.state.set_docker_mode_target(docker_mode_from_wire(v));

--- a/fleet/arcbox-fleet-agent/src/control/watch.rs
+++ b/fleet/arcbox-fleet-agent/src/control/watch.rs
@@ -1,0 +1,45 @@
+//! `FleetStateService` — streams [`AgentState`](crate::state::AgentState) to
+//! subscribers. Same shape as `arcbox-api`'s `watch_setup_status`
+//! (`app/arcbox-api/src/system.rs`).
+
+use std::pin::Pin;
+
+use arcbox_fleet_control_proto::v1::fleet_state_service_server::FleetStateService;
+use arcbox_fleet_control_proto::v1::{WatchRequest, WatchResponse};
+use tokio_stream::Stream;
+use tonic::{Request, Response, Status};
+
+use crate::state::AgentState;
+
+pub struct WatchService {
+    state: AgentState,
+}
+
+impl WatchService {
+    pub fn new(state: AgentState) -> Self {
+        Self { state }
+    }
+}
+
+#[tonic::async_trait]
+impl FleetStateService for WatchService {
+    type WatchStream = Pin<Box<dyn Stream<Item = Result<WatchResponse, Status>> + Send>>;
+
+    async fn watch(
+        &self,
+        _request: Request<WatchRequest>,
+    ) -> Result<Response<Self::WatchStream>, Status> {
+        let mut rx = self.state.subscribe();
+        let stream = async_stream::stream! {
+            // Send the current snapshot immediately, then one per change —
+            // the client holds no state of its own between messages.
+            let snapshot = rx.borrow_and_update().clone();
+            yield Ok(WatchResponse { snapshot: Some(snapshot) });
+            while rx.changed().await.is_ok() {
+                let snapshot = rx.borrow_and_update().clone();
+                yield Ok(WatchResponse { snapshot: Some(snapshot) });
+            }
+        };
+        Ok(Response::new(Box::pin(stream)))
+    }
+}

--- a/fleet/arcbox-fleet-agent/src/credentials.rs
+++ b/fleet/arcbox-fleet-agent/src/credentials.rs
@@ -24,6 +24,12 @@ pub struct Credential {
     pub machine_id: String,
     /// Long-lived machine token, presented in `Attach` metadata.
     pub machine_token: String,
+    /// Gateway URL this credential was enrolled against, if it overrides the
+    /// agent's configured default. Set from the local control-plane
+    /// `Enroll` RPC's `control_plane` field; `None` for the CLI's
+    /// `enroll` subcommand, which always uses the configured gateway.
+    #[serde(default)]
+    pub control_plane: Option<String>,
 }
 
 /// Reads and writes the [`Credential`] via the platform-appropriate backend.
@@ -77,6 +83,17 @@ impl CredentialStore {
             Self::Keyring(store) => store.store(cred),
         }
     }
+
+    /// Remove the persisted credential, if any. A no-op, not an error, when
+    /// none is stored — `Disconnect` clears unconditionally rather than
+    /// first checking `load()`.
+    pub fn clear(&self) -> Result<()> {
+        match self {
+            Self::File(store) => store.clear(),
+            #[cfg(any(target_os = "macos", target_os = "windows"))]
+            Self::Keyring(store) => store.clear(),
+        }
+    }
 }
 
 /// Stores the credential as an owner-only JSON file at a fixed path.
@@ -113,6 +130,14 @@ impl FileStore {
         std::fs::rename(&tmp, &self.path)
             .with_context(|| format!("renaming {} -> {}", tmp.display(), self.path.display()))?;
         Ok(())
+    }
+
+    fn clear(&self) -> Result<()> {
+        match std::fs::remove_file(&self.path) {
+            Ok(()) => Ok(()),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+            Err(e) => Err(e).with_context(|| format!("removing {}", self.path.display())),
+        }
     }
 }
 
@@ -187,6 +212,14 @@ impl KeyringStore {
             .set_password(&json)
             .context("writing credential to OS keychain")
     }
+
+    fn clear(&self) -> Result<()> {
+        match self.entry()?.delete_credential() {
+            Ok(()) => Ok(()),
+            Err(keyring::Error::NoEntry) => Ok(()),
+            Err(e) => Err(e).context("deleting credential from OS keychain"),
+        }
+    }
 }
 
 #[cfg(test)]
@@ -212,16 +245,32 @@ mod tests {
         let cred = Credential {
             machine_id: "fltm_test".into(),
             machine_token: "secret".into(),
+            control_plane: Some("http://127.0.0.1:50061".into()),
         };
         store.store(&cred).unwrap();
 
         let loaded = store.load().unwrap().expect("credential present");
         assert_eq!(loaded.machine_id, cred.machine_id);
         assert_eq!(loaded.machine_token, cred.machine_token);
+        assert_eq!(loaded.control_plane, cred.control_plane);
 
         let mode = std::fs::metadata(&path).unwrap().permissions().mode();
         assert_eq!(mode & 0o777, 0o600);
 
+        store.clear().unwrap();
+        assert!(store.load().unwrap().is_none());
+        // Clearing an already-absent credential is a no-op, not an error.
+        store.clear().unwrap();
+
         let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn missing_control_plane_deserializes_as_none() {
+        // Credentials persisted before `control_plane` existed must still
+        // load: the field defaults rather than failing to parse.
+        let json = r#"{"machine_id":"fltm_old","machine_token":"secret"}"#;
+        let cred: Credential = serde_json::from_str(json).unwrap();
+        assert_eq!(cred.control_plane, None);
     }
 }

--- a/fleet/arcbox-fleet-agent/src/credentials.rs
+++ b/fleet/arcbox-fleet-agent/src/credentials.rs
@@ -109,10 +109,9 @@ impl FileStore {
     }
 
     fn store(&self, cred: &Credential) -> Result<()> {
-        // `write_private` refuses a plaintext write on non-Unix, so the raw
-        // token never lands in an unhardened file; on Unix it's `0600` from
-        // creation and the rename preserves that mode.
-        crate::fsutil::write_json_atomic(&self.path, cred, write_private)
+        // Owner-only (`0600`) from creation, and the rename preserves that
+        // mode, so the raw token is never briefly world-readable.
+        crate::fsutil::write_json_atomic(&self.path, cred)
     }
 
     fn clear(&self) -> Result<()> {
@@ -122,12 +121,6 @@ impl FileStore {
             Err(e) => Err(e).with_context(|| format!("removing {}", self.path.display())),
         }
     }
-}
-
-/// Write `bytes` to `path`, owner-only (`0600`) from creation on Unix — every
-/// supported target (macOS, Linux) is Unix, so this is the only backend.
-fn write_private(path: &std::path::Path, bytes: &[u8]) -> Result<()> {
-    crate::fsutil::write_owner_only(path, bytes)
 }
 
 /// Stores the credential as a single JSON blob in the OS keychain, one entry

--- a/fleet/arcbox-fleet-agent/src/credentials.rs
+++ b/fleet/arcbox-fleet-agent/src/credentials.rs
@@ -79,7 +79,7 @@ impl CredentialStore {
     }
 
     /// Remove the persisted credential, if any. A no-op, not an error, when
-    /// none is stored — `Disconnect` clears unconditionally rather than
+    /// none is stored — `Unenroll` clears unconditionally rather than
     /// first checking `load()`.
     pub fn clear(&self) -> Result<()> {
         match self {

--- a/fleet/arcbox-fleet-agent/src/credentials.rs
+++ b/fleet/arcbox-fleet-agent/src/credentials.rs
@@ -1,12 +1,12 @@
 //! Persistence of the long-lived machine credential.
 //!
 //! The credential is written once at enrollment and read on every `run`. The
-//! backend is chosen by [`CredentialMode`]: the OS keychain on macOS (login
-//! Keychain) and Windows (Credential Manager), or an owner-only (`0600`) file on
-//! Linux. The keychain item is access-controlled to this binary by the OS, so a
-//! same-user process can't read it without a prompt — a boundary the file lacks.
-//! The macOS login Keychain is unlocked by the user's login, so the agent must
-//! run in that session; Linux has no keychain backend that fits a headless,
+//! backend is chosen by [`CredentialMode`]: the OS keychain (login Keychain) on
+//! macOS, or an owner-only (`0600`) file on Linux. The keychain item is
+//! access-controlled to this binary by the OS, so a same-user process can't
+//! read it without a prompt — a boundary the file lacks. The macOS login
+//! Keychain is unlocked by the user's login, so the agent must run in that
+//! session; Linux has no keychain backend that fits a headless,
 //! reboot-persistent agent, so it uses the file (encryption at rest there is the
 //! deployment's job, via LUKS). See [`CredentialStore::new`].
 
@@ -30,17 +30,17 @@ pub struct Credential {
 pub enum CredentialStore {
     /// Owner-only JSON file in the data directory.
     File(FileStore),
-    /// OS keychain: the login Keychain on macOS, Credential Manager on Windows.
-    #[cfg(any(target_os = "macos", target_os = "windows"))]
+    /// OS keychain: the login Keychain on macOS.
+    #[cfg(target_os = "macos")]
     Keyring(KeyringStore),
 }
 
 impl CredentialStore {
     /// Select a backend from `mode` and the platform.
     ///
-    /// `Auto` uses the OS keychain on macOS/Windows and the `path` file
-    /// elsewhere; `Keyring` forces the keychain; `File` forces the file. `mode`
-    /// is validated against the platform when parsed from the environment, so
+    /// `Auto` uses the OS keychain on macOS and the `path` file elsewhere;
+    /// `Keyring` forces the keychain; `File` forces the file. `mode` is
+    /// validated against the platform when parsed from the environment, so
     /// `Keyring` never reaches here on a platform without a keychain.
     ///
     /// `gateway` scopes the credential to the environment it was enrolled
@@ -49,13 +49,13 @@ impl CredentialStore {
     /// silently overwriting each other. The file backend is scoped by `path`
     /// (per data dir) instead.
     pub fn new(mode: CredentialMode, path: PathBuf, gateway: &str) -> Self {
-        #[cfg(any(target_os = "macos", target_os = "windows"))]
+        #[cfg(target_os = "macos")]
         if matches!(mode, CredentialMode::Keyring | CredentialMode::Auto) {
             return Self::Keyring(KeyringStore {
                 account: gateway.to_owned(),
             });
         }
-        #[cfg(not(any(target_os = "macos", target_os = "windows")))]
+        #[cfg(not(target_os = "macos"))]
         let _ = (mode, gateway);
         Self::File(FileStore { path })
     }
@@ -64,7 +64,7 @@ impl CredentialStore {
     pub fn load(&self) -> Result<Option<Credential>> {
         match self {
             Self::File(store) => store.load(),
-            #[cfg(any(target_os = "macos", target_os = "windows"))]
+            #[cfg(target_os = "macos")]
             Self::Keyring(store) => store.load(),
         }
     }
@@ -73,7 +73,7 @@ impl CredentialStore {
     pub fn store(&self, cred: &Credential) -> Result<()> {
         match self {
             Self::File(store) => store.store(cred),
-            #[cfg(any(target_os = "macos", target_os = "windows"))]
+            #[cfg(target_os = "macos")]
             Self::Keyring(store) => store.store(cred),
         }
     }
@@ -84,7 +84,7 @@ impl CredentialStore {
     pub fn clear(&self) -> Result<()> {
         match self {
             Self::File(store) => store.clear(),
-            #[cfg(any(target_os = "macos", target_os = "windows"))]
+            #[cfg(target_os = "macos")]
             Self::Keyring(store) => store.clear(),
         }
     }
@@ -124,35 +124,22 @@ impl FileStore {
     }
 }
 
-/// Write `bytes` to `path`, owner-only (`0600`) from creation on Unix.
-#[cfg(unix)]
+/// Write `bytes` to `path`, owner-only (`0600`) from creation on Unix — every
+/// supported target (macOS, Linux) is Unix, so this is the only backend.
 fn write_private(path: &std::path::Path, bytes: &[u8]) -> Result<()> {
     crate::fsutil::write_owner_only(path, bytes)
-}
-
-/// Refuse to persist the machine token via a file on platforms without
-/// owner-only file permissions. On Windows the secure path is the OS keychain
-/// (`ARCBOX_FLEET_CREDENTIAL_STORE=auto`, the default there); the file backend
-/// has no ACL hardening, so writing the long-lived token at the default ACL
-/// would leave it readable by other local accounts.
-#[cfg(not(unix))]
-fn write_private(_path: &std::path::Path, _bytes: &[u8]) -> Result<()> {
-    anyhow::bail!(
-        "file credential storage is not hardened on this platform; use the OS \
-         keychain (ARCBOX_FLEET_CREDENTIAL_STORE=auto)"
-    )
 }
 
 /// Stores the credential as a single JSON blob in the OS keychain, one entry
 /// per gateway (the account is the gateway URI), so enrolling against another
 /// environment never clobbers this one's credential.
-#[cfg(any(target_os = "macos", target_os = "windows"))]
+#[cfg(target_os = "macos")]
 pub struct KeyringStore {
     /// Keychain account: the gateway URI this credential enrolls against.
     account: String,
 }
 
-#[cfg(any(target_os = "macos", target_os = "windows"))]
+#[cfg(target_os = "macos")]
 impl KeyringStore {
     /// Keychain service under which every credential entry is stored.
     const SERVICE: &'static str = "dev.arcbox.fleet-agent";
@@ -194,7 +181,7 @@ mod tests {
     use super::*;
 
     // The file backend is the default (and only) store on Linux, where the test
-    // suite runs; the keychain backends are exercised on macOS/Windows builds.
+    // suite runs; the keychain backend is exercised on macOS builds.
     #[cfg(unix)]
     #[test]
     fn file_store_round_trips_at_0600() {

--- a/fleet/arcbox-fleet-agent/src/credentials.rs
+++ b/fleet/arcbox-fleet-agent/src/credentials.rs
@@ -109,21 +109,10 @@ impl FileStore {
     }
 
     fn store(&self, cred: &Credential) -> Result<()> {
-        if let Some(parent) = self.path.parent() {
-            std::fs::create_dir_all(parent)
-                .with_context(|| format!("creating {}", parent.display()))?;
-        }
-        let json = serde_json::to_vec_pretty(cred).context("serializing credential")?;
-        // Write-then-rename so a crash mid-write can't leave a truncated
-        // credentials.json that fails to parse and strands the host unenrolled.
-        // The temp file is created `0600` from the open(2) call, so the raw
-        // token is never briefly world-readable — not in the temp file and not
-        // (via rename, which preserves the mode) in the final path.
-        let tmp = self.path.with_extension("json.tmp");
-        write_private(&tmp, &json)?;
-        std::fs::rename(&tmp, &self.path)
-            .with_context(|| format!("renaming {} -> {}", tmp.display(), self.path.display()))?;
-        Ok(())
+        // `write_private` refuses a plaintext write on non-Unix, so the raw
+        // token never lands in an unhardened file; on Unix it's `0600` from
+        // creation and the rename preserves that mode.
+        crate::fsutil::write_json_atomic(&self.path, cred, write_private)
     }
 
     fn clear(&self) -> Result<()> {

--- a/fleet/arcbox-fleet-agent/src/credentials.rs
+++ b/fleet/arcbox-fleet-agent/src/credentials.rs
@@ -24,12 +24,6 @@ pub struct Credential {
     pub machine_id: String,
     /// Long-lived machine token, presented in `Attach` metadata.
     pub machine_token: String,
-    /// Gateway URL this credential was enrolled against, if it overrides the
-    /// agent's configured default. Set from the local control-plane
-    /// `Enroll` RPC's `control_plane` field; `None` for the CLI's
-    /// `enroll` subcommand, which always uses the configured gateway.
-    #[serde(default)]
-    pub control_plane: Option<String>,
 }
 
 /// Reads and writes the [`Credential`] via the platform-appropriate backend.
@@ -144,23 +138,7 @@ impl FileStore {
 /// Write `bytes` to `path`, owner-only (`0600`) from creation on Unix.
 #[cfg(unix)]
 fn write_private(path: &std::path::Path, bytes: &[u8]) -> Result<()> {
-    use std::io::Write;
-    use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
-
-    let mut file = std::fs::OpenOptions::new()
-        .write(true)
-        .create(true)
-        .truncate(true)
-        .mode(0o600)
-        .open(path)
-        .with_context(|| format!("creating {}", path.display()))?;
-    // `mode` only takes effect when this call creates the file; a leftover temp
-    // from a crashed run keeps its old mode, so fchmod the open handle as a
-    // backstop (operating on the fd, never racing a path lookup).
-    file.set_permissions(std::fs::Permissions::from_mode(0o600))
-        .with_context(|| format!("chmod 0600 {}", path.display()))?;
-    file.write_all(bytes)
-        .with_context(|| format!("writing {}", path.display()))
+    crate::fsutil::write_owner_only(path, bytes)
 }
 
 /// Refuse to persist the machine token via a file on platforms without
@@ -245,14 +223,12 @@ mod tests {
         let cred = Credential {
             machine_id: "fltm_test".into(),
             machine_token: "secret".into(),
-            control_plane: Some("http://127.0.0.1:50061".into()),
         };
         store.store(&cred).unwrap();
 
         let loaded = store.load().unwrap().expect("credential present");
         assert_eq!(loaded.machine_id, cred.machine_id);
         assert_eq!(loaded.machine_token, cred.machine_token);
-        assert_eq!(loaded.control_plane, cred.control_plane);
 
         let mode = std::fs::metadata(&path).unwrap().permissions().mode();
         assert_eq!(mode & 0o777, 0o600);
@@ -263,14 +239,5 @@ mod tests {
         store.clear().unwrap();
 
         let _ = std::fs::remove_dir_all(dir);
-    }
-
-    #[test]
-    fn missing_control_plane_deserializes_as_none() {
-        // Credentials persisted before `control_plane` existed must still
-        // load: the field defaults rather than failing to parse.
-        let json = r#"{"machine_id":"fltm_old","machine_token":"secret"}"#;
-        let cred: Credential = serde_json::from_str(json).unwrap();
-        assert_eq!(cred.control_plane, None);
     }
 }

--- a/fleet/arcbox-fleet-agent/src/docker.rs
+++ b/fleet/arcbox-fleet-agent/src/docker.rs
@@ -23,7 +23,7 @@ pub struct RunSpec<'a> {
     pub encoded_jit_config: &'a str,
     /// Target CPU architecture (`arm64` or `amd64`).
     pub arch: &'a str,
-    /// Image to run this job in — the live-settable `runner_image`, read
+    /// Image to run this job in — the live-settable `linux_runner_image`, read
     /// fresh by the caller for each job rather than fixed at construction.
     pub runner_image: &'a str,
 }
@@ -180,10 +180,11 @@ impl DockerRunner {
     ///
     /// `default_image` is a local bootstrap parameter, not stored: it is
     /// only used to verify readiness here. Live jobs use whatever
-    /// `runner_image` is current at dispatch time (`RunSpec::runner_image`),
-    /// which may since have changed via `UpdateSettings` — see
-    /// [`Self::verify_pullable`], `FleetSettingsService.UpdateSettings`'s
-    /// guard against a runner_image change that would silently strand a
+    /// `linux_runner_image` is current at dispatch time
+    /// (`RunSpec::runner_image`), which may since have changed via
+    /// `UpdateSettings` — see [`Self::verify_pullable`],
+    /// `FleetSettingsService.UpdateSettings`'s guard against a
+    /// linux_runner_image change that would silently strand a
     /// currently-advertised arch.
     pub async fn new(default_image: &str) -> Result<Self> {
         let client = connect().await?;
@@ -207,11 +208,11 @@ impl DockerRunner {
 
     /// Verify `image` is pullable for each of `arches`, returning the subset
     /// that succeeded. Used by `FleetSettingsService.UpdateSettings` to
-    /// check a candidate `runner_image` against the arches already
+    /// check a candidate `linux_runner_image` against the arches already
     /// advertised (`Self::linux_arches`) before accepting it — catching a
     /// bad image at the settings boundary rather than as job-dispatch churn
     /// later. A pull that already has the image cached returns quickly, so
-    /// this is cheap to call on every runner_image change.
+    /// this is cheap to call on every linux_runner_image change.
     pub async fn verify_pullable(&self, image: &str, arches: &[String]) -> Vec<String> {
         Self::pullable_arches(&self.client, image, arches.to_vec()).await
     }

--- a/fleet/arcbox-fleet-agent/src/docker.rs
+++ b/fleet/arcbox-fleet-agent/src/docker.rs
@@ -23,6 +23,9 @@ pub struct RunSpec<'a> {
     pub encoded_jit_config: &'a str,
     /// Target CPU architecture (`arm64` or `amd64`).
     pub arch: &'a str,
+    /// Image to run this job in — the live-settable `runner_image`, read
+    /// fresh by the caller for each job rather than fixed at construction.
+    pub runner_image: &'a str,
 }
 
 /// A container that has been created and started. Held by the caller while the
@@ -87,8 +90,6 @@ impl RunningContainer {
 #[derive(Clone)]
 pub struct DockerRunner {
     client: Docker,
-    /// Image used when the platform sends no image override.
-    default_image: String,
     /// Linux arches verified pullable at startup, advertised as capacity pools.
     linux_arches: Vec<String>,
 }
@@ -176,13 +177,18 @@ impl DockerRunner {
     /// never advertises it. Docker counts as available only if at least one arch
     /// pulls; otherwise this returns an error and the caller proceeds without it
     /// (`Auto`) or fails startup (`Enabled`).
-    pub async fn new(default_image: String) -> Result<Self> {
+    ///
+    /// `default_image` is a local bootstrap parameter, not stored: it is
+    /// only used to verify readiness here. Live jobs use whatever
+    /// `runner_image` is current at dispatch time (`RunSpec::runner_image`),
+    /// which may since have changed via `UpdateSettings`.
+    pub async fn new(default_image: &str) -> Result<Self> {
         let client = connect().await?;
 
         let mut linux_arches = Vec::new();
         for arch in candidate_arches() {
             let platform = format!("linux/{arch}");
-            match Self::pull_image(&client, &default_image, &platform).await {
+            match Self::pull_image(&client, default_image, &platform).await {
                 Ok(()) => linux_arches.push(arch),
                 Err(e) => warn!(arch, error = %e, "skipping arch: default image pull failed"),
             }
@@ -194,7 +200,6 @@ impl DockerRunner {
         info!(?linux_arches, "docker runtime available");
         Ok(Self {
             client,
-            default_image,
             linux_arches,
         })
     }
@@ -213,7 +218,7 @@ impl DockerRunner {
     pub async fn start(&self, spec: RunSpec<'_>) -> Result<RunningContainer> {
         let platform = format!("linux/{}", spec.arch);
 
-        Self::pull_image(&self.client, &self.default_image, &platform).await?;
+        Self::pull_image(&self.client, spec.runner_image, &platform).await?;
 
         let container_name = container_name(spec.job_id);
 
@@ -223,7 +228,7 @@ impl DockerRunner {
         self.remove_job_container(spec.job_id).await;
 
         let config = ContainerCreateBody {
-            image: Some(self.default_image.clone()),
+            image: Some(spec.runner_image.to_owned()),
             cmd: Some(vec![
                 "./run.sh".to_owned(),
                 "--jitconfig".to_owned(),

--- a/fleet/arcbox-fleet-agent/src/docker.rs
+++ b/fleet/arcbox-fleet-agent/src/docker.rs
@@ -181,18 +181,14 @@ impl DockerRunner {
     /// `default_image` is a local bootstrap parameter, not stored: it is
     /// only used to verify readiness here. Live jobs use whatever
     /// `runner_image` is current at dispatch time (`RunSpec::runner_image`),
-    /// which may since have changed via `UpdateSettings`.
+    /// which may since have changed via `UpdateSettings` — see
+    /// [`Self::verify_pullable`], `FleetSettingsService.UpdateSettings`'s
+    /// guard against a runner_image change that would silently strand a
+    /// currently-advertised arch.
     pub async fn new(default_image: &str) -> Result<Self> {
         let client = connect().await?;
 
-        let mut linux_arches = Vec::new();
-        for arch in candidate_arches() {
-            let platform = format!("linux/{arch}");
-            match Self::pull_image(&client, default_image, &platform).await {
-                Ok(()) => linux_arches.push(arch),
-                Err(e) => warn!(arch, error = %e, "skipping arch: default image pull failed"),
-            }
-        }
+        let linux_arches = Self::pullable_arches(&client, default_image, candidate_arches()).await;
         if linux_arches.is_empty() {
             anyhow::bail!("docker reachable but could not pull {default_image} for any arch");
         }
@@ -207,6 +203,32 @@ impl DockerRunner {
     /// Linux architectures this Docker host serves, verified pullable at startup.
     pub fn linux_arches(&self) -> Vec<String> {
         self.linux_arches.clone()
+    }
+
+    /// Verify `image` is pullable for each of `arches`, returning the subset
+    /// that succeeded. Used by `FleetSettingsService.UpdateSettings` to
+    /// check a candidate `runner_image` against the arches already
+    /// advertised (`Self::linux_arches`) before accepting it — catching a
+    /// bad image at the settings boundary rather than as job-dispatch churn
+    /// later. A pull that already has the image cached returns quickly, so
+    /// this is cheap to call on every runner_image change.
+    pub async fn verify_pullable(&self, image: &str, arches: &[String]) -> Vec<String> {
+        Self::pullable_arches(&self.client, image, arches.to_vec()).await
+    }
+
+    /// Shared by [`Self::new`] (verifying `default_image` against every
+    /// candidate arch at startup) and [`Self::verify_pullable`] (verifying
+    /// an arbitrary candidate image against a caller-supplied arch set).
+    async fn pullable_arches(client: &Docker, image: &str, arches: Vec<String>) -> Vec<String> {
+        let mut ok = Vec::new();
+        for arch in arches {
+            let platform = format!("linux/{arch}");
+            match Self::pull_image(client, image, &platform).await {
+                Ok(()) => ok.push(arch),
+                Err(e) => warn!(arch, error = %e, "skipping arch: image pull failed"),
+            }
+        }
+        ok
     }
 
     /// Create and start a container for `spec`, returning a handle to await.

--- a/fleet/arcbox-fleet-agent/src/docker.rs
+++ b/fleet/arcbox-fleet-agent/src/docker.rs
@@ -1,7 +1,7 @@
 //! Docker API-based execution of Linux runner jobs.
 //!
 //! Talks to any Docker-compatible runtime (ArcBox on macOS, Docker Engine on
-//! Linux/Windows) via the local socket. Each Linux job runs inside a container
+//! Linux) via the local socket. Each Linux job runs inside a container
 //! launched from the configured runner image.
 
 use anyhow::{Context, Result};
@@ -169,8 +169,8 @@ impl DockerRunner {
     ///
     /// On macOS, prefers ArcBox's own socket (`~/.arcbox/docker.sock`) and falls
     /// back to the system default (Docker Desktop, Colima, …) when ArcBox is
-    /// absent or unresponsive. On other platforms it uses the system default
-    /// directly (e.g. `/var/run/docker.sock` on Linux, named pipe on Windows).
+    /// absent or unresponsive. On Linux it uses the system default directly
+    /// (`/var/run/docker.sock`).
     ///
     /// The pull is the readiness check: an arch is advertised only if its image
     /// pulls, so a host that cannot realize `linux/amd64` (no working emulation)

--- a/fleet/arcbox-fleet-agent/src/docker.rs
+++ b/fleet/arcbox-fleet-agent/src/docker.rs
@@ -181,11 +181,10 @@ impl DockerRunner {
     /// `default_image` is a local bootstrap parameter, not stored: it is
     /// only used to verify readiness here. Live jobs use whatever
     /// `linux_runner_image` is current at dispatch time
-    /// (`RunSpec::runner_image`), which may since have changed via
-    /// `UpdateSettings` — see [`Self::verify_pullable`],
-    /// `FleetSettingsService.UpdateSettings`'s guard against a
-    /// linux_runner_image change that would silently strand a
-    /// currently-advertised arch.
+    /// (`RunSpec::runner_image`) — and that image only *becomes* current
+    /// once `FleetImageService.Prepare` has pulled it for every arch this
+    /// probe decided to advertise (see [`Self::pull`]), so dispatch never
+    /// meets an unverified image.
     pub async fn new(default_image: &str) -> Result<Self> {
         let client = connect().await?;
 
@@ -206,20 +205,18 @@ impl DockerRunner {
         self.linux_arches.clone()
     }
 
-    /// Verify `image` is pullable for each of `arches`, returning the subset
-    /// that succeeded. Used by `FleetSettingsService.UpdateSettings` to
-    /// check a candidate `linux_runner_image` against the arches already
-    /// advertised (`Self::linux_arches`) before accepting it — catching a
-    /// bad image at the settings boundary rather than as job-dispatch churn
-    /// later. A pull that already has the image cached returns quickly, so
-    /// this is cheap to call on every linux_runner_image change.
-    pub async fn verify_pullable(&self, image: &str, arches: &[String]) -> Vec<String> {
-        Self::pullable_arches(&self.client, image, arches.to_vec()).await
+    /// Pull `image` for one Linux `arch` (`"arm64"`/`"amd64"`), verifying it
+    /// is realizable on this host. `FleetImageService.Prepare` drives this
+    /// for every advertised arch before promoting a new
+    /// `linux_runner_image` to current; a pull the runtime already has
+    /// cached returns quickly, so re-preparation is cheap when nothing
+    /// changed.
+    pub async fn pull(&self, image: &str, arch: &str) -> Result<()> {
+        Self::pull_image(&self.client, image, &format!("linux/{arch}")).await
     }
 
-    /// Shared by [`Self::new`] (verifying `default_image` against every
-    /// candidate arch at startup) and [`Self::verify_pullable`] (verifying
-    /// an arbitrary candidate image against a caller-supplied arch set).
+    /// Verifies `default_image` against every candidate arch at startup,
+    /// returning the subset that pulled ([`Self::new`]'s readiness probe).
     async fn pullable_arches(client: &Docker, image: &str, arches: Vec<String>) -> Vec<String> {
         let mut ok = Vec::new();
         for arch in arches {

--- a/fleet/arcbox-fleet-agent/src/enroll.rs
+++ b/fleet/arcbox-fleet-agent/src/enroll.rs
@@ -9,20 +9,17 @@ use crate::config::{AgentConfig, PROTOCOL_VERSION};
 use crate::credentials::{Credential, CredentialStore};
 use crate::host;
 
-/// Call `Enroll` on the gateway and persist the returned credential.
-///
-/// `control_plane` overrides the agent's configured default gateway for
-/// this enrollment (the desktop-managed handoff's per-enrollment gateway);
-/// `None` uses `config.gateway`, as the CLI's `enroll` subcommand always
-/// does. Whichever gateway is used is persisted onto the returned
-/// [`Credential`] so later reconnects target the same one.
+/// Call `Enroll` on `gateway` and persist the returned credential. The
+/// caller resolves `gateway`: the CLI `enroll` subcommand uses the
+/// persisted settings (or configured default) gateway; the control-plane
+/// `Enroll` RPC uses its `control_plane` override if given, else the
+/// current settings target — see `AgentSupervisor::enroll`.
 pub async fn enroll(
     config: &AgentConfig,
     token: String,
     capabilities: Vec<Capability>,
-    control_plane: Option<&str>,
+    gateway: &str,
 ) -> Result<Credential> {
-    let gateway = control_plane.unwrap_or(&config.gateway);
     let channel = config
         .endpoint_for(gateway)?
         .connect()
@@ -50,14 +47,9 @@ pub async fn enroll(
     let credential = Credential {
         machine_id: response.machine_id,
         machine_token: response.machine_token,
-        control_plane: control_plane.map(str::to_owned),
     };
-    CredentialStore::new(
-        config.credential_store,
-        config.credentials_path(),
-        &config.gateway,
-    )
-    .store(&credential)?;
+    CredentialStore::new(config.credential_store, config.credentials_path(), gateway)
+        .store(&credential)?;
     info!(machine_id = %credential.machine_id, "enrolled");
     Ok(credential)
 }

--- a/fleet/arcbox-fleet-agent/src/enroll.rs
+++ b/fleet/arcbox-fleet-agent/src/enroll.rs
@@ -6,14 +6,18 @@ use arcbox_fleet_proto::v1::{Capability, EnrollRequest};
 use tracing::info;
 
 use crate::config::{AgentConfig, PROTOCOL_VERSION};
-use crate::credentials::{Credential, CredentialStore};
+use crate::credentials::Credential;
 use crate::host;
 
-/// Call `Enroll` on `gateway` and persist the returned credential. The
-/// caller resolves `gateway`: the CLI `enroll` subcommand uses the
-/// persisted settings (or configured default) gateway; the control-plane
-/// `Enroll` RPC uses its `control_plane` override if given, else the
-/// current settings target — see `AgentSupervisor::enroll`.
+/// Call `Enroll` on `gateway` and return the machine credential — persisting
+/// it is the caller's job, done only once the caller has committed to the
+/// result: the CLI `enroll` subcommand stores it straight away, while the
+/// control-plane `Enroll` RPC stores it only after winning the enrollment
+/// race, so a losing concurrent enroll never overwrites the winner's
+/// credential (see `AgentSupervisor::enroll`). The caller also resolves
+/// `gateway`: the CLI uses the persisted-settings (or configured default)
+/// gateway; the RPC uses its `control_plane` override if given, else the
+/// current settings target.
 pub async fn enroll(
     config: &AgentConfig,
     token: String,
@@ -48,8 +52,6 @@ pub async fn enroll(
         machine_id: response.machine_id,
         machine_token: response.machine_token,
     };
-    CredentialStore::new(config.credential_store, config.credentials_path(), gateway)
-        .store(&credential)?;
     info!(machine_id = %credential.machine_id, "enrolled");
     Ok(credential)
 }

--- a/fleet/arcbox-fleet-agent/src/enroll.rs
+++ b/fleet/arcbox-fleet-agent/src/enroll.rs
@@ -10,16 +10,24 @@ use crate::credentials::{Credential, CredentialStore};
 use crate::host;
 
 /// Call `Enroll` on the gateway and persist the returned credential.
+///
+/// `control_plane` overrides the agent's configured default gateway for
+/// this enrollment (the desktop-managed handoff's per-enrollment gateway);
+/// `None` uses `config.gateway`, as the CLI's `enroll` subcommand always
+/// does. Whichever gateway is used is persisted onto the returned
+/// [`Credential`] so later reconnects target the same one.
 pub async fn enroll(
     config: &AgentConfig,
     token: String,
     capabilities: Vec<Capability>,
+    control_plane: Option<&str>,
 ) -> Result<Credential> {
+    let gateway = control_plane.unwrap_or(&config.gateway);
     let channel = config
-        .endpoint()?
+        .endpoint_for(gateway)?
         .connect()
         .await
-        .with_context(|| format!("connecting to fleet gateway at {}", config.gateway))?;
+        .with_context(|| format!("connecting to fleet gateway at {gateway}"))?;
     let mut client = FleetGatewayServiceClient::new(channel);
 
     let request = EnrollRequest {
@@ -42,6 +50,7 @@ pub async fn enroll(
     let credential = Credential {
         machine_id: response.machine_id,
         machine_token: response.machine_token,
+        control_plane: control_plane.map(str::to_owned),
     };
     CredentialStore::new(
         config.credential_store,

--- a/fleet/arcbox-fleet-agent/src/enroll.rs
+++ b/fleet/arcbox-fleet-agent/src/enroll.rs
@@ -1,10 +1,13 @@
-//! One-shot enrollment: exchange an enrollment token for the machine credential.
+//! One-shot gateway RPCs: enroll (exchange an enrollment token for the
+//! machine credential) and unenroll (decommission the machine, revoking
+//! that credential server-side).
 
 use anyhow::{Context, Result};
 use arcbox_fleet_proto::v1::fleet_gateway_service_client::FleetGatewayServiceClient;
-use arcbox_fleet_proto::v1::{Capability, EnrollRequest};
+use arcbox_fleet_proto::v1::{Capability, EnrollRequest, UnenrollRequest};
 use tracing::info;
 
+use crate::attach::authenticated_request;
 use crate::config::{AgentConfig, PROTOCOL_VERSION};
 use crate::credentials::Credential;
 use crate::host;
@@ -54,4 +57,31 @@ pub async fn enroll(
     };
     info!(machine_id = %credential.machine_id, "enrolled");
     Ok(credential)
+}
+
+/// Call `Unenroll` on `gateway`, authenticated with `machine_token` — the
+/// server half of leaving the fleet: marks the machine decommissioned and
+/// revokes this credential. `UNAUTHENTICATED` means the credential is
+/// already revoked, which is exactly the state unenrolling wants, so it
+/// counts as success.
+pub async fn unenroll(config: &AgentConfig, gateway: &str, machine_token: &str) -> Result<()> {
+    let channel = config
+        .endpoint_for(gateway)?
+        .connect()
+        .await
+        .with_context(|| format!("connecting to fleet gateway at {gateway}"))?;
+    let mut client = FleetGatewayServiceClient::new(channel);
+
+    let request = authenticated_request(UnenrollRequest {}, machine_token)?;
+    match client.unenroll(request).await {
+        Ok(_) => {
+            info!("unenrolled at gateway (machine decommissioned)");
+            Ok(())
+        }
+        Err(status) if status.code() == tonic::Code::Unauthenticated => {
+            info!("gateway reports the credential already revoked");
+            Ok(())
+        }
+        Err(status) => Err(status).context("Unenroll RPC failed"),
+    }
 }

--- a/fleet/arcbox-fleet-agent/src/fsutil.rs
+++ b/fleet/arcbox-fleet-agent/src/fsutil.rs
@@ -6,11 +6,8 @@ use std::path::{Path, PathBuf};
 use anyhow::{Context, Result};
 use serde::Serialize;
 
-/// Write `bytes` to `path`, owner-only (`0600`) from creation on Unix. On
-/// non-Unix platforms this writes normally — callers with a secret to
-/// protect (unlike a plain settings file) must refuse or otherwise harden
-/// separately; see `credentials.rs`'s own `write_private`.
-#[cfg(unix)]
+/// Write `bytes` to `path`, owner-only (`0600`) from creation on Unix — every
+/// supported target (macOS, Linux) is Unix.
 pub fn write_owner_only(path: &Path, bytes: &[u8]) -> Result<()> {
     use std::io::Write;
     use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
@@ -29,11 +26,6 @@ pub fn write_owner_only(path: &Path, bytes: &[u8]) -> Result<()> {
         .with_context(|| format!("chmod 0600 {}", path.display()))?;
     file.write_all(bytes)
         .with_context(|| format!("writing {}", path.display()))
-}
-
-#[cfg(not(unix))]
-pub fn write_owner_only(path: &Path, bytes: &[u8]) -> Result<()> {
-    std::fs::write(path, bytes).with_context(|| format!("writing {}", path.display()))
 }
 
 /// Serialize `value` as pretty JSON and write it to `path` atomically: write a

--- a/fleet/arcbox-fleet-agent/src/fsutil.rs
+++ b/fleet/arcbox-fleet-agent/src/fsutil.rs
@@ -1,9 +1,10 @@
 //! Small filesystem helper shared by anything that persists state to the
 //! data directory with an owner-only file mode.
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
+use serde::Serialize;
 
 /// Write `bytes` to `path`, owner-only (`0600`) from creation on Unix. On
 /// non-Unix platforms this writes normally — callers with a secret to
@@ -33,4 +34,30 @@ pub fn write_owner_only(path: &Path, bytes: &[u8]) -> Result<()> {
 #[cfg(not(unix))]
 pub fn write_owner_only(path: &Path, bytes: &[u8]) -> Result<()> {
     std::fs::write(path, bytes).with_context(|| format!("writing {}", path.display()))
+}
+
+/// Serialize `value` as pretty JSON and write it to `path` atomically: write a
+/// `<path>.tmp` sibling via `write` — the owner-only primitive the caller
+/// chooses, since a plain settings file and a secret credential harden
+/// differently (the latter refuses a plaintext write on non-Unix) — then
+/// rename it over `path`. The rename makes the replace atomic, so a crash
+/// mid-write can't leave a truncated file that fails to parse on the next
+/// read, and it preserves the temp file's mode so a secret is never briefly
+/// world-readable at the final path.
+pub fn write_json_atomic<T: Serialize>(
+    path: &Path,
+    value: &T,
+    write: impl FnOnce(&Path, &[u8]) -> Result<()>,
+) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("creating {}", parent.display()))?;
+    }
+    let json = serde_json::to_vec_pretty(value).context("serializing to JSON")?;
+    let mut tmp = path.as_os_str().to_owned();
+    tmp.push(".tmp");
+    let tmp = PathBuf::from(tmp);
+    write(&tmp, &json)?;
+    std::fs::rename(&tmp, path)
+        .with_context(|| format!("renaming {} -> {}", tmp.display(), path.display()))
 }

--- a/fleet/arcbox-fleet-agent/src/fsutil.rs
+++ b/fleet/arcbox-fleet-agent/src/fsutil.rs
@@ -6,9 +6,9 @@ use std::path::{Path, PathBuf};
 use anyhow::{Context, Result};
 use serde::Serialize;
 
-/// Write `bytes` to `path`, owner-only (`0600`) from creation on Unix — every
+/// Write `bytes` to `path`, owner-only (`0600`) from creation — every
 /// supported target (macOS, Linux) is Unix.
-pub fn write_owner_only(path: &Path, bytes: &[u8]) -> Result<()> {
+fn write_owner_only(path: &Path, bytes: &[u8]) -> Result<()> {
     use std::io::Write;
     use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
 
@@ -28,19 +28,13 @@ pub fn write_owner_only(path: &Path, bytes: &[u8]) -> Result<()> {
         .with_context(|| format!("writing {}", path.display()))
 }
 
-/// Serialize `value` as pretty JSON and write it to `path` atomically: write a
-/// `<path>.tmp` sibling via `write` — the owner-only primitive the caller
-/// chooses, since a plain settings file and a secret credential harden
-/// differently (the latter refuses a plaintext write on non-Unix) — then
+/// Serialize `value` as pretty JSON and write it to `path` atomically:
+/// write a `<path>.tmp` sibling owner-only (`0600` from creation), then
 /// rename it over `path`. The rename makes the replace atomic, so a crash
 /// mid-write can't leave a truncated file that fails to parse on the next
 /// read, and it preserves the temp file's mode so a secret is never briefly
 /// world-readable at the final path.
-pub fn write_json_atomic<T: Serialize>(
-    path: &Path,
-    value: &T,
-    write: impl FnOnce(&Path, &[u8]) -> Result<()>,
-) -> Result<()> {
+pub fn write_json_atomic<T: Serialize>(path: &Path, value: &T) -> Result<()> {
     if let Some(parent) = path.parent() {
         std::fs::create_dir_all(parent)
             .with_context(|| format!("creating {}", parent.display()))?;
@@ -49,7 +43,7 @@ pub fn write_json_atomic<T: Serialize>(
     let mut tmp = path.as_os_str().to_owned();
     tmp.push(".tmp");
     let tmp = PathBuf::from(tmp);
-    write(&tmp, &json)?;
+    write_owner_only(&tmp, &json)?;
     std::fs::rename(&tmp, path)
         .with_context(|| format!("renaming {} -> {}", tmp.display(), path.display()))
 }

--- a/fleet/arcbox-fleet-agent/src/fsutil.rs
+++ b/fleet/arcbox-fleet-agent/src/fsutil.rs
@@ -1,5 +1,8 @@
 //! Small filesystem helper shared by anything that persists state to the
-//! data directory with an owner-only file mode.
+//! data directory with an owner-only file mode. The directory itself gets
+//! the same owner-only barrier: callers persist secrets here from paths
+//! that never run `control::serve` (the headless `enroll`), so the helper
+//! cannot rely on the socket startup's chmod.
 
 use std::path::{Path, PathBuf};
 
@@ -35,9 +38,17 @@ fn write_owner_only(path: &Path, bytes: &[u8]) -> Result<()> {
 /// read, and it preserves the temp file's mode so a secret is never briefly
 /// world-readable at the final path.
 pub fn write_json_atomic<T: Serialize>(path: &Path, value: &T) -> Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+
     if let Some(parent) = path.parent() {
         std::fs::create_dir_all(parent)
             .with_context(|| format!("creating {}", parent.display()))?;
+        // Owner-only like the file below, and unconditional (not just on
+        // creation) so a dir left behind by an older or umask-lenient run
+        // gets the same traversal barrier `control::serve` applies at
+        // startup — the headless `enroll` persists here without `serve`.
+        std::fs::set_permissions(parent, std::fs::Permissions::from_mode(0o700))
+            .with_context(|| format!("chmod 0700 {}", parent.display()))?;
     }
     let json = serde_json::to_vec_pretty(value).context("serializing to JSON")?;
     let mut tmp = path.as_os_str().to_owned();
@@ -46,4 +57,33 @@ pub fn write_json_atomic<T: Serialize>(path: &Path, value: &T) -> Result<()> {
     write_owner_only(&tmp, &json)?;
     std::fs::rename(&tmp, path)
         .with_context(|| format!("renaming {} -> {}", tmp.display(), path.display()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::os::unix::fs::PermissionsExt;
+
+    /// The parent directory must come out owner-only even when this write is
+    /// what creates it (the headless `enroll` path, which never runs
+    /// `control::serve`), and even when it pre-exists with a lenient mode.
+    #[test]
+    fn write_json_atomic_makes_the_parent_owner_only() {
+        let dir = std::env::temp_dir().join(format!("fleet-fsutil-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        let path = dir.join("state").join("creds.json");
+
+        write_json_atomic(&path, &serde_json::json!({"k": "v"})).unwrap();
+        let parent = path.parent().unwrap();
+        let mode = std::fs::metadata(parent).unwrap().permissions().mode();
+        assert_eq!(mode & 0o777, 0o700);
+
+        // A lenient pre-existing dir is tightened, not trusted.
+        std::fs::set_permissions(parent, std::fs::Permissions::from_mode(0o755)).unwrap();
+        write_json_atomic(&path, &serde_json::json!({"k": "v2"})).unwrap();
+        let mode = std::fs::metadata(parent).unwrap().permissions().mode();
+        assert_eq!(mode & 0o777, 0o700);
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
 }

--- a/fleet/arcbox-fleet-agent/src/fsutil.rs
+++ b/fleet/arcbox-fleet-agent/src/fsutil.rs
@@ -1,0 +1,36 @@
+//! Small filesystem helper shared by anything that persists state to the
+//! data directory with an owner-only file mode.
+
+use std::path::Path;
+
+use anyhow::{Context, Result};
+
+/// Write `bytes` to `path`, owner-only (`0600`) from creation on Unix. On
+/// non-Unix platforms this writes normally — callers with a secret to
+/// protect (unlike a plain settings file) must refuse or otherwise harden
+/// separately; see `credentials.rs`'s own `write_private`.
+#[cfg(unix)]
+pub fn write_owner_only(path: &Path, bytes: &[u8]) -> Result<()> {
+    use std::io::Write;
+    use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
+
+    let mut file = std::fs::OpenOptions::new()
+        .write(true)
+        .create(true)
+        .truncate(true)
+        .mode(0o600)
+        .open(path)
+        .with_context(|| format!("creating {}", path.display()))?;
+    // `mode` only takes effect when this call creates the file; a leftover temp
+    // from a crashed run keeps its old mode, so fchmod the open handle as a
+    // backstop (operating on the fd, never racing a path lookup).
+    file.set_permissions(std::fs::Permissions::from_mode(0o600))
+        .with_context(|| format!("chmod 0600 {}", path.display()))?;
+    file.write_all(bytes)
+        .with_context(|| format!("writing {}", path.display()))
+}
+
+#[cfg(not(unix))]
+pub fn write_owner_only(path: &Path, bytes: &[u8]) -> Result<()> {
+    std::fs::write(path, bytes).with_context(|| format!("writing {}", path.display()))
+}

--- a/fleet/arcbox-fleet-agent/src/host.rs
+++ b/fleet/arcbox-fleet-agent/src/host.rs
@@ -84,11 +84,16 @@ pub fn telemetry() -> HostTelemetry {
 ///   `docker`. On Apple Silicon that is arm64 (native) plus amd64 (Rosetta).
 /// - **Host-runner capability.** The native `(os, arch)` served by the
 ///   pre-installed runner, backed by `host_runner`. Omitted when no runner
-///   directory is configured, or when Linux jobs are already Docker-served on
+///   script is configured, or when Linux jobs are already Docker-served on
 ///   this host (a Linux host with Docker). macOS is `host_runner` today; the
 ///   `vm` backend arrives with VM isolation.
-pub fn capabilities(runner_dir_present: bool, docker_arches: &[String]) -> Vec<Capability> {
-    build_capabilities(&host_os(), &host_arch(), runner_dir_present, docker_arches)
+pub fn capabilities(runner_script_present: bool, docker_arches: &[String]) -> Vec<Capability> {
+    build_capabilities(
+        &host_os(),
+        &host_arch(),
+        runner_script_present,
+        docker_arches,
+    )
 }
 
 /// Platform-independent core of [`capabilities`], taking the native `(os, arch)`
@@ -96,7 +101,7 @@ pub fn capabilities(runner_dir_present: bool, docker_arches: &[String]) -> Vec<C
 fn build_capabilities(
     native_os: &str,
     native_arch: &str,
-    runner_dir_present: bool,
+    runner_script_present: bool,
     docker_arches: &[String],
 ) -> Vec<Capability> {
     let mut caps = Vec::new();
@@ -110,7 +115,7 @@ fn build_capabilities(
     }
 
     let host_served_by_docker = native_os == "linux" && !docker_arches.is_empty();
-    if runner_dir_present && !host_served_by_docker {
+    if runner_script_present && !host_served_by_docker {
         caps.push(Capability {
             os: native_os.to_owned(),
             arch: native_arch.to_owned(),
@@ -171,8 +176,8 @@ mod tests {
     }
 
     #[test]
-    fn omits_host_capability_without_runner_dir() {
-        // Docker-only macOS: no runner dir means no darwin capability.
+    fn omits_host_capability_without_runner_script() {
+        // Docker-only macOS: no runner script means no darwin capability.
         let caps = build_capabilities("darwin", "arm64", false, &["arm64".to_owned()]);
         assert_eq!(caps.len(), 1);
         assert_eq!(triple(&caps[0]), ("linux", "arm64", Backend::Docker as i32));

--- a/fleet/arcbox-fleet-agent/src/main.rs
+++ b/fleet/arcbox-fleet-agent/src/main.rs
@@ -13,6 +13,7 @@
 
 mod attach;
 mod config;
+mod control;
 mod credentials;
 mod docker;
 mod enroll;
@@ -20,8 +21,10 @@ mod host;
 mod runner;
 
 use std::path::PathBuf;
+use std::sync::Arc;
 
 use anyhow::{Context, Result};
+use arcbox_fleet_control_proto::v1 as control_proto;
 use arcbox_fleet_proto::v1::Capability;
 use arcbox_logging::LogConfig;
 use clap::{Parser, Subcommand};
@@ -60,6 +63,17 @@ enum Command {
     },
     /// Attach to the gateway and run dispatched jobs until terminated.
     Run,
+    /// Show the running agent's enrollment/attachment status.
+    Status,
+    /// Stop the running agent from accepting new offers; in-flight jobs
+    /// finish normally.
+    Drain,
+    /// Resume accepting new offers after `drain`.
+    Resume,
+    /// Remove the running agent's machine credential and stop attaching.
+    /// A fresh `enroll` (or the control-plane `Enroll` RPC) is required to
+    /// rejoin the fleet.
+    Disconnect,
 }
 
 fn main() -> Result<()> {
@@ -92,34 +106,93 @@ async fn run(command: Command, config: AgentConfig) -> Result<()> {
             // heartbeat once the agent attaches, so we advertise what we know
             // without probing the runtime.
             let capabilities = capabilities(&config, None);
-            enroll::enroll(&config, token, capabilities).await?;
+            enroll::enroll(&config, token, capabilities, None).await?;
             Ok(())
         }
         Command::Run => {
             let docker = init_docker(&config).await?;
             let capabilities = capabilities(&config, docker.as_ref());
-            let credential = CredentialStore::new(
+            let credential_store = CredentialStore::new(
                 config.credential_store,
                 config.credentials_path(),
                 &config.gateway,
-            )
-            .load()?
-            .context(
-                "no credential found — run `arcbox-fleet-agent enroll --token-file …` first",
-            )?;
-            info!(machine_id = %credential.machine_id, "starting fleet agent");
+            );
+            let socket_path = config.control_socket_path();
 
-            // Cancelled on the first termination signal; `attach::run` then
-            // stops accepting work and tears down in-flight runners.
+            // Cancelled on the first termination signal; cascades to every
+            // attach task's child token, so runners still drain on SIGTERM
+            // even though `Disconnect` can also cancel one independently.
             let shutdown = CancellationToken::new();
             let signal_token = shutdown.clone();
             tokio::spawn(async move {
                 shutdown_signal().await;
-                info!("termination signal received; draining runners");
+                info!("termination signal received; shutting down");
                 signal_token.cancel();
             });
 
-            attach::run(config, credential, docker, capabilities, shutdown).await
+            let supervisor = Arc::new(
+                control::AgentSupervisor::new(
+                    config,
+                    docker,
+                    capabilities,
+                    credential_store,
+                    shutdown.clone(),
+                )
+                .await?,
+            );
+            control::serve(&socket_path, Arc::clone(&supervisor), shutdown).await?;
+            // The control server has stopped accepting connections; give any
+            // live attach task its own shutdown grace before the process exits.
+            supervisor.join().await;
+            Ok(())
+        }
+        Command::Status => {
+            let mut client = control::client::connect_default(&config).await?;
+            let response = client
+                .get_status(control_proto::GetStatusRequest {})
+                .await
+                .context("GetStatus RPC failed")?
+                .into_inner();
+            match control_proto::ConnectionState::try_from(response.state)
+                .unwrap_or(control_proto::ConnectionState::Unspecified)
+            {
+                control_proto::ConnectionState::Unenrolled => println!("unenrolled"),
+                control_proto::ConnectionState::Enrolled => {
+                    println!("enrolled (machine_id={})", response.machine_id);
+                }
+                control_proto::ConnectionState::Draining => {
+                    println!("draining (machine_id={})", response.machine_id);
+                }
+                control_proto::ConnectionState::Unspecified => println!("unknown state"),
+            }
+            Ok(())
+        }
+        Command::Drain => {
+            let mut client = control::client::connect_default(&config).await?;
+            client
+                .drain(control_proto::DrainRequest {})
+                .await
+                .context("Drain RPC failed")?;
+            println!("draining");
+            Ok(())
+        }
+        Command::Resume => {
+            let mut client = control::client::connect_default(&config).await?;
+            client
+                .resume(control_proto::ResumeRequest {})
+                .await
+                .context("Resume RPC failed")?;
+            println!("resumed");
+            Ok(())
+        }
+        Command::Disconnect => {
+            let mut client = control::client::connect_default(&config).await?;
+            client
+                .disconnect(control_proto::DisconnectRequest {})
+                .await
+                .context("Disconnect RPC failed")?;
+            println!("disconnected");
+            Ok(())
         }
     }
 }

--- a/fleet/arcbox-fleet-agent/src/main.rs
+++ b/fleet/arcbox-fleet-agent/src/main.rs
@@ -164,7 +164,13 @@ async fn run(command: Command, config: AgentConfig) -> Result<()> {
             // heartbeat once the agent attaches, so we advertise what we know
             // without probing the runtime.
             let capabilities = capabilities(seed.runner_script.is_some(), None);
-            enroll::enroll(&config, token, capabilities, &seed.gateway).await?;
+            let credential = enroll::enroll(&config, token, capabilities, &seed.gateway).await?;
+            CredentialStore::new(
+                config.credential_store,
+                config.credentials_path(),
+                &seed.gateway,
+            )
+            .store(&credential)?;
             Ok(())
         }
         Command::Run => {
@@ -213,11 +219,6 @@ async fn run(command: Command, config: AgentConfig) -> Result<()> {
             let seed = load_or_seed_settings(&settings_store, &config)?;
             let docker = init_docker(seed.docker_mode, &seed.runner_image).await?;
             let capabilities = capabilities(seed.runner_script.is_some(), docker.as_ref());
-            let credential_store = CredentialStore::new(
-                config.credential_store,
-                config.credentials_path(),
-                &seed.gateway,
-            );
             let socket_path = config.control_socket_path();
 
             // Cascades to every attach task's child token, so runners still
@@ -231,7 +232,6 @@ async fn run(command: Command, config: AgentConfig) -> Result<()> {
                     config,
                     docker,
                     capabilities,
-                    credential_store,
                     shutdown.clone(),
                     agent_state.clone(),
                     settings_store.clone(),

--- a/fleet/arcbox-fleet-agent/src/main.rs
+++ b/fleet/arcbox-fleet-agent/src/main.rs
@@ -14,7 +14,7 @@
 //! Two ways to run: `run` requires a credential from a prior `enroll` (the
 //! headless/farm path) and does nothing else. `serve` additionally exposes
 //! the local control-plane API on `agent.sock`, and does not require a
-//! credential up front — `enroll`/`drain`/`resume`/`disconnect` can drive it
+//! credential up front — `enroll`/`drain`/`resume`/`unenroll` can drive it
 //! from another invocation of this CLI, or from the desktop app, while it
 //! runs.
 
@@ -96,7 +96,7 @@ enum Command {
     /// Unlike `run`, a credential is not required at startup: if one is
     /// already persisted this behaves like `run`, but with none it idles
     /// until an `Enroll` call arrives over the socket (the desktop-managed
-    /// handoff) or `disconnect`/`enroll` change that from another
+    /// handoff) or `unenroll`/`enroll` change that from another
     /// invocation. This is what a launchd LaunchAgent should invoke.
     Serve,
     /// Show the running agent's enrollment/attachment status.
@@ -106,10 +106,10 @@ enum Command {
     Drain,
     /// Resume accepting new offers after `drain`.
     Resume,
-    /// Remove the running agent's machine credential and stop attaching.
-    /// A fresh `enroll` (or the control-plane `Enroll` RPC) is required to
-    /// rejoin the fleet.
-    Disconnect,
+    /// Leave the fleet — terminal. Stops attaching and removes the machine
+    /// credential; the server keeps the machine record, so a fresh `enroll`
+    /// (or the control-plane `Enroll` RPC) joins as a new machine.
+    Unenroll,
     /// Get or update the running agent's live-settable configuration.
     #[command(subcommand)]
     Settings(SettingsCommand),
@@ -240,7 +240,7 @@ async fn run(command: Command, config: AgentConfig) -> Result<()> {
             let socket_path = config.control_socket_path();
 
             // Cascades to every attach task's child token, so runners still
-            // drain on SIGTERM even though `Disconnect` can also cancel one
+            // drain on SIGTERM even though `Unenroll` can also cancel one
             // independently.
             let shutdown = spawn_shutdown_signal("termination signal received; shutting down");
 
@@ -311,14 +311,14 @@ async fn run(command: Command, config: AgentConfig) -> Result<()> {
             println!("resumed");
             Ok(())
         }
-        Command::Disconnect => {
+        Command::Unenroll => {
             let channel = control::client::connect_default(&config).await?;
             let mut client = FleetLifecycleServiceClient::new(channel);
             client
-                .disconnect(control_proto::DisconnectRequest {})
+                .unenroll(control_proto::UnenrollRequest {})
                 .await
-                .context("Disconnect RPC failed")?;
-            println!("disconnected");
+                .context("Unenroll RPC failed")?;
+            println!("unenrolled");
             Ok(())
         }
         Command::Settings(SettingsCommand::Get) => {

--- a/fleet/arcbox-fleet-agent/src/main.rs
+++ b/fleet/arcbox-fleet-agent/src/main.rs
@@ -119,7 +119,7 @@ enum SettingsCommand {
     /// Show every setting's current (in-effect) and target (requested) value.
     Get,
     /// Update one or more settings. Only the flags given are changed;
-    /// `load_ceiling`/`mem_floor_mib`/`runner_image` apply on the next
+    /// `load_ceiling`/`mem_floor_mib`/`linux_runner_image` apply on the next
     /// offer/job, `gateway` on the next reconnect, and `docker_mode`/
     /// `runner_script` on the next full restart.
     Set {
@@ -128,7 +128,7 @@ enum SettingsCommand {
         #[arg(long)]
         mem_floor_mib: Option<u64>,
         #[arg(long)]
-        runner_image: Option<String>,
+        linux_runner_image: Option<String>,
         #[arg(long)]
         gateway: Option<String>,
         /// "auto" | "enabled" | "disabled".
@@ -183,7 +183,7 @@ async fn run(command: Command, config: AgentConfig) -> Result<()> {
         Command::Run => {
             let settings_store = SettingsStore::new(config.settings_path());
             let seed = load_or_seed_settings(&settings_store, &config)?;
-            let docker = init_docker(seed.docker_mode, &seed.runner_image).await?;
+            let docker = init_docker(seed.docker_mode, &seed.linux_runner_image).await?;
             let capabilities = capabilities(seed.runner_script.is_some(), docker.as_ref());
             let credential = CredentialStore::new(
                 config.credential_store,
@@ -224,7 +224,7 @@ async fn run(command: Command, config: AgentConfig) -> Result<()> {
         Command::Serve => {
             let settings_store = SettingsStore::new(config.settings_path());
             let seed = load_or_seed_settings(&settings_store, &config)?;
-            let docker = init_docker(seed.docker_mode, &seed.runner_image).await?;
+            let docker = init_docker(seed.docker_mode, &seed.linux_runner_image).await?;
             let capabilities = capabilities(seed.runner_script.is_some(), docker.as_ref());
             let socket_path = config.control_socket_path();
 
@@ -328,7 +328,7 @@ async fn run(command: Command, config: AgentConfig) -> Result<()> {
         Command::Settings(SettingsCommand::Set {
             load_ceiling,
             mem_floor_mib,
-            runner_image,
+            linux_runner_image,
             gateway,
             docker_mode,
             runner_script,
@@ -344,7 +344,7 @@ async fn run(command: Command, config: AgentConfig) -> Result<()> {
                 .update_settings(control_proto::UpdateSettingsRequest {
                     load_ceiling,
                     mem_floor_mib,
-                    runner_image,
+                    linux_runner_image,
                     gateway,
                     docker_mode,
                     runner_script: runner_script.map(|p| p.to_string_lossy().into_owned()),
@@ -443,14 +443,14 @@ fn capabilities(runner_script_present: bool, docker: Option<&DockerRunner>) -> V
 }
 
 /// Probe Docker availability according to `mode`.
-async fn init_docker(mode: DockerMode, runner_image: &str) -> Result<Option<DockerRunner>> {
+async fn init_docker(mode: DockerMode, linux_runner_image: &str) -> Result<Option<DockerRunner>> {
     match mode {
         DockerMode::Disabled => Ok(None),
         DockerMode::Enabled => {
-            let runner = DockerRunner::new(runner_image).await?;
+            let runner = DockerRunner::new(linux_runner_image).await?;
             Ok(Some(runner))
         }
-        DockerMode::Auto => match DockerRunner::new(runner_image).await {
+        DockerMode::Auto => match DockerRunner::new(linux_runner_image).await {
             Ok(runner) => Ok(Some(runner)),
             Err(e) => {
                 warn!(error = %e, "docker not available; linux capabilities will not be advertised");
@@ -515,8 +515,8 @@ fn print_settings(s: control_proto::AgentSettings) {
             &v.target.to_string(),
         );
     }
-    if let Some(v) = s.runner_image {
-        print_setting("runner_image", &v.current, &v.target);
+    if let Some(v) = s.linux_runner_image {
+        print_setting("linux_runner_image", &v.current, &v.target);
     }
     if let Some(v) = s.gateway {
         print_setting("gateway", &v.current, &v.target);

--- a/fleet/arcbox-fleet-agent/src/main.rs
+++ b/fleet/arcbox-fleet-agent/src/main.rs
@@ -42,6 +42,7 @@ use std::sync::Arc;
 
 use anyhow::{Context, Result};
 use arcbox_fleet_control_proto::v1 as control_proto;
+use arcbox_fleet_control_proto::v1::fleet_image_service_client::FleetImageServiceClient;
 use arcbox_fleet_control_proto::v1::fleet_lifecycle_service_client::FleetLifecycleServiceClient;
 use arcbox_fleet_control_proto::v1::fleet_settings_service_client::FleetSettingsServiceClient;
 use arcbox_fleet_proto::v1::Capability;
@@ -112,6 +113,15 @@ enum Command {
     /// Get or update the running agent's live-settable configuration.
     #[command(subcommand)]
     Settings(SettingsCommand),
+    /// Converge the running agent's image settings onto their targets:
+    /// fetch and verify each target image through the runtime that owns it,
+    /// then promote it to current. Also the "update to latest" verb — a
+    /// floating target (a moving tag) is re-fetched and re-promoted.
+    Prepare {
+        /// Image kinds to prepare ("linux-runner-image"). Empty prepares
+        /// every kind the agent supports.
+        kinds: Vec<String>,
+    },
 }
 
 #[derive(Debug, Subcommand)]
@@ -119,9 +129,10 @@ enum SettingsCommand {
     /// Show every setting's current (in-effect) and target (requested) value.
     Get,
     /// Update one or more settings. Only the flags given are changed;
-    /// `load_ceiling`/`mem_floor_mib`/`linux_runner_image` apply on the next
-    /// offer/job, `gateway` on the next reconnect, and `docker_mode`/
-    /// `runner_script` on the next full restart.
+    /// `load_ceiling`/`mem_floor_mib` apply on the next offer/job,
+    /// `linux_runner_image` once `prepare` verifies it, `gateway` on the
+    /// next reconnect, and `docker_mode`/`runner_script` on the next full
+    /// restart.
     Set {
         #[arg(long)]
         load_ceiling: Option<f64>,
@@ -359,6 +370,23 @@ async fn run(command: Command, config: AgentConfig) -> Result<()> {
             );
             Ok(())
         }
+        Command::Prepare { kinds } => {
+            let kinds = kinds
+                .iter()
+                .map(|s| parse_image_kind(s).map(|k| k as i32))
+                .collect::<Result<Vec<_>>>()?;
+            let channel = control::client::connect_default(&config).await?;
+            let mut client = FleetImageServiceClient::new(channel);
+            let mut stream = client
+                .prepare(control_proto::PrepareRequest { kinds })
+                .await
+                .context("Prepare RPC failed")?
+                .into_inner();
+            while let Some(event) = stream.message().await.context("prepare failed")? {
+                print_prepare_event(&event);
+            }
+            Ok(())
+        }
     }
 }
 
@@ -466,6 +494,31 @@ fn load_or_seed_settings(store: &SettingsStore, config: &AgentConfig) -> Result<
     Ok(store
         .load()?
         .unwrap_or_else(|| PersistedSettings::from(config)))
+}
+
+fn parse_image_kind(s: &str) -> Result<control_proto::ImageKind> {
+    match s.to_lowercase().as_str() {
+        "linux-runner-image" => Ok(control_proto::ImageKind::LinuxRunnerImage),
+        other => anyhow::bail!("image kind must be 'linux-runner-image', got '{other}'"),
+    }
+}
+
+fn image_kind_label(raw: i32) -> &'static str {
+    match control_proto::ImageKind::try_from(raw).unwrap_or(control_proto::ImageKind::Unspecified) {
+        control_proto::ImageKind::LinuxRunnerImage => "linux_runner_image",
+        control_proto::ImageKind::Unspecified => "unknown",
+    }
+}
+
+/// Print one preparation progress event as `kind: stage [detail] (pct%)`.
+fn print_prepare_event(event: &control_proto::PrepareResponse) {
+    let label = image_kind_label(event.kind);
+    let pct = (event.fraction * 100.0).round();
+    if event.detail.is_empty() {
+        println!("{label}: {} ({pct:.0}%)", event.stage);
+    } else {
+        println!("{label}: {} {} ({pct:.0}%)", event.stage, event.detail);
+    }
 }
 
 fn parse_docker_mode(s: &str) -> Result<control_proto::DockerMode> {

--- a/fleet/arcbox-fleet-agent/src/main.rs
+++ b/fleet/arcbox-fleet-agent/src/main.rs
@@ -191,9 +191,6 @@ async fn run(command: Command, config: AgentConfig) -> Result<()> {
             // this over `Watch` — but `RunnerSupervisor` still reads
             // admission thresholds live from it, so it's load-bearing.
             let agent_state = AgentState::new(&seed);
-            agent_state
-                .set_docker_mode_current(resolved_docker_mode(seed.docker_mode, docker.as_ref()));
-            agent_state.set_runner_script_current(seed.runner_script.as_deref());
             let (supervisor, egress_rx) = attach::spawn_supervisor(
                 &config,
                 docker,
@@ -229,9 +226,6 @@ async fn run(command: Command, config: AgentConfig) -> Result<()> {
             let shutdown = spawn_shutdown_signal("termination signal received; shutting down");
 
             let agent_state = AgentState::new(&seed);
-            agent_state
-                .set_docker_mode_current(resolved_docker_mode(seed.docker_mode, docker.as_ref()));
-            agent_state.set_runner_script_current(seed.runner_script.as_deref());
             let supervisor = Arc::new(
                 control::AgentSupervisor::new(
                     config,
@@ -468,17 +462,6 @@ fn load_or_seed_settings(store: &SettingsStore, config: &AgentConfig) -> Result<
     Ok(store
         .load()?
         .unwrap_or_else(|| PersistedSettings::from(config)))
-}
-
-/// The `docker_mode` actually in effect after [`init_docker`] runs —
-/// `Auto` resolves concretely to whether Docker actually came up, so
-/// `current` never reports "auto" as a steady state.
-fn resolved_docker_mode(configured: DockerMode, docker: Option<&DockerRunner>) -> DockerMode {
-    match configured {
-        DockerMode::Auto if docker.is_some() => DockerMode::Enabled,
-        DockerMode::Auto => DockerMode::Disabled,
-        other => other,
-    }
 }
 
 fn parse_docker_mode(s: &str) -> Result<control_proto::DockerMode> {

--- a/fleet/arcbox-fleet-agent/src/main.rs
+++ b/fleet/arcbox-fleet-agent/src/main.rs
@@ -1,9 +1,9 @@
 //! ArcBox Fleet runner agent.
 //!
-//! A standalone, cross-platform binary that enrolls a host with the Fleet
-//! gateway and, once attached, runs GitHub Actions jobs. Linux jobs run in a
-//! Docker container for isolation when a Docker-compatible runtime is
-//! available; other jobs run via the pre-installed runner
+//! A standalone binary, for macOS and Linux hosts, that enrolls with the
+//! Fleet gateway and, once attached, runs GitHub Actions jobs. Linux jobs
+//! run in a Docker container for isolation when a Docker-compatible runtime
+//! is available; other jobs run via the pre-installed runner
 //! (`run.sh --jitconfig …`).
 //!
 //! Configuration is environment-driven (`ARCBOX_FLEET_*`). The `enroll`
@@ -17,6 +17,13 @@
 //! credential up front — `enroll`/`drain`/`resume`/`disconnect` can drive it
 //! from another invocation of this CLI, or from the desktop app, while it
 //! runs.
+
+// The local control-plane API (agent.sock) is a Unix domain socket with no
+// Windows equivalent implemented, so this crate targets macOS and Linux
+// only. A single, clear message here beats a scattered trail of
+// "type not found" errors across `control/`.
+#[cfg(not(unix))]
+compile_error!("arcbox-fleet-agent supports macOS and Linux only");
 
 mod attach;
 mod config;
@@ -369,8 +376,9 @@ fn spawn_shutdown_signal(message: &'static str) -> CancellationToken {
     shutdown
 }
 
-/// Resolve when the process receives a termination signal: Ctrl-C on any
-/// platform, or SIGTERM on Unix (e.g. a service-manager stop). If a listener
+/// Resolve when the process receives a termination signal: Ctrl-C, or
+/// SIGTERM (e.g. a service-manager stop) — every supported target (macOS,
+/// Linux) is Unix, so SIGTERM handling is unconditional. If a listener
 /// cannot be installed, that signal simply never fires rather than aborting
 /// startup.
 async fn shutdown_signal() {
@@ -381,7 +389,6 @@ async fn shutdown_signal() {
         }
     };
 
-    #[cfg(unix)]
     let terminate = async {
         use tokio::signal::unix::{SignalKind, signal};
         match signal(SignalKind::terminate()) {
@@ -394,9 +401,6 @@ async fn shutdown_signal() {
             }
         }
     };
-
-    #[cfg(not(unix))]
-    let terminate = std::future::pending::<()>();
 
     tokio::select! {
         () = ctrl_c => {}

--- a/fleet/arcbox-fleet-agent/src/main.rs
+++ b/fleet/arcbox-fleet-agent/src/main.rs
@@ -26,6 +26,7 @@ mod docker;
 mod enroll;
 mod host;
 mod runner;
+mod state;
 
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -41,6 +42,7 @@ use tracing::{info, warn};
 use crate::config::{AgentConfig, DockerMode};
 use crate::credentials::CredentialStore;
 use crate::docker::DockerRunner;
+use crate::state::AgentState;
 
 #[derive(Debug, Parser)]
 #[command(name = "arcbox-fleet-agent", author, version, about)]
@@ -154,8 +156,15 @@ async fn run(command: Command, config: AgentConfig) -> Result<()> {
                 signal_token.cancel();
             });
 
-            let (supervisor, egress_rx) =
-                attach::spawn_supervisor(&config, docker, capabilities.clone());
+            // `run` opens no control socket, so nothing ever subscribes to
+            // this — it only exists to satisfy `attach`'s shared signature.
+            let agent_state = AgentState::new();
+            let (supervisor, egress_rx) = attach::spawn_supervisor(
+                &config,
+                docker,
+                capabilities.clone(),
+                agent_state.clone(),
+            );
             attach::run(
                 config,
                 credential,
@@ -163,6 +172,7 @@ async fn run(command: Command, config: AgentConfig) -> Result<()> {
                 egress_rx,
                 capabilities,
                 shutdown,
+                agent_state,
             )
             .await
         }
@@ -187,6 +197,7 @@ async fn run(command: Command, config: AgentConfig) -> Result<()> {
                 signal_token.cancel();
             });
 
+            let agent_state = AgentState::new();
             let supervisor = Arc::new(
                 control::AgentSupervisor::new(
                     config,
@@ -194,10 +205,11 @@ async fn run(command: Command, config: AgentConfig) -> Result<()> {
                     capabilities,
                     credential_store,
                     shutdown.clone(),
+                    agent_state.clone(),
                 )
                 .await?,
             );
-            control::serve(&socket_path, Arc::clone(&supervisor), shutdown).await?;
+            control::serve(&socket_path, Arc::clone(&supervisor), agent_state, shutdown).await?;
             // The control server has stopped accepting connections; give any
             // live attach task its own shutdown grace before the process exits.
             supervisor.join().await;

--- a/fleet/arcbox-fleet-agent/src/main.rs
+++ b/fleet/arcbox-fleet-agent/src/main.rs
@@ -24,8 +24,10 @@ mod control;
 mod credentials;
 mod docker;
 mod enroll;
+mod fsutil;
 mod host;
 mod runner;
+mod settings;
 mod state;
 
 use std::path::PathBuf;
@@ -33,6 +35,8 @@ use std::sync::Arc;
 
 use anyhow::{Context, Result};
 use arcbox_fleet_control_proto::v1 as control_proto;
+use arcbox_fleet_control_proto::v1::fleet_lifecycle_service_client::FleetLifecycleServiceClient;
+use arcbox_fleet_control_proto::v1::fleet_settings_service_client::FleetSettingsServiceClient;
 use arcbox_fleet_proto::v1::Capability;
 use arcbox_logging::LogConfig;
 use clap::{Parser, Subcommand};
@@ -42,6 +46,7 @@ use tracing::{info, warn};
 use crate::config::{AgentConfig, DockerMode};
 use crate::credentials::CredentialStore;
 use crate::docker::DockerRunner;
+use crate::settings::{PersistedSettings, SettingsStore};
 use crate::state::AgentState;
 
 #[derive(Debug, Parser)]
@@ -97,6 +102,34 @@ enum Command {
     /// A fresh `enroll` (or the control-plane `Enroll` RPC) is required to
     /// rejoin the fleet.
     Disconnect,
+    /// Get or update the running agent's live-settable configuration.
+    #[command(subcommand)]
+    Settings(SettingsCommand),
+}
+
+#[derive(Debug, Subcommand)]
+enum SettingsCommand {
+    /// Show every setting's current (in-effect) and target (requested) value.
+    Get,
+    /// Update one or more settings. Only the flags given are changed;
+    /// `load_ceiling`/`mem_floor_mib`/`runner_image` apply on the next
+    /// offer/job, `gateway` on the next reconnect, and `docker_mode`/
+    /// `runner_script` on the next full restart.
+    Set {
+        #[arg(long)]
+        load_ceiling: Option<f64>,
+        #[arg(long)]
+        mem_floor_mib: Option<u64>,
+        #[arg(long)]
+        runner_image: Option<String>,
+        #[arg(long)]
+        gateway: Option<String>,
+        /// "auto" | "enabled" | "disabled".
+        #[arg(long)]
+        docker_mode: Option<String>,
+        #[arg(long)]
+        runner_script: Option<PathBuf>,
+    },
 }
 
 fn main() -> Result<()> {
@@ -123,22 +156,26 @@ async fn run(command: Command, config: AgentConfig) -> Result<()> {
     match command {
         Command::Enroll { token_file, token } => {
             let token = resolve_enrollment_token(token_file, token)?;
+            let settings_store = SettingsStore::new(config.settings_path());
+            let seed = load_or_seed_settings(&settings_store, &config)?;
             // Enrollment is pure credential exchange — it never needs Docker, so
             // an operator can enroll before the runtime is up. The capabilities
             // sent here are an initial hint, replaced wholesale by the first
             // heartbeat once the agent attaches, so we advertise what we know
             // without probing the runtime.
-            let capabilities = capabilities(&config, None);
-            enroll::enroll(&config, token, capabilities, None).await?;
+            let capabilities = capabilities(seed.runner_script.is_some(), None);
+            enroll::enroll(&config, token, capabilities, &seed.gateway).await?;
             Ok(())
         }
         Command::Run => {
-            let docker = init_docker(&config).await?;
-            let capabilities = capabilities(&config, docker.as_ref());
+            let settings_store = SettingsStore::new(config.settings_path());
+            let seed = load_or_seed_settings(&settings_store, &config)?;
+            let docker = init_docker(seed.docker_mode, &seed.runner_image).await?;
+            let capabilities = capabilities(seed.runner_script.is_some(), docker.as_ref());
             let credential = CredentialStore::new(
                 config.credential_store,
                 config.credentials_path(),
-                &config.gateway,
+                &seed.gateway,
             )
             .load()?
             .context(
@@ -151,8 +188,12 @@ async fn run(command: Command, config: AgentConfig) -> Result<()> {
             let shutdown = spawn_shutdown_signal("termination signal received; draining runners");
 
             // `run` opens no control socket, so nothing ever subscribes to
-            // this — it only exists to satisfy `attach`'s shared signature.
-            let agent_state = AgentState::new();
+            // this over `Watch` — but `RunnerSupervisor` still reads
+            // admission thresholds live from it, so it's load-bearing.
+            let agent_state = AgentState::new(&seed);
+            agent_state
+                .set_docker_mode_current(resolved_docker_mode(seed.docker_mode, docker.as_ref()));
+            agent_state.set_runner_script_current(seed.runner_script.as_deref());
             let (supervisor, egress_rx) = attach::spawn_supervisor(
                 &config,
                 docker,
@@ -171,12 +212,14 @@ async fn run(command: Command, config: AgentConfig) -> Result<()> {
             .await
         }
         Command::Serve => {
-            let docker = init_docker(&config).await?;
-            let capabilities = capabilities(&config, docker.as_ref());
+            let settings_store = SettingsStore::new(config.settings_path());
+            let seed = load_or_seed_settings(&settings_store, &config)?;
+            let docker = init_docker(seed.docker_mode, &seed.runner_image).await?;
+            let capabilities = capabilities(seed.runner_script.is_some(), docker.as_ref());
             let credential_store = CredentialStore::new(
                 config.credential_store,
                 config.credentials_path(),
-                &config.gateway,
+                &seed.gateway,
             );
             let socket_path = config.control_socket_path();
 
@@ -185,7 +228,10 @@ async fn run(command: Command, config: AgentConfig) -> Result<()> {
             // independently.
             let shutdown = spawn_shutdown_signal("termination signal received; shutting down");
 
-            let agent_state = AgentState::new();
+            let agent_state = AgentState::new(&seed);
+            agent_state
+                .set_docker_mode_current(resolved_docker_mode(seed.docker_mode, docker.as_ref()));
+            agent_state.set_runner_script_current(seed.runner_script.as_deref());
             let supervisor = Arc::new(
                 control::AgentSupervisor::new(
                     config,
@@ -194,17 +240,26 @@ async fn run(command: Command, config: AgentConfig) -> Result<()> {
                     credential_store,
                     shutdown.clone(),
                     agent_state.clone(),
+                    settings_store.clone(),
                 )
                 .await?,
             );
-            control::serve(&socket_path, Arc::clone(&supervisor), agent_state, shutdown).await?;
+            control::serve(
+                &socket_path,
+                Arc::clone(&supervisor),
+                agent_state,
+                settings_store,
+                shutdown,
+            )
+            .await?;
             // The control server has stopped accepting connections; give any
             // live attach task its own shutdown grace before the process exits.
             supervisor.join().await;
             Ok(())
         }
         Command::Status => {
-            let mut client = control::client::connect_default(&config).await?;
+            let channel = control::client::connect_default(&config).await?;
+            let mut client = FleetLifecycleServiceClient::new(channel);
             let response = client
                 .get_status(control_proto::GetStatusRequest {})
                 .await
@@ -225,7 +280,8 @@ async fn run(command: Command, config: AgentConfig) -> Result<()> {
             Ok(())
         }
         Command::Drain => {
-            let mut client = control::client::connect_default(&config).await?;
+            let channel = control::client::connect_default(&config).await?;
+            let mut client = FleetLifecycleServiceClient::new(channel);
             client
                 .drain(control_proto::DrainRequest {})
                 .await
@@ -234,7 +290,8 @@ async fn run(command: Command, config: AgentConfig) -> Result<()> {
             Ok(())
         }
         Command::Resume => {
-            let mut client = control::client::connect_default(&config).await?;
+            let channel = control::client::connect_default(&config).await?;
+            let mut client = FleetLifecycleServiceClient::new(channel);
             client
                 .resume(control_proto::ResumeRequest {})
                 .await
@@ -243,12 +300,62 @@ async fn run(command: Command, config: AgentConfig) -> Result<()> {
             Ok(())
         }
         Command::Disconnect => {
-            let mut client = control::client::connect_default(&config).await?;
+            let channel = control::client::connect_default(&config).await?;
+            let mut client = FleetLifecycleServiceClient::new(channel);
             client
                 .disconnect(control_proto::DisconnectRequest {})
                 .await
                 .context("Disconnect RPC failed")?;
             println!("disconnected");
+            Ok(())
+        }
+        Command::Settings(SettingsCommand::Get) => {
+            let channel = control::client::connect_default(&config).await?;
+            let mut client = FleetSettingsServiceClient::new(channel);
+            let response = client
+                .get_settings(control_proto::GetSettingsRequest {})
+                .await
+                .context("GetSettings RPC failed")?
+                .into_inner();
+            print_settings(
+                response
+                    .settings
+                    .context("GetSettings response missing settings")?,
+            );
+            Ok(())
+        }
+        Command::Settings(SettingsCommand::Set {
+            load_ceiling,
+            mem_floor_mib,
+            runner_image,
+            gateway,
+            docker_mode,
+            runner_script,
+        }) => {
+            let docker_mode = docker_mode
+                .as_deref()
+                .map(parse_docker_mode)
+                .transpose()?
+                .map(|m| m as i32);
+            let channel = control::client::connect_default(&config).await?;
+            let mut client = FleetSettingsServiceClient::new(channel);
+            let response = client
+                .update_settings(control_proto::UpdateSettingsRequest {
+                    load_ceiling,
+                    mem_floor_mib,
+                    runner_image,
+                    gateway,
+                    docker_mode,
+                    runner_script: runner_script.map(|p| p.to_string_lossy().into_owned()),
+                })
+                .await
+                .context("UpdateSettings RPC failed")?
+                .into_inner();
+            print_settings(
+                response
+                    .settings
+                    .context("UpdateSettings response missing settings")?,
+            );
             Ok(())
         }
     }
@@ -329,28 +436,124 @@ fn resolve_enrollment_token(token_file: Option<PathBuf>, token: Option<String>) 
 }
 
 /// Build the capabilities this agent advertises: the native host-runner
-/// capability (if a runner directory is set) plus any Docker-served Linux
-/// capabilities. Capacity is decided per offer from live telemetry, not here.
-fn capabilities(config: &AgentConfig, docker: Option<&DockerRunner>) -> Vec<Capability> {
+/// capability (if a runner script is configured) plus any Docker-served
+/// Linux capabilities. Capacity is decided per offer from live telemetry,
+/// not here.
+fn capabilities(runner_script_present: bool, docker: Option<&DockerRunner>) -> Vec<Capability> {
     let docker_arches = docker.map(DockerRunner::linux_arches).unwrap_or_default();
-    host::capabilities(config.runner_dir.is_some(), &docker_arches)
+    host::capabilities(runner_script_present, &docker_arches)
 }
 
-/// Probe Docker availability according to the configured [`DockerMode`].
-async fn init_docker(config: &AgentConfig) -> Result<Option<DockerRunner>> {
-    match config.docker.mode {
+/// Probe Docker availability according to `mode`.
+async fn init_docker(mode: DockerMode, runner_image: &str) -> Result<Option<DockerRunner>> {
+    match mode {
         DockerMode::Disabled => Ok(None),
         DockerMode::Enabled => {
-            let runner = DockerRunner::new(config.docker.runner_image.clone()).await?;
+            let runner = DockerRunner::new(runner_image).await?;
             Ok(Some(runner))
         }
-        DockerMode::Auto => match DockerRunner::new(config.docker.runner_image.clone()).await {
+        DockerMode::Auto => match DockerRunner::new(runner_image).await {
             Ok(runner) => Ok(Some(runner)),
             Err(e) => {
                 warn!(error = %e, "docker not available; linux capabilities will not be advertised");
                 Ok(None)
             }
         },
+    }
+}
+
+/// Load persisted settings, seeding from `config`'s env-derived values on
+/// first-ever start.
+fn load_or_seed_settings(store: &SettingsStore, config: &AgentConfig) -> Result<PersistedSettings> {
+    Ok(store
+        .load()?
+        .unwrap_or_else(|| PersistedSettings::from(config)))
+}
+
+/// The `docker_mode` actually in effect after [`init_docker`] runs —
+/// `Auto` resolves concretely to whether Docker actually came up, so
+/// `current` never reports "auto" as a steady state.
+fn resolved_docker_mode(configured: DockerMode, docker: Option<&DockerRunner>) -> DockerMode {
+    match configured {
+        DockerMode::Auto if docker.is_some() => DockerMode::Enabled,
+        DockerMode::Auto => DockerMode::Disabled,
+        other => other,
+    }
+}
+
+fn parse_docker_mode(s: &str) -> Result<control_proto::DockerMode> {
+    match s.to_lowercase().as_str() {
+        "auto" => Ok(control_proto::DockerMode::Auto),
+        "enabled" => Ok(control_proto::DockerMode::Enabled),
+        "disabled" => Ok(control_proto::DockerMode::Disabled),
+        other => {
+            anyhow::bail!("docker_mode must be 'auto', 'enabled', or 'disabled', got '{other}'")
+        }
+    }
+}
+
+fn docker_mode_label(raw: i32) -> &'static str {
+    match control_proto::DockerMode::try_from(raw).unwrap_or(control_proto::DockerMode::Unspecified)
+    {
+        control_proto::DockerMode::Auto => "auto",
+        control_proto::DockerMode::Enabled => "enabled",
+        control_proto::DockerMode::Disabled => "disabled",
+        control_proto::DockerMode::Unspecified => "unspecified",
+    }
+}
+
+/// Print one setting as `name: <current>`, or `name: <current> (target:
+/// <target>)` when the two differ (e.g. `gateway` before the next
+/// reconnect, or `docker_mode`/`runner_script` before the next restart).
+fn print_setting(name: &str, current: &str, target: &str) {
+    if current == target {
+        println!("{name}: {current}");
+    } else {
+        println!("{name}: {current} (target: {target})");
+    }
+}
+
+fn print_settings(s: control_proto::AgentSettings) {
+    if let Some(v) = s.load_ceiling {
+        print_setting(
+            "load_ceiling",
+            &v.current.to_string(),
+            &v.target.to_string(),
+        );
+    }
+    if let Some(v) = s.mem_floor_mib {
+        print_setting(
+            "mem_floor_mib",
+            &v.current.to_string(),
+            &v.target.to_string(),
+        );
+    }
+    if let Some(v) = s.runner_image {
+        print_setting("runner_image", &v.current, &v.target);
+    }
+    if let Some(v) = s.gateway {
+        print_setting("gateway", &v.current, &v.target);
+    }
+    if let Some(v) = s.docker_mode {
+        print_setting(
+            "docker_mode",
+            docker_mode_label(v.current),
+            docker_mode_label(v.target),
+        );
+    }
+    if let Some(v) = s.runner_script {
+        let none = "(none)".to_owned();
+        let current = if v.current.is_empty() {
+            &none
+        } else {
+            &v.current
+        };
+        let target = if v.target.is_empty() {
+            &none
+        } else {
+            &v.target
+        };
+        print_setting("runner_script", current, target);
     }
 }
 

--- a/fleet/arcbox-fleet-agent/src/main.rs
+++ b/fleet/arcbox-fleet-agent/src/main.rs
@@ -130,10 +130,10 @@ enum SettingsCommand {
     Get,
     /// Update one or more settings. Only the flags given are changed;
     /// `load_ceiling`/`mem_floor_mib` apply on the next offer/job,
-    /// `linux_runner_image` once `prepare` verifies it, `gateway` on the
-    /// next reconnect, `participate` as soon as the detach/reattach
-    /// completes, and `docker_mode`/`runner_script` on the next full
-    /// restart.
+    /// `linux_runner_image` once `prepare` verifies it, `participate` as
+    /// soon as the detach/reattach completes, and `docker_mode`/
+    /// `runner_script` on the next full restart. `gateway` is only
+    /// settable while unenrolled (it takes effect on the next enroll).
     Set {
         #[arg(long)]
         load_ceiling: Option<f64>,

--- a/fleet/arcbox-fleet-agent/src/main.rs
+++ b/fleet/arcbox-fleet-agent/src/main.rs
@@ -10,6 +10,13 @@
 //! subcommand reads the fleet join token from a file (`--token-file`) or stdin
 //! by default; `--token` is accepted for convenience but discouraged, as it
 //! leaks the token through the process argument list and shell history.
+//!
+//! Two ways to run: `run` requires a credential from a prior `enroll` (the
+//! headless/farm path) and does nothing else. `serve` additionally exposes
+//! the local control-plane API on `agent.sock`, and does not require a
+//! credential up front — `enroll`/`drain`/`resume`/`disconnect` can drive it
+//! from another invocation of this CLI, or from the desktop app, while it
+//! runs.
 
 mod attach;
 mod config;
@@ -62,7 +69,21 @@ enum Command {
         token: Option<String>,
     },
     /// Attach to the gateway and run dispatched jobs until terminated.
+    ///
+    /// Requires a credential from a prior `enroll` — the headless/farm path,
+    /// unchanged by the local control-plane API. For the desktop-managed
+    /// handoff, where enrollment arrives later over `agent.sock`, use `serve`
+    /// instead.
     Run,
+    /// Start the local control-plane API (`agent.sock`) and, once enrolled,
+    /// attach to the gateway and run dispatched jobs until terminated.
+    ///
+    /// Unlike `run`, a credential is not required at startup: if one is
+    /// already persisted this behaves like `run`, but with none it idles
+    /// until an `Enroll` call arrives over the socket (the desktop-managed
+    /// handoff) or `disconnect`/`enroll` change that from another
+    /// invocation. This is what a launchd LaunchAgent should invoke.
+    Serve,
     /// Show the running agent's enrollment/attachment status.
     Status,
     /// Stop the running agent from accepting new offers; in-flight jobs
@@ -110,6 +131,42 @@ async fn run(command: Command, config: AgentConfig) -> Result<()> {
             Ok(())
         }
         Command::Run => {
+            let docker = init_docker(&config).await?;
+            let capabilities = capabilities(&config, docker.as_ref());
+            let credential = CredentialStore::new(
+                config.credential_store,
+                config.credentials_path(),
+                &config.gateway,
+            )
+            .load()?
+            .context(
+                "no credential found — run `arcbox-fleet-agent enroll --token-file …` first",
+            )?;
+            info!(machine_id = %credential.machine_id, "starting fleet agent");
+
+            // Cancelled on the first termination signal; `attach::run` then
+            // stops accepting work and tears down in-flight runners.
+            let shutdown = CancellationToken::new();
+            let signal_token = shutdown.clone();
+            tokio::spawn(async move {
+                shutdown_signal().await;
+                info!("termination signal received; draining runners");
+                signal_token.cancel();
+            });
+
+            let (supervisor, egress_rx) =
+                attach::spawn_supervisor(&config, docker, capabilities.clone());
+            attach::run(
+                config,
+                credential,
+                supervisor,
+                egress_rx,
+                capabilities,
+                shutdown,
+            )
+            .await
+        }
+        Command::Serve => {
             let docker = init_docker(&config).await?;
             let capabilities = capabilities(&config, docker.as_ref());
             let credential_store = CredentialStore::new(

--- a/fleet/arcbox-fleet-agent/src/main.rs
+++ b/fleet/arcbox-fleet-agent/src/main.rs
@@ -300,6 +300,13 @@ async fn run(command: Command, config: AgentConfig) -> Result<()> {
                         response.machine_id
                     );
                 }
+                control_proto::ConnectionState::CredentialRejected => {
+                    println!(
+                        "credential rejected (machine_id={}; the machine was decommissioned \
+                         server-side — run `unenroll` to clear it and re-enroll to rejoin)",
+                        response.machine_id
+                    );
+                }
                 control_proto::ConnectionState::Unspecified => println!("unknown state"),
             }
             Ok(())

--- a/fleet/arcbox-fleet-agent/src/main.rs
+++ b/fleet/arcbox-fleet-agent/src/main.rs
@@ -131,7 +131,8 @@ enum SettingsCommand {
     /// Update one or more settings. Only the flags given are changed;
     /// `load_ceiling`/`mem_floor_mib` apply on the next offer/job,
     /// `linux_runner_image` once `prepare` verifies it, `gateway` on the
-    /// next reconnect, and `docker_mode`/`runner_script` on the next full
+    /// next reconnect, `participate` as soon as the detach/reattach
+    /// completes, and `docker_mode`/`runner_script` on the next full
     /// restart.
     Set {
         #[arg(long)]
@@ -147,6 +148,10 @@ enum SettingsCommand {
         docker_mode: Option<String>,
         #[arg(long)]
         runner_script: Option<PathBuf>,
+        /// "false" detaches from the fleet keeping the credential; "true"
+        /// reattaches with the same identity.
+        #[arg(long)]
+        participate: Option<bool>,
     },
 }
 
@@ -256,6 +261,7 @@ async fn run(command: Command, config: AgentConfig) -> Result<()> {
                 )
                 .await?,
             );
+            let reconciler = supervisor.spawn_participation_reconciler(shutdown.clone());
             control::serve(
                 &socket_path,
                 Arc::clone(&supervisor),
@@ -267,6 +273,7 @@ async fn run(command: Command, config: AgentConfig) -> Result<()> {
             // The control server has stopped accepting connections; give any
             // live attach task its own shutdown grace before the process exits.
             supervisor.join().await;
+            let _ = reconciler.await;
             Ok(())
         }
         Command::Status => {
@@ -286,6 +293,12 @@ async fn run(command: Command, config: AgentConfig) -> Result<()> {
                 }
                 control_proto::ConnectionState::Draining => {
                     println!("draining (machine_id={})", response.machine_id);
+                }
+                control_proto::ConnectionState::Detached => {
+                    println!(
+                        "detached (machine_id={}; participate=false — set participate=true to reattach)",
+                        response.machine_id
+                    );
                 }
                 control_proto::ConnectionState::Unspecified => println!("unknown state"),
             }
@@ -343,6 +356,7 @@ async fn run(command: Command, config: AgentConfig) -> Result<()> {
             gateway,
             docker_mode,
             runner_script,
+            participate,
         }) => {
             let docker_mode = docker_mode
                 .as_deref()
@@ -359,6 +373,7 @@ async fn run(command: Command, config: AgentConfig) -> Result<()> {
                     gateway,
                     docker_mode,
                     runner_script: runner_script.map(|p| p.to_string_lossy().into_owned()),
+                    participate,
                 })
                 .await
                 .context("UpdateSettings RPC failed")?
@@ -554,6 +569,9 @@ fn print_setting(name: &str, current: &str, target: &str) {
 }
 
 fn print_settings(s: control_proto::AgentSettings) {
+    if let Some(v) = s.participate {
+        print_setting("participate", &v.current.to_string(), &v.target.to_string());
+    }
     if let Some(v) = s.load_ceiling {
         print_setting(
             "load_ceiling",

--- a/fleet/arcbox-fleet-agent/src/main.rs
+++ b/fleet/arcbox-fleet-agent/src/main.rs
@@ -146,15 +146,9 @@ async fn run(command: Command, config: AgentConfig) -> Result<()> {
             )?;
             info!(machine_id = %credential.machine_id, "starting fleet agent");
 
-            // Cancelled on the first termination signal; `attach::run` then
-            // stops accepting work and tears down in-flight runners.
-            let shutdown = CancellationToken::new();
-            let signal_token = shutdown.clone();
-            tokio::spawn(async move {
-                shutdown_signal().await;
-                info!("termination signal received; draining runners");
-                signal_token.cancel();
-            });
+            // `attach::run` stops accepting work and tears down in-flight
+            // runners once this fires.
+            let shutdown = spawn_shutdown_signal("termination signal received; draining runners");
 
             // `run` opens no control socket, so nothing ever subscribes to
             // this — it only exists to satisfy `attach`'s shared signature.
@@ -186,16 +180,10 @@ async fn run(command: Command, config: AgentConfig) -> Result<()> {
             );
             let socket_path = config.control_socket_path();
 
-            // Cancelled on the first termination signal; cascades to every
-            // attach task's child token, so runners still drain on SIGTERM
-            // even though `Disconnect` can also cancel one independently.
-            let shutdown = CancellationToken::new();
-            let signal_token = shutdown.clone();
-            tokio::spawn(async move {
-                shutdown_signal().await;
-                info!("termination signal received; shutting down");
-                signal_token.cancel();
-            });
+            // Cascades to every attach task's child token, so runners still
+            // drain on SIGTERM even though `Disconnect` can also cancel one
+            // independently.
+            let shutdown = spawn_shutdown_signal("termination signal received; shutting down");
 
             let agent_state = AgentState::new();
             let supervisor = Arc::new(
@@ -264,6 +252,20 @@ async fn run(command: Command, config: AgentConfig) -> Result<()> {
             Ok(())
         }
     }
+}
+
+/// Build a `CancellationToken` cancelled on the first termination signal
+/// (see [`shutdown_signal`]), logging `message` when it fires. Shared by
+/// `run` and `serve`, whose shutdown trigger is otherwise identical.
+fn spawn_shutdown_signal(message: &'static str) -> CancellationToken {
+    let shutdown = CancellationToken::new();
+    let signal_token = shutdown.clone();
+    tokio::spawn(async move {
+        shutdown_signal().await;
+        info!("{message}");
+        signal_token.cancel();
+    });
+    shutdown
 }
 
 /// Resolve when the process receives a termination signal: Ctrl-C on any

--- a/fleet/arcbox-fleet-agent/src/runner.rs
+++ b/fleet/arcbox-fleet-agent/src/runner.rs
@@ -423,7 +423,7 @@ impl RunnerSupervisor {
         // Startup is cancellation-aware: a slow image pull must not make the
         // agent deaf to CancelRunner and then accept a job the platform has
         // already concluded.
-        let runner_image = self.inner.state.runner_image_current();
+        let runner_image = self.inner.state.linux_runner_image_current();
         let started = {
             let start = std::pin::pin!(docker.start(RunSpec {
                 job_id,
@@ -582,7 +582,7 @@ mod tests {
         crate::settings::PersistedSettings {
             load_ceiling: 0.9,
             mem_floor_mib: 2048,
-            runner_image: "ghcr.io/actions/actions-runner:latest".to_owned(),
+            linux_runner_image: "ghcr.io/actions/actions-runner:latest".to_owned(),
             gateway: "https://fleet.arcbox.dev".to_owned(),
             docker_mode: crate::config::DockerMode::Auto,
             runner_script: None,

--- a/fleet/arcbox-fleet-agent/src/runner.rs
+++ b/fleet/arcbox-fleet-agent/src/runner.rs
@@ -272,11 +272,21 @@ impl RunnerSupervisor {
         }
     }
 
-    /// Stop accepting new work; in-flight jobs run to completion.
-    pub fn handle_drain(&self) {
+    /// Stop admitting new offers locally, without touching the observable
+    /// [`AgentState`] draining flag. Shared by the user-facing `Drain` (which
+    /// also flips the observable flag) and by [`Self::shutdown`] (which must
+    /// not: a disconnect's teardown would otherwise leave the shared,
+    /// process-lifetime state stuck draining, so a re-enroll on the same
+    /// process would inherit it and report Draining while actually admitting).
+    fn stop_accepting(&self) {
         self.inner
             .draining
             .store(true, std::sync::atomic::Ordering::Relaxed);
+    }
+
+    /// Stop accepting new work; in-flight jobs run to completion.
+    pub fn handle_drain(&self) {
+        self.stop_accepting();
         self.inner.state.set_draining(true);
         info!("draining: no new offers will be accepted");
     }
@@ -299,7 +309,7 @@ impl RunnerSupervisor {
     /// to release their slots. The guarantee is that no runner process group or
     /// container is left orphaned when the agent exits.
     pub async fn shutdown(&self, grace: Duration) {
-        self.handle_drain();
+        self.stop_accepting();
         // Cancelling is idempotent, so jobs already mid-cancel just keep
         // tearing down and are covered by the wait below.
         for entry in &self.inner.in_flight {
@@ -926,5 +936,32 @@ mod tests {
         sup.shutdown(Duration::from_millis(250)).await;
 
         assert!(!sup.inner.in_flight.is_empty());
+    }
+
+    /// The user-facing `Drain` flips the observable `AgentState.draining`
+    /// flag, but teardown (`shutdown`) must not: that flag is process-lifetime
+    /// and shared across attachments, so a disconnect that faked a drain would
+    /// leave a later re-enroll reporting Draining while it is in fact admitting
+    /// jobs. Both still stop admission locally (see the shutdown tests above,
+    /// which assert `inner.draining`).
+    #[tokio::test]
+    async fn shutdown_does_not_flip_observable_draining_but_drain_does() {
+        let drained = AgentState::new(&seed());
+        let (events, _rx) = mpsc::channel(1);
+        RunnerSupervisor::new(events, None, None, Vec::new(), drained.clone()).handle_drain();
+        assert!(
+            drained.current().draining,
+            "Drain flips the observable flag"
+        );
+
+        let torn_down = AgentState::new(&seed());
+        let (events, _rx) = mpsc::channel(1);
+        RunnerSupervisor::new(events, None, None, Vec::new(), torn_down.clone())
+            .shutdown(Duration::from_secs(1))
+            .await;
+        assert!(
+            !torn_down.current().draining,
+            "teardown must not flip the observable flag",
+        );
     }
 }

--- a/fleet/arcbox-fleet-agent/src/runner.rs
+++ b/fleet/arcbox-fleet-agent/src/runner.rs
@@ -85,8 +85,8 @@ struct Inner {
     /// still starting is observed at the next cancellation point rather than
     /// lost; see [`RunnerSupervisor::handle_cancel`].
     in_flight: DashMap<String, CancellationToken>,
-    /// Path to the installed runner's entry point (`run.sh` / `run.cmd`).
-    /// `None` when only Docker-based execution is configured.
+    /// Path to the installed runner's entry point (`run.sh`). `None` when
+    /// only Docker-based execution is configured.
     runner_script: Option<PathBuf>,
     /// Docker runtime for Linux jobs, if available.
     docker: Option<DockerRunner>,
@@ -545,27 +545,14 @@ impl RunnerSupervisor {
     }
 }
 
-/// Build the platform-appropriate runner invocation. `script` is the direct
-/// path to the entry point (`run.sh` / `run.cmd`); no `.current_dir()` is
-/// set because these wrapper scripts locate their own sibling files via
-/// `$0`'s dirname, not the caller's working directory.
+/// Build the runner invocation. `script` is the direct path to the entry
+/// point (`run.sh`); no `.current_dir()` is set because the wrapper script
+/// locates its own sibling files via `$0`'s dirname, not the caller's
+/// working directory.
 fn runner_command(script: &Path, encoded_jit_config: &str) -> tokio::process::Command {
-    #[cfg(windows)]
-    {
-        let mut command = tokio::process::Command::new("cmd");
-        command
-            .arg("/C")
-            .arg(script)
-            .arg("--jitconfig")
-            .arg(encoded_jit_config);
-        command
-    }
-    #[cfg(not(windows))]
-    {
-        let mut command = tokio::process::Command::new(script);
-        command.arg("--jitconfig").arg(encoded_jit_config);
-        command
-    }
+    let mut command = tokio::process::Command::new(script);
+    command.arg("--jitconfig").arg(encoded_jit_config);
+    command
 }
 
 #[cfg(test)]

--- a/fleet/arcbox-fleet-agent/src/runner.rs
+++ b/fleet/arcbox-fleet-agent/src/runner.rs
@@ -586,6 +586,7 @@ mod tests {
             gateway: "https://fleet.arcbox.dev".to_owned(),
             docker_mode: crate::config::DockerMode::Auto,
             runner_script: None,
+            participate: true,
         }
     }
 

--- a/fleet/arcbox-fleet-agent/src/runner.rs
+++ b/fleet/arcbox-fleet-agent/src/runner.rs
@@ -250,6 +250,24 @@ impl RunnerSupervisor {
         info!("draining: no new offers will be accepted");
     }
 
+    /// Resume accepting new work after a local [`Self::handle_drain`]. This
+    /// is the local control-plane's `Resume`, distinct from the gateway's
+    /// own `Drain` push (e.g. a machine being decommissioned), which this
+    /// agent has no way to countermand.
+    pub fn resume(&self) {
+        self.inner
+            .draining
+            .store(false, std::sync::atomic::Ordering::Relaxed);
+        info!("resumed: accepting new offers");
+    }
+
+    /// Whether the supervisor is currently refusing new offers.
+    pub fn is_draining(&self) -> bool {
+        self.inner
+            .draining
+            .load(std::sync::atomic::Ordering::Relaxed)
+    }
+
     /// Begin graceful shutdown: stop accepting offers, cancel every in-flight
     /// job (each `run_job` tears down its runner — process group for host jobs,
     /// container for Docker jobs), and wait — bounded by `grace` — for the jobs
@@ -576,6 +594,26 @@ mod tests {
             sup.admit("rjob_b", "darwin", "arm64", &idle()),
             Admission::Reject(_)
         ));
+    }
+
+    #[test]
+    fn resume_undoes_drain() {
+        let sup = supervisor(vec![capability("darwin", "arm64", Backend::HostRunner)]);
+        assert!(!sup.is_draining());
+
+        sup.handle_drain();
+        assert!(sup.is_draining());
+        assert!(matches!(
+            sup.admit("rjob_a", "darwin", "arm64", &idle()),
+            Admission::Reject(_)
+        ));
+
+        sup.resume();
+        assert!(!sup.is_draining());
+        assert_eq!(
+            sup.admit("rjob_a", "darwin", "arm64", &idle()),
+            Admission::Accept(Backend::HostRunner)
+        );
     }
 
     #[test]

--- a/fleet/arcbox-fleet-agent/src/runner.rs
+++ b/fleet/arcbox-fleet-agent/src/runner.rs
@@ -275,7 +275,7 @@ impl RunnerSupervisor {
     /// Stop admitting new offers locally, without touching the observable
     /// [`AgentState`] draining flag. Shared by the user-facing `Drain` (which
     /// also flips the observable flag) and by [`Self::shutdown`] (which must
-    /// not: a disconnect's teardown would otherwise leave the shared,
+    /// not: an unenroll's teardown would otherwise leave the shared,
     /// process-lifetime state stuck draining, so a re-enroll on the same
     /// process would inherit it and report Draining while actually admitting).
     fn stop_accepting(&self) {
@@ -927,7 +927,7 @@ mod tests {
 
     /// The user-facing `Drain` flips the observable `AgentState.draining`
     /// flag, but teardown (`shutdown`) must not: that flag is process-lifetime
-    /// and shared across attachments, so a disconnect that faked a drain would
+    /// and shared across attachments, so an unenroll that faked a drain would
     /// leave a later re-enroll reporting Draining while it is in fact admitting
     /// jobs. Both still stop admission locally (see the shutdown tests above,
     /// which assert `inner.draining`).

--- a/fleet/arcbox-fleet-agent/src/runner.rs
+++ b/fleet/arcbox-fleet-agent/src/runner.rs
@@ -85,17 +85,13 @@ struct Inner {
     /// still starting is observed at the next cancellation point rather than
     /// lost; see [`RunnerSupervisor::handle_cancel`].
     in_flight: DashMap<String, CancellationToken>,
-    /// Directory holding the installed runner (`run.sh` / `run.cmd`).
+    /// Path to the installed runner's entry point (`run.sh` / `run.cmd`).
     /// `None` when only Docker-based execution is configured.
-    runner_dir: Option<PathBuf>,
+    runner_script: Option<PathBuf>,
     /// Docker runtime for Linux jobs, if available.
     docker: Option<DockerRunner>,
     /// The backend serving each advertised `(os, arch)` — the routing table.
     backends: HashMap<(String, String), Backend>,
-    /// Reject an offer when 1-minute load per core exceeds this.
-    load_ceiling: f64,
-    /// Reject an offer when available memory (MiB) is below this.
-    mem_floor_mib: u64,
     /// Set once `Drain` is received; no new jobs are accepted.
     draining: std::sync::atomic::AtomicBool,
     /// Observable state mirrored to `FleetStateService.Watch` subscribers.
@@ -125,13 +121,14 @@ impl Drop for ReleaseGuard {
 impl RunnerSupervisor {
     /// Create a supervisor that emits verdicts on `events`. `capabilities` is the
     /// same set advertised to the gateway, so routing and advertisement agree.
+    /// `load_ceiling`/`mem_floor_mib` are not parameters: `admit()` reads
+    /// them live from `state`, which is the single source of truth settings
+    /// write through.
     pub fn new(
         events: mpsc::Sender<AttachRequest>,
-        runner_dir: Option<PathBuf>,
+        runner_script: Option<PathBuf>,
         docker: Option<DockerRunner>,
         capabilities: Vec<Capability>,
-        load_ceiling: f64,
-        mem_floor_mib: u64,
         state: AgentState,
     ) -> Self {
         // Static for the attachment's lifetime, so this is set once rather
@@ -150,11 +147,9 @@ impl RunnerSupervisor {
                 events,
                 outstanding: DashMap::new(),
                 in_flight: DashMap::new(),
-                runner_dir,
+                runner_script,
                 docker,
                 backends,
-                load_ceiling,
-                mem_floor_mib,
                 draining: std::sync::atomic::AtomicBool::new(false),
                 state,
             }),
@@ -240,10 +235,12 @@ impl RunnerSupervisor {
         } else {
             telemetry.load_avg_1m
         };
-        if load_per_core > self.inner.load_ceiling {
+        let load_ceiling = self.inner.state.load_ceiling_current();
+        if load_per_core > load_ceiling {
             return Admission::Reject(format!("load too high ({load_per_core:.2}/core)"));
         }
-        if telemetry.mem_available_mib < self.inner.mem_floor_mib {
+        let mem_floor_mib = self.inner.state.mem_floor_mib_current();
+        if telemetry.mem_available_mib < mem_floor_mib {
             return Admission::Reject(format!(
                 "low memory ({} MiB free)",
                 telemetry.mem_available_mib
@@ -359,12 +356,12 @@ impl RunnerSupervisor {
         token: &str,
         cancel: CancellationToken,
     ) {
-        let Some(runner_dir) = &self.inner.runner_dir else {
-            self.reject(job_id, token, "no host runner directory configured");
+        let Some(runner_script) = &self.inner.runner_script else {
+            self.reject(job_id, token, "no host runner script configured");
             return;
         };
 
-        let mut command = runner_command(runner_dir, &order.encoded_jit_config);
+        let mut command = runner_command(runner_script, &order.encoded_jit_config);
         let mut child = match command.group_spawn() {
             Ok(child) => child,
             Err(e) => {
@@ -416,11 +413,13 @@ impl RunnerSupervisor {
         // Startup is cancellation-aware: a slow image pull must not make the
         // agent deaf to CancelRunner and then accept a job the platform has
         // already concluded.
+        let runner_image = self.inner.state.runner_image_current();
         let started = {
             let start = std::pin::pin!(docker.start(RunSpec {
                 job_id,
                 encoded_jit_config: &order.encoded_jit_config,
                 arch: &order.arch,
+                runner_image: &runner_image,
             }));
             tokio::select! {
                 result = start => Some(result),
@@ -536,11 +535,13 @@ impl RunnerSupervisor {
     }
 }
 
-/// Build the platform-appropriate runner invocation.
-fn runner_command(runner_dir: &Path, encoded_jit_config: &str) -> tokio::process::Command {
+/// Build the platform-appropriate runner invocation. `script` is the direct
+/// path to the entry point (`run.sh` / `run.cmd`); no `.current_dir()` is
+/// set because these wrapper scripts locate their own sibling files via
+/// `$0`'s dirname, not the caller's working directory.
+fn runner_command(script: &Path, encoded_jit_config: &str) -> tokio::process::Command {
     #[cfg(windows)]
     {
-        let script = runner_dir.join("run.cmd");
         let mut command = tokio::process::Command::new("cmd");
         command
             .arg("/C")
@@ -551,7 +552,6 @@ fn runner_command(runner_dir: &Path, encoded_jit_config: &str) -> tokio::process
     }
     #[cfg(not(windows))]
     {
-        let script = runner_dir.join("run.sh");
         let mut command = tokio::process::Command::new(script);
         command.arg("--jitconfig").arg(encoded_jit_config);
         command
@@ -579,6 +579,19 @@ mod tests {
         }
     }
 
+    /// Seed matching the pre-slice-3 hardcoded test defaults (0.9 load
+    /// ceiling, 2048 MiB memory floor).
+    fn seed() -> crate::settings::PersistedSettings {
+        crate::settings::PersistedSettings {
+            load_ceiling: 0.9,
+            mem_floor_mib: 2048,
+            runner_image: "ghcr.io/actions/actions-runner:latest".to_owned(),
+            gateway: "https://fleet.arcbox.dev".to_owned(),
+            docker_mode: crate::config::DockerMode::Auto,
+            runner_script: None,
+        }
+    }
+
     fn supervisor(capabilities: Vec<Capability>) -> RunnerSupervisor {
         let (events, _rx) = mpsc::channel(1);
         RunnerSupervisor::new(
@@ -586,9 +599,7 @@ mod tests {
             Some(PathBuf::from("/nonexistent")),
             None,
             capabilities,
-            0.9,
-            2048,
-            AgentState::new(),
+            AgentState::new(&seed()),
         )
     }
 
@@ -692,9 +703,29 @@ mod tests {
             Some(PathBuf::from("/nonexistent")),
             None,
             vec![capability("darwin", "arm64", Backend::HostRunner)],
-            0.9,
-            2048,
-            AgentState::new(),
+            AgentState::new(&seed()),
+        );
+        (sup, rx)
+    }
+
+    /// A supervisor whose load/memory thresholds can never reject, for
+    /// tests that exercise `handle_provision`'s real `host::telemetry()`
+    /// path (unlike `admit()`-level tests, which inject fake telemetry
+    /// directly and so aren't sensitive to the test machine's actual load).
+    fn supervisor_with_rx_unconstrained(
+        capacity: usize,
+    ) -> (RunnerSupervisor, mpsc::Receiver<AttachRequest>) {
+        let (events, rx) = mpsc::channel(capacity);
+        let sup = RunnerSupervisor::new(
+            events,
+            Some(PathBuf::from("/nonexistent")),
+            None,
+            vec![capability("darwin", "arm64", Backend::HostRunner)],
+            AgentState::new(&crate::settings::PersistedSettings {
+                load_ceiling: f64::MAX,
+                mem_floor_mib: 0,
+                ..seed()
+            }),
         );
         (sup, rx)
     }
@@ -731,7 +762,7 @@ mod tests {
 
     #[tokio::test]
     async fn accepted_offer_is_tracked_in_state_in_flight() {
-        let (sup, _rx) = supervisor_with_rx(8);
+        let (sup, _rx) = supervisor_with_rx_unconstrained(8);
         sup.handle_provision(ProvisionRunner {
             job_id: "rjob_a".to_owned(),
             os: "darwin".to_owned(),

--- a/fleet/arcbox-fleet-agent/src/runner.rs
+++ b/fleet/arcbox-fleet-agent/src/runner.rs
@@ -15,6 +15,7 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Duration;
 
+use arcbox_fleet_control_proto::v1 as control_proto;
 use arcbox_fleet_proto::v1::{
     AttachRequest, Backend, Capability, HostTelemetry, ProvisionRunner, RunnerAccepted,
     RunnerRejected, attach_request,
@@ -27,6 +28,25 @@ use tracing::{info, warn};
 
 use crate::docker::{DockerRunner, RunSpec};
 use crate::host;
+use crate::state::AgentState;
+
+/// Convert a gateway-advertised capability into its control-plane
+/// counterpart. A plain function, not `From`: both `Capability` types are
+/// generated in other crates, so Rust's orphan rule blocks implementing a
+/// foreign trait (`From`) for two foreign types here.
+fn capability_to_control(c: &Capability) -> control_proto::Capability {
+    let backed_by = match Backend::try_from(c.backed_by) {
+        Ok(Backend::HostRunner) => control_proto::Backend::HostRunner,
+        Ok(Backend::Docker) => control_proto::Backend::Docker,
+        Ok(Backend::Vm) => control_proto::Backend::Vm,
+        Ok(Backend::Unspecified) | Err(_) => control_proto::Backend::Unspecified,
+    };
+    control_proto::Capability {
+        os: c.os.clone(),
+        arch: c.arch.clone(),
+        backed_by: backed_by as i32,
+    }
+}
 
 /// Outcome of the admission decision for an incoming offer.
 #[derive(Debug, PartialEq, Eq)]
@@ -78,6 +98,8 @@ struct Inner {
     mem_floor_mib: u64,
     /// Set once `Drain` is received; no new jobs are accepted.
     draining: std::sync::atomic::AtomicBool,
+    /// Observable state mirrored to `FleetStateService.Watch` subscribers.
+    state: AgentState,
 }
 
 /// Clears a job's `in_flight` entry when dropped. Held by the runner task so
@@ -96,6 +118,7 @@ struct ReleaseGuard {
 impl Drop for ReleaseGuard {
     fn drop(&mut self) {
         self.inner.in_flight.remove(&self.job_id);
+        self.inner.state.remove_in_flight(&self.job_id);
     }
 }
 
@@ -109,7 +132,11 @@ impl RunnerSupervisor {
         capabilities: Vec<Capability>,
         load_ceiling: f64,
         mem_floor_mib: u64,
+        state: AgentState,
     ) -> Self {
+        // Static for the attachment's lifetime, so this is set once rather
+        // than tracked incrementally alongside `backends` below.
+        state.set_capabilities(capabilities.iter().map(capability_to_control).collect());
         let backends = capabilities
             .into_iter()
             .filter_map(|c| {
@@ -129,6 +156,7 @@ impl RunnerSupervisor {
                 load_ceiling,
                 mem_floor_mib,
                 draining: std::sync::atomic::AtomicBool::new(false),
+                state,
             }),
         }
     }
@@ -164,7 +192,12 @@ impl RunnerSupervisor {
                 // down the runner — process group (host) or container (Docker),
                 // awaited — so `CancelRunner` never orphans the runner's work.
                 let cancel = CancellationToken::new();
-                self.inner.in_flight.insert(job_id, cancel.clone());
+                self.inner.in_flight.insert(job_id.clone(), cancel.clone());
+                self.inner.state.add_in_flight(control_proto::InFlightJob {
+                    job_id,
+                    os: order.os.clone(),
+                    arch: order.arch.clone(),
+                });
                 let sup = self.clone();
                 tokio::spawn(async move {
                     // The guard releases the job on any task exit, including a
@@ -247,6 +280,7 @@ impl RunnerSupervisor {
         self.inner
             .draining
             .store(true, std::sync::atomic::Ordering::Relaxed);
+        self.inner.state.set_draining(true);
         info!("draining: no new offers will be accepted");
     }
 
@@ -258,14 +292,8 @@ impl RunnerSupervisor {
         self.inner
             .draining
             .store(false, std::sync::atomic::Ordering::Relaxed);
+        self.inner.state.set_draining(false);
         info!("resumed: accepting new offers");
-    }
-
-    /// Whether the supervisor is currently refusing new offers.
-    pub fn is_draining(&self) -> bool {
-        self.inner
-            .draining
-            .load(std::sync::atomic::Ordering::Relaxed)
     }
 
     /// Begin graceful shutdown: stop accepting offers, cancel every in-flight
@@ -448,6 +476,11 @@ impl RunnerSupervisor {
 
     /// Accept an offer (the runner has started).
     fn accept(&self, job_id: &str, token: &str) {
+        self.inner.state.push_verdict(control_proto::OfferVerdict {
+            job_id: job_id.to_owned(),
+            accepted: true,
+            reason: String::new(),
+        });
         self.send_verdict(
             token,
             attach_request::Msg::RunnerAccepted(RunnerAccepted {
@@ -460,6 +493,11 @@ impl RunnerSupervisor {
     /// Reject an offer with a reason.
     fn reject(&self, job_id: &str, token: &str, reason: &str) {
         info!(job_id, reason, "offer rejected");
+        self.inner.state.push_verdict(control_proto::OfferVerdict {
+            job_id: job_id.to_owned(),
+            accepted: false,
+            reason: reason.to_owned(),
+        });
         self.send_verdict(
             token,
             attach_request::Msg::RunnerRejected(RunnerRejected {
@@ -550,12 +588,23 @@ mod tests {
             capabilities,
             0.9,
             2048,
+            AgentState::new(),
         )
     }
 
     // Idle host: plenty of headroom.
     fn idle() -> HostTelemetry {
         telemetry(0.5, 8192)
+    }
+
+    #[test]
+    fn constructor_mirrors_capabilities_into_state() {
+        let sup = supervisor(vec![capability("darwin", "arm64", Backend::HostRunner)]);
+        let caps = sup.inner.state.current().capabilities;
+        assert_eq!(caps.len(), 1);
+        assert_eq!(caps[0].os, "darwin");
+        assert_eq!(caps[0].arch, "arm64");
+        assert_eq!(caps[0].backed_by, control_proto::Backend::HostRunner as i32);
     }
 
     #[test]
@@ -599,17 +648,17 @@ mod tests {
     #[test]
     fn resume_undoes_drain() {
         let sup = supervisor(vec![capability("darwin", "arm64", Backend::HostRunner)]);
-        assert!(!sup.is_draining());
+        assert!(!sup.inner.state.current().draining);
 
         sup.handle_drain();
-        assert!(sup.is_draining());
+        assert!(sup.inner.state.current().draining);
         assert!(matches!(
             sup.admit("rjob_a", "darwin", "arm64", &idle()),
             Admission::Reject(_)
         ));
 
         sup.resume();
-        assert!(!sup.is_draining());
+        assert!(!sup.inner.state.current().draining);
         assert_eq!(
             sup.admit("rjob_a", "darwin", "arm64", &idle()),
             Admission::Accept(Backend::HostRunner)
@@ -645,6 +694,7 @@ mod tests {
             vec![capability("darwin", "arm64", Backend::HostRunner)],
             0.9,
             2048,
+            AgentState::new(),
         );
         (sup, rx)
     }
@@ -664,6 +714,54 @@ mod tests {
         assert!(!sup.inner.outstanding.contains_key("tok1"));
         sup.resend_outstanding();
         assert!(rx.try_recv().is_err());
+    }
+
+    #[tokio::test]
+    async fn accept_and_reject_push_verdicts_into_state() {
+        let (sup, _rx) = supervisor_with_rx(8);
+        sup.accept("rjob_a", "tok1");
+        sup.reject("rjob_b", "tok2", "busy");
+
+        let verdicts = sup.inner.state.current().recent_verdicts;
+        assert_eq!(verdicts.len(), 2);
+        assert!(verdicts[0].accepted);
+        assert!(!verdicts[1].accepted);
+        assert_eq!(verdicts[1].reason, "busy");
+    }
+
+    #[tokio::test]
+    async fn accepted_offer_is_tracked_in_state_in_flight() {
+        let (sup, _rx) = supervisor_with_rx(8);
+        sup.handle_provision(ProvisionRunner {
+            job_id: "rjob_a".to_owned(),
+            os: "darwin".to_owned(),
+            arch: "arm64".to_owned(),
+            encoded_jit_config: String::new(),
+            offer_token: "tok1".to_owned(),
+        });
+
+        let in_flight = sup.inner.state.current().in_flight;
+        assert_eq!(in_flight.len(), 1);
+        assert_eq!(in_flight[0].job_id, "rjob_a");
+        assert_eq!(in_flight[0].os, "darwin");
+        assert_eq!(in_flight[0].arch, "arm64");
+    }
+
+    #[test]
+    fn release_guard_drop_removes_from_state_in_flight() {
+        let sup = supervisor(vec![capability("darwin", "arm64", Backend::HostRunner)]);
+        sup.inner.state.add_in_flight(control_proto::InFlightJob {
+            job_id: "rjob_a".to_owned(),
+            os: "darwin".to_owned(),
+            arch: "arm64".to_owned(),
+        });
+        {
+            let _guard = ReleaseGuard {
+                inner: sup.inner.clone(),
+                job_id: "rjob_a".to_owned(),
+            };
+        }
+        assert!(sup.inner.state.current().in_flight.is_empty());
     }
 
     #[tokio::test]

--- a/fleet/arcbox-fleet-agent/src/settings.rs
+++ b/fleet/arcbox-fleet-agent/src/settings.rs
@@ -27,6 +27,10 @@ pub struct PersistedSettings {
     /// Direct path to the runner entry point (`run.sh`), not its containing
     /// directory.
     pub runner_script: Option<PathBuf>,
+    /// Whether this machine takes part in the fleet; `false` keeps the
+    /// credential but stays detached. Persisted so a launchd restart honors
+    /// an operator's detach instead of silently reattaching.
+    pub participate: bool,
 }
 
 impl From<&AgentConfig> for PersistedSettings {
@@ -39,6 +43,9 @@ impl From<&AgentConfig> for PersistedSettings {
             gateway: config.gateway.clone(),
             docker_mode: config.docker.mode,
             runner_script: config.runner_script.clone(),
+            // No env seed: a fresh install participates; only an explicit
+            // UpdateSettings opts a machine out.
+            participate: true,
         }
     }
 }
@@ -97,6 +104,7 @@ mod tests {
             gateway: "https://fleet.arcbox.dev".to_owned(),
             docker_mode: DockerMode::Auto,
             runner_script: Some(PathBuf::from("/opt/actions-runner/run.sh")),
+            participate: true,
         }
     }
 

--- a/fleet/arcbox-fleet-agent/src/settings.rs
+++ b/fleet/arcbox-fleet-agent/src/settings.rs
@@ -22,7 +22,7 @@ use crate::fsutil::{write_json_atomic, write_owner_only};
 pub struct PersistedSettings {
     pub load_ceiling: f64,
     pub mem_floor_mib: u64,
-    pub runner_image: String,
+    pub linux_runner_image: String,
     pub gateway: String,
     pub docker_mode: DockerMode,
     /// Direct path to the runner entry point (`run.sh`), not its containing
@@ -36,7 +36,7 @@ impl From<&AgentConfig> for PersistedSettings {
         Self {
             load_ceiling: config.load_ceiling,
             mem_floor_mib: config.mem_floor_mib,
-            runner_image: config.docker.runner_image.clone(),
+            linux_runner_image: config.docker.linux_runner_image.clone(),
             gateway: config.gateway.clone(),
             docker_mode: config.docker.mode,
             runner_script: config.runner_script.clone(),
@@ -94,7 +94,7 @@ mod tests {
         PersistedSettings {
             load_ceiling: 0.75,
             mem_floor_mib: 4096,
-            runner_image: "ghcr.io/actions/actions-runner:latest".to_owned(),
+            linux_runner_image: "ghcr.io/actions/actions-runner:latest".to_owned(),
             gateway: "https://fleet.arcbox.dev".to_owned(),
             docker_mode: DockerMode::Auto,
             runner_script: Some(PathBuf::from("/opt/actions-runner/run.sh")),
@@ -133,7 +133,7 @@ mod tests {
             data_dir: PathBuf::from("/tmp/does-not-matter"),
             docker: crate::config::DockerConfig {
                 mode: DockerMode::Enabled,
-                runner_image: "example/image:latest".to_owned(),
+                linux_runner_image: "example/image:latest".to_owned(),
             },
             credential_store: crate::config::CredentialMode::File,
         };
@@ -144,6 +144,6 @@ mod tests {
         assert_eq!(seeded.load_ceiling, config.load_ceiling);
         assert_eq!(seeded.mem_floor_mib, config.mem_floor_mib);
         assert_eq!(seeded.docker_mode, config.docker.mode);
-        assert_eq!(seeded.runner_image, config.docker.runner_image);
+        assert_eq!(seeded.linux_runner_image, config.docker.linux_runner_image);
     }
 }

--- a/fleet/arcbox-fleet-agent/src/settings.rs
+++ b/fleet/arcbox-fleet-agent/src/settings.rs
@@ -13,7 +13,7 @@ use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
 
 use crate::config::{AgentConfig, DockerMode};
-use crate::fsutil::write_owner_only;
+use crate::fsutil::{write_json_atomic, write_owner_only};
 
 /// Live-settable agent configuration, as last requested (`target`) — see
 /// [`crate::state::AgentState`] for the paired `current` values the engine
@@ -73,20 +73,11 @@ impl SettingsStore {
         }
     }
 
-    /// Persist `settings`, replacing whatever was there before.
+    /// Persist `settings`, replacing whatever was there before. Settings
+    /// aren't secret, so a plain owner-only write suffices on every platform
+    /// (unlike the credential, which refuses a file backend off Unix).
     pub fn store(&self, settings: &PersistedSettings) -> Result<()> {
-        if let Some(parent) = self.path.parent() {
-            std::fs::create_dir_all(parent)
-                .with_context(|| format!("creating {}", parent.display()))?;
-        }
-        let json = serde_json::to_vec_pretty(settings).context("serializing settings")?;
-        // Write-then-rename so a crash mid-write can't leave a truncated
-        // settings.json that fails to parse on the next start.
-        let tmp = self.path.with_extension("json.tmp");
-        write_owner_only(&tmp, &json)?;
-        std::fs::rename(&tmp, &self.path)
-            .with_context(|| format!("renaming {} -> {}", tmp.display(), self.path.display()))?;
-        Ok(())
+        write_json_atomic(&self.path, settings, write_owner_only)
     }
 }
 

--- a/fleet/arcbox-fleet-agent/src/settings.rs
+++ b/fleet/arcbox-fleet-agent/src/settings.rs
@@ -4,8 +4,7 @@
 //! derived fresh by the engine at each start (see
 //! [`crate::state::AgentState`]). Settings aren't secret, unlike the
 //! machine credential, so this is always a plain file — there's no
-//! OS-keychain backend to fall back to, and no reason to refuse on
-//! non-Unix platforms the way `credentials.rs` does.
+//! OS-keychain backend the way `credentials.rs` has.
 
 use std::path::PathBuf;
 
@@ -13,7 +12,7 @@ use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
 
 use crate::config::{AgentConfig, DockerMode};
-use crate::fsutil::{write_json_atomic, write_owner_only};
+use crate::fsutil::write_json_atomic;
 
 /// Live-settable agent configuration, as last requested (`target`) — see
 /// [`crate::state::AgentState`] for the paired `current` values the engine
@@ -74,10 +73,10 @@ impl SettingsStore {
     }
 
     /// Persist `settings`, replacing whatever was there before. Settings
-    /// aren't secret, so a plain owner-only write suffices on every platform
-    /// (unlike the credential, which refuses a file backend off Unix).
+    /// aren't secret, so the plain owner-only file always suffices (unlike
+    /// the credential, which prefers the OS keychain on macOS).
     pub fn store(&self, settings: &PersistedSettings) -> Result<()> {
-        write_json_atomic(&self.path, settings, write_owner_only)
+        write_json_atomic(&self.path, settings)
     }
 }
 

--- a/fleet/arcbox-fleet-agent/src/settings.rs
+++ b/fleet/arcbox-fleet-agent/src/settings.rs
@@ -25,8 +25,8 @@ pub struct PersistedSettings {
     pub runner_image: String,
     pub gateway: String,
     pub docker_mode: DockerMode,
-    /// Direct path to the runner entry point (`run.sh`/`run.cmd`), not its
-    /// containing directory.
+    /// Direct path to the runner entry point (`run.sh`), not its containing
+    /// directory.
     pub runner_script: Option<PathBuf>,
 }
 

--- a/fleet/arcbox-fleet-agent/src/settings.rs
+++ b/fleet/arcbox-fleet-agent/src/settings.rs
@@ -1,0 +1,158 @@
+//! Persistence of live-settable agent configuration.
+//!
+//! Only `target` values are ever persisted here — `current` is always
+//! derived fresh by the engine at each start (see
+//! [`crate::state::AgentState`]). Settings aren't secret, unlike the
+//! machine credential, so this is always a plain file — there's no
+//! OS-keychain backend to fall back to, and no reason to refuse on
+//! non-Unix platforms the way `credentials.rs` does.
+
+use std::path::PathBuf;
+
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+
+use crate::config::{AgentConfig, DockerMode};
+use crate::fsutil::write_owner_only;
+
+/// Live-settable agent configuration, as last requested (`target`) — see
+/// [`crate::state::AgentState`] for the paired `current` values the engine
+/// actually runs with.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct PersistedSettings {
+    pub load_ceiling: f64,
+    pub mem_floor_mib: u64,
+    pub runner_image: String,
+    pub gateway: String,
+    pub docker_mode: DockerMode,
+    /// Direct path to the runner entry point (`run.sh`/`run.cmd`), not its
+    /// containing directory.
+    pub runner_script: Option<PathBuf>,
+}
+
+impl From<&AgentConfig> for PersistedSettings {
+    /// Seed on first-ever start: whatever the environment resolved to.
+    fn from(config: &AgentConfig) -> Self {
+        Self {
+            load_ceiling: config.load_ceiling,
+            mem_floor_mib: config.mem_floor_mib,
+            runner_image: config.docker.runner_image.clone(),
+            gateway: config.gateway.clone(),
+            docker_mode: config.docker.mode,
+            runner_script: config.runner_script.clone(),
+        }
+    }
+}
+
+/// Reads and writes [`PersistedSettings`] as an owner-only JSON file.
+/// Cheap to clone (just the path) — `AgentSupervisor` and
+/// `control::settings::SettingsService` each hold their own handle to the
+/// same file rather than sharing one instance, since there's no in-memory
+/// state here to keep in sync.
+#[derive(Clone)]
+pub struct SettingsStore {
+    path: PathBuf,
+}
+
+impl SettingsStore {
+    pub fn new(path: PathBuf) -> Self {
+        Self { path }
+    }
+
+    /// Load the persisted settings, or `None` if never written (first-ever
+    /// start — the caller seeds from [`AgentConfig`] instead).
+    pub fn load(&self) -> Result<Option<PersistedSettings>> {
+        match std::fs::read(&self.path) {
+            Ok(bytes) => {
+                let settings = serde_json::from_slice(&bytes)
+                    .with_context(|| format!("malformed settings at {}", self.path.display()))?;
+                Ok(Some(settings))
+            }
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),
+            Err(e) => Err(e).with_context(|| format!("reading {}", self.path.display())),
+        }
+    }
+
+    /// Persist `settings`, replacing whatever was there before.
+    pub fn store(&self, settings: &PersistedSettings) -> Result<()> {
+        if let Some(parent) = self.path.parent() {
+            std::fs::create_dir_all(parent)
+                .with_context(|| format!("creating {}", parent.display()))?;
+        }
+        let json = serde_json::to_vec_pretty(settings).context("serializing settings")?;
+        // Write-then-rename so a crash mid-write can't leave a truncated
+        // settings.json that fails to parse on the next start.
+        let tmp = self.path.with_extension("json.tmp");
+        write_owner_only(&tmp, &json)?;
+        std::fs::rename(&tmp, &self.path)
+            .with_context(|| format!("renaming {} -> {}", tmp.display(), self.path.display()))?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+#[allow(
+    clippy::float_cmp,
+    reason = "settings values are moved/copied here, never computed, so exact \
+              float equality is always well-defined — no rounding can occur"
+)]
+mod tests {
+    use super::*;
+
+    fn sample() -> PersistedSettings {
+        PersistedSettings {
+            load_ceiling: 0.75,
+            mem_floor_mib: 4096,
+            runner_image: "ghcr.io/actions/actions-runner:latest".to_owned(),
+            gateway: "https://fleet.arcbox.dev".to_owned(),
+            docker_mode: DockerMode::Auto,
+            runner_script: Some(PathBuf::from("/opt/actions-runner/run.sh")),
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn round_trips_at_0600() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = std::env::temp_dir().join(format!("fleet-settings-{}", std::process::id()));
+        let path = dir.join("settings.json");
+        let store = SettingsStore::new(path.clone());
+        assert!(store.load().unwrap().is_none());
+
+        let settings = sample();
+        store.store(&settings).unwrap();
+
+        let loaded = store.load().unwrap().expect("settings present");
+        assert_eq!(loaded, settings);
+
+        let mode = std::fs::metadata(&path).unwrap().permissions().mode();
+        assert_eq!(mode & 0o777, 0o600);
+
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn seeds_from_agent_config() {
+        let config = AgentConfig {
+            gateway: "https://example.test".to_owned(),
+            runner_script: Some(PathBuf::from("/opt/runner/run.sh")),
+            load_ceiling: 0.5,
+            mem_floor_mib: 1024,
+            data_dir: PathBuf::from("/tmp/does-not-matter"),
+            docker: crate::config::DockerConfig {
+                mode: DockerMode::Enabled,
+                runner_image: "example/image:latest".to_owned(),
+            },
+            credential_store: crate::config::CredentialMode::File,
+        };
+
+        let seeded = PersistedSettings::from(&config);
+        assert_eq!(seeded.gateway, config.gateway);
+        assert_eq!(seeded.runner_script, config.runner_script);
+        assert_eq!(seeded.load_ceiling, config.load_ceiling);
+        assert_eq!(seeded.mem_floor_mib, config.mem_floor_mib);
+        assert_eq!(seeded.docker_mode, config.docker.mode);
+        assert_eq!(seeded.runner_image, config.docker.runner_image);
+    }
+}

--- a/fleet/arcbox-fleet-agent/src/state.rs
+++ b/fleet/arcbox-fleet-agent/src/state.rs
@@ -370,6 +370,37 @@ impl AgentState {
         });
     }
 
+    /// Set `gateway.target` iff the enrollment snapshot at the moment of
+    /// the write is `Unenrolled`. Both the check and the write happen
+    /// inside the same `send_modify` closure, so a concurrent
+    /// [`Self::set_enrollment`] (which uses the same watch sender) cannot
+    /// interleave between them.
+    ///
+    /// This is what closes the race that a plain
+    /// `validate() ... set_gateway_target(...)` pair leaks: an `Enroll`
+    /// entering its round-trip flips enrollment to `Attaching` between
+    /// validate's read and the write, and by the time the write lands the
+    /// credential would be persisted under one gateway while the settings
+    /// wrote the other. Returns the observed enrollment on refusal.
+    pub fn try_set_gateway_target(&self, value: &str) -> Result<(), Enrollment> {
+        let mut observed: Result<(), Enrollment> = Ok(());
+        self.tx.send_modify(|s| {
+            let enrollment = Enrollment::try_from(s.enrollment).unwrap_or(Enrollment::Unenrolled);
+            if enrollment != Enrollment::Unenrolled {
+                observed = Err(enrollment);
+                return;
+            }
+            value.clone_into(
+                &mut settings_mut(s)
+                    .gateway
+                    .as_mut()
+                    .expect(SETTINGS_INVARIANT)
+                    .target,
+            );
+        });
+        observed
+    }
+
     pub fn set_gateway_current(&self, value: &str) {
         self.tx.send_modify(|s| {
             value.clone_into(
@@ -521,6 +552,40 @@ mod tests {
 
         state.set_gateway_current("https://staging.fleet.arcbox.dev");
         assert_eq!(gateway_current(&state), state.gateway_target());
+    }
+
+    /// The atomic setter that closes the `settings::validate` race: it must
+    /// accept a write while `Unenrolled` and refuse (leaving the target
+    /// unchanged) for every non-`Unenrolled` enrollment. The check and the
+    /// write both happen inside one `send_modify`, so a concurrent
+    /// `set_enrollment` cannot slip between them.
+    #[test]
+    fn try_set_gateway_target_gates_on_enrollment() {
+        let state = AgentState::new(&seed());
+        assert!(
+            state
+                .try_set_gateway_target("https://staging.fleet.arcbox.dev")
+                .is_ok()
+        );
+        assert_eq!(state.gateway_target(), "https://staging.fleet.arcbox.dev");
+
+        for enrollment in [
+            Enrollment::Attaching,
+            Enrollment::Attached,
+            Enrollment::Detached,
+            Enrollment::CredentialRejected,
+        ] {
+            state.set_enrollment(enrollment, "fltm_test");
+            assert_eq!(
+                state.try_set_gateway_target("https://other.gateway.test"),
+                Err(enrollment)
+            );
+            assert_eq!(
+                state.gateway_target(),
+                "https://staging.fleet.arcbox.dev",
+                "{enrollment:?}: refused write must not mutate the target"
+            );
+        }
     }
 
     #[test]

--- a/fleet/arcbox-fleet-agent/src/state.rs
+++ b/fleet/arcbox-fleet-agent/src/state.rs
@@ -8,8 +8,8 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use arcbox_fleet_control_proto::v1::{
-    AgentSettings, AgentStateSnapshot, Capability, DockerModeSetting, DoubleSetting, Enrollment,
-    HostTelemetry, InFlightJob, OfferVerdict, StringSetting, Uint64Setting,
+    AgentSettings, AgentStateSnapshot, BoolSetting, Capability, DockerModeSetting, DoubleSetting,
+    Enrollment, HostTelemetry, InFlightJob, OfferVerdict, StringSetting, Uint64Setting,
 };
 use tokio::sync::watch;
 
@@ -125,6 +125,10 @@ impl AgentState {
                 current: runner_script.clone(),
                 target: runner_script,
             }),
+            participate: Some(BoolSetting {
+                current: seed.participate,
+                target: seed.participate,
+            }),
         };
         let (tx, _) = watch::channel(AgentStateSnapshot {
             enrollment: Enrollment::Unenrolled as i32,
@@ -179,6 +183,7 @@ impl AgentState {
             runner_script: setting_value_to_path(
                 &s.runner_script.as_ref().expect(SETTINGS_INVARIANT).target,
             ),
+            participate: s.participate.as_ref().expect(SETTINGS_INVARIANT).target,
         }
     }
 
@@ -262,6 +267,16 @@ impl AgentState {
             .clone()
     }
 
+    /// The desired participation — what `AgentSupervisor`'s reconciler
+    /// converges the attachment onto.
+    pub fn participate_target(&self) -> bool {
+        settings_of(&self.tx.borrow())
+            .participate
+            .as_ref()
+            .expect(SETTINGS_INVARIANT)
+            .target
+    }
+
     /// The desired gateway — what `attach.rs` dials on its next attempt.
     /// There's no `gateway_current` reader: nothing needs to read back what
     /// was last dialed outside of the full `settings()`/`persisted_settings()`
@@ -287,13 +302,15 @@ impl AgentState {
     // actually found Docker is observable via `capabilities`, not by
     // resolving `current` away from the requested policy.
     //
-    // `gateway` and `linux_runner_image` have independent `current`
-    // setters, written only once the engine has realized the value:
-    // `attach.rs` sets the gateway's `current` when it has actually dialed
-    // that gateway, and `FleetImageService.Prepare` sets the image's
+    // `gateway`, `linux_runner_image`, and `participate` have independent
+    // `current` setters, written only once the engine has realized the
+    // value: `attach.rs` sets the gateway's `current` when it has actually
+    // dialed that gateway, `FleetImageService.Prepare` sets the image's
     // `current` when the target has been pulled for every advertised arch
     // (startup's `init_docker` verifies the seed the same way, which is
-    // why `AgentState::new` may seed `current == target`).
+    // why `AgentState::new` may seed `current == target`), and the
+    // supervisor's participation reconciler flips `participate`'s
+    // `current` when the detach/reattach completes.
 
     pub fn set_load_ceiling(&self, value: f64) {
         self.tx.send_modify(|s| {
@@ -386,6 +403,26 @@ impl AgentState {
                 .target = value;
         });
     }
+
+    pub fn set_participate_target(&self, value: bool) {
+        self.tx.send_modify(|s| {
+            settings_mut(s)
+                .participate
+                .as_mut()
+                .expect(SETTINGS_INVARIANT)
+                .target = value;
+        });
+    }
+
+    pub fn set_participate_current(&self, value: bool) {
+        self.tx.send_modify(|s| {
+            settings_mut(s)
+                .participate
+                .as_mut()
+                .expect(SETTINGS_INVARIANT)
+                .current = value;
+        });
+    }
 }
 
 #[cfg(test)]
@@ -405,6 +442,7 @@ mod tests {
             gateway: "https://fleet.arcbox.dev".to_owned(),
             docker_mode: DockerMode::Auto,
             runner_script: None,
+            participate: true,
         }
     }
 

--- a/fleet/arcbox-fleet-agent/src/state.rs
+++ b/fleet/arcbox-fleet-agent/src/state.rs
@@ -56,7 +56,7 @@ impl From<arcbox_fleet_control_proto::v1::DockerMode> for DockerMode {
 /// Parse a wire `DockerMode` i32 that may not be a recognized variant
 /// (an older/newer client sent something this build doesn't know) into the
 /// internal type, falling back to `Auto`.
-fn docker_mode_from_wire(raw: i32) -> DockerMode {
+pub fn docker_mode_from_wire(raw: i32) -> DockerMode {
     arcbox_fleet_control_proto::v1::DockerMode::try_from(raw)
         .unwrap_or(arcbox_fleet_control_proto::v1::DockerMode::Unspecified)
         .into()

--- a/fleet/arcbox-fleet-agent/src/state.rs
+++ b/fleet/arcbox-fleet-agent/src/state.rs
@@ -251,6 +251,17 @@ impl AgentState {
             .clone()
     }
 
+    /// The desired image — what `FleetImageService.Prepare` verifies and
+    /// then promotes to `current`.
+    pub fn linux_runner_image_target(&self) -> String {
+        settings_of(&self.tx.borrow())
+            .linux_runner_image
+            .as_ref()
+            .expect(SETTINGS_INVARIANT)
+            .target
+            .clone()
+    }
+
     /// The desired gateway — what `attach.rs` dials on its next attempt.
     /// There's no `gateway_current` reader: nothing needs to read back what
     /// was last dialed outside of the full `settings()`/`persisted_settings()`
@@ -264,10 +275,9 @@ impl AgentState {
             .clone()
     }
 
-    // -- Settings: writers. `load_ceiling`/`mem_floor_mib`/`linux_runner_image`
-    // apply instantly, so their setters write both `current` and `target`
-    // in one `send_modify` — there's never a moment where they should
-    // differ.
+    // -- Settings: writers. `load_ceiling`/`mem_floor_mib` apply instantly,
+    // so their setters write both `current` and `target` in one
+    // `send_modify` — there's never a moment where they should differ.
     //
     // `docker_mode`/`runner_script` are restart-scoped: `UpdateSettings`
     // moves only their `target`, and `current` stays whatever the process
@@ -277,9 +287,13 @@ impl AgentState {
     // actually found Docker is observable via `capabilities`, not by
     // resolving `current` away from the requested policy.
     //
-    // `gateway` alone has an independent `current` setter: `UpdateSettings`
-    // writes `target`, and `attach.rs` writes `current` once it has
-    // actually dialed that gateway.
+    // `gateway` and `linux_runner_image` have independent `current`
+    // setters, written only once the engine has realized the value:
+    // `attach.rs` sets the gateway's `current` when it has actually dialed
+    // that gateway, and `FleetImageService.Prepare` sets the image's
+    // `current` when the target has been pulled for every advertised arch
+    // (startup's `init_docker` verifies the seed the same way, which is
+    // why `AgentState::new` may seed `current == target`).
 
     pub fn set_load_ceiling(&self, value: f64) {
         self.tx.send_modify(|s| {
@@ -303,14 +317,27 @@ impl AgentState {
         });
     }
 
-    pub fn set_linux_runner_image(&self, value: String) {
+    pub fn set_linux_runner_image_target(&self, value: &str) {
         self.tx.send_modify(|s| {
-            let setting = settings_mut(s)
-                .linux_runner_image
-                .as_mut()
-                .expect(SETTINGS_INVARIANT);
-            setting.current.clone_from(&value);
-            setting.target = value;
+            value.clone_into(
+                &mut settings_mut(s)
+                    .linux_runner_image
+                    .as_mut()
+                    .expect(SETTINGS_INVARIANT)
+                    .target,
+            );
+        });
+    }
+
+    pub fn set_linux_runner_image_current(&self, value: &str) {
+        self.tx.send_modify(|s| {
+            value.clone_into(
+                &mut settings_mut(s)
+                    .linux_runner_image
+                    .as_mut()
+                    .expect(SETTINGS_INVARIANT)
+                    .current,
+            );
         });
     }
 
@@ -456,6 +483,23 @@ mod tests {
 
         state.set_gateway_current("https://staging.fleet.arcbox.dev");
         assert_eq!(gateway_current(&state), state.gateway_target());
+    }
+
+    #[test]
+    fn linux_runner_image_current_and_target_are_independent() {
+        let state = AgentState::new(&seed());
+        state.set_linux_runner_image_target("ghcr.io/acme/runner:v2");
+        assert_eq!(
+            state.linux_runner_image_current(),
+            "ghcr.io/actions/actions-runner:latest"
+        );
+        assert_eq!(state.linux_runner_image_target(), "ghcr.io/acme/runner:v2");
+
+        state.set_linux_runner_image_current("ghcr.io/acme/runner:v2");
+        assert_eq!(
+            state.linux_runner_image_current(),
+            state.linux_runner_image_target()
+        );
     }
 
     #[test]

--- a/fleet/arcbox-fleet-agent/src/state.rs
+++ b/fleet/arcbox-fleet-agent/src/state.rs
@@ -109,9 +109,9 @@ impl AgentState {
                 current: seed.mem_floor_mib,
                 target: seed.mem_floor_mib,
             }),
-            runner_image: Some(StringSetting {
-                current: seed.runner_image.clone(),
-                target: seed.runner_image.clone(),
+            linux_runner_image: Some(StringSetting {
+                current: seed.linux_runner_image.clone(),
+                target: seed.linux_runner_image.clone(),
             }),
             gateway: Some(StringSetting {
                 current: seed.gateway.clone(),
@@ -166,8 +166,8 @@ impl AgentState {
         PersistedSettings {
             load_ceiling: s.load_ceiling.as_ref().expect(SETTINGS_INVARIANT).target,
             mem_floor_mib: s.mem_floor_mib.as_ref().expect(SETTINGS_INVARIANT).target,
-            runner_image: s
-                .runner_image
+            linux_runner_image: s
+                .linux_runner_image
                 .as_ref()
                 .expect(SETTINGS_INVARIANT)
                 .target
@@ -242,9 +242,9 @@ impl AgentState {
             .current
     }
 
-    pub fn runner_image_current(&self) -> String {
+    pub fn linux_runner_image_current(&self) -> String {
         settings_of(&self.tx.borrow())
-            .runner_image
+            .linux_runner_image
             .as_ref()
             .expect(SETTINGS_INVARIANT)
             .current
@@ -264,7 +264,7 @@ impl AgentState {
             .clone()
     }
 
-    // -- Settings: writers. `load_ceiling`/`mem_floor_mib`/`runner_image`
+    // -- Settings: writers. `load_ceiling`/`mem_floor_mib`/`linux_runner_image`
     // apply instantly, so their setters write both `current` and `target`
     // in one `send_modify` — there's never a moment where they should
     // differ.
@@ -303,10 +303,10 @@ impl AgentState {
         });
     }
 
-    pub fn set_runner_image(&self, value: String) {
+    pub fn set_linux_runner_image(&self, value: String) {
         self.tx.send_modify(|s| {
             let setting = settings_mut(s)
-                .runner_image
+                .linux_runner_image
                 .as_mut()
                 .expect(SETTINGS_INVARIANT);
             setting.current.clone_from(&value);
@@ -374,7 +374,7 @@ mod tests {
         PersistedSettings {
             load_ceiling: 0.9,
             mem_floor_mib: 2048,
-            runner_image: "ghcr.io/actions/actions-runner:latest".to_owned(),
+            linux_runner_image: "ghcr.io/actions/actions-runner:latest".to_owned(),
             gateway: "https://fleet.arcbox.dev".to_owned(),
             docker_mode: DockerMode::Auto,
             runner_script: None,
@@ -433,8 +433,8 @@ mod tests {
         assert_eq!(load_ceiling.current, load_ceiling.target);
         let mem_floor = settings.mem_floor_mib.unwrap();
         assert_eq!(mem_floor.current, mem_floor.target);
-        let runner_image = settings.runner_image.unwrap();
-        assert_eq!(runner_image.current, runner_image.target);
+        let linux_runner_image = settings.linux_runner_image.unwrap();
+        assert_eq!(linux_runner_image.current, linux_runner_image.target);
         let gateway = settings.gateway.unwrap();
         assert_eq!(gateway.current, gateway.target);
         let docker_mode = settings.docker_mode.unwrap();

--- a/fleet/arcbox-fleet-agent/src/state.rs
+++ b/fleet/arcbox-fleet-agent/src/state.rs
@@ -71,6 +71,18 @@ fn setting_value_to_path(value: &str) -> Option<PathBuf> {
     (!value.is_empty()).then(|| PathBuf::from(value))
 }
 
+/// The always-present settings block. Every accessor goes through these two
+/// helpers so the outer [`SETTINGS_INVARIANT`] assertion is spelled once here
+/// rather than at each of the ~15 call sites (and each new settable field
+/// inherits it for free).
+fn settings_of(snapshot: &AgentStateSnapshot) -> &AgentSettings {
+    snapshot.settings.as_ref().expect(SETTINGS_INVARIANT)
+}
+
+fn settings_mut(snapshot: &mut AgentStateSnapshot) -> &mut AgentSettings {
+    snapshot.settings.as_mut().expect(SETTINGS_INVARIANT)
+}
+
 /// Cheap-to-clone handle onto the agent's observable state. Every setter is
 /// synchronous (`watch::Sender::send_modify` never awaits), so it can be
 /// called from non-async contexts like `Drop` impls.
@@ -140,7 +152,7 @@ impl AgentState {
 
     /// The current settings, for `GetSettings`.
     pub fn settings(&self) -> AgentSettings {
-        self.tx.borrow().settings.clone().expect(SETTINGS_INVARIANT)
+        settings_of(&self.tx.borrow()).clone()
     }
 
     /// The current settings, projected down to their persisted
@@ -150,7 +162,7 @@ impl AgentState {
     /// request.
     pub fn persisted_settings(&self) -> PersistedSettings {
         let snapshot = self.tx.borrow();
-        let s = snapshot.settings.as_ref().expect(SETTINGS_INVARIANT);
+        let s = settings_of(&snapshot);
         PersistedSettings {
             load_ceiling: s.load_ceiling.as_ref().expect(SETTINGS_INVARIANT).target,
             mem_floor_mib: s.mem_floor_mib.as_ref().expect(SETTINGS_INVARIANT).target,
@@ -215,11 +227,7 @@ impl AgentState {
     // pulls) — extract just the one field needed, no whole-snapshot clone.
 
     pub fn load_ceiling_current(&self) -> f64 {
-        self.tx
-            .borrow()
-            .settings
-            .as_ref()
-            .expect(SETTINGS_INVARIANT)
+        settings_of(&self.tx.borrow())
             .load_ceiling
             .as_ref()
             .expect(SETTINGS_INVARIANT)
@@ -227,11 +235,7 @@ impl AgentState {
     }
 
     pub fn mem_floor_mib_current(&self) -> u64 {
-        self.tx
-            .borrow()
-            .settings
-            .as_ref()
-            .expect(SETTINGS_INVARIANT)
+        settings_of(&self.tx.borrow())
             .mem_floor_mib
             .as_ref()
             .expect(SETTINGS_INVARIANT)
@@ -239,11 +243,7 @@ impl AgentState {
     }
 
     pub fn runner_image_current(&self) -> String {
-        self.tx
-            .borrow()
-            .settings
-            .as_ref()
-            .expect(SETTINGS_INVARIANT)
+        settings_of(&self.tx.borrow())
             .runner_image
             .as_ref()
             .expect(SETTINGS_INVARIANT)
@@ -256,11 +256,7 @@ impl AgentState {
     /// was last dialed outside of the full `settings()`/`persisted_settings()`
     /// snapshots, which `GetSettings`/`Watch` already expose it through.
     pub fn gateway_target(&self) -> String {
-        self.tx
-            .borrow()
-            .settings
-            .as_ref()
-            .expect(SETTINGS_INVARIANT)
+        settings_of(&self.tx.borrow())
             .gateway
             .as_ref()
             .expect(SETTINGS_INVARIANT)
@@ -287,10 +283,7 @@ impl AgentState {
 
     pub fn set_load_ceiling(&self, value: f64) {
         self.tx.send_modify(|s| {
-            let setting = s
-                .settings
-                .as_mut()
-                .expect(SETTINGS_INVARIANT)
+            let setting = settings_mut(s)
                 .load_ceiling
                 .as_mut()
                 .expect(SETTINGS_INVARIANT);
@@ -301,10 +294,7 @@ impl AgentState {
 
     pub fn set_mem_floor_mib(&self, value: u64) {
         self.tx.send_modify(|s| {
-            let setting = s
-                .settings
-                .as_mut()
-                .expect(SETTINGS_INVARIANT)
+            let setting = settings_mut(s)
                 .mem_floor_mib
                 .as_mut()
                 .expect(SETTINGS_INVARIANT);
@@ -315,10 +305,7 @@ impl AgentState {
 
     pub fn set_runner_image(&self, value: String) {
         self.tx.send_modify(|s| {
-            let setting = s
-                .settings
-                .as_mut()
-                .expect(SETTINGS_INVARIANT)
+            let setting = settings_mut(s)
                 .runner_image
                 .as_mut()
                 .expect(SETTINGS_INVARIANT);
@@ -330,10 +317,7 @@ impl AgentState {
     pub fn set_gateway_target(&self, value: &str) {
         self.tx.send_modify(|s| {
             value.clone_into(
-                &mut s
-                    .settings
-                    .as_mut()
-                    .expect(SETTINGS_INVARIANT)
+                &mut settings_mut(s)
                     .gateway
                     .as_mut()
                     .expect(SETTINGS_INVARIANT)
@@ -345,10 +329,7 @@ impl AgentState {
     pub fn set_gateway_current(&self, value: &str) {
         self.tx.send_modify(|s| {
             value.clone_into(
-                &mut s
-                    .settings
-                    .as_mut()
-                    .expect(SETTINGS_INVARIANT)
+                &mut settings_mut(s)
                     .gateway
                     .as_mut()
                     .expect(SETTINGS_INVARIANT)
@@ -360,9 +341,7 @@ impl AgentState {
     pub fn set_docker_mode_target(&self, mode: DockerMode) {
         let mode = docker_mode_to_control(mode) as i32;
         self.tx.send_modify(|s| {
-            s.settings
-                .as_mut()
-                .expect(SETTINGS_INVARIANT)
+            settings_mut(s)
                 .docker_mode
                 .as_mut()
                 .expect(SETTINGS_INVARIANT)
@@ -373,9 +352,7 @@ impl AgentState {
     pub fn set_runner_script_target(&self, script: Option<&Path>) {
         let value = path_to_setting_value(script);
         self.tx.send_modify(|s| {
-            s.settings
-                .as_mut()
-                .expect(SETTINGS_INVARIANT)
+            settings_mut(s)
                 .runner_script
                 .as_mut()
                 .expect(SETTINGS_INVARIANT)

--- a/fleet/arcbox-fleet-agent/src/state.rs
+++ b/fleet/arcbox-fleet-agent/src/state.rs
@@ -1,0 +1,178 @@
+//! Reactive, observable agent state: a single value pushed via `watch`,
+//! mirroring `arcbox-api`'s `SetupState`. Every module that owns a
+//! transition (enrollment, admission, telemetry) calls straight into this;
+//! `FleetStateService::watch` (`control/watch.rs`) is the only reader that
+//! turns it into a stream. Settings (a later addition) will push through
+//! this same snapshot rather than needing their own notification path.
+
+use std::sync::Arc;
+
+use arcbox_fleet_control_proto::v1::{
+    AgentStateSnapshot, Capability, Enrollment, HostTelemetry, InFlightJob, OfferVerdict,
+};
+use tokio::sync::watch;
+
+/// Bound on `recent_verdicts` so a long-lived agent's snapshot doesn't grow
+/// without limit; only recent history is useful for a live status view.
+const RECENT_VERDICTS_CAP: usize = 20;
+
+/// Cheap-to-clone handle onto the agent's observable state. Every setter is
+/// synchronous (`watch::Sender::send_modify` never awaits), so it can be
+/// called from non-async contexts like `Drop` impls.
+#[derive(Clone)]
+pub struct AgentState {
+    tx: Arc<watch::Sender<AgentStateSnapshot>>,
+}
+
+impl AgentState {
+    /// A fresh, unenrolled snapshot — no credential, nothing running.
+    pub fn new() -> Self {
+        let (tx, _) = watch::channel(AgentStateSnapshot {
+            enrollment: Enrollment::Unenrolled as i32,
+            machine_id: String::new(),
+            draining: false,
+            capabilities: Vec::new(),
+            in_flight: Vec::new(),
+            recent_verdicts: Vec::new(),
+            telemetry: None,
+        });
+        Self { tx: Arc::new(tx) }
+    }
+
+    /// Subscribe to future changes. `FleetStateService::watch` yields the
+    /// current value first (`borrow_and_update`), then one per change.
+    pub fn subscribe(&self) -> watch::Receiver<AgentStateSnapshot> {
+        self.tx.subscribe()
+    }
+
+    /// A snapshot of the current state.
+    pub fn current(&self) -> AgentStateSnapshot {
+        self.tx.borrow().clone()
+    }
+
+    pub fn set_enrollment(&self, enrollment: Enrollment, machine_id: &str) {
+        self.tx.send_modify(|s| {
+            s.enrollment = enrollment as i32;
+            machine_id.clone_into(&mut s.machine_id);
+        });
+    }
+
+    pub fn set_draining(&self, draining: bool) {
+        self.tx.send_modify(|s| s.draining = draining);
+    }
+
+    /// Advertised capabilities are static for an attachment's lifetime, so
+    /// this is set once rather than tracked incrementally.
+    pub fn set_capabilities(&self, capabilities: Vec<Capability>) {
+        self.tx.send_modify(|s| s.capabilities = capabilities);
+    }
+
+    pub fn add_in_flight(&self, job: InFlightJob) {
+        self.tx.send_modify(|s| s.in_flight.push(job));
+    }
+
+    pub fn remove_in_flight(&self, job_id: &str) {
+        self.tx
+            .send_modify(|s| s.in_flight.retain(|j| j.job_id != job_id));
+    }
+
+    /// Append a verdict, dropping the oldest once [`RECENT_VERDICTS_CAP`] is
+    /// exceeded. Most-recent-last.
+    pub fn push_verdict(&self, verdict: OfferVerdict) {
+        self.tx.send_modify(|s| {
+            s.recent_verdicts.push(verdict);
+            if s.recent_verdicts.len() > RECENT_VERDICTS_CAP {
+                s.recent_verdicts.remove(0);
+            }
+        });
+    }
+
+    pub fn set_telemetry(&self, telemetry: HostTelemetry) {
+        self.tx.send_modify(|s| s.telemetry = Some(telemetry));
+    }
+}
+
+impl Default for AgentState {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn job(id: &str) -> InFlightJob {
+        InFlightJob {
+            job_id: id.to_owned(),
+            os: "darwin".to_owned(),
+            arch: "arm64".to_owned(),
+        }
+    }
+
+    fn verdict(id: &str) -> OfferVerdict {
+        OfferVerdict {
+            job_id: id.to_owned(),
+            accepted: true,
+            reason: String::new(),
+        }
+    }
+
+    #[test]
+    fn starts_unenrolled_and_empty() {
+        let snap = AgentState::new().current();
+        assert_eq!(snap.enrollment, Enrollment::Unenrolled as i32);
+        assert_eq!(snap.machine_id, "");
+        assert!(!snap.draining);
+        assert!(snap.capabilities.is_empty());
+        assert!(snap.in_flight.is_empty());
+        assert!(snap.recent_verdicts.is_empty());
+        assert!(snap.telemetry.is_none());
+    }
+
+    #[test]
+    fn in_flight_add_and_remove_round_trips() {
+        let state = AgentState::new();
+        state.add_in_flight(job("rjob_a"));
+        state.add_in_flight(job("rjob_b"));
+        assert_eq!(state.current().in_flight.len(), 2);
+
+        state.remove_in_flight("rjob_a");
+        let remaining = state.current().in_flight;
+        assert_eq!(remaining.len(), 1);
+        assert_eq!(remaining[0].job_id, "rjob_b");
+    }
+
+    #[test]
+    fn recent_verdicts_cap_drops_oldest_and_keeps_most_recent_last() {
+        let state = AgentState::new();
+        for i in 0..RECENT_VERDICTS_CAP + 5 {
+            state.push_verdict(verdict(&format!("rjob_{i}")));
+        }
+        let verdicts = state.current().recent_verdicts;
+        assert_eq!(verdicts.len(), RECENT_VERDICTS_CAP);
+        assert_eq!(verdicts.first().unwrap().job_id, "rjob_5");
+        assert_eq!(
+            verdicts.last().unwrap().job_id,
+            format!("rjob_{}", RECENT_VERDICTS_CAP + 4)
+        );
+    }
+
+    #[test]
+    fn set_enrollment_updates_machine_id() {
+        let state = AgentState::new();
+        state.set_enrollment(Enrollment::Attaching, "fltm_test");
+        let snap = state.current();
+        assert_eq!(snap.enrollment, Enrollment::Attaching as i32);
+        assert_eq!(snap.machine_id, "fltm_test");
+    }
+
+    #[test]
+    fn set_draining_toggles() {
+        let state = AgentState::new();
+        state.set_draining(true);
+        assert!(state.current().draining);
+        state.set_draining(false);
+        assert!(!state.current().draining);
+    }
+}

--- a/fleet/arcbox-fleet-agent/src/state.rs
+++ b/fleet/arcbox-fleet-agent/src/state.rs
@@ -271,9 +271,19 @@ impl AgentState {
     // -- Settings: writers. `load_ceiling`/`mem_floor_mib`/`runner_image`
     // apply instantly, so their setters write both `current` and `target`
     // in one `send_modify` — there's never a moment where they should
-    // differ. `gateway`/`docker_mode`/`runner_script` have independent
-    // current/target setters: `target` is written by `UpdateSettings`,
-    // `current` by whichever engine code actually resolves/applies it.
+    // differ.
+    //
+    // `docker_mode`/`runner_script` are restart-scoped: `UpdateSettings`
+    // moves only their `target`, and `current` stays whatever the process
+    // started with (fixed by `AgentState::new` from the persisted seed)
+    // until the next restart re-seeds from it — so they get a `target`
+    // setter but no `current` setter. Whether an `Auto` docker_mode
+    // actually found Docker is observable via `capabilities`, not by
+    // resolving `current` away from the requested policy.
+    //
+    // `gateway` alone has an independent `current` setter: `UpdateSettings`
+    // writes `target`, and `attach.rs` writes `current` once it has
+    // actually dialed that gateway.
 
     pub fn set_load_ceiling(&self, value: f64) {
         self.tx.send_modify(|s| {
@@ -360,19 +370,6 @@ impl AgentState {
         });
     }
 
-    pub fn set_docker_mode_current(&self, mode: DockerMode) {
-        let mode = docker_mode_to_control(mode) as i32;
-        self.tx.send_modify(|s| {
-            s.settings
-                .as_mut()
-                .expect(SETTINGS_INVARIANT)
-                .docker_mode
-                .as_mut()
-                .expect(SETTINGS_INVARIANT)
-                .current = mode;
-        });
-    }
-
     pub fn set_runner_script_target(&self, script: Option<&Path>) {
         let value = path_to_setting_value(script);
         self.tx.send_modify(|s| {
@@ -383,19 +380,6 @@ impl AgentState {
                 .as_mut()
                 .expect(SETTINGS_INVARIANT)
                 .target = value;
-        });
-    }
-
-    pub fn set_runner_script_current(&self, script: Option<&Path>) {
-        let value = path_to_setting_value(script);
-        self.tx.send_modify(|s| {
-            s.settings
-                .as_mut()
-                .expect(SETTINGS_INVARIANT)
-                .runner_script
-                .as_mut()
-                .expect(SETTINGS_INVARIANT)
-                .current = value;
         });
     }
 }
@@ -455,17 +439,35 @@ mod tests {
         state.settings().gateway.unwrap().current
     }
 
+    /// A freshly-seeded agent must report `current == target` for *every*
+    /// setting, so a client's "current != target ⇒ pending" rendering shows
+    /// nothing pending on a clean start. `docker_mode` is the load-bearing
+    /// case: the seed here is `Auto`, and nothing at startup may resolve its
+    /// `current` to a concrete `Enabled`/`Disabled` (which would leave it
+    /// perpetually != the `Auto` target) — that resolution is observable via
+    /// `capabilities`, not by moving `current` off the requested policy.
     #[test]
     fn settings_seed_current_equals_target() {
         let state = AgentState::new(&seed());
         assert_eq!(state.load_ceiling_current(), 0.9);
         assert_eq!(state.mem_floor_mib_current(), 2048);
-        assert_eq!(gateway_current(&state), state.gateway_target());
         let settings = state.settings();
+        let load_ceiling = settings.load_ceiling.unwrap();
+        assert_eq!(load_ceiling.current, load_ceiling.target);
+        let mem_floor = settings.mem_floor_mib.unwrap();
+        assert_eq!(mem_floor.current, mem_floor.target);
+        let runner_image = settings.runner_image.unwrap();
+        assert_eq!(runner_image.current, runner_image.target);
+        let gateway = settings.gateway.unwrap();
+        assert_eq!(gateway.current, gateway.target);
+        let docker_mode = settings.docker_mode.unwrap();
         assert_eq!(
-            settings.docker_mode.unwrap().current,
+            docker_mode.current,
             arcbox_fleet_control_proto::v1::DockerMode::Auto as i32
         );
+        assert_eq!(docker_mode.current, docker_mode.target);
+        let runner_script = settings.runner_script.unwrap();
+        assert_eq!(runner_script.current, runner_script.target);
     }
 
     #[test]

--- a/fleet/arcbox-fleet-agent/src/state.rs
+++ b/fleet/arcbox-fleet-agent/src/state.rs
@@ -1,20 +1,75 @@
 //! Reactive, observable agent state: a single value pushed via `watch`,
 //! mirroring `arcbox-api`'s `SetupState`. Every module that owns a
-//! transition (enrollment, admission, telemetry) calls straight into this;
-//! `FleetStateService::watch` (`control/watch.rs`) is the only reader that
-//! turns it into a stream. Settings (a later addition) will push through
-//! this same snapshot rather than needing their own notification path.
+//! transition (enrollment, admission, telemetry, settings) calls straight
+//! into this; `FleetStateService::watch` (`control/watch.rs`) is the only
+//! reader that turns it into a stream.
 
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use arcbox_fleet_control_proto::v1::{
-    AgentStateSnapshot, Capability, Enrollment, HostTelemetry, InFlightJob, OfferVerdict,
+    AgentSettings, AgentStateSnapshot, Capability, DockerModeSetting, DoubleSetting, Enrollment,
+    HostTelemetry, InFlightJob, OfferVerdict, StringSetting, Uint64Setting,
 };
 use tokio::sync::watch;
+
+use crate::config::DockerMode;
+use crate::settings::PersistedSettings;
 
 /// Bound on `recent_verdicts` so a long-lived agent's snapshot doesn't grow
 /// without limit; only recent history is useful for a live status view.
 const RECENT_VERDICTS_CAP: usize = 20;
+
+/// `AgentState::new` always populates `settings` fully, unlike `telemetry`
+/// (legitimately absent until the first heartbeat) — every accessor below
+/// relies on this and panics via this message if it's ever violated.
+const SETTINGS_INVARIANT: &str = "AgentState::new always initializes settings";
+
+/// Convert a gateway-facing `DockerMode` into its control-plane
+/// counterpart. A plain function, not `From`: `control_proto::DockerMode`
+/// is generated in another crate, so Rust's orphan rule blocks
+/// implementing a foreign trait for a foreign *target* type here.
+fn docker_mode_to_control(mode: DockerMode) -> arcbox_fleet_control_proto::v1::DockerMode {
+    match mode {
+        DockerMode::Auto => arcbox_fleet_control_proto::v1::DockerMode::Auto,
+        DockerMode::Enabled => arcbox_fleet_control_proto::v1::DockerMode::Enabled,
+        DockerMode::Disabled => arcbox_fleet_control_proto::v1::DockerMode::Disabled,
+    }
+}
+
+/// The reverse direction has no such restriction — `DockerMode` (the
+/// target here) is local to this crate, so the orphan rule allows a real
+/// `From` impl even though the source type is foreign. Unrecognized/absent
+/// wire values fall back to `Auto`, matching `AgentConfig::from_env`'s own
+/// default.
+impl From<arcbox_fleet_control_proto::v1::DockerMode> for DockerMode {
+    fn from(mode: arcbox_fleet_control_proto::v1::DockerMode) -> Self {
+        match mode {
+            arcbox_fleet_control_proto::v1::DockerMode::Enabled => Self::Enabled,
+            arcbox_fleet_control_proto::v1::DockerMode::Disabled => Self::Disabled,
+            arcbox_fleet_control_proto::v1::DockerMode::Auto
+            | arcbox_fleet_control_proto::v1::DockerMode::Unspecified => Self::Auto,
+        }
+    }
+}
+
+/// Parse a wire `DockerMode` i32 that may not be a recognized variant
+/// (an older/newer client sent something this build doesn't know) into the
+/// internal type, falling back to `Auto`.
+fn docker_mode_from_wire(raw: i32) -> DockerMode {
+    arcbox_fleet_control_proto::v1::DockerMode::try_from(raw)
+        .unwrap_or(arcbox_fleet_control_proto::v1::DockerMode::Unspecified)
+        .into()
+}
+
+fn path_to_setting_value(path: Option<&Path>) -> String {
+    path.map(|p| p.to_string_lossy().into_owned())
+        .unwrap_or_default()
+}
+
+fn setting_value_to_path(value: &str) -> Option<PathBuf> {
+    (!value.is_empty()).then(|| PathBuf::from(value))
+}
 
 /// Cheap-to-clone handle onto the agent's observable state. Every setter is
 /// synchronous (`watch::Sender::send_modify` never awaits), so it can be
@@ -26,7 +81,39 @@ pub struct AgentState {
 
 impl AgentState {
     /// A fresh, unenrolled snapshot — no credential, nothing running.
-    pub fn new() -> Self {
+    /// `seed`'s values populate `settings` with `current == target`
+    /// everywhere; callers that resolve a different `current` post-startup
+    /// (e.g. `docker_mode`, once `init_docker()` actually runs) update it
+    /// separately.
+    pub fn new(seed: &PersistedSettings) -> Self {
+        let runner_script = path_to_setting_value(seed.runner_script.as_deref());
+        let docker_mode = docker_mode_to_control(seed.docker_mode) as i32;
+        let settings = AgentSettings {
+            load_ceiling: Some(DoubleSetting {
+                current: seed.load_ceiling,
+                target: seed.load_ceiling,
+            }),
+            mem_floor_mib: Some(Uint64Setting {
+                current: seed.mem_floor_mib,
+                target: seed.mem_floor_mib,
+            }),
+            runner_image: Some(StringSetting {
+                current: seed.runner_image.clone(),
+                target: seed.runner_image.clone(),
+            }),
+            gateway: Some(StringSetting {
+                current: seed.gateway.clone(),
+                target: seed.gateway.clone(),
+            }),
+            docker_mode: Some(DockerModeSetting {
+                current: docker_mode,
+                target: docker_mode,
+            }),
+            runner_script: Some(StringSetting {
+                current: runner_script.clone(),
+                target: runner_script,
+            }),
+        };
         let (tx, _) = watch::channel(AgentStateSnapshot {
             enrollment: Enrollment::Unenrolled as i32,
             machine_id: String::new(),
@@ -35,6 +122,7 @@ impl AgentState {
             in_flight: Vec::new(),
             recent_verdicts: Vec::new(),
             telemetry: None,
+            settings: Some(settings),
         });
         Self { tx: Arc::new(tx) }
     }
@@ -48,6 +136,38 @@ impl AgentState {
     /// A snapshot of the current state.
     pub fn current(&self) -> AgentStateSnapshot {
         self.tx.borrow().clone()
+    }
+
+    /// The current settings, for `GetSettings`.
+    pub fn settings(&self) -> AgentSettings {
+        self.tx.borrow().settings.clone().expect(SETTINGS_INVARIANT)
+    }
+
+    /// The current settings, projected down to their persisted
+    /// (`target`-only) shape — what [`crate::settings::SettingsStore`]
+    /// writes to disk, and the baseline `FleetSettingsService.UpdateSettings`
+    /// computes "effective post-update" values against before applying a
+    /// request.
+    pub fn persisted_settings(&self) -> PersistedSettings {
+        let snapshot = self.tx.borrow();
+        let s = snapshot.settings.as_ref().expect(SETTINGS_INVARIANT);
+        PersistedSettings {
+            load_ceiling: s.load_ceiling.as_ref().expect(SETTINGS_INVARIANT).target,
+            mem_floor_mib: s.mem_floor_mib.as_ref().expect(SETTINGS_INVARIANT).target,
+            runner_image: s
+                .runner_image
+                .as_ref()
+                .expect(SETTINGS_INVARIANT)
+                .target
+                .clone(),
+            gateway: s.gateway.as_ref().expect(SETTINGS_INVARIANT).target.clone(),
+            docker_mode: docker_mode_from_wire(
+                s.docker_mode.as_ref().expect(SETTINGS_INVARIANT).target,
+            ),
+            runner_script: setting_value_to_path(
+                &s.runner_script.as_ref().expect(SETTINGS_INVARIANT).target,
+            ),
+        }
     }
 
     pub fn set_enrollment(&self, enrollment: Enrollment, machine_id: &str) {
@@ -90,17 +210,215 @@ impl AgentState {
     pub fn set_telemetry(&self, telemetry: HostTelemetry) {
         self.tx.send_modify(|s| s.telemetry = Some(telemetry));
     }
-}
 
-impl Default for AgentState {
-    fn default() -> Self {
-        Self::new()
+    // -- Settings: cheap reads for the engine's hot paths (admit(), image
+    // pulls) — extract just the one field needed, no whole-snapshot clone.
+
+    pub fn load_ceiling_current(&self) -> f64 {
+        self.tx
+            .borrow()
+            .settings
+            .as_ref()
+            .expect(SETTINGS_INVARIANT)
+            .load_ceiling
+            .as_ref()
+            .expect(SETTINGS_INVARIANT)
+            .current
+    }
+
+    pub fn mem_floor_mib_current(&self) -> u64 {
+        self.tx
+            .borrow()
+            .settings
+            .as_ref()
+            .expect(SETTINGS_INVARIANT)
+            .mem_floor_mib
+            .as_ref()
+            .expect(SETTINGS_INVARIANT)
+            .current
+    }
+
+    pub fn runner_image_current(&self) -> String {
+        self.tx
+            .borrow()
+            .settings
+            .as_ref()
+            .expect(SETTINGS_INVARIANT)
+            .runner_image
+            .as_ref()
+            .expect(SETTINGS_INVARIANT)
+            .current
+            .clone()
+    }
+
+    /// The desired gateway — what `attach.rs` dials on its next attempt.
+    /// There's no `gateway_current` reader: nothing needs to read back what
+    /// was last dialed outside of the full `settings()`/`persisted_settings()`
+    /// snapshots, which `GetSettings`/`Watch` already expose it through.
+    pub fn gateway_target(&self) -> String {
+        self.tx
+            .borrow()
+            .settings
+            .as_ref()
+            .expect(SETTINGS_INVARIANT)
+            .gateway
+            .as_ref()
+            .expect(SETTINGS_INVARIANT)
+            .target
+            .clone()
+    }
+
+    // -- Settings: writers. `load_ceiling`/`mem_floor_mib`/`runner_image`
+    // apply instantly, so their setters write both `current` and `target`
+    // in one `send_modify` — there's never a moment where they should
+    // differ. `gateway`/`docker_mode`/`runner_script` have independent
+    // current/target setters: `target` is written by `UpdateSettings`,
+    // `current` by whichever engine code actually resolves/applies it.
+
+    pub fn set_load_ceiling(&self, value: f64) {
+        self.tx.send_modify(|s| {
+            let setting = s
+                .settings
+                .as_mut()
+                .expect(SETTINGS_INVARIANT)
+                .load_ceiling
+                .as_mut()
+                .expect(SETTINGS_INVARIANT);
+            setting.current = value;
+            setting.target = value;
+        });
+    }
+
+    pub fn set_mem_floor_mib(&self, value: u64) {
+        self.tx.send_modify(|s| {
+            let setting = s
+                .settings
+                .as_mut()
+                .expect(SETTINGS_INVARIANT)
+                .mem_floor_mib
+                .as_mut()
+                .expect(SETTINGS_INVARIANT);
+            setting.current = value;
+            setting.target = value;
+        });
+    }
+
+    pub fn set_runner_image(&self, value: String) {
+        self.tx.send_modify(|s| {
+            let setting = s
+                .settings
+                .as_mut()
+                .expect(SETTINGS_INVARIANT)
+                .runner_image
+                .as_mut()
+                .expect(SETTINGS_INVARIANT);
+            setting.current.clone_from(&value);
+            setting.target = value;
+        });
+    }
+
+    pub fn set_gateway_target(&self, value: &str) {
+        self.tx.send_modify(|s| {
+            value.clone_into(
+                &mut s
+                    .settings
+                    .as_mut()
+                    .expect(SETTINGS_INVARIANT)
+                    .gateway
+                    .as_mut()
+                    .expect(SETTINGS_INVARIANT)
+                    .target,
+            );
+        });
+    }
+
+    pub fn set_gateway_current(&self, value: &str) {
+        self.tx.send_modify(|s| {
+            value.clone_into(
+                &mut s
+                    .settings
+                    .as_mut()
+                    .expect(SETTINGS_INVARIANT)
+                    .gateway
+                    .as_mut()
+                    .expect(SETTINGS_INVARIANT)
+                    .current,
+            );
+        });
+    }
+
+    pub fn set_docker_mode_target(&self, mode: DockerMode) {
+        let mode = docker_mode_to_control(mode) as i32;
+        self.tx.send_modify(|s| {
+            s.settings
+                .as_mut()
+                .expect(SETTINGS_INVARIANT)
+                .docker_mode
+                .as_mut()
+                .expect(SETTINGS_INVARIANT)
+                .target = mode;
+        });
+    }
+
+    pub fn set_docker_mode_current(&self, mode: DockerMode) {
+        let mode = docker_mode_to_control(mode) as i32;
+        self.tx.send_modify(|s| {
+            s.settings
+                .as_mut()
+                .expect(SETTINGS_INVARIANT)
+                .docker_mode
+                .as_mut()
+                .expect(SETTINGS_INVARIANT)
+                .current = mode;
+        });
+    }
+
+    pub fn set_runner_script_target(&self, script: Option<&Path>) {
+        let value = path_to_setting_value(script);
+        self.tx.send_modify(|s| {
+            s.settings
+                .as_mut()
+                .expect(SETTINGS_INVARIANT)
+                .runner_script
+                .as_mut()
+                .expect(SETTINGS_INVARIANT)
+                .target = value;
+        });
+    }
+
+    pub fn set_runner_script_current(&self, script: Option<&Path>) {
+        let value = path_to_setting_value(script);
+        self.tx.send_modify(|s| {
+            s.settings
+                .as_mut()
+                .expect(SETTINGS_INVARIANT)
+                .runner_script
+                .as_mut()
+                .expect(SETTINGS_INVARIANT)
+                .current = value;
+        });
     }
 }
 
 #[cfg(test)]
+#[allow(
+    clippy::float_cmp,
+    reason = "settings values are moved/copied here, never computed, so exact \
+              float equality is always well-defined — no rounding can occur"
+)]
 mod tests {
     use super::*;
+
+    fn seed() -> PersistedSettings {
+        PersistedSettings {
+            load_ceiling: 0.9,
+            mem_floor_mib: 2048,
+            runner_image: "ghcr.io/actions/actions-runner:latest".to_owned(),
+            gateway: "https://fleet.arcbox.dev".to_owned(),
+            docker_mode: DockerMode::Auto,
+            runner_script: None,
+        }
+    }
 
     fn job(id: &str) -> InFlightJob {
         InFlightJob {
@@ -120,7 +438,7 @@ mod tests {
 
     #[test]
     fn starts_unenrolled_and_empty() {
-        let snap = AgentState::new().current();
+        let snap = AgentState::new(&seed()).current();
         assert_eq!(snap.enrollment, Enrollment::Unenrolled as i32);
         assert_eq!(snap.machine_id, "");
         assert!(!snap.draining);
@@ -130,9 +448,48 @@ mod tests {
         assert!(snap.telemetry.is_none());
     }
 
+    /// `AgentState` has no `gateway_current` reader (nothing outside tests
+    /// needs it — see its doc comment), so tests read it via the full
+    /// `settings()` snapshot instead.
+    fn gateway_current(state: &AgentState) -> String {
+        state.settings().gateway.unwrap().current
+    }
+
+    #[test]
+    fn settings_seed_current_equals_target() {
+        let state = AgentState::new(&seed());
+        assert_eq!(state.load_ceiling_current(), 0.9);
+        assert_eq!(state.mem_floor_mib_current(), 2048);
+        assert_eq!(gateway_current(&state), state.gateway_target());
+        let settings = state.settings();
+        assert_eq!(
+            settings.docker_mode.unwrap().current,
+            arcbox_fleet_control_proto::v1::DockerMode::Auto as i32
+        );
+    }
+
+    #[test]
+    fn gateway_current_and_target_are_independent() {
+        let state = AgentState::new(&seed());
+        state.set_gateway_target("https://staging.fleet.arcbox.dev");
+        assert_eq!(gateway_current(&state), "https://fleet.arcbox.dev");
+        assert_eq!(state.gateway_target(), "https://staging.fleet.arcbox.dev");
+
+        state.set_gateway_current("https://staging.fleet.arcbox.dev");
+        assert_eq!(gateway_current(&state), state.gateway_target());
+    }
+
+    #[test]
+    fn set_load_ceiling_sets_both_current_and_target() {
+        let state = AgentState::new(&seed());
+        state.set_load_ceiling(0.5);
+        assert_eq!(state.load_ceiling_current(), 0.5);
+        assert_eq!(state.settings().load_ceiling.unwrap().target, 0.5);
+    }
+
     #[test]
     fn in_flight_add_and_remove_round_trips() {
-        let state = AgentState::new();
+        let state = AgentState::new(&seed());
         state.add_in_flight(job("rjob_a"));
         state.add_in_flight(job("rjob_b"));
         assert_eq!(state.current().in_flight.len(), 2);
@@ -145,7 +502,7 @@ mod tests {
 
     #[test]
     fn recent_verdicts_cap_drops_oldest_and_keeps_most_recent_last() {
-        let state = AgentState::new();
+        let state = AgentState::new(&seed());
         for i in 0..RECENT_VERDICTS_CAP + 5 {
             state.push_verdict(verdict(&format!("rjob_{i}")));
         }
@@ -160,7 +517,7 @@ mod tests {
 
     #[test]
     fn set_enrollment_updates_machine_id() {
-        let state = AgentState::new();
+        let state = AgentState::new(&seed());
         state.set_enrollment(Enrollment::Attaching, "fltm_test");
         let snap = state.current();
         assert_eq!(snap.enrollment, Enrollment::Attaching as i32);
@@ -169,7 +526,7 @@ mod tests {
 
     #[test]
     fn set_draining_toggles() {
-        let state = AgentState::new();
+        let state = AgentState::new(&seed());
         state.set_draining(true);
         assert!(state.current().draining);
         state.set_draining(false);

--- a/fleet/arcbox-fleet-agent/tests/control.rs
+++ b/fleet/arcbox-fleet-agent/tests/control.rs
@@ -178,17 +178,15 @@ async fn unenrolled_agent_reports_status_and_rejects_drain() {
         settings.gateway.expect("gateway present").current,
         "http://127.0.0.1:1"
     );
+    let docker_mode = settings.docker_mode.expect("docker_mode present");
     assert_eq!(
-        DockerMode::try_from(settings.docker_mode.expect("docker_mode present").current).unwrap(),
+        DockerMode::try_from(docker_mode.current).unwrap(),
         DockerMode::Disabled
     );
-    assert_eq!(
-        settings
-            .runner_script
-            .expect("runner_script present")
-            .current,
-        ""
-    );
+    assert_eq!(docker_mode.current, docker_mode.target);
+    let runner_script = settings.runner_script.expect("runner_script present");
+    assert_eq!(runner_script.current, "");
+    assert_eq!(runner_script.current, runner_script.target);
 
     // UpdateSettings: load_ceiling applies instantly — current and target
     // both move together, with no reattach or restart involved.

--- a/fleet/arcbox-fleet-agent/tests/control.rs
+++ b/fleet/arcbox-fleet-agent/tests/control.rs
@@ -14,8 +14,9 @@ use std::task::{Context, Poll};
 use std::time::{Duration, Instant};
 
 use arcbox_fleet_control_proto::v1::fleet_lifecycle_service_client::FleetLifecycleServiceClient;
+use arcbox_fleet_control_proto::v1::fleet_state_service_client::FleetStateServiceClient;
 use arcbox_fleet_control_proto::v1::{
-    ConnectionState, DrainRequest, GetAgentInfoRequest, GetStatusRequest,
+    ConnectionState, DrainRequest, Enrollment, GetAgentInfoRequest, GetStatusRequest, WatchRequest,
 };
 use hyper_util::rt::TokioIo;
 use tokio::net::UnixStream;
@@ -49,12 +50,11 @@ impl Service<Uri> for TestUnixConnector {
     }
 }
 
-async fn connect(socket_path: &Path) -> FleetLifecycleServiceClient<Channel> {
-    let channel = Endpoint::from_static("http://[::]:50051")
+async fn connect(socket_path: &Path) -> Channel {
+    Endpoint::from_static("http://[::]:50051")
         .connect_with_connector(TestUnixConnector(socket_path.to_path_buf()))
         .await
-        .expect("connect to control socket");
-    FleetLifecycleServiceClient::new(channel)
+        .expect("connect to control socket")
 }
 
 /// Poll for `agent.sock` to appear, failing fast (with the exit status) if
@@ -99,7 +99,8 @@ async fn unenrolled_agent_reports_status_and_rejects_drain() {
     );
 
     wait_for_socket(&mut agent.0, &socket_path);
-    let mut client = connect(&socket_path).await;
+    let channel = connect(&socket_path).await;
+    let mut client = FleetLifecycleServiceClient::new(channel.clone());
 
     let info = client
         .get_agent_info(GetAgentInfoRequest {})
@@ -119,6 +120,31 @@ async fn unenrolled_agent_reports_status_and_rejects_drain() {
         ConnectionState::Unenrolled
     );
     assert_eq!(status.machine_id, "");
+
+    // FleetStateService.Watch: the client holds no state of its own, so the
+    // very first message must already be a full, current snapshot — not
+    // require a change to happen first.
+    let mut watch_client = FleetStateServiceClient::new(channel);
+    let mut stream = watch_client
+        .watch(WatchRequest {})
+        .await
+        .expect("Watch RPC")
+        .into_inner();
+    let snapshot = stream
+        .message()
+        .await
+        .expect("watch stream")
+        .expect("initial snapshot")
+        .snapshot
+        .expect("snapshot present");
+    assert_eq!(
+        Enrollment::try_from(snapshot.enrollment).unwrap(),
+        Enrollment::Unenrolled
+    );
+    assert_eq!(snapshot.machine_id, "");
+    assert!(snapshot.capabilities.is_empty());
+    assert!(snapshot.in_flight.is_empty());
+    assert!(snapshot.recent_verdicts.is_empty());
 
     let drain_err = client
         .drain(DrainRequest {})

--- a/fleet/arcbox-fleet-agent/tests/control.rs
+++ b/fleet/arcbox-fleet-agent/tests/control.rs
@@ -1,0 +1,131 @@
+//! End-to-end test of the local control-plane API.
+//!
+//! `arcbox-fleet-agent` ships only a binary (no library target), so this
+//! spawns the real compiled `run` binary against a scratch data dir and
+//! exercises `FleetLifecycleService` over the real Unix socket — the same
+//! path the CLI's `status`/`drain`/`resume`/`disconnect` subcommands and the
+//! desktop app use.
+
+use std::future::Future;
+use std::path::{Path, PathBuf};
+use std::pin::Pin;
+use std::process::{Child, Command, Stdio};
+use std::task::{Context, Poll};
+use std::time::{Duration, Instant};
+
+use arcbox_fleet_control_proto::v1::fleet_lifecycle_service_client::FleetLifecycleServiceClient;
+use arcbox_fleet_control_proto::v1::{
+    ConnectionState, DrainRequest, GetAgentInfoRequest, GetStatusRequest,
+};
+use hyper_util::rt::TokioIo;
+use tokio::net::UnixStream;
+use tonic::codegen::{Service, http::Uri};
+use tonic::transport::{Channel, Endpoint};
+
+/// Kills the spawned agent on drop, so a failing assertion can't leak it.
+struct AgentProcess(Child);
+
+impl Drop for AgentProcess {
+    fn drop(&mut self) {
+        let _ = self.0.kill();
+        let _ = self.0.wait();
+    }
+}
+
+struct TestUnixConnector(PathBuf);
+
+impl Service<Uri> for TestUnixConnector {
+    type Response = TokioIo<UnixStream>;
+    type Error = std::io::Error;
+    type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send>>;
+
+    fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn call(&mut self, _: Uri) -> Self::Future {
+        let path = self.0.clone();
+        Box::pin(async move { Ok(TokioIo::new(UnixStream::connect(path).await?)) })
+    }
+}
+
+async fn connect(socket_path: &Path) -> FleetLifecycleServiceClient<Channel> {
+    let channel = Endpoint::from_static("http://[::]:50051")
+        .connect_with_connector(TestUnixConnector(socket_path.to_path_buf()))
+        .await
+        .expect("connect to control socket");
+    FleetLifecycleServiceClient::new(channel)
+}
+
+/// Poll for `agent.sock` to appear, failing fast (with the exit status) if
+/// the agent process dies before it does.
+fn wait_for_socket(child: &mut Child, socket_path: &Path) {
+    let deadline = Instant::now() + Duration::from_secs(10);
+    loop {
+        if socket_path.exists() {
+            return;
+        }
+        if let Ok(Some(status)) = child.try_wait() {
+            panic!("agent exited before binding its control socket: {status}");
+        }
+        assert!(
+            Instant::now() < deadline,
+            "agent.sock never appeared within the deadline"
+        );
+        std::thread::sleep(Duration::from_millis(50));
+    }
+}
+
+#[tokio::test]
+async fn unenrolled_agent_reports_status_and_rejects_drain() {
+    let data_dir = std::env::temp_dir().join(format!("fleet-agent-control-{}", std::process::id()));
+    std::fs::create_dir_all(&data_dir).unwrap();
+    let socket_path = data_dir.join("agent.sock");
+
+    let mut agent = AgentProcess(
+        Command::new(env!("CARGO_BIN_EXE_arcbox-fleet-agent"))
+            .arg("run")
+            .env("ARCBOX_FLEET_DATA_DIR", &data_dir)
+            // Forced to the file backend so this never touches the real OS
+            // keychain; nothing listens on this gateway, but the Unenrolled
+            // state this test exercises never dials out to it.
+            .env("ARCBOX_FLEET_CREDENTIAL_STORE", "file")
+            .env("ARCBOX_FLEET_GATEWAY", "http://127.0.0.1:1")
+            .env("ARCBOX_FLEET_DOCKER", "false")
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("spawn arcbox-fleet-agent"),
+    );
+
+    wait_for_socket(&mut agent.0, &socket_path);
+    let mut client = connect(&socket_path).await;
+
+    let info = client
+        .get_agent_info(GetAgentInfoRequest {})
+        .await
+        .expect("GetAgentInfo")
+        .into_inner();
+    assert_eq!(info.agent_version, env!("CARGO_PKG_VERSION"));
+    assert_eq!(info.api_version, 1);
+
+    let status = client
+        .get_status(GetStatusRequest {})
+        .await
+        .expect("GetStatus")
+        .into_inner();
+    assert_eq!(
+        ConnectionState::try_from(status.state).unwrap(),
+        ConnectionState::Unenrolled
+    );
+    assert_eq!(status.machine_id, "");
+
+    let drain_err = client
+        .drain(DrainRequest {})
+        .await
+        .expect_err("Drain should fail while unenrolled");
+    assert_eq!(drain_err.code(), tonic::Code::FailedPrecondition);
+
+    drop(agent);
+    let _ = std::fs::remove_dir_all(&data_dir);
+}

--- a/fleet/arcbox-fleet-agent/tests/control.rs
+++ b/fleet/arcbox-fleet-agent/tests/control.rs
@@ -19,12 +19,13 @@ use std::process::{Child, Command, Stdio};
 use std::task::{Context, Poll};
 use std::time::{Duration, Instant};
 
+use arcbox_fleet_control_proto::v1::fleet_image_service_client::FleetImageServiceClient;
 use arcbox_fleet_control_proto::v1::fleet_lifecycle_service_client::FleetLifecycleServiceClient;
 use arcbox_fleet_control_proto::v1::fleet_settings_service_client::FleetSettingsServiceClient;
 use arcbox_fleet_control_proto::v1::fleet_state_service_client::FleetStateServiceClient;
 use arcbox_fleet_control_proto::v1::{
     ConnectionState, DockerMode, DrainRequest, Enrollment, GetAgentInfoRequest, GetSettingsRequest,
-    GetStatusRequest, UpdateSettingsRequest, WatchRequest,
+    GetStatusRequest, PrepareRequest, UpdateSettingsRequest, WatchRequest,
 };
 use hyper_util::rt::TokioIo;
 use tokio::net::UnixStream;
@@ -133,7 +134,7 @@ async fn unenrolled_agent_reports_status_and_rejects_drain() {
     // FleetStateService.Watch: the client holds no state of its own, so the
     // very first message must already be a full, current snapshot — not
     // require a change to happen first.
-    let mut watch_client = FleetStateServiceClient::new(channel);
+    let mut watch_client = FleetStateServiceClient::new(channel.clone());
     let mut stream = watch_client
         .watch(WatchRequest {})
         .await
@@ -227,6 +228,49 @@ async fn unenrolled_agent_reports_status_and_rejects_drain() {
             .current,
         0.5
     );
+
+    // linux_runner_image is prepare-scoped end-to-end: UpdateSettings moves
+    // only `target`; FleetImageService.Prepare is what promotes it. This
+    // agent runs with Docker disabled, so preparation has nothing to verify
+    // the image against and promotes directly ("skipped" then "promoted").
+    let updated = settings_client
+        .update_settings(UpdateSettingsRequest {
+            linux_runner_image: Some("ghcr.io/acme/runner:v2".to_owned()),
+            ..Default::default()
+        })
+        .await
+        .expect("UpdateSettings")
+        .into_inner()
+        .settings
+        .expect("settings present")
+        .linux_runner_image
+        .expect("linux_runner_image present");
+    assert_eq!(updated.current, "ghcr.io/actions/actions-runner:latest");
+    assert_eq!(updated.target, "ghcr.io/acme/runner:v2");
+
+    let mut image_client = FleetImageServiceClient::new(channel);
+    let mut prepare = image_client
+        .prepare(PrepareRequest { kinds: Vec::new() })
+        .await
+        .expect("Prepare RPC")
+        .into_inner();
+    let mut stages = Vec::new();
+    while let Some(event) = prepare.message().await.expect("prepare stream") {
+        stages.push(event.stage);
+    }
+    assert_eq!(stages, ["skipped", "promoted"]);
+
+    let prepared = settings_client
+        .get_settings(GetSettingsRequest {})
+        .await
+        .expect("GetSettings")
+        .into_inner()
+        .settings
+        .expect("settings present")
+        .linux_runner_image
+        .expect("linux_runner_image present");
+    assert_eq!(prepared.current, "ghcr.io/acme/runner:v2");
+    assert_eq!(prepared.current, prepared.target);
 
     // Safety invariant enforced end-to-end: this agent already has
     // docker_mode=Disabled and no runner_script (its env-derived seed —

--- a/fleet/arcbox-fleet-agent/tests/control.rs
+++ b/fleet/arcbox-fleet-agent/tests/control.rs
@@ -6,6 +6,12 @@
 //! same path the CLI's `status`/`drain`/`resume`/`disconnect` subcommands
 //! and the desktop app use.
 
+#![allow(
+    clippy::float_cmp,
+    reason = "settings values are moved/copied here, never computed, so exact \
+              float equality is always well-defined — no rounding can occur"
+)]
+
 use std::future::Future;
 use std::path::{Path, PathBuf};
 use std::pin::Pin;
@@ -14,9 +20,11 @@ use std::task::{Context, Poll};
 use std::time::{Duration, Instant};
 
 use arcbox_fleet_control_proto::v1::fleet_lifecycle_service_client::FleetLifecycleServiceClient;
+use arcbox_fleet_control_proto::v1::fleet_settings_service_client::FleetSettingsServiceClient;
 use arcbox_fleet_control_proto::v1::fleet_state_service_client::FleetStateServiceClient;
 use arcbox_fleet_control_proto::v1::{
-    ConnectionState, DrainRequest, Enrollment, GetAgentInfoRequest, GetStatusRequest, WatchRequest,
+    ConnectionState, DockerMode, DrainRequest, Enrollment, GetAgentInfoRequest, GetSettingsRequest,
+    GetStatusRequest, UpdateSettingsRequest, WatchRequest,
 };
 use hyper_util::rt::TokioIo;
 use tokio::net::UnixStream;
@@ -101,6 +109,7 @@ async fn unenrolled_agent_reports_status_and_rejects_drain() {
     wait_for_socket(&mut agent.0, &socket_path);
     let channel = connect(&socket_path).await;
     let mut client = FleetLifecycleServiceClient::new(channel.clone());
+    let mut settings_client = FleetSettingsServiceClient::new(channel.clone());
 
     let info = client
         .get_agent_info(GetAgentInfoRequest {})
@@ -145,6 +154,95 @@ async fn unenrolled_agent_reports_status_and_rejects_drain() {
     assert!(snapshot.capabilities.is_empty());
     assert!(snapshot.in_flight.is_empty());
     assert!(snapshot.recent_verdicts.is_empty());
+
+    // FleetSettingsService.GetSettings: a fresh agent reports current ==
+    // target everywhere, seeded from its env configuration.
+    let settings = settings_client
+        .get_settings(GetSettingsRequest {})
+        .await
+        .expect("GetSettings")
+        .into_inner()
+        .settings
+        .expect("settings present");
+    let load_ceiling = settings.load_ceiling.expect("load_ceiling present");
+    assert_eq!(load_ceiling.current, 0.9);
+    assert_eq!(load_ceiling.current, load_ceiling.target);
+    assert_eq!(
+        settings
+            .mem_floor_mib
+            .expect("mem_floor_mib present")
+            .current,
+        2048
+    );
+    assert_eq!(
+        settings.gateway.expect("gateway present").current,
+        "http://127.0.0.1:1"
+    );
+    assert_eq!(
+        DockerMode::try_from(settings.docker_mode.expect("docker_mode present").current).unwrap(),
+        DockerMode::Disabled
+    );
+    assert_eq!(
+        settings
+            .runner_script
+            .expect("runner_script present")
+            .current,
+        ""
+    );
+
+    // UpdateSettings: load_ceiling applies instantly — current and target
+    // both move together, with no reattach or restart involved.
+    let updated = settings_client
+        .update_settings(UpdateSettingsRequest {
+            load_ceiling: Some(0.5),
+            ..Default::default()
+        })
+        .await
+        .expect("UpdateSettings")
+        .into_inner()
+        .settings
+        .expect("settings present");
+    let load_ceiling = updated.load_ceiling.expect("load_ceiling present");
+    assert_eq!(load_ceiling.current, 0.5);
+    assert_eq!(load_ceiling.target, 0.5);
+
+    // The change reaches a fresh Watch subscription without polling —
+    // settings ride the same object as everything else `Watch` streams.
+    let mut confirm_stream = watch_client
+        .watch(WatchRequest {})
+        .await
+        .expect("Watch RPC")
+        .into_inner();
+    let confirmed = confirm_stream
+        .message()
+        .await
+        .expect("watch stream")
+        .expect("snapshot")
+        .snapshot
+        .expect("snapshot present");
+    assert_eq!(
+        confirmed
+            .settings
+            .expect("settings present")
+            .load_ceiling
+            .expect("load_ceiling present")
+            .current,
+        0.5
+    );
+
+    // Safety invariant enforced end-to-end: this agent already has
+    // docker_mode=Disabled and no runner_script (its env-derived seed —
+    // a legitimate Docker-only farm shape), so a request that explicitly
+    // touches docker_mode without also supplying a runner_script is
+    // rejected rather than silently leaving the host serving nothing.
+    let unsafe_err = settings_client
+        .update_settings(UpdateSettingsRequest {
+            docker_mode: Some(DockerMode::Disabled as i32),
+            ..Default::default()
+        })
+        .await
+        .expect_err("should reject docker_mode=disabled with no runner_script");
+    assert_eq!(unsafe_err.code(), tonic::Code::InvalidArgument);
 
     let drain_err = client
         .drain(DrainRequest {})

--- a/fleet/arcbox-fleet-agent/tests/control.rs
+++ b/fleet/arcbox-fleet-agent/tests/control.rs
@@ -188,6 +188,9 @@ async fn unenrolled_agent_reports_status_and_rejects_drain() {
     let runner_script = settings.runner_script.expect("runner_script present");
     assert_eq!(runner_script.current, "");
     assert_eq!(runner_script.current, runner_script.target);
+    let participate = settings.participate.expect("participate present");
+    assert!(participate.current);
+    assert!(participate.target);
 
     // UpdateSettings: load_ceiling applies instantly — current and target
     // both move together, with no reattach or restart involved.
@@ -271,6 +274,45 @@ async fn unenrolled_agent_reports_status_and_rejects_drain() {
         .expect("linux_runner_image present");
     assert_eq!(prepared.current, "ghcr.io/acme/runner:v2");
     assert_eq!(prepared.current, prepared.target);
+
+    // participate rides the same settings surface, target-only: the
+    // supervisor's reconciler realizes it. Unenrolled, there is nothing to
+    // detach, so `current` follows the target trivially — but still
+    // asynchronously (the reconciler observes the watch channel), so poll
+    // briefly rather than assume ordering.
+    let updated = settings_client
+        .update_settings(UpdateSettingsRequest {
+            participate: Some(false),
+            ..Default::default()
+        })
+        .await
+        .expect("UpdateSettings")
+        .into_inner()
+        .settings
+        .expect("settings present")
+        .participate
+        .expect("participate present");
+    assert!(!updated.target);
+    let deadline = Instant::now() + Duration::from_secs(5);
+    loop {
+        let participate = settings_client
+            .get_settings(GetSettingsRequest {})
+            .await
+            .expect("GetSettings")
+            .into_inner()
+            .settings
+            .expect("settings present")
+            .participate
+            .expect("participate present");
+        if !participate.current {
+            break;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "reconciler never realized participate=false on an unenrolled agent"
+        );
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
 
     // Safety invariant enforced end-to-end: this agent already has
     // docker_mode=Disabled and no runner_script (its env-derived seed —

--- a/fleet/arcbox-fleet-agent/tests/control.rs
+++ b/fleet/arcbox-fleet-agent/tests/control.rs
@@ -1,10 +1,10 @@
 //! End-to-end test of the local control-plane API.
 //!
 //! `arcbox-fleet-agent` ships only a binary (no library target), so this
-//! spawns the real compiled `run` binary against a scratch data dir and
-//! exercises `FleetLifecycleService` over the real Unix socket — the same
-//! path the CLI's `status`/`drain`/`resume`/`disconnect` subcommands and the
-//! desktop app use.
+//! spawns the real compiled `serve` subcommand against a scratch data dir
+//! and exercises `FleetLifecycleService` over the real Unix socket — the
+//! same path the CLI's `status`/`drain`/`resume`/`disconnect` subcommands
+//! and the desktop app use.
 
 use std::future::Future;
 use std::path::{Path, PathBuf};
@@ -84,7 +84,7 @@ async fn unenrolled_agent_reports_status_and_rejects_drain() {
 
     let mut agent = AgentProcess(
         Command::new(env!("CARGO_BIN_EXE_arcbox-fleet-agent"))
-            .arg("run")
+            .arg("serve")
             .env("ARCBOX_FLEET_DATA_DIR", &data_dir)
             // Forced to the file backend so this never touches the real OS
             // keychain; nothing listens on this gateway, but the Unenrolled

--- a/fleet/arcbox-fleet-agent/tests/control.rs
+++ b/fleet/arcbox-fleet-agent/tests/control.rs
@@ -3,7 +3,7 @@
 //! `arcbox-fleet-agent` ships only a binary (no library target), so this
 //! spawns the real compiled `serve` subcommand against a scratch data dir
 //! and exercises `FleetLifecycleService` over the real Unix socket — the
-//! same path the CLI's `status`/`drain`/`resume`/`disconnect` subcommands
+//! same path the CLI's `status`/`drain`/`resume`/`unenroll` subcommands
 //! and the desktop app use.
 
 #![allow(

--- a/fleet/arcbox-fleet-control-proto/Cargo.toml
+++ b/fleet/arcbox-fleet-control-proto/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "arcbox-fleet-control-proto"
+publish = false
+description = "Generated tonic client/server stubs for the fleet agent's local control-plane API (agent.sock)"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+authors.workspace = true
+
+[dependencies]
+tonic = { workspace = true }
+prost = { workspace = true }
+
+[build-dependencies]
+tonic-build = { workspace = true }
+
+[lints]
+workspace = true

--- a/fleet/arcbox-fleet-control-proto/buf.yaml
+++ b/fleet/arcbox-fleet-control-proto/buf.yaml
@@ -1,0 +1,6 @@
+version: v2
+modules:
+  - path: proto
+lint:
+  use:
+    - STANDARD

--- a/fleet/arcbox-fleet-control-proto/buf.yaml
+++ b/fleet/arcbox-fleet-control-proto/buf.yaml
@@ -4,3 +4,12 @@ modules:
 lint:
   use:
     - STANDARD
+# The desktop and agent ship and self-update independently, so a shipped
+# desktop reads whatever wire shape a newer agent sends. WIRE_JSON locks the
+# runtime contract (binary + JSON representation) shipped clients depend on
+# while still allowing source-level refactors (renaming fields, moving
+# messages between files) that never cross the version boundary. Enforced by
+# `buf breaking` against the base branch in CI.
+breaking:
+  use:
+    - WIRE_JSON

--- a/fleet/arcbox-fleet-control-proto/build.rs
+++ b/fleet/arcbox-fleet-control-proto/build.rs
@@ -1,0 +1,17 @@
+//! Generates the fleet agent's local control-plane server/client stubs.
+//!
+//! Unlike `arcbox-fleet-proto` (the vendored, client-only gateway contract),
+//! this proto is internal-only: the agent is the server, the
+//! `arcbox-fleet-agent` CLI and the desktop app are clients.
+
+fn main() {
+    let proto = "proto/arcbox/fleet/control/v1/control.proto";
+
+    tonic_build::configure()
+        .build_client(true)
+        .build_server(true)
+        .compile_protos(&[proto], &["proto"])
+        .expect("Failed to compile control.proto");
+
+    println!("cargo:rerun-if-changed={proto}");
+}

--- a/fleet/arcbox-fleet-control-proto/proto/arcbox/fleet/control/v1/control.proto
+++ b/fleet/arcbox-fleet-control-proto/proto/arcbox/fleet/control/v1/control.proto
@@ -199,7 +199,9 @@ enum DockerMode {
 message UpdateSettingsRequest {
   optional double load_ceiling = 1;
   optional uint64 mem_floor_mib = 2;
-  optional string runner_image = 3;
+  // Container image Linux jobs run in ("linux" names the jobs' platform;
+  // macOS jobs get their own image setting alongside the VM backend).
+  optional string linux_runner_image = 3;
   optional string gateway = 4;
   optional DockerMode docker_mode = 5;
   // Direct path to the runner entry point (run.sh), not its containing
@@ -230,7 +232,7 @@ message DockerModeSetting {
 message AgentSettings {
   DoubleSetting load_ceiling = 1;
   Uint64Setting mem_floor_mib = 2;
-  StringSetting runner_image = 3;
+  StringSetting linux_runner_image = 3;
   StringSetting gateway = 4;
   DockerModeSetting docker_mode = 5;
   StringSetting runner_script = 6;

--- a/fleet/arcbox-fleet-control-proto/proto/arcbox/fleet/control/v1/control.proto
+++ b/fleet/arcbox-fleet-control-proto/proto/arcbox/fleet/control/v1/control.proto
@@ -89,3 +89,80 @@ message GetStatusResponse {
   // Empty when unenrolled.
   string machine_id = 2;
 }
+
+// Live state-watch: the desktop holds no state of its own and renders only
+// what this streams — settings (a later addition) will push through the
+// same snapshot instead of needing their own notification path.
+service FleetStateService {
+  // Server-streaming: the first message is the current snapshot, then one
+  // per change for as long as the client stays subscribed.
+  rpc Watch(WatchRequest) returns (stream WatchResponse);
+}
+
+message WatchRequest {}
+
+message WatchResponse {
+  AgentStateSnapshot snapshot = 1;
+}
+
+// Distinguishes a live gateway connection from a reconnect-in-progress,
+// which GetStatus's coarser ConnectionState cannot (see its comment above).
+enum Enrollment {
+  ENROLLMENT_UNSPECIFIED = 0;
+  ENROLLMENT_UNENROLLED = 1;
+  // Enrolled, dialing or reconnecting to the gateway.
+  ENROLLMENT_ATTACHING = 2;
+  // Enrolled, attach stream live.
+  ENROLLMENT_ATTACHED = 3;
+}
+
+// What execution backend serves a capability. Deliberately redefined here
+// rather than imported from arcbox-fleet-proto (the vendored, externally
+// owned gateway contract) — this keeps the two contracts free to evolve
+// independently even though the shapes overlap.
+enum Backend {
+  BACKEND_UNSPECIFIED = 0;
+  BACKEND_HOST_RUNNER = 1;
+  BACKEND_DOCKER = 2;
+  BACKEND_VM = 3;
+}
+
+message Capability {
+  string os = 1;
+  string arch = 2;
+  Backend backed_by = 3;
+}
+
+message InFlightJob {
+  string job_id = 1;
+  string os = 2;
+  string arch = 3;
+}
+
+message OfferVerdict {
+  string job_id = 1;
+  bool accepted = 2;
+  // Empty when accepted.
+  string reason = 3;
+}
+
+message HostTelemetry {
+  double load_avg_1m = 1;
+  uint32 cpu_count = 2;
+  uint64 mem_total_mib = 3;
+  uint64 mem_available_mib = 4;
+}
+
+message AgentStateSnapshot {
+  Enrollment enrollment = 1;
+  // Empty when unenrolled.
+  string machine_id = 2;
+  bool draining = 3;
+  repeated Capability capabilities = 4;
+  repeated InFlightJob in_flight = 5;
+  // Bounded ring buffer, most recent last (see AgentState::push_verdict).
+  repeated OfferVerdict recent_verdicts = 6;
+  // Absent until the first heartbeat tick after attaching. Singular message
+  // fields are presence-tracked by default in proto3 (no `optional` needed).
+  HostTelemetry telemetry = 7;
+}

--- a/fleet/arcbox-fleet-control-proto/proto/arcbox/fleet/control/v1/control.proto
+++ b/fleet/arcbox-fleet-control-proto/proto/arcbox/fleet/control/v1/control.proto
@@ -81,6 +81,8 @@ enum ConnectionState {
   CONNECTION_STATE_ENROLLED = 2;
   // Enrolled but not accepting new offers.
   CONNECTION_STATE_DRAINING = 3;
+  // Enrolled but deliberately offline: the participate setting is off.
+  CONNECTION_STATE_DETACHED = 4;
 }
 
 message GetStatusRequest {}
@@ -115,6 +117,10 @@ enum Enrollment {
   ENROLLMENT_ATTACHING = 2;
   // Enrolled, attach stream live.
   ENROLLMENT_ATTACHED = 3;
+  // Enrolled — the credential is kept — but deliberately not attached:
+  // the participate setting is off. The machine shows Offline server-side;
+  // participate=true reattaches with the same identity.
+  ENROLLMENT_DETACHED = 4;
 }
 
 // What execution backend serves a capability. Deliberately redefined here
@@ -211,6 +217,13 @@ message UpdateSettingsRequest {
   // Direct path to the runner entry point (run.sh), not its containing
   // directory.
   optional string runner_script = 6;
+  // Whether this machine takes part in the fleet. false detaches — the
+  // credential is kept and the machine shows Offline server-side — and
+  // true reattaches with the same identity. Writes `target` only; the
+  // supervisor reconciles, and `current` flips when the attach/detach
+  // actually completes. This is deliberately the one lifecycle-touching
+  // setting (see FleetSettingsService's doc).
+  optional bool participate = 7;
 }
 
 // Reused across every setting regardless of type, so a client's rendering
@@ -232,6 +245,10 @@ message DockerModeSetting {
   DockerMode current = 1;
   DockerMode target = 2;
 }
+message BoolSetting {
+  bool current = 1;
+  bool target = 2;
+}
 
 message AgentSettings {
   DoubleSetting load_ceiling = 1;
@@ -244,6 +261,7 @@ message AgentSettings {
   StringSetting gateway = 4;
   DockerModeSetting docker_mode = 5;
   StringSetting runner_script = 6;
+  BoolSetting participate = 7;
 }
 
 // Long-running image preparation, split out of FleetSettingsService so

--- a/fleet/arcbox-fleet-control-proto/proto/arcbox/fleet/control/v1/control.proto
+++ b/fleet/arcbox-fleet-control-proto/proto/arcbox/fleet/control/v1/control.proto
@@ -165,4 +165,73 @@ message AgentStateSnapshot {
   // Absent until the first heartbeat tick after attaching. Singular message
   // fields are presence-tracked by default in proto3 (no `optional` needed).
   HostTelemetry telemetry = 7;
+  AgentSettings settings = 8;
+}
+
+// Persisted, settable configuration. The desktop holds no state of its
+// own, so this rides the same Watch stream as everything else above
+// instead of needing its own notification path.
+service FleetSettingsService {
+  rpc GetSettings(GetSettingsRequest) returns (GetSettingsResponse);
+  rpc UpdateSettings(UpdateSettingsRequest) returns (UpdateSettingsResponse);
+}
+
+message GetSettingsRequest {}
+message GetSettingsResponse {
+  AgentSettings settings = 1;
+}
+message UpdateSettingsResponse {
+  AgentSettings settings = 1;
+}
+
+enum DockerMode {
+  DOCKER_MODE_UNSPECIFIED = 0;
+  DOCKER_MODE_AUTO = 1;
+  DOCKER_MODE_ENABLED = 2;
+  DOCKER_MODE_DISABLED = 3;
+}
+
+// A client only ever writes `target`; `current` is engine-observed and
+// only changes because the engine itself reports a new value. Rejected
+// with INVALID_ARGUMENT as a whole (no partial apply) if the resulting
+// docker_mode/runner_script combination would leave nothing servable —
+// see FleetSettingsService.UpdateSettings's implementation.
+message UpdateSettingsRequest {
+  optional double load_ceiling = 1;
+  optional uint64 mem_floor_mib = 2;
+  optional string runner_image = 3;
+  optional string gateway = 4;
+  optional DockerMode docker_mode = 5;
+  // Direct path to the runner entry point (run.sh / run.cmd), not its
+  // containing directory.
+  optional string runner_script = 6;
+}
+
+// Reused across every setting regardless of type, so a client's rendering
+// logic ("show current; if current != target, show pending") never needs
+// to special-case a field.
+message DoubleSetting {
+  double current = 1;
+  double target = 2;
+}
+message Uint64Setting {
+  uint64 current = 1;
+  uint64 target = 2;
+}
+message StringSetting {
+  string current = 1;
+  string target = 2;
+}
+message DockerModeSetting {
+  DockerMode current = 1;
+  DockerMode target = 2;
+}
+
+message AgentSettings {
+  DoubleSetting load_ceiling = 1;
+  Uint64Setting mem_floor_mib = 2;
+  StringSetting runner_image = 3;
+  StringSetting gateway = 4;
+  DockerModeSetting docker_mode = 5;
+  StringSetting runner_script = 6;
 }

--- a/fleet/arcbox-fleet-control-proto/proto/arcbox/fleet/control/v1/control.proto
+++ b/fleet/arcbox-fleet-control-proto/proto/arcbox/fleet/control/v1/control.proto
@@ -1,0 +1,91 @@
+syntax = "proto3";
+
+package arcbox.fleet.control.v1;
+
+// Local control-plane API served by the fleet agent on a Unix socket
+// (~/.arcbox/fleet/agent.sock, owner-only). Clients: the arcbox-fleet-agent
+// CLI and the desktop app. The agent and its clients ship and self-update
+// independently, so this API evolves additively — call GetAgentInfo and
+// adapt to what it reports, rather than gating other RPCs on an exact
+// version match.
+service FleetLifecycleService {
+  // Version/capability handshake. Call first; do not hard-reject on skew.
+  rpc GetAgentInfo(GetAgentInfoRequest) returns (GetAgentInfoResponse);
+
+  // Exchanges an enrollment token for the machine credential via the
+  // gateway, persists it, and starts attaching. This is the desktop-managed
+  // handoff: the machine credential is created and persisted here, in the
+  // agent — never in the desktop. Fails if already enrolled; Disconnect
+  // first. The headless/farm path instead uses the `arcbox-fleet-agent
+  // enroll` CLI subcommand before this process is even running.
+  rpc Enroll(EnrollRequest) returns (EnrollResponse);
+
+  // Stops accepting new offers; in-flight jobs finish normally.
+  rpc Drain(DrainRequest) returns (DrainResponse);
+
+  // Resumes accepting new offers after a Drain.
+  rpc Resume(ResumeRequest) returns (ResumeResponse);
+
+  // Removes the machine credential and stops attaching. Returns to the
+  // unenrolled state; a fresh Enroll is required to rejoin the fleet.
+  rpc Disconnect(DisconnectRequest) returns (DisconnectResponse);
+
+  // Current lifecycle/attachment status.
+  rpc GetStatus(GetStatusRequest) returns (GetStatusResponse);
+}
+
+message GetAgentInfoRequest {}
+
+message GetAgentInfoResponse {
+  // `CARGO_PKG_VERSION` of the running agent.
+  string agent_version = 1;
+  // Bumped only on breaking control-API changes.
+  uint32 api_version = 2;
+  // Forward-compatible capability flags a client can probe for instead of
+  // gating behavior on `api_version` alone.
+  repeated string features = 3;
+}
+
+message EnrollRequest {
+  string enrollment_token = 1;
+  // Gateway URL override for this enrollment; empty uses the agent's
+  // configured default (ARCBOX_FLEET_GATEWAY / DEFAULT_GATEWAY).
+  string control_plane = 2;
+}
+
+message EnrollResponse {
+  // Prefixed machine id (`fltm_...`).
+  string machine_id = 1;
+}
+
+message DrainRequest {}
+message DrainResponse {}
+
+message ResumeRequest {}
+message ResumeResponse {}
+
+message DisconnectRequest {}
+message DisconnectResponse {}
+
+// Lifecycle state of the agent's relationship to the gateway. Distinguishing
+// a live gateway connection from a reconnect-in-progress ("attaching" vs
+// "attached", per RUN-35's live state-watch group) needs a connectivity
+// signal this RPC does not have; that lands with the state-watch API.
+enum ConnectionState {
+  CONNECTION_STATE_UNSPECIFIED = 0;
+  // No machine credential is persisted; Enroll is required.
+  CONNECTION_STATE_UNENROLLED = 1;
+  // Credential persisted; the agent attaches (and reconnects) in the
+  // background.
+  CONNECTION_STATE_ENROLLED = 2;
+  // Enrolled but not accepting new offers.
+  CONNECTION_STATE_DRAINING = 3;
+}
+
+message GetStatusRequest {}
+
+message GetStatusResponse {
+  ConnectionState state = 1;
+  // Empty when unenrolled.
+  string machine_id = 2;
+}

--- a/fleet/arcbox-fleet-control-proto/proto/arcbox/fleet/control/v1/control.proto
+++ b/fleet/arcbox-fleet-control-proto/proto/arcbox/fleet/control/v1/control.proto
@@ -83,6 +83,9 @@ enum ConnectionState {
   CONNECTION_STATE_DRAINING = 3;
   // Enrolled but deliberately offline: the participate setting is off.
   CONNECTION_STATE_DETACHED = 4;
+  // The gateway rejected the credential (machine decommissioned
+  // server-side); parked until an explicit Unenroll.
+  CONNECTION_STATE_CREDENTIAL_REJECTED = 5;
 }
 
 message GetStatusRequest {}
@@ -121,6 +124,11 @@ enum Enrollment {
   // the participate setting is off. The machine shows Offline server-side;
   // participate=true reattaches with the same identity.
   ENROLLMENT_DETACHED = 4;
+  // The gateway rejected the credential (revoked server-side — the machine
+  // was decommissioned). The agent stops reconnecting and keeps the
+  // credential on disk until an explicit Unenroll, so a server-side auth
+  // regression can never make agents wipe their own credentials.
+  ENROLLMENT_CREDENTIAL_REJECTED = 5;
 }
 
 // What execution backend serves a capability. Deliberately redefined here

--- a/fleet/arcbox-fleet-control-proto/proto/arcbox/fleet/control/v1/control.proto
+++ b/fleet/arcbox-fleet-control-proto/proto/arcbox/fleet/control/v1/control.proto
@@ -202,8 +202,8 @@ message UpdateSettingsRequest {
   optional string runner_image = 3;
   optional string gateway = 4;
   optional DockerMode docker_mode = 5;
-  // Direct path to the runner entry point (run.sh / run.cmd), not its
-  // containing directory.
+  // Direct path to the runner entry point (run.sh), not its containing
+  // directory.
   optional string runner_script = 6;
 }
 

--- a/fleet/arcbox-fleet-control-proto/proto/arcbox/fleet/control/v1/control.proto
+++ b/fleet/arcbox-fleet-control-proto/proto/arcbox/fleet/control/v1/control.proto
@@ -15,7 +15,7 @@ service FleetLifecycleService {
   // Exchanges an enrollment token for the machine credential via the
   // gateway, persists it, and starts attaching. This is the desktop-managed
   // handoff: the machine credential is created and persisted here, in the
-  // agent — never in the desktop. Fails if already enrolled; Disconnect
+  // agent — never in the desktop. Fails if already enrolled; Unenroll
   // first. The headless/farm path instead uses the `arcbox-fleet-agent
   // enroll` CLI subcommand before this process is even running.
   rpc Enroll(EnrollRequest) returns (EnrollResponse);
@@ -26,9 +26,10 @@ service FleetLifecycleService {
   // Resumes accepting new offers after a Drain.
   rpc Resume(ResumeRequest) returns (ResumeResponse);
 
-  // Removes the machine credential and stops attaching. Returns to the
-  // unenrolled state; a fresh Enroll is required to rejoin the fleet.
-  rpc Disconnect(DisconnectRequest) returns (DisconnectResponse);
+  // Leaves the fleet — terminal. Stops attaching and removes the machine
+  // credential; the server keeps the machine record (decommissioned), so a
+  // later Enroll joins as a new machine.
+  rpc Unenroll(UnenrollRequest) returns (UnenrollResponse);
 
   // Current lifecycle/attachment status.
   rpc GetStatus(GetStatusRequest) returns (GetStatusResponse);
@@ -64,8 +65,8 @@ message DrainResponse {}
 message ResumeRequest {}
 message ResumeResponse {}
 
-message DisconnectRequest {}
-message DisconnectResponse {}
+message UnenrollRequest {}
+message UnenrollResponse {}
 
 // Lifecycle state of the agent's relationship to the gateway. Distinguishing
 // a live gateway connection from a reconnect-in-progress ("attaching" vs

--- a/fleet/arcbox-fleet-control-proto/proto/arcbox/fleet/control/v1/control.proto
+++ b/fleet/arcbox-fleet-control-proto/proto/arcbox/fleet/control/v1/control.proto
@@ -201,6 +201,9 @@ message UpdateSettingsRequest {
   optional uint64 mem_floor_mib = 2;
   // Container image Linux jobs run in ("linux" names the jobs' platform;
   // macOS jobs get their own image setting alongside the VM backend).
+  // Writes `target` only — the image becomes `current` when
+  // FleetImageService.Prepare verifies it, never as a side effect of this
+  // call.
   optional string linux_runner_image = 3;
   optional string gateway = 4;
   optional DockerMode docker_mode = 5;
@@ -232,8 +235,54 @@ message DockerModeSetting {
 message AgentSettings {
   DoubleSetting load_ceiling = 1;
   Uint64Setting mem_floor_mib = 2;
+  // For image settings, `target` is operator intent and may float (a
+  // moving tag or an unpinned stream); `current` is the verified artifact
+  // jobs actually use. FleetImageService.Prepare is what converges the
+  // two — including re-resolving a floating target that moved.
   StringSetting linux_runner_image = 3;
   StringSetting gateway = 4;
   DockerModeSetting docker_mode = 5;
   StringSetting runner_script = 6;
+}
+
+// Long-running image preparation, split out of FleetSettingsService so
+// quick state reads/writes never share a service with RPCs that stream a
+// multi-gigabyte transfer's progress.
+service FleetImageService {
+  // Converge each requested image setting's `current` onto its `target`:
+  // fetch and verify the target artifact through the runtime that owns it
+  // (the Docker socket today; the arcbox-daemon socket once the macOS VM
+  // backend lands), then promote `current` — all-or-nothing per kind.
+  // Cancelling the stream (client disconnect) abandons the promotion;
+  // re-running Prepare resumes from whatever the runtime already cached.
+  rpc Prepare(PrepareRequest) returns (stream PrepareResponse);
+}
+
+// Which image setting a Prepare call (or event) concerns. One value per
+// preparable image setting; the macOS image kind arrives with the VM
+// backend.
+enum ImageKind {
+  IMAGE_KIND_UNSPECIFIED = 0;
+  // `linux_runner_image`, prepared by pulling it for every
+  // currently-advertised Docker-served Linux arch.
+  IMAGE_KIND_LINUX_RUNNER_IMAGE = 1;
+}
+
+message PrepareRequest {
+  // Image settings to converge; empty prepares every kind this agent
+  // supports. An unrecognized kind (from a newer client) is rejected with
+  // INVALID_ARGUMENT rather than silently skipped.
+  repeated ImageKind kinds = 1;
+}
+
+// Progress for one preparation step. Human-oriented: `detail`/`stage` are
+// display strings ("linux/arm64", "pulling"), not a machine contract.
+message PrepareResponse {
+  ImageKind kind = 1;
+  // What within the kind is progressing — a platform for Docker pulls.
+  string detail = 2;
+  // Coarse stage label; "promoted" is always the kind's final event.
+  string stage = 3;
+  // Completion fraction within the stage (0.0..=1.0).
+  double fraction = 4;
 }

--- a/fleet/arcbox-fleet-control-proto/src/lib.rs
+++ b/fleet/arcbox-fleet-control-proto/src/lib.rs
@@ -1,0 +1,15 @@
+//! Generated tonic client/server stubs for the fleet agent's local
+//! control-plane API.
+//!
+//! Served by `arcbox-fleet-agent` on `~/.arcbox/fleet/agent.sock`; consumed
+//! by the `arcbox-fleet-agent` CLI and the desktop app. Internal-only —
+//! unlike `arcbox-fleet-proto`, this contract is never published.
+
+/// Fleet agent control-plane protocol (`arcbox.fleet.control.v1` package).
+// `tonic_build` turns the `.proto` message comments into Rust doc comments;
+// some first paragraphs exceed Clippy's length limit. This is generated code
+// whose wording is owned by the proto, so the doc-style lint doesn't apply.
+#[allow(clippy::too_long_first_doc_paragraph)]
+pub mod v1 {
+    tonic::include_proto!("arcbox.fleet.control.v1");
+}

--- a/fleet/arcbox-fleet-proto/build.rs
+++ b/fleet/arcbox-fleet-proto/build.rs
@@ -1,15 +1,16 @@
 //! Generates the Fleet gateway client stubs from the vendored proto.
 //!
 //! The proto is the public `buf.build/arcboxlabs/fleet` module, vendored under
-//! `proto/` (refresh with `make fleet-proto-sync`). Only the client is built —
-//! the agent is a client of the gateway, never a server.
+//! `proto/` (refresh with `make fleet-proto-sync`). The agent is a client of
+//! the gateway, never a server — the server stubs are generated only so the
+//! agent's tests can stand up a mock gateway.
 
 fn main() {
     let proto = "proto/arcbox/fleet/v1/fleet.proto";
 
     tonic_build::configure()
         .build_client(true)
-        .build_server(false)
+        .build_server(true)
         .compile_protos(&[proto], &["proto"])
         .expect("Failed to compile fleet.proto");
 

--- a/fleet/arcbox-fleet-proto/proto/arcbox/fleet/v1/fleet.proto
+++ b/fleet/arcbox-fleet-proto/proto/arcbox/fleet/v1/fleet.proto
@@ -123,6 +123,7 @@ message AttachResponse {
     CancelRunner cancel = 2;
     Drain drain = 3;
     OfferVerdictAck offer_verdict_ack = 4;
+    Keepalive keepalive = 5;
   }
 }
 
@@ -158,3 +159,9 @@ message CancelRunner {
 
 // Stop accepting new work ahead of removal.
 message Drain {}
+
+// No-op the gateway sends back for every Heartbeat, riding the agent's own
+// cadence so a proxy in front of the gateway (e.g. Cloudflare) sees
+// server->client traffic and never idle-times-out the stream. The agent
+// ignores it.
+message Keepalive {}

--- a/fleet/arcbox-fleet-proto/proto/arcbox/fleet/v1/fleet.proto
+++ b/fleet/arcbox-fleet-proto/proto/arcbox/fleet/v1/fleet.proto
@@ -14,7 +14,18 @@ service FleetGatewayService {
   // credential in the `x-arcbox-machine-token` metadata key.
   // (Named Attach because tonic reserves `connect` on generated clients.)
   rpc Attach(stream AttachRequest) returns (stream AttachResponse);
+
+  // Machine-initiated removal from the fleet — terminal. Marks the machine
+  // decommissioned and revokes its credential in the same write; any live
+  // attach stream is evicted. Authenticated like Attach. Effectively
+  // idempotent from the machine's view: a repeat call fails UNAUTHENTICATED
+  // (the credential is already revoked), which the agent treats the same as
+  // success.
+  rpc Unenroll(UnenrollRequest) returns (UnenrollResponse);
 }
+
+message UnenrollRequest {}
+message UnenrollResponse {}
 
 message EnrollRequest {
   // Multi-use fleet join token: valid for any machine in the fleet until it
@@ -117,10 +128,12 @@ message AttachResponse {
 
 // Tells the agent to stop resending an offer verdict
 // (RunnerAccepted/RunnerRejected): the gateway either durably handed it off to
-// the workflow or found the offer obsolete (its workflow already moved on or
-// expired) — resending can achieve nothing more. Until it arrives, the agent
-// resends the same verdict so a gateway crash-after-read cannot lose it; the
-// echoed token lets the agent match the ack to the verdict it is retrying.
+// the workflow (which also covers an offer whose workflow already moved on or
+// expired — the completion is accepted and dropped) or proved the verdict can
+// never be delivered — resending can achieve nothing more. Until it arrives,
+// the agent resends the same verdict so a gateway crash-after-read cannot
+// lose it; the echoed token lets the agent match the ack to the verdict it is
+// retrying.
 message OfferVerdictAck {
   // Opaque correlation token from the offer, echoed back from the verdict.
   string offer_token = 1;


### PR DESCRIPTION
Stacked on #339 (RUN-23). Layers a local control/observability plane onto run-23's headless runner agent. Pairs with arcboxlabs/platform#103 (RUN-40), which gives the server a machine-unenrollment model this PR's lifecycle verbs terminate against.

## What it implements
- **`serve` subcommand** — owner-only gRPC on `~/.arcbox/fleet/agent.sock` (socket `0600`, parent dir forced `0700` before bind); a runtime enrollment state machine the CLI and desktop drive while the agent runs. `run` is unchanged for the headless/farm path.
- **Lifecycle verbs with honest server semantics (RUN-40):**
  - `enroll` — desktop handoff; the agent performs the gateway exchange and persists the credential.
  - `drain` / `resume` — connected, admission off/on.
  - **`participate` setting** — reversible offline: `false` detaches keeping the credential (machine shows Offline server-side), `true` reattaches with the same identity. Persisted, so a launchd restart honors an operator's detach. Target-only through `UpdateSettings`; the supervisor's reconciler observes the state watch channel and converges, keeping the settings service free of lifecycle dependencies.
  - **`unenroll`** (replaces the earlier Disconnect) — terminal: tears down, calls the gateway's `Unenroll` RPC (best-effort, time-bounded; `UNAUTHENTICATED` = already revoked = success), and clears the local credential. Works from attached or detached.
  - **Credential-rejected parking** — an `UNAUTHENTICATED` attach (revoked credential / server-side decommission) stops the reconnect loop and parks in a visible `CREDENTIAL_REJECTED` state; the credential is only ever cleared by an explicit unenroll, so a server-side auth regression can never make agents wipe their own credentials.
- **`AgentState`** — a single `tokio::watch` source of truth, streamed via `FleetStateService.Watch`; `GetStatus` derives from it. Admission thresholds and the runner image are read live.
- **Live, persisted settings** (`FleetSettingsService`) with a current/target model; env vars demote to a first-run seed. `gateway` is settable only while unenrolled — credentials are keyed by the gateway they enrolled against, so a moved target could only strand one.
- **Image preparation** (`FleetImageService.Prepare`, streaming): `linux_runner_image` moves target-only and becomes current only when Prepare has pulled it for **every** advertised arch (all-or-nothing); re-running `prepare` doubles as update-to-latest. The `ImageKind` enum is the additive extension point for the macOS image setting arriving with the VM backend.
- The CLI is a client of its own socket (`status` / `drain` / `resume` / `unenroll` / `settings get|set` / `prepare`).
- New `arcbox-fleet-control-proto` crate (versioned `GetAgentInfo` handshake, additive-only) plus a `buf breaking` CI gate; an end-to-end test drives all four services over the real socket. CI workflow token restricted to `contents: read`.

## User-facing breaks
- `ARCBOX_FLEET_RUNNER_DIR` → `ARCBOX_FLEET_RUNNER_SCRIPT`, now the direct path to `run.sh`.
- `ARCBOX_FLEET_RUNNER_IMAGE` → `ARCBOX_FLEET_LINUX_RUNNER_IMAGE`, matching the `linux_runner_image` setting.

## Base
Targets `feat/run-23-offer-reject` (not yet merged); GitHub will auto-retarget to `master` once #339 merges. The gateway `Unenroll` call needs arcboxlabs/platform#103 deployed; until then it degrades to the documented best-effort path (log + local clear).

## Verification
`cargo fmt --check`, `cargo clippy --all-targets` (zero warnings), `cargo test -p arcbox-fleet-agent` (62 unit + 1 e2e, including a mock-gateway credential-rejection test), and `buf lint` all pass. The prepare flow was additionally driven end-to-end against a live Docker daemon.
