### PR TITLE
refactor(core): drive VM lifecycle via a statig HSM + actor (ABX-387)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -307,6 +307,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
+ "statig",
  "tempfile",
  "thiserror",
  "tokio",
@@ -3519,6 +3520,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-error-attr2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "proc-macro-error2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
+dependencies = [
+ "proc-macro-error-attr2",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4511,6 +4534,27 @@ name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "statig"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03c04b4a9f2d66294d63bdd8df834caad9f8e181997c3cf766b6b4f6d12d4fbc"
+dependencies = [
+ "statig_macro",
+]
+
+[[package]]
+name = "statig_macro"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8090ca395ee30c4b38fee68cf4ddf0bcc5f01aa83364cd4c3ec737a1596dab4d"
+dependencies = [
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "strsim"

--- a/app/arcbox-core/Cargo.toml
+++ b/app/arcbox-core/Cargo.toml
@@ -41,6 +41,7 @@ arcbox-helper = { workspace = true }
 arcbox-migration = { workspace = true }
 libc = { workspace = true }
 tempfile = "3"
+statig = { version = "0.4.1", features = ["async"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 ifbridge = { workspace = true }

--- a/app/arcbox-core/Cargo.toml
+++ b/app/arcbox-core/Cargo.toml
@@ -41,7 +41,7 @@ arcbox-helper = { workspace = true }
 arcbox-migration = { workspace = true }
 libc = { workspace = true }
 tempfile = "3"
-statig = { version = "0.4.1", features = ["async"] }
+statig = "0.4.1"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 ifbridge = { workspace = true }

--- a/app/arcbox-core/src/vm_lifecycle/actor.rs
+++ b/app/arcbox-core/src/vm_lifecycle/actor.rs
@@ -597,18 +597,29 @@ impl LifecycleActor {
         }
     }
 
-    /// Whether a boot from `state` must (re)create the machine first.
+    /// Whether a boot from `state` must (re)create the machine first: only
+    /// when no machine record exists.
     ///
-    /// Config drift against the resolved boot assets is re-checked inside the
-    /// boot sub-task, where resolving assets (a potential download) cannot
-    /// block the actor.
+    /// The lifecycle state deliberately plays no part: the machine re-enters
+    /// at `NotExist` on every daemon start, while the registry may well hold
+    /// the persisted machine — which must be started, not recreated
+    /// (`MachineManager::create` rejects duplicate names). Config drift
+    /// against the resolved boot assets is re-checked inside the boot
+    /// sub-task, where resolving assets (a potential download) cannot block
+    /// the actor.
     fn decide_create(&self, state: VmLifecycleState) -> bool {
-        state == VmLifecycleState::NotExist
-            || self
-                .shared
-                .machine_manager
-                .get(&self.shared.machine_name)
-                .is_none()
+        let exists = self
+            .shared
+            .machine_manager
+            .get(&self.shared.machine_name)
+            .is_some();
+        if !exists && state != VmLifecycleState::NotExist {
+            tracing::warn!(
+                state = state.as_str(),
+                "machine record missing while lifecycle state indicates existing VM; recreating"
+            );
+        }
+        !exists
     }
 }
 

--- a/app/arcbox-core/src/vm_lifecycle/actor.rs
+++ b/app/arcbox-core/src/vm_lifecycle/actor.rs
@@ -1,0 +1,562 @@
+//! The lifecycle actor: sole owner of the statig machine.
+//!
+//! One actor task per [`super::VmLifecycleManager`]. Commands arrive on an
+//! `mpsc` channel, boot/stop sub-tasks report completions on a second channel,
+//! and the public state is published through a `watch` channel — so read paths
+//! never contend with a boot in flight, and `ForceStop` preempts by aborting
+//! the in-flight sub-task instead of racing a lock (the role the old
+//! `transition_lock` bypass played).
+//!
+//! The actor never blocks: slow I/O (machine create/start, agent probing,
+//! graceful stop) runs in spawned sub-tasks (see `boot.rs`) whose completions
+//! come back as [`InternalEvent`]s. Every dispatch drains the machine's
+//! [`Effect`]s and executes them here.
+
+use std::sync::Arc;
+use std::sync::atomic::Ordering;
+use std::time::Duration;
+
+use statig::blocking::IntoStateMachineExt;
+use tokio::sync::{mpsc, oneshot, watch};
+use tokio::task::JoinHandle;
+
+use crate::boot_assets::BootAssetProvider;
+use crate::error::{CoreError, Result};
+use crate::event::{Event, EventBus};
+use crate::machine::MachineManager;
+
+use super::machine::{BalloonTarget, Effect, Effects, Notify, VmEvent, VmLifecycle};
+use super::{
+    BALLOON_SHRINK_DELAY_SECS, HealthMonitor, IDLE_BALLOON_TARGET_MB, RecoveryPolicy,
+    VmLifecycleConfig, VmLifecycleState,
+};
+
+/// A command sent from the facade to the lifecycle actor.
+pub(super) enum Command {
+    /// Ensure the VM is ready; reply with the agent CID.
+    EnsureReady {
+        /// Startup budget for a boot this command may initiate.
+        timeout: Duration,
+        /// Resolved with the CID once the agent is ready.
+        reply: oneshot::Sender<Result<u32>>,
+    },
+    /// Gracefully stop the VM; reply when the stop completes.
+    Shutdown {
+        /// Resolved when the VM reached `Stopped` (or the stop failed).
+        reply: oneshot::Sender<Result<()>>,
+    },
+    /// Force-terminate the VM, preempting any in-flight boot or stop.
+    ForceStop {
+        /// Resolved once the machine record is removed.
+        reply: oneshot::Sender<Result<()>>,
+    },
+    /// Activity signal (e.g. a Kubernetes hold): exit `Idle` if applicable.
+    Activity,
+}
+
+/// A completion reported by a boot/stop sub-task.
+pub(super) enum InternalEvent {
+    /// The boot sub-task finished: the guest agent is ready.
+    AgentReady,
+    /// The boot sub-task failed terminally (retries exhausted or timeout).
+    BootFailed(String),
+    /// The stop sub-task finished: the machine stopped.
+    Stopped,
+    /// The stop sub-task failed.
+    StopFailed(String),
+}
+
+/// State shared between the facade, the actor, and boot/stop sub-tasks.
+///
+/// Everything here is either immutable after construction or atomic, so the
+/// facade can serve synchronous reads (`backend()`, `restart_generation()`)
+/// without a round-trip through the actor.
+pub(super) struct LifecycleShared {
+    /// Machine name this lifecycle operates on.
+    pub(super) machine_name: String,
+    /// Filename of the persistent dockerd data image under `<data_dir>/data/`.
+    pub(super) data_image_filename: String,
+    /// Data directory.
+    pub(super) data_dir: std::path::PathBuf,
+    /// Machine manager for VM operations.
+    pub(super) machine_manager: Arc<MachineManager>,
+    /// Event bus for lifecycle notifications.
+    pub(super) event_bus: EventBus,
+    /// Boot asset provider.
+    pub(super) boot_assets: Arc<BootAssetProvider>,
+    /// Recovery policy (retry counter persists across boot attempts).
+    pub(super) recovery: RecoveryPolicy,
+    /// Health monitor.
+    pub(super) health_monitor: Arc<HealthMonitor>,
+    /// Configuration.
+    pub(super) config: VmLifecycleConfig,
+    /// Live hypervisor backend, encoded as `VmBackend as u8`. Seeded from the
+    /// persisted machine; updated by `set_backend` for the next (re)boot.
+    pub(super) backend: std::sync::atomic::AtomicU8,
+    /// VM incarnation counter, bumped on every stop (see `restart_generation`).
+    pub(super) restart_generation: std::sync::atomic::AtomicU64,
+    /// Timestamp of last activity (epoch millis, for idle detection).
+    pub(super) last_activity_ms: std::sync::atomic::AtomicU64,
+    /// Whether the balloon is currently shrunk for the idle state.
+    pub(super) balloon_shrunk: std::sync::atomic::AtomicBool,
+    /// Whether Kubernetes holds the VM in the active state.
+    pub(super) kubernetes_hold: std::sync::atomic::AtomicBool,
+}
+
+impl LifecycleShared {
+    /// Records activity, updating the last-activity timestamp.
+    pub(super) fn record_activity(&self) {
+        let now_ms = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_millis() as u64;
+        self.last_activity_ms.store(now_ms, Ordering::Relaxed);
+    }
+
+    /// Returns seconds since last activity.
+    fn idle_seconds(&self) -> u64 {
+        let now_ms = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_millis() as u64;
+        let last = self.last_activity_ms.load(Ordering::Relaxed);
+        now_ms.saturating_sub(last) / 1000
+    }
+
+    /// Returns the System VM's current hypervisor backend.
+    pub(super) fn backend(&self) -> arcbox_vmm::VmBackend {
+        // Encoded as `VmBackend as u8` (Hv = 0, Vz = 1).
+        match self.backend.load(Ordering::Acquire) {
+            0 => arcbox_vmm::VmBackend::Hv,
+            _ => arcbox_vmm::VmBackend::Vz,
+        }
+    }
+
+    /// Shrinks the balloon to reclaim guest memory during idle.
+    ///
+    /// Sets the balloon target to [`IDLE_BALLOON_TARGET_MB`] so the guest
+    /// returns memory to the host, reducing idle footprint.
+    #[cfg(target_os = "macos")]
+    fn shrink_balloon(&self) {
+        if self.balloon_shrunk.load(Ordering::Relaxed) {
+            return;
+        }
+
+        let target_bytes = IDLE_BALLOON_TARGET_MB * 1024 * 1024;
+        if let Some(info) = self.machine_manager.get(&self.machine_name) {
+            match self
+                .machine_manager
+                .vm_manager()
+                .set_balloon_target(&info.vm_id, target_bytes)
+            {
+                Ok(()) => {
+                    self.balloon_shrunk.store(true, Ordering::Relaxed);
+                    tracing::info!("Balloon shrunk to {}MB for idle VM", IDLE_BALLOON_TARGET_MB);
+                }
+                Err(e) => {
+                    tracing::debug!("Failed to shrink balloon: {}", e);
+                }
+            }
+        }
+    }
+
+    /// Restores the balloon to the full configured memory size.
+    ///
+    /// Called when the VM exits idle state (new container activity).
+    #[cfg(target_os = "macos")]
+    fn restore_balloon(&self) {
+        if !self.balloon_shrunk.load(Ordering::Relaxed) {
+            return;
+        }
+
+        if let Some(info) = self.machine_manager.get(&self.machine_name) {
+            let full_bytes = info.memory_mb * 1024 * 1024;
+            match self
+                .machine_manager
+                .vm_manager()
+                .set_balloon_target(&info.vm_id, full_bytes)
+            {
+                Ok(()) => {
+                    self.balloon_shrunk.store(false, Ordering::Relaxed);
+                    tracing::info!("Balloon restored to {}MB", info.memory_mb);
+                }
+                Err(e) => {
+                    tracing::debug!("Failed to restore balloon: {}", e);
+                }
+            }
+        }
+    }
+
+    #[cfg(not(target_os = "macos"))]
+    fn shrink_balloon(&self) {}
+
+    #[cfg(not(target_os = "macos"))]
+    fn restore_balloon(&self) {}
+
+    /// Gets the agent CID for this lifecycle's machine.
+    fn get_cid(&self) -> Result<u32> {
+        self.machine_manager
+            .get_cid(&self.machine_name)
+            .ok_or_else(|| CoreError::Machine("default machine has no CID".to_string()))
+    }
+}
+
+/// The lifecycle actor: owns the statig machine and executes its effects.
+pub(super) struct LifecycleActor {
+    shared: Arc<LifecycleShared>,
+    /// Commands from the facade.
+    commands: mpsc::UnboundedReceiver<Command>,
+    /// Completions from boot/stop sub-tasks.
+    events_rx: mpsc::UnboundedReceiver<InternalEvent>,
+    /// Cloned into every spawned sub-task so it can report back.
+    events_tx: mpsc::UnboundedSender<InternalEvent>,
+    /// Publishes the public state after every dispatch.
+    state_tx: watch::Sender<VmLifecycleState>,
+    /// Effect sink passed to every dispatch as the statig context.
+    effects: Effects,
+    /// Parked `ensure_ready` callers, resolved on agent-ready or boot failure.
+    waiters: Vec<oneshot::Sender<Result<u32>>>,
+    /// Parked `shutdown` callers, resolved when the stop completes.
+    stop_waiters: Vec<oneshot::Sender<Result<()>>>,
+    /// Startup budget for a boot deferred until the current stop finishes.
+    pending_timeout: Option<Duration>,
+    /// A graceful stop requested while a boot was in flight, dispatched as
+    /// soon as the boot resolves (the actor-model equivalent of the old
+    /// `transition_lock` making `shutdown` wait for the boot).
+    pending_stop: bool,
+    /// The in-flight boot or stop sub-task, aborted on `ForceStop`.
+    inflight: Option<JoinHandle<()>>,
+}
+
+impl LifecycleActor {
+    /// Creates the actor half of a lifecycle channel pair.
+    pub(super) fn new(
+        shared: Arc<LifecycleShared>,
+        commands: mpsc::UnboundedReceiver<Command>,
+        state_tx: watch::Sender<VmLifecycleState>,
+    ) -> Self {
+        let (events_tx, events_rx) = mpsc::unbounded_channel();
+        Self {
+            shared,
+            commands,
+            events_rx,
+            events_tx,
+            state_tx,
+            effects: Effects::default(),
+            waiters: Vec::new(),
+            stop_waiters: Vec::new(),
+            pending_timeout: None,
+            pending_stop: false,
+            inflight: None,
+        }
+    }
+
+    /// Runs the actor until the facade (all command senders) is dropped.
+    pub(super) async fn run(mut self) {
+        let mut machine = VmLifecycle
+            .uninitialized_state_machine()
+            .init_with_context(&mut self.effects);
+
+        let mut idle_ticker = tokio::time::interval(Duration::from_secs(BALLOON_SHRINK_DELAY_SECS));
+        idle_ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+
+        loop {
+            // Split-borrow the receivers away from `self` so the dispatch
+            // helpers can borrow `self` mutably inside the match arms.
+            tokio::select! {
+                cmd = self.commands.recv() => {
+                    let Some(cmd) = cmd else { break };
+                    self.on_command(&mut machine, cmd);
+                }
+                Some(ev) = self.events_rx.recv() => {
+                    self.on_internal(&mut machine, ev);
+                }
+                _ = idle_ticker.tick() => {
+                    self.on_idle_tick(&mut machine);
+                }
+            }
+        }
+
+        // Facade dropped: tear down any in-flight sub-task.
+        if let Some(handle) = self.inflight.take() {
+            handle.abort();
+        }
+    }
+
+    /// Current public state.
+    fn public(&self) -> VmLifecycleState {
+        *self.state_tx.borrow()
+    }
+
+    /// Dispatches one event to the machine, publishes the new public state,
+    /// and executes the effects the transition emitted.
+    ///
+    /// Synchronous by design: the machine is a pure decision core (its
+    /// handlers never await), so dispatch uses statig's blocking engine —
+    /// which also sidesteps the rustc higher-ranked `Send` inference
+    /// limitation (rust#100013) the async engine runs into.
+    fn dispatch(&mut self, machine: &mut Machine, event: VmEvent) {
+        let before = machine.state().to_public();
+        machine.handle_with_context(&event, &mut self.effects);
+        let after = machine.state().to_public();
+
+        if before != after {
+            tracing::info!(
+                machine = %self.shared.machine_name,
+                from = before.as_str(),
+                to = after.as_str(),
+                "VM lifecycle transition"
+            );
+            self.state_tx.send_replace(after);
+        }
+
+        for effect in self.effects.take() {
+            self.apply(effect);
+        }
+    }
+
+    /// Executes one effect emitted by a transition.
+    fn apply(&mut self, effect: Effect) {
+        match effect {
+            Effect::SpawnBoot { create, timeout_ms } => {
+                let shared = Arc::clone(&self.shared);
+                let events = self.events_tx.clone();
+                let timeout = Duration::from_millis(timeout_ms);
+                self.inflight = Some(tokio::spawn(async move {
+                    shared.run_boot(create, timeout, &events).await;
+                }));
+            }
+            Effect::SpawnStop => {
+                // Stopping preempts a still-running boot: there is no point
+                // finishing a boot for a VM we are about to stop.
+                if let Some(handle) = self.inflight.take() {
+                    handle.abort();
+                }
+                let shared = Arc::clone(&self.shared);
+                let events = self.events_tx.clone();
+                self.inflight = Some(tokio::spawn(async move {
+                    shared.run_stop(&events).await;
+                }));
+            }
+            Effect::AbortInflight => {
+                if let Some(handle) = self.inflight.take() {
+                    handle.abort();
+                }
+            }
+            Effect::RemoveMachine => {
+                let _ = self
+                    .shared
+                    .machine_manager
+                    .remove(&self.shared.machine_name, true);
+            }
+            Effect::Balloon(BalloonTarget::Idle) => self.shared.shrink_balloon(),
+            Effect::Balloon(BalloonTarget::Full) => self.shared.restore_balloon(),
+            Effect::BumpGeneration => {
+                self.shared
+                    .restart_generation
+                    .fetch_add(1, Ordering::Release);
+            }
+            Effect::Publish(notify) => {
+                let name = self.shared.machine_name.clone();
+                self.shared.event_bus.publish(match notify {
+                    Notify::Started => Event::MachineStarted { name },
+                    Notify::Idle => Event::MachineIdle { name },
+                    Notify::Stopped => Event::MachineStopped { name },
+                });
+            }
+            Effect::ReadyWaiters => {
+                for waiter in self.waiters.drain(..) {
+                    let _ = waiter.send(self.shared.get_cid());
+                }
+            }
+            Effect::FailWaiters(reason) => {
+                for waiter in self.waiters.drain(..) {
+                    let _ = waiter.send(Err(CoreError::Vm(reason.clone())));
+                }
+            }
+        }
+    }
+
+    fn on_command(&mut self, machine: &mut Machine, cmd: Command) {
+        match cmd {
+            Command::EnsureReady { timeout, reply } => {
+                self.on_ensure_ready(machine, timeout, reply);
+            }
+            Command::Shutdown { reply } => self.on_shutdown(machine, reply),
+            Command::ForceStop { reply } => {
+                // Match the old force_stop ordering: silence health checks
+                // before tearing the machine down.
+                self.shared.health_monitor.stop();
+                self.dispatch(machine, VmEvent::ForceStop);
+                // A graceful stop preempted mid-flight has reached its goal:
+                // the VM is down.
+                for waiter in self.stop_waiters.drain(..) {
+                    let _ = waiter.send(Ok(()));
+                }
+                self.pending_timeout = None;
+                self.pending_stop = false;
+                let _ = reply.send(Ok(()));
+            }
+            Command::Activity => {
+                self.dispatch(machine, VmEvent::Activity);
+            }
+        }
+    }
+
+    fn on_ensure_ready(
+        &mut self,
+        machine: &mut Machine,
+        timeout: Duration,
+        reply: oneshot::Sender<Result<u32>>,
+    ) {
+        self.shared.record_activity();
+        let state = self.public();
+
+        if state.is_ready() {
+            // Exit idle (restoring the balloon) and answer immediately.
+            self.dispatch(machine, VmEvent::Activity);
+            let _ = reply.send(self.shared.get_cid());
+            return;
+        }
+
+        self.waiters.push(reply);
+
+        if state.needs_start() && self.inflight.is_none() {
+            let create = self.decide_create(state);
+            self.dispatch(
+                machine,
+                VmEvent::Start {
+                    create,
+                    timeout_ms: timeout.as_millis() as u64,
+                },
+            );
+        } else {
+            // Booting or stopping: park. A boot in flight resolves the waiter;
+            // a stop in flight defers the boot until `Stopped` lands.
+            self.pending_timeout.get_or_insert(timeout);
+        }
+    }
+
+    fn on_shutdown(&mut self, machine: &mut Machine, reply: oneshot::Sender<Result<()>>) {
+        let state = self.public();
+
+        match state {
+            VmLifecycleState::Stopping => {
+                // A stop is already in flight; resolve when it lands.
+                self.stop_waiters.push(reply);
+            }
+            VmLifecycleState::Creating | VmLifecycleState::Starting => {
+                // A boot is in flight: stop right after it lands — the old
+                // implementation reached the same outcome by making `shutdown`
+                // wait on `transition_lock` until the boot finished. If the
+                // boot fails instead, there is nothing to stop and the waiter
+                // resolves Ok.
+                self.stop_waiters.push(reply);
+                self.pending_stop = true;
+            }
+            state if state.is_ready() => {
+                self.stop_waiters.push(reply);
+                self.dispatch(machine, VmEvent::Stop);
+            }
+            _ => {
+                // Not running: nothing to do.
+                let _ = reply.send(Ok(()));
+            }
+        }
+    }
+
+    fn on_internal(&mut self, machine: &mut Machine, ev: InternalEvent) {
+        self.inflight = None;
+        match ev {
+            InternalEvent::AgentReady => {
+                self.dispatch(machine, VmEvent::AgentReady);
+                // Serve a shutdown that arrived mid-boot now that the boot
+                // (and its waiters) have resolved.
+                if std::mem::take(&mut self.pending_stop) {
+                    self.dispatch(machine, VmEvent::Stop);
+                }
+            }
+            InternalEvent::BootFailed(reason) => {
+                self.dispatch(machine, VmEvent::Failure);
+                for waiter in self.waiters.drain(..) {
+                    let _ = waiter.send(Err(CoreError::Vm(reason.clone())));
+                }
+                // A shutdown parked behind this boot has nothing left to stop.
+                if std::mem::take(&mut self.pending_stop) {
+                    for waiter in self.stop_waiters.drain(..) {
+                        let _ = waiter.send(Ok(()));
+                    }
+                }
+            }
+            InternalEvent::Stopped => {
+                self.dispatch(machine, VmEvent::Stopped);
+                for waiter in self.stop_waiters.drain(..) {
+                    let _ = waiter.send(Ok(()));
+                }
+            }
+            InternalEvent::StopFailed(reason) => {
+                self.dispatch(machine, VmEvent::Failure);
+                for waiter in self.stop_waiters.drain(..) {
+                    let _ = waiter.send(Err(CoreError::Vm(reason.clone())));
+                }
+            }
+        }
+        self.start_if_pending(machine);
+    }
+
+    /// Boots the VM for callers that parked while a stop (or failed stop) was
+    /// in flight — the actor-model equivalent of the old `transition_lock`
+    /// serialization, where a parked `ensure_ready` proceeded to boot as soon
+    /// as the shutdown released the lock.
+    fn start_if_pending(&mut self, machine: &mut Machine) {
+        let state = self.public();
+        if self.waiters.is_empty() || !state.needs_start() || self.inflight.is_some() {
+            return;
+        }
+        let timeout = self
+            .pending_timeout
+            .take()
+            .unwrap_or(self.shared.config.startup_timeout);
+        let create = self.decide_create(state);
+        self.dispatch(
+            machine,
+            VmEvent::Start {
+                create,
+                timeout_ms: timeout.as_millis() as u64,
+            },
+        );
+    }
+
+    fn on_idle_tick(&mut self, machine: &mut Machine) {
+        if !self.shared.config.auto_stop
+            || self.shared.kubernetes_hold.load(Ordering::Relaxed)
+            || self.public() != VmLifecycleState::Running
+        {
+            return;
+        }
+        if self.shared.idle_seconds() >= self.shared.config.idle_timeout.as_secs() {
+            tracing::info!(
+                "VM entered idle state after {}s of inactivity",
+                self.shared.idle_seconds()
+            );
+            self.dispatch(machine, VmEvent::IdleTimeout);
+        }
+    }
+
+    /// Whether a boot from `state` must (re)create the machine first.
+    ///
+    /// Config drift against the resolved boot assets is re-checked inside the
+    /// boot sub-task, where resolving assets (a potential download) cannot
+    /// block the actor.
+    fn decide_create(&self, state: VmLifecycleState) -> bool {
+        state == VmLifecycleState::NotExist
+            || self
+                .shared
+                .machine_manager
+                .get(&self.shared.machine_name)
+                .is_none()
+    }
+}
+
+/// The initialized statig machine driven by the actor.
+type Machine = statig::blocking::InitializedStateMachine<VmLifecycle>;

--- a/app/arcbox-core/src/vm_lifecycle/actor.rs
+++ b/app/arcbox-core/src/vm_lifecycle/actor.rs
@@ -66,6 +66,21 @@ pub(super) enum InternalEvent {
     StopFailed(String),
 }
 
+/// An [`InternalEvent`] tagged with the epoch of the sub-task that sent it.
+///
+/// `JoinHandle::abort` is best-effort: a sub-task that already completed and
+/// enqueued its outcome is unaffected, so after a `ForceStop` + reboot a stale
+/// completion from the superseded task can still be sitting in the channel.
+/// The actor bumps its epoch on every spawn/abort and drops completions whose
+/// epoch doesn't match the live sub-task, so a stale `AgentReady`/`Stopped`
+/// can neither clobber the new task's `inflight` handle nor drive the machine.
+pub(super) struct Completion {
+    /// Epoch of the sub-task that produced this outcome.
+    pub(super) epoch: u64,
+    /// The outcome itself.
+    pub(super) outcome: InternalEvent,
+}
+
 /// State shared between the facade, the actor, and boot/stop sub-tasks.
 ///
 /// Everything here is either immutable after construction or atomic, so the
@@ -207,9 +222,9 @@ pub(super) struct LifecycleActor {
     /// Commands from the facade.
     commands: mpsc::UnboundedReceiver<Command>,
     /// Completions from boot/stop sub-tasks.
-    events_rx: mpsc::UnboundedReceiver<InternalEvent>,
+    events_rx: mpsc::UnboundedReceiver<Completion>,
     /// Cloned into every spawned sub-task so it can report back.
-    events_tx: mpsc::UnboundedSender<InternalEvent>,
+    events_tx: mpsc::UnboundedSender<Completion>,
     /// Publishes the public state after every dispatch.
     state_tx: watch::Sender<VmLifecycleState>,
     /// Effect sink passed to every dispatch as the statig context.
@@ -226,6 +241,12 @@ pub(super) struct LifecycleActor {
     pending_stop: bool,
     /// The in-flight boot or stop sub-task, aborted on `ForceStop`.
     inflight: Option<JoinHandle<()>>,
+    /// Epoch of the live sub-task; bumped on every spawn and abort so stale
+    /// completions from superseded tasks are recognized and dropped.
+    epoch: u64,
+    /// The detached machine-removal task of a force stop, joined by the
+    /// force-stop reply so callers still observe "removed" on return.
+    removal: Option<JoinHandle<()>>,
 }
 
 impl LifecycleActor {
@@ -248,6 +269,8 @@ impl LifecycleActor {
             pending_timeout: None,
             pending_stop: false,
             inflight: None,
+            epoch: 0,
+            removal: None,
         }
     }
 
@@ -319,35 +342,35 @@ impl LifecycleActor {
     fn apply(&mut self, effect: Effect) {
         match effect {
             Effect::SpawnBoot { create, timeout_ms } => {
+                let epoch = self.abort_inflight();
                 let shared = Arc::clone(&self.shared);
                 let events = self.events_tx.clone();
                 let timeout = Duration::from_millis(timeout_ms);
                 self.inflight = Some(tokio::spawn(async move {
-                    shared.run_boot(create, timeout, &events).await;
+                    shared.run_boot(create, timeout, epoch, &events).await;
                 }));
             }
             Effect::SpawnStop => {
-                // Stopping preempts a still-running boot: there is no point
-                // finishing a boot for a VM we are about to stop.
-                if let Some(handle) = self.inflight.take() {
-                    handle.abort();
-                }
+                let epoch = self.abort_inflight();
                 let shared = Arc::clone(&self.shared);
                 let events = self.events_tx.clone();
                 self.inflight = Some(tokio::spawn(async move {
-                    shared.run_stop(&events).await;
+                    shared.run_stop(epoch, &events).await;
                 }));
             }
             Effect::AbortInflight => {
-                if let Some(handle) = self.inflight.take() {
-                    handle.abort();
-                }
+                self.abort_inflight();
             }
             Effect::RemoveMachine => {
-                let _ = self
-                    .shared
-                    .machine_manager
-                    .remove(&self.shared.machine_name, true);
+                // `remove(force = true)` tears the VM down synchronously (a
+                // hypervisor stop that can block for seconds); keep it off the
+                // actor so the command loop stays responsive. The force-stop
+                // reply joins `removal`, preserving the caller-visible
+                // "returned ⇒ removed" contract.
+                let shared = Arc::clone(&self.shared);
+                self.removal = Some(tokio::task::spawn_blocking(move || {
+                    let _ = shared.machine_manager.remove(&shared.machine_name, true);
+                }));
             }
             Effect::Balloon(BalloonTarget::Idle) => self.shared.shrink_balloon(),
             Effect::Balloon(BalloonTarget::Full) => self.shared.restore_balloon(),
@@ -395,7 +418,16 @@ impl LifecycleActor {
                 }
                 self.pending_timeout = None;
                 self.pending_stop = false;
-                let _ = reply.send(Ok(()));
+                // Reply once the detached removal finishes, so callers keep
+                // the old "force_stop returned ⇒ machine removed" contract
+                // without the removal blocking the actor.
+                let removal = self.removal.take();
+                drop(tokio::spawn(async move {
+                    if let Some(handle) = removal {
+                        let _ = handle.await;
+                    }
+                    let _ = reply.send(Ok(()));
+                }));
             }
             Command::Activity => {
                 self.dispatch(machine, VmEvent::Activity);
@@ -465,9 +497,31 @@ impl LifecycleActor {
         }
     }
 
-    fn on_internal(&mut self, machine: &mut Machine, ev: InternalEvent) {
+    /// Aborts the in-flight sub-task (if any) and bumps the epoch so any
+    /// completion it already enqueued is recognized as stale. Returns the new
+    /// epoch for the next sub-task to tag its completion with.
+    fn abort_inflight(&mut self) -> u64 {
+        if let Some(handle) = self.inflight.take() {
+            handle.abort();
+        }
+        self.epoch += 1;
+        self.epoch
+    }
+
+    fn on_internal(&mut self, machine: &mut Machine, completion: Completion) {
+        if completion.epoch != self.epoch {
+            // Completion from a superseded sub-task (aborted after it had
+            // already finished): the machine has moved on; ignore it.
+            tracing::debug!(
+                machine = %self.shared.machine_name,
+                stale_epoch = completion.epoch,
+                current_epoch = self.epoch,
+                "dropping stale lifecycle sub-task completion"
+            );
+            return;
+        }
         self.inflight = None;
-        match ev {
+        match completion.outcome {
             InternalEvent::AgentReady => {
                 self.dispatch(machine, VmEvent::AgentReady);
                 // Serve a shutdown that arrived mid-boot now that the boot

--- a/app/arcbox-core/src/vm_lifecycle/boot.rs
+++ b/app/arcbox-core/src/vm_lifecycle/boot.rs
@@ -18,28 +18,35 @@ use crate::machine::MachineConfig;
 use arcbox_constants::cmdline::{GUEST_DOCKER_VSOCK_PORT_KEY, HV_EARLYCON_DIRECTIVE};
 use arcbox_error::CommonError;
 
-use super::actor::{InternalEvent, LifecycleShared};
+use super::actor::{Completion, InternalEvent, LifecycleShared};
 use super::types::{DesiredBoot, machine_drift_reason};
 use super::{DOCKER_DATA_IMAGE_SIZE_BYTES, RecoveryAction};
 
 impl LifecycleShared {
     /// Boots the VM end-to-end (create if needed, start with retries, wait for
-    /// the agent) and reports the outcome to the actor.
+    /// the agent) and reports the outcome to the actor, tagged with the epoch
+    /// this sub-task was spawned under.
     pub(super) async fn run_boot(
         self: Arc<Self>,
         create: bool,
         timeout: Duration,
-        events: &mpsc::UnboundedSender<InternalEvent>,
+        epoch: u64,
+        events: &mpsc::UnboundedSender<Completion>,
     ) {
         let outcome = match self.boot(create, timeout).await {
             Ok(()) => InternalEvent::AgentReady,
             Err(e) => InternalEvent::BootFailed(e.to_string()),
         };
-        let _ = events.send(outcome);
+        let _ = events.send(Completion { epoch, outcome });
     }
 
-    /// Gracefully stops the VM (force-stop fallback) and reports the outcome.
-    pub(super) async fn run_stop(self: Arc<Self>, events: &mpsc::UnboundedSender<InternalEvent>) {
+    /// Gracefully stops the VM (force-stop fallback) and reports the outcome,
+    /// tagged with the epoch this sub-task was spawned under.
+    pub(super) async fn run_stop(
+        self: Arc<Self>,
+        epoch: u64,
+        events: &mpsc::UnboundedSender<Completion>,
+    ) {
         // Stop health monitoring before tearing the VM down.
         self.health_monitor.stop();
 
@@ -81,7 +88,7 @@ impl LifecycleShared {
             }
             Err(e) => InternalEvent::StopFailed(e.to_string()),
         };
-        let _ = events.send(outcome);
+        let _ = events.send(Completion { epoch, outcome });
     }
 
     /// The boot body: drift check, optional (re)create, start loop with

--- a/app/arcbox-core/src/vm_lifecycle/boot.rs
+++ b/app/arcbox-core/src/vm_lifecycle/boot.rs
@@ -1,0 +1,604 @@
+//! Boot and stop sub-tasks: the slow I/O side of the lifecycle.
+//!
+//! These run in `tokio::spawn`ed tasks owned by the actor (`actor.rs`), which
+//! keeps the actor itself non-blocking so `ForceStop` can preempt at any time.
+//! Completion is reported back as an [`InternalEvent`]; the bodies are ports
+//! of the pre-actor `start_default_vm` / `wait_for_agent` / `shutdown`.
+
+use std::fs::OpenOptions;
+use std::path::Path;
+use std::sync::Arc;
+use std::time::Duration;
+
+use tokio::sync::mpsc;
+
+use crate::error::{CoreError, Result};
+use crate::event::Event;
+use crate::machine::MachineConfig;
+use arcbox_constants::cmdline::{GUEST_DOCKER_VSOCK_PORT_KEY, HV_EARLYCON_DIRECTIVE};
+use arcbox_error::CommonError;
+
+use super::actor::{InternalEvent, LifecycleShared};
+use super::types::{DesiredBoot, machine_drift_reason};
+use super::{DOCKER_DATA_IMAGE_SIZE_BYTES, RecoveryAction};
+
+impl LifecycleShared {
+    /// Boots the VM end-to-end (create if needed, start with retries, wait for
+    /// the agent) and reports the outcome to the actor.
+    pub(super) async fn run_boot(
+        self: Arc<Self>,
+        create: bool,
+        timeout: Duration,
+        events: &mpsc::UnboundedSender<InternalEvent>,
+    ) {
+        let outcome = match self.boot(create, timeout).await {
+            Ok(()) => InternalEvent::AgentReady,
+            Err(e) => InternalEvent::BootFailed(e.to_string()),
+        };
+        let _ = events.send(outcome);
+    }
+
+    /// Gracefully stops the VM (force-stop fallback) and reports the outcome.
+    pub(super) async fn run_stop(self: Arc<Self>, events: &mpsc::UnboundedSender<InternalEvent>) {
+        // Stop health monitoring before tearing the VM down.
+        self.health_monitor.stop();
+
+        let mm = Arc::clone(&self.machine_manager);
+        let name = self.machine_name.clone();
+        // `graceful_stop` and `stop` are synchronous VM calls that can block up
+        // to the host shutdown timeout; keep them off the async workers.
+        let stop_result = tokio::task::spawn_blocking(move || {
+            match mm.graceful_stop(
+                &name,
+                Duration::from_secs(arcbox_constants::timeouts::HOST_SHUTDOWN_TIMEOUT_SECS),
+            ) {
+                Ok(true) => Ok(()),
+                Ok(false) => {
+                    tracing::warn!(
+                        "Graceful stop timed out for '{}', falling back to force stop",
+                        name
+                    );
+                    mm.stop(&name)
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        "Graceful stop failed for '{}': {}, falling back to force stop",
+                        name,
+                        e
+                    );
+                    mm.stop(&name)
+                }
+            }
+        })
+        .await
+        .map_err(|e| CoreError::Vm(format!("stop task panicked: {e}")))
+        .and_then(|r| r);
+
+        let outcome = match stop_result {
+            Ok(()) => {
+                tracing::info!("Default VM stopped");
+                InternalEvent::Stopped
+            }
+            Err(e) => InternalEvent::StopFailed(e.to_string()),
+        };
+        let _ = events.send(outcome);
+    }
+
+    /// The boot body: drift check, optional (re)create, start loop with
+    /// recovery retries, then agent readiness.
+    async fn boot(&self, create_hint: bool, timeout: Duration) -> Result<()> {
+        let existing_machine = self.machine_manager.get(&self.machine_name);
+        let machine_exists = existing_machine.is_some();
+        if !create_hint && !machine_exists {
+            tracing::warn!(
+                "default machine missing while lifecycle state indicates existing VM; recreating"
+            );
+        }
+
+        // Recreate the persisted machine if any daemon-overridable field has
+        // drifted from the desired config. The desired kernel + cmdline are
+        // resolved through the same `resolve_desired_boot` path that
+        // `create_default_machine` uses, so drift detection can never disagree
+        // with what would actually be created. Resolving assets may download,
+        // which is why the whole check lives in this sub-task rather than the
+        // actor.
+        let desired_boot = match self.resolve_desired_boot().await {
+            Ok(boot) => Some(boot),
+            Err(e) => {
+                tracing::warn!(error = %e, "could not resolve desired boot params; skipping drift check");
+                None
+            }
+        };
+        let drift_reason = match (existing_machine.as_ref(), desired_boot.as_ref()) {
+            (Some(m), Some(boot)) => machine_drift_reason(m, &self.config.default_vm, boot),
+            _ => None,
+        };
+        if let Some(field) = drift_reason {
+            let m = existing_machine.as_ref().unwrap();
+            tracing::warn!(
+                drifted_field = field,
+                persisted_cpus = m.cpus,
+                persisted_memory = m.memory_mb,
+                persisted_kernel = m.kernel.as_deref().unwrap_or("none"),
+                desired_cpus = self.config.default_vm.cpus,
+                desired_memory = self.config.default_vm.memory_mb,
+                "default machine config drifted from desired defaults; recreating"
+            );
+            let _ = self.machine_manager.remove(&self.machine_name, true);
+        }
+
+        if create_hint || !machine_exists || drift_reason.is_some() {
+            self.create_default_machine().await?;
+            self.event_bus.publish(Event::MachineCreated {
+                name: self.machine_name.clone(),
+            });
+        }
+
+        self.start_with_retries(timeout).await?;
+        self.wait_for_agent(timeout).await?;
+
+        // Reset recovery counters on a fully successful boot.
+        self.recovery.reset();
+        self.health_monitor.reset();
+
+        Ok(())
+    }
+
+    /// Starts the machine, retrying per the recovery policy within `timeout`,
+    /// recreating the machine if it disappeared underneath us.
+    async fn start_with_retries(&self, timeout: Duration) -> Result<()> {
+        let deadline = tokio::time::Instant::now() + timeout;
+
+        loop {
+            match self.machine_manager.start(&self.machine_name).await {
+                Ok(()) => {
+                    tracing::info!("Default VM started successfully");
+                    self.spawn_route_reconciler();
+                    return Ok(());
+                }
+                Err(e) => {
+                    if is_not_found_error(&e) {
+                        tracing::warn!(
+                            "default machine disappeared before start; recreating and retrying"
+                        );
+                        self.create_default_machine().await?;
+                        self.event_bus.publish(Event::MachineCreated {
+                            name: self.machine_name.clone(),
+                        });
+                        continue;
+                    }
+
+                    tracing::warn!("Failed to start VM: {}", e);
+
+                    // Check if we should retry.
+                    // Avoid wrapping "VM error: ..." multiple times when propagating.
+                    let recovery_error = match &e {
+                        CoreError::Vm(msg) => msg.as_str(),
+                        _ => &e.to_string(),
+                    };
+                    match self.recovery.handle_failure(recovery_error) {
+                        RecoveryAction::RetryAfter(delay) => {
+                            if tokio::time::Instant::now() + delay > deadline {
+                                return Err(CoreError::Vm(format!(
+                                    "VM startup timeout after {} retries",
+                                    self.recovery.retry_count()
+                                )));
+                            }
+
+                            tracing::info!("Retrying VM start in {:?}", delay);
+                            tokio::time::sleep(delay).await;
+                        }
+                        RecoveryAction::GiveUp(err) => {
+                            return Err(CoreError::Vm(err));
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    /// Installs the host route for container subnets via the bridge NIC.
+    ///
+    /// Non-blocking: retries transient failures (helper not ready, bridge FDB
+    /// not populated) but does not gate VM readiness.
+    #[cfg(all(target_os = "macos", feature = "vmnet"))]
+    fn spawn_route_reconciler(&self) {
+        if let Some(bridge) = self.machine_manager.vmnet_bridge_name(&self.machine_name) {
+            // vmnet path: bridge name is known instantly, only need
+            // helper retry (1-2 attempts for XPC readiness).
+            let event_bus = self.event_bus.clone();
+            let name = self.machine_name.clone();
+            drop(tokio::spawn(async move {
+                match crate::route_reconciler::ensure_route_for_bridge(&bridge).await {
+                    Ok(()) => {
+                        event_bus.publish(Event::ContainerRouteInstalled { name });
+                    }
+                    Err(e) => {
+                        tracing::warn!(error = %e, "failed to install container route (vmnet)");
+                    }
+                }
+            }));
+        }
+    }
+
+    /// See the vmnet variant; this path discovers the bridge by scanning the
+    /// kernel FDB (retries up to ~10s for FDB learning).
+    #[cfg(all(target_os = "macos", not(feature = "vmnet")))]
+    fn spawn_route_reconciler(&self) {
+        if let Some(mac) = self.machine_manager.bridge_mac(&self.machine_name) {
+            let event_bus = self.event_bus.clone();
+            let name = self.machine_name.clone();
+            drop(tokio::spawn(async move {
+                match crate::route_reconciler::ensure_route_with_retry(&mac).await {
+                    Ok(()) => {
+                        event_bus.publish(Event::ContainerRouteInstalled { name });
+                    }
+                    Err(e) => {
+                        tracing::warn!(error = %e, "failed to install container route");
+                    }
+                }
+            }));
+        }
+    }
+
+    #[cfg(not(target_os = "macos"))]
+    fn spawn_route_reconciler(&self) {}
+
+    /// Creates the default machine with EROFS rootfs and no initramfs.
+    ///
+    /// Block devices:
+    /// - vda: rootfs.erofs (read-only)
+    /// - vdb: docker-data.img (read-write)
+    async fn create_default_machine(&self) -> Result<()> {
+        let boot = self.resolve_desired_boot().await?;
+        let rootfs_path = boot.rootfs_image.to_string_lossy().to_string();
+
+        // Block devices: vda = EROFS rootfs (read-only), vdb = Docker data (read-write).
+        let mut block_devices = vec![crate::vm::BlockDeviceConfig {
+            path: rootfs_path.clone(),
+            read_only: true,
+        }];
+
+        // Attach persistent Docker data disk.
+        let docker_data_image = self
+            .data_dir
+            .join(arcbox_constants::paths::host::DATA)
+            .join(&self.data_image_filename);
+        ensure_sparse_block_image(&docker_data_image, DOCKER_DATA_IMAGE_SIZE_BYTES)?;
+
+        // Don't inject docker_data_device into cmdline — let the agent
+        // auto-detect. It prefers /dev/arcboxhvc1 (HVC fast path) when
+        // available, falling back to /dev/vdb (VirtIO block).
+        block_devices.push(crate::vm::BlockDeviceConfig {
+            path: docker_data_image.to_string_lossy().to_string(),
+            read_only: false,
+        });
+
+        let config = MachineConfig {
+            name: self.machine_name.clone(),
+            cpus: self.config.default_vm.cpus,
+            memory_mb: self.config.default_vm.memory_mb,
+            disk_gb: self.config.default_vm.disk_gb,
+            kernel: Some(boot.kernel),
+            cmdline: Some(boot.cmdline),
+            block_devices,
+            distro: None,
+            distro_version: None,
+            backend: self.backend(),
+            // Host Rosetta capability. Whether the Rosetta share is actually
+            // wired is decided per-backend at VM build time (VZ only), so the
+            // value stays correct across a backend switch — see
+            // `VmManager::build_vmm_config`.
+            enable_rosetta: self.config.default_vm.rosetta,
+        };
+
+        tracing::info!(
+            "Creating default machine: cpus={}, memory={}MB, kernel={}, rootfs={}",
+            config.cpus,
+            config.memory_mb,
+            config.kernel.as_deref().unwrap_or("default"),
+            rootfs_path,
+        );
+
+        self.machine_manager.create(config).await?;
+
+        Ok(())
+    }
+
+    /// Resolves the default VM's boot parameters (kernel image, final kernel
+    /// command line, and rootfs image) from config + boot assets.
+    ///
+    /// Shared by [`Self::create_default_machine`] and the drift check in
+    /// [`Self::boot`] so machine creation and drift detection always agree on
+    /// the desired kernel and cmdline. The cmdline is the base (explicit
+    /// override or the boot manifest default) with `quiet` stripped,
+    /// `earlycon` ensured, and the guest docker vsock port injected.
+    async fn resolve_desired_boot(&self) -> Result<DesiredBoot> {
+        let assets = self.boot_assets.get_assets().await?;
+        let mut cmdline = self
+            .config
+            .default_vm
+            .cmdline
+            .clone()
+            .unwrap_or(assets.cmdline);
+
+        // Strip "quiet" so kernel boot messages are visible on the serial console.
+        cmdline = cmdline
+            .split_whitespace()
+            .filter(|t| *t != "quiet")
+            .collect::<Vec<_>>()
+            .join(" ");
+
+        // Ensure an explicit earlycon directive so early boot output reaches the
+        // host `guest_serial` log — but only on the custom-HV backend, whose PL011
+        // emulator the directive targets (VZ has no such device). See
+        // `ensure_earlycon`.
+        cmdline = ensure_earlycon(cmdline, self.backend());
+
+        // Inject guest docker vsock port if configured.
+        if let Some(port) = self.config.guest_docker_vsock_port {
+            if !cmdline
+                .split_whitespace()
+                .any(|token| token.starts_with(GUEST_DOCKER_VSOCK_PORT_KEY))
+            {
+                cmdline.push(' ');
+                cmdline.push_str(GUEST_DOCKER_VSOCK_PORT_KEY);
+                cmdline.push_str(&port.to_string());
+            }
+        }
+
+        Ok(DesiredBoot {
+            kernel: assets.kernel.to_string_lossy().to_string(),
+            cmdline,
+            rootfs_image: assets.rootfs_image,
+        })
+    }
+
+    /// Waits for the agent to become ready.
+    async fn wait_for_agent(&self, timeout: Duration) -> Result<()> {
+        tracing::debug!("Waiting for agent to become ready...");
+
+        enum AgentProbe {
+            Ready,
+            Watch(crate::agent_client::AgentClient),
+        }
+
+        let mm = Arc::clone(&self.machine_manager);
+        let machine_name = self.machine_name.clone();
+
+        // Run the entire probe loop on a blocking thread. On macOS HV backend,
+        // the agent transport is AF_UNIX socketpair → BlockingVsockTransport.
+        // Rapid connect/teardown of these fds stalls the tokio kqueue reactor's
+        // timer wheel, so neither tokio::time::sleep nor tokio::time::timeout
+        // can be used reliably inside this loop. spawn_blocking isolates the
+        // probe from the async runtime entirely.
+        let probe_result = tokio::task::spawn_blocking(move || {
+            let deadline = std::time::Instant::now() + timeout;
+            // Failed probes are ~1ms (vsock RST via the event-driven RX
+            // path), so a tight interval costs little and bounds the
+            // discovery overshoot once the agent starts listening.
+            let poll_interval = Duration::from_millis(25);
+            // Remember the last genuine readiness error so an exhausted deadline
+            // surfaces it instead of a bare "timeout" (a guest-reported failure
+            // also arrives here as an Err).
+            let mut last_readiness_err: Option<String> = None;
+
+            while std::time::Instant::now() < deadline {
+                // Console output (best-effort, non-blocking).
+                #[cfg(target_os = "macos")]
+                if let Ok(output) = mm.read_console_output(&machine_name) {
+                    let trimmed = output.trim_matches('\0');
+                    if !trimmed.is_empty() {
+                        tracing::info!("{}", trimmed.trim_end());
+                    }
+                }
+
+                // connect_agent discovers when the guest starts listening on
+                // the agent vsock port, then the readiness event stream waits
+                // for the guest to report a terminal state.
+                //
+                // On the HV AF_UNIX socketpair, connect_agent can succeed
+                // optimistically *before* the guest agent is actually listening
+                // (the guest's /sbin/init has not even run yet at this point),
+                // so the readiness read then fails with EOF. That is a normal
+                // "not ready yet" race, not a fatal protocol error — keep
+                // polling until a genuine readiness event arrives or the
+                // deadline elapses. HV's AF_UNIX transport stays on this
+                // blocking thread; async transports are handed back to tokio.
+                match mm.connect_agent(&machine_name) {
+                    Ok(agent) if agent.is_blocking() => {
+                        let remaining =
+                            deadline.saturating_duration_since(std::time::Instant::now());
+                        if remaining.is_zero() {
+                            return Err(agent_timeout_error(last_readiness_err.as_deref()));
+                        }
+                        match agent.watch_readiness_blocking(false, remaining) {
+                            Ok(_) => return Ok(AgentProbe::Ready),
+                            Err(e) => {
+                                tracing::debug!("agent not ready yet: {e}");
+                                last_readiness_err = Some(e.to_string());
+                            }
+                        }
+                    }
+                    Ok(agent) => return Ok(AgentProbe::Watch(agent)),
+                    Err(e) => tracing::debug!("Agent connection failed: {e}"),
+                }
+
+                std::thread::sleep(poll_interval);
+            }
+
+            Err(agent_timeout_error(last_readiness_err.as_deref()))
+        })
+        .await
+        .map_err(|e| CoreError::Vm(format!("probe task panicked: {e}")))?;
+
+        match probe_result? {
+            AgentProbe::Ready => {}
+            AgentProbe::Watch(first_agent) => {
+                // Mirror the blocking path's tolerance: an async transport may
+                // also connect before the guest agent is listening, so retry
+                // both the connect and the readiness watch (reconnecting each
+                // round) until it yields a genuine event or the timeout elapses.
+                let deadline = tokio::time::Instant::now() + timeout;
+                let mut next_agent = Some(first_agent);
+                let mut last_readiness_err: Option<String> = None;
+                loop {
+                    let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+                    if remaining.is_zero() {
+                        return Err(agent_timeout_error(last_readiness_err.as_deref()));
+                    }
+                    // Reuse the connection from the probe loop on the first
+                    // iteration, then reconnect on each retry.
+                    let agent = match next_agent.take() {
+                        Some(agent) => agent,
+                        None => match self.machine_manager.connect_agent(&self.machine_name) {
+                            Ok(agent) => agent,
+                            Err(e) => {
+                                tracing::debug!("agent reconnect failed: {e}");
+                                tokio::time::sleep(Duration::from_millis(25)).await;
+                                continue;
+                            }
+                        },
+                    };
+                    // Recompute the budget after a potentially slow reconnect so
+                    // watch_readiness doesn't block past the deadline.
+                    let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+                    if remaining.is_zero() {
+                        return Err(agent_timeout_error(last_readiness_err.as_deref()));
+                    }
+                    match agent.watch_readiness(false, remaining).await {
+                        Ok(_) => break,
+                        Err(e) => {
+                            tracing::debug!("agent not ready yet: {e}");
+                            last_readiness_err = Some(e.to_string());
+                            tokio::time::sleep(Duration::from_millis(25)).await;
+                        }
+                    }
+                }
+            }
+        }
+
+        // Back on async context — do async follow-up work.
+        tracing::info!("Agent is ready");
+        self.health_monitor.record_success();
+        #[cfg(target_os = "macos")]
+        {
+            let mm = Arc::clone(&self.machine_manager);
+            tokio::spawn(super::serial::serial_read_adaptive(mm));
+        }
+
+        Ok(())
+    }
+}
+
+/// Ensures an explicit `earlycon=` directive on the custom-HV backend.
+///
+/// A bare `earlycon` relies on the device-tree `stdout-path` and produces nothing
+/// on the custom-HV PL011 emulator, so on `Hv` it is upgraded to the pinned
+/// `earlycon=pl011,<base>` form. The `Vz` backend has no PL011 MMIO device (it
+/// uses a VirtIO console), so pointing the kernel at that address would break VZ
+/// early boot — its cmdline is left untouched. An explicit operator `earlycon=`
+/// is always respected.
+pub(super) fn ensure_earlycon(cmdline: String, backend: arcbox_vmm::VmBackend) -> String {
+    if !matches!(backend, arcbox_vmm::VmBackend::Hv) {
+        return cmdline;
+    }
+    if cmdline
+        .split_whitespace()
+        .any(|t| t.starts_with("earlycon="))
+    {
+        return cmdline;
+    }
+    let mut tokens: Vec<&str> = cmdline
+        .split_whitespace()
+        .filter(|t| *t != "earlycon")
+        .collect();
+    tokens.push(HV_EARLYCON_DIRECTIVE);
+    tokens.join(" ")
+}
+
+/// Builds the "timeout waiting for agent" error, folding in the last observed
+/// readiness error so a genuine guest-reported failure isn't masked as a plain
+/// timeout (per-iteration errors are otherwise only logged at debug level).
+pub(super) fn agent_timeout_error(last_error: Option<&str>) -> CoreError {
+    match last_error {
+        Some(e) => CoreError::Vm(format!("timeout waiting for agent (last error: {e})")),
+        None => CoreError::Vm("timeout waiting for agent".to_string()),
+    }
+}
+
+/// Ensures a sparse, thin-provisioned block image of `size_bytes` virtual
+/// size exists at `path`, creating parent directories as needed.
+///
+/// `set_len` extends only the logical size (EOF); it reserves no physical
+/// blocks, so the host file stays sparse and consumes disk only for blocks
+/// the guest actually writes — matching OrbStack's thin data image.
+///
+/// We deliberately do NOT pre-allocate physical space. An upfront macOS
+/// `F_PREALLOCATE` reservation (previously capped at 64 GiB) made a fresh
+/// install report tens of GiB of disk usage with zero containers — wasteful
+/// and a regression against OrbStack on idle footprint. APFS/Btrfs allocate
+/// on write lazily, so the working set still benefits from CoW without the
+/// upfront cost. An existing image is never shrunk.
+pub(super) fn ensure_sparse_block_image(path: &Path, size_bytes: u64) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).map_err(|e| {
+            CoreError::config(format!(
+                "failed to create block image directory '{}': {}",
+                parent.display(),
+                e
+            ))
+        })?;
+    }
+
+    let file_exists = path.exists();
+    let file = OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .truncate(false)
+        .open(path)
+        .map_err(|e| {
+            CoreError::config(format!(
+                "failed to open block image '{}': {}",
+                path.display(),
+                e
+            ))
+        })?;
+
+    let current_len = file.metadata().map_err(|e| {
+        CoreError::config(format!(
+            "failed to stat block image '{}': {}",
+            path.display(),
+            e
+        ))
+    })?;
+
+    // Extend the logical size only — `set_len` leaves the file sparse, so
+    // no physical disk is consumed until the guest writes. Never shrink an
+    // existing image (guards against a smaller `size_bytes` truncating
+    // user data).
+    if current_len.len() < size_bytes {
+        file.set_len(size_bytes).map_err(|e| {
+            CoreError::config(format!(
+                "failed to resize block image '{}': {}",
+                path.display(),
+                e
+            ))
+        })?;
+    }
+
+    if !file_exists {
+        tracing::info!(
+            path = %path.display(),
+            size_bytes,
+            "created persistent docker data image"
+        );
+    }
+
+    Ok(())
+}
+
+const fn is_not_found_error(err: &CoreError) -> bool {
+    matches!(err, CoreError::Common(CommonError::NotFound(_)))
+}

--- a/app/arcbox-core/src/vm_lifecycle/machine.rs
+++ b/app/arcbox-core/src/vm_lifecycle/machine.rs
@@ -13,15 +13,14 @@
 //! ```text
 //! managed                                 ForceStop / Failure (anywhere)
 //!  ├─ booting ── creating, starting       AgentReady → running
-//!  ├─ active  ── running, idle            Stop → stopping
+//!  ├─ active  ── running, idle            Stop → stopping; IdleTimeout ⇄ Activity
 //!  ├─ stopping                            Stopped → stopped
 //!  └─ resting ── not_exist, created,      Start → creating | starting
 //!                stopped, failed
 //! ```
-
-// The machine and its plumbing are introduced here additively and wired into
-// `VmLifecycleManager` in a follow-up commit; until then the items are unused.
-#![allow(dead_code)]
+//!
+//! `Stop` during `booting` is not a machine transition: the actor defers it
+//! until the boot resolves (see `actor.rs`).
 
 use statig::prelude::*;
 
@@ -32,13 +31,13 @@ type Outcome = statig::Outcome<State>;
 
 /// A lifecycle event fed to the state machine.
 ///
-/// Replaces the previously-undispatched `types::VmEvent`. Every variant is
-/// produced by the actor (commands) or by a boot/stop sub-task (completions).
+/// Every variant is produced by the actor (commands) or by a boot/stop
+/// sub-task (completions); none is dead vocabulary.
 #[derive(Debug, Clone)]
 pub(super) enum VmEvent {
     /// `ensure_ready` on a VM that needs starting. `create` is precomputed by
-    /// the actor's `plan_boot` (drift/missing detection); it selects
-    /// `creating` vs `starting`.
+    /// the actor (`decide_create`: missing machine record) and selects
+    /// `creating` vs `starting`; config drift is re-checked in the boot task.
     Start {
         /// Whether the machine must be (re)created before starting.
         create: bool,
@@ -50,8 +49,9 @@ pub(super) enum VmEvent {
     Activity,
     /// Boot sub-task: the guest agent reported ready.
     AgentReady,
-    /// Boot or stop sub-task: terminal failure (reason carried for the actor).
-    Failure(String),
+    /// Boot or stop sub-task: terminal failure. The reason string stays on the
+    /// actor side (`InternalEvent`), which delivers it to waiting callers.
+    Failure,
     /// Idle ticker fired and the idle threshold was exceeded.
     IdleTimeout,
     /// Graceful shutdown request.
@@ -104,6 +104,9 @@ pub(super) enum Effect {
     RemoveMachine,
     /// Apply a balloon target.
     Balloon(BalloonTarget),
+    /// Bump the VM incarnation counter (the Docker proxy watches it to detect
+    /// restarts and reset cached readiness + pooled connections).
+    BumpGeneration,
     /// Publish a lifecycle notification on the event bus.
     Publish(Notify),
     /// Resolve all parked `ensure_ready` callers with the agent CID.
@@ -137,6 +140,7 @@ impl Effects {
     fn force_stop(&mut self) -> Outcome {
         self.emit(Effect::AbortInflight);
         self.emit(Effect::RemoveMachine);
+        self.emit(Effect::BumpGeneration);
         self.emit(Effect::Publish(Notify::Stopped));
         self.emit(Effect::FailWaiters("force stopped".to_owned()));
         Transition(State::not_exist())
@@ -157,10 +161,10 @@ impl VmLifecycle {
     // ----- managed (root): ForceStop / Failure, anywhere -----
 
     #[superstate]
-    async fn managed(event: &VmEvent, context: &mut Effects) -> Outcome {
+    fn managed(event: &VmEvent, context: &mut Effects) -> Outcome {
         match event {
             VmEvent::ForceStop => context.force_stop(),
-            VmEvent::Failure(_) => Transition(State::failed()),
+            VmEvent::Failure => Transition(State::failed()),
             _ => Handled,
         }
     }
@@ -168,7 +172,7 @@ impl VmLifecycle {
     // ----- resting leaves: Start kicks off a boot -----
 
     #[superstate(superstate = "managed")]
-    async fn resting(event: &VmEvent, context: &mut Effects) -> Outcome {
+    fn resting(event: &VmEvent, context: &mut Effects) -> Outcome {
         match event {
             VmEvent::Start { create, timeout_ms } => {
                 context.emit(Effect::SpawnBoot {
@@ -186,29 +190,29 @@ impl VmLifecycle {
     }
 
     #[state(superstate = "resting")]
-    async fn not_exist() -> Outcome {
+    fn not_exist() -> Outcome {
         Super
     }
 
     #[state(superstate = "resting")]
-    async fn created() -> Outcome {
+    fn created() -> Outcome {
         Super
     }
 
     #[state(superstate = "resting")]
-    async fn stopped() -> Outcome {
+    fn stopped() -> Outcome {
         Super
     }
 
     #[state(superstate = "resting")]
-    async fn failed() -> Outcome {
+    fn failed() -> Outcome {
         Super
     }
 
     // ----- booting leaves: AgentReady promotes to running -----
 
     #[superstate(superstate = "managed")]
-    async fn booting(event: &VmEvent, context: &mut Effects) -> Outcome {
+    fn booting(event: &VmEvent, context: &mut Effects) -> Outcome {
         match event {
             VmEvent::AgentReady => {
                 context.emit(Effect::Publish(Notify::Started));
@@ -219,26 +223,24 @@ impl VmLifecycle {
         }
     }
 
+    // `Stop` during a boot is deliberately not a transition here: the actor
+    // parks it (`pending_stop`) and dispatches it once the boot resolves,
+    // mirroring how the old `transition_lock` serialized shutdown behind an
+    // in-flight boot.
     #[state(superstate = "booting")]
-    async fn creating() -> Outcome {
+    fn creating() -> Outcome {
         Super
     }
 
     #[state(superstate = "booting")]
-    async fn starting(event: &VmEvent, context: &mut Effects) -> Outcome {
-        match event {
-            VmEvent::Stop => {
-                context.emit(Effect::SpawnStop);
-                Transition(State::stopping())
-            }
-            _ => Super,
-        }
+    fn starting() -> Outcome {
+        Super
     }
 
     // ----- active leaves: running / idle -----
 
     #[superstate(superstate = "managed")]
-    async fn active(event: &VmEvent, context: &mut Effects) -> Outcome {
+    fn active(event: &VmEvent, context: &mut Effects) -> Outcome {
         match event {
             VmEvent::Stop => {
                 context.emit(Effect::SpawnStop);
@@ -249,7 +251,7 @@ impl VmLifecycle {
     }
 
     #[state(superstate = "active")]
-    async fn running(event: &VmEvent, context: &mut Effects) -> Outcome {
+    fn running(event: &VmEvent, context: &mut Effects) -> Outcome {
         match event {
             VmEvent::IdleTimeout => {
                 context.emit(Effect::Balloon(BalloonTarget::Idle));
@@ -263,7 +265,7 @@ impl VmLifecycle {
     }
 
     #[state(superstate = "active")]
-    async fn idle(event: &VmEvent, context: &mut Effects) -> Outcome {
+    fn idle(event: &VmEvent, context: &mut Effects) -> Outcome {
         match event {
             VmEvent::Activity | VmEvent::Start { .. } => {
                 context.emit(Effect::Balloon(BalloonTarget::Full));
@@ -276,9 +278,10 @@ impl VmLifecycle {
     // ----- stopping leaf -----
 
     #[state(superstate = "managed")]
-    async fn stopping(event: &VmEvent, context: &mut Effects) -> Outcome {
+    fn stopping(event: &VmEvent, context: &mut Effects) -> Outcome {
         match event {
             VmEvent::Stopped => {
+                context.emit(Effect::BumpGeneration);
                 context.emit(Effect::Publish(Notify::Stopped));
                 Transition(State::stopped())
             }
@@ -308,24 +311,19 @@ impl State {
 mod machine_tests {
     use super::*;
 
-    type Machine = statig::awaitable::InitializedStateMachine<VmLifecycle>;
+    type Machine = statig::blocking::InitializedStateMachine<VmLifecycle>;
 
     /// Builds an initialized machine starting from `not_exist`.
-    async fn machine(fx: &mut Effects) -> Machine {
+    fn machine(fx: &mut Effects) -> Machine {
         VmLifecycle
             .uninitialized_state_machine()
             .init_with_context(fx)
-            .await
     }
 
     /// Dispatches `event`, returning the resulting public state and the effects
     /// the transition emitted.
-    async fn step(
-        sm: &mut Machine,
-        fx: &mut Effects,
-        event: VmEvent,
-    ) -> (VmLifecycleState, Vec<Effect>) {
-        sm.handle_with_context(&event, fx).await;
+    fn step(sm: &mut Machine, fx: &mut Effects, event: VmEvent) -> (VmLifecycleState, Vec<Effect>) {
+        sm.handle_with_context(&event, fx);
         (sm.state().to_public(), fx.take())
     }
 
@@ -338,13 +336,13 @@ mod machine_tests {
         }
     }
 
-    #[tokio::test]
-    async fn start_from_not_exist_creates_then_boots_to_running() {
+    #[test]
+    fn start_from_not_exist_creates_then_boots_to_running() {
         let mut fx = Effects::default();
-        let mut sm = machine(&mut fx).await;
+        let mut sm = machine(&mut fx);
         assert_eq!(sm.state().to_public(), VmLifecycleState::NotExist);
 
-        let (state, effects) = step(&mut sm, &mut fx, start(true)).await;
+        let (state, effects) = step(&mut sm, &mut fx, start(true));
         assert_eq!(state, VmLifecycleState::Creating);
         assert_eq!(
             effects,
@@ -354,7 +352,7 @@ mod machine_tests {
             }]
         );
 
-        let (state, effects) = step(&mut sm, &mut fx, VmEvent::AgentReady).await;
+        let (state, effects) = step(&mut sm, &mut fx, VmEvent::AgentReady);
         assert_eq!(state, VmLifecycleState::Running);
         assert_eq!(
             effects,
@@ -362,11 +360,11 @@ mod machine_tests {
         );
     }
 
-    #[tokio::test]
-    async fn start_without_create_goes_straight_to_starting() {
+    #[test]
+    fn start_without_create_goes_straight_to_starting() {
         let mut fx = Effects::default();
-        let mut sm = machine(&mut fx).await;
-        let (state, effects) = step(&mut sm, &mut fx, start(false)).await;
+        let mut sm = machine(&mut fx);
+        let (state, effects) = step(&mut sm, &mut fx, start(false));
         assert_eq!(state, VmLifecycleState::Starting);
         assert_eq!(
             effects,
@@ -377,22 +375,22 @@ mod machine_tests {
         );
     }
 
-    #[tokio::test]
-    async fn boot_failure_lands_in_failed() {
+    #[test]
+    fn boot_failure_lands_in_failed() {
         let mut fx = Effects::default();
-        let mut sm = machine(&mut fx).await;
-        step(&mut sm, &mut fx, start(true)).await;
-        let (state, effects) = step(&mut sm, &mut fx, VmEvent::Failure("boom".into())).await;
+        let mut sm = machine(&mut fx);
+        step(&mut sm, &mut fx, start(true));
+        let (state, effects) = step(&mut sm, &mut fx, VmEvent::Failure);
         assert_eq!(state, VmLifecycleState::Failed);
         assert!(effects.is_empty());
     }
 
-    #[tokio::test]
-    async fn idle_round_trip_shrinks_then_restores_balloon() {
+    #[test]
+    fn idle_round_trip_shrinks_then_restores_balloon() {
         let mut fx = Effects::default();
-        let mut sm = running_machine(&mut fx).await;
+        let mut sm = running_machine(&mut fx);
 
-        let (state, effects) = step(&mut sm, &mut fx, VmEvent::IdleTimeout).await;
+        let (state, effects) = step(&mut sm, &mut fx, VmEvent::IdleTimeout);
         assert_eq!(state, VmLifecycleState::Idle);
         assert_eq!(
             effects,
@@ -402,46 +400,51 @@ mod machine_tests {
             ]
         );
 
-        let (state, effects) = step(&mut sm, &mut fx, VmEvent::Activity).await;
+        let (state, effects) = step(&mut sm, &mut fx, VmEvent::Activity);
         assert_eq!(state, VmLifecycleState::Running);
         assert_eq!(effects, vec![Effect::Balloon(BalloonTarget::Full)]);
     }
 
-    #[tokio::test]
-    async fn activity_while_running_is_a_noop() {
+    #[test]
+    fn activity_while_running_is_a_noop() {
         let mut fx = Effects::default();
-        let mut sm = running_machine(&mut fx).await;
-        let (state, effects) = step(&mut sm, &mut fx, VmEvent::Activity).await;
+        let mut sm = running_machine(&mut fx);
+        let (state, effects) = step(&mut sm, &mut fx, VmEvent::Activity);
         assert_eq!(state, VmLifecycleState::Running);
         assert!(effects.is_empty());
     }
 
-    #[tokio::test]
-    async fn stop_from_running_drains_through_stopping() {
+    #[test]
+    fn stop_from_running_drains_through_stopping() {
         let mut fx = Effects::default();
-        let mut sm = running_machine(&mut fx).await;
+        let mut sm = running_machine(&mut fx);
 
-        let (state, effects) = step(&mut sm, &mut fx, VmEvent::Stop).await;
+        let (state, effects) = step(&mut sm, &mut fx, VmEvent::Stop);
         assert_eq!(state, VmLifecycleState::Stopping);
         assert_eq!(effects, vec![Effect::SpawnStop]);
 
-        let (state, effects) = step(&mut sm, &mut fx, VmEvent::Stopped).await;
+        let (state, effects) = step(&mut sm, &mut fx, VmEvent::Stopped);
         assert_eq!(state, VmLifecycleState::Stopped);
-        assert_eq!(effects, vec![Effect::Publish(Notify::Stopped)]);
+        assert_eq!(
+            effects,
+            vec![Effect::BumpGeneration, Effect::Publish(Notify::Stopped)]
+        );
     }
 
-    #[tokio::test]
-    async fn stop_is_accepted_while_starting() {
+    #[test]
+    fn stop_while_booting_is_swallowed_for_actor_deferral() {
+        // The actor parks a mid-boot Stop (`pending_stop`) instead of the
+        // machine transitioning; the machine must treat it as handled noise.
         let mut fx = Effects::default();
-        let mut sm = machine(&mut fx).await;
-        step(&mut sm, &mut fx, start(false)).await;
-        let (state, effects) = step(&mut sm, &mut fx, VmEvent::Stop).await;
-        assert_eq!(state, VmLifecycleState::Stopping);
-        assert_eq!(effects, vec![Effect::SpawnStop]);
+        let mut sm = machine(&mut fx);
+        step(&mut sm, &mut fx, start(false));
+        let (state, effects) = step(&mut sm, &mut fx, VmEvent::Stop);
+        assert_eq!(state, VmLifecycleState::Starting);
+        assert!(effects.is_empty());
     }
 
-    #[tokio::test]
-    async fn force_stop_preempts_from_every_phase() {
+    #[test]
+    fn force_stop_preempts_from_every_phase() {
         for reach in [
             ReachState::Creating,
             ReachState::Running,
@@ -449,10 +452,10 @@ mod machine_tests {
             ReachState::Stopping,
         ] {
             let mut fx = Effects::default();
-            let mut sm = machine(&mut fx).await;
-            reach.drive(&mut sm, &mut fx).await;
+            let mut sm = machine(&mut fx);
+            reach.drive(&mut sm, &mut fx);
 
-            let (state, effects) = step(&mut sm, &mut fx, VmEvent::ForceStop).await;
+            let (state, effects) = step(&mut sm, &mut fx, VmEvent::ForceStop);
             assert_eq!(
                 state,
                 VmLifecycleState::NotExist,
@@ -463,6 +466,7 @@ mod machine_tests {
                 vec![
                     Effect::AbortInflight,
                     Effect::RemoveMachine,
+                    Effect::BumpGeneration,
                     Effect::Publish(Notify::Stopped),
                     Effect::FailWaiters("force stopped".to_owned()),
                 ]
@@ -470,10 +474,10 @@ mod machine_tests {
         }
     }
 
-    async fn running_machine(fx: &mut Effects) -> Machine {
-        let mut sm = machine(fx).await;
-        sm.handle_with_context(&start(true), fx).await;
-        sm.handle_with_context(&VmEvent::AgentReady, fx).await;
+    fn running_machine(fx: &mut Effects) -> Machine {
+        let mut sm = machine(fx);
+        sm.handle_with_context(&start(true), fx);
+        sm.handle_with_context(&VmEvent::AgentReady, fx);
         fx.take();
         sm
     }
@@ -487,20 +491,20 @@ mod machine_tests {
     }
 
     impl ReachState {
-        async fn drive(self, sm: &mut Machine, fx: &mut Effects) {
-            sm.handle_with_context(&start(true), fx).await;
+        fn drive(self, sm: &mut Machine, fx: &mut Effects) {
+            sm.handle_with_context(&start(true), fx);
             match self {
                 Self::Creating => {}
                 Self::Running => {
-                    sm.handle_with_context(&VmEvent::AgentReady, fx).await;
+                    sm.handle_with_context(&VmEvent::AgentReady, fx);
                 }
                 Self::Idle => {
-                    sm.handle_with_context(&VmEvent::AgentReady, fx).await;
-                    sm.handle_with_context(&VmEvent::IdleTimeout, fx).await;
+                    sm.handle_with_context(&VmEvent::AgentReady, fx);
+                    sm.handle_with_context(&VmEvent::IdleTimeout, fx);
                 }
                 Self::Stopping => {
-                    sm.handle_with_context(&VmEvent::AgentReady, fx).await;
-                    sm.handle_with_context(&VmEvent::Stop, fx).await;
+                    sm.handle_with_context(&VmEvent::AgentReady, fx);
+                    sm.handle_with_context(&VmEvent::Stop, fx);
                 }
             }
             fx.take();

--- a/app/arcbox-core/src/vm_lifecycle/machine.rs
+++ b/app/arcbox-core/src/vm_lifecycle/machine.rs
@@ -1,0 +1,509 @@
+//! The VM lifecycle as a `statig` hierarchical state machine.
+//!
+//! This is the **decision core**: handlers are pure transition logic that emit
+//! [`Effect`]s into the externally-owned [`Effects`] context. They never touch
+//! the hypervisor, spawn tasks, or block — all I/O is performed by the lifecycle
+//! actor (see `actor.rs`), which owns the `Effects` buffer, reads it after every
+//! `handle_with_context`, and applies the effects. The machine therefore holds
+//! no `Arc<MachineManager>`, channels, or timers, so the whole transition table
+//! is testable with nothing but an `Effects` scratch buffer.
+//!
+//! ## State hierarchy
+//!
+//! ```text
+//! managed                                 ForceStop / Failure (anywhere)
+//!  ├─ booting ── creating, starting       AgentReady → running
+//!  ├─ active  ── running, idle            Stop → stopping
+//!  ├─ stopping                            Stopped → stopped
+//!  └─ resting ── not_exist, created,      Start → creating | starting
+//!                stopped, failed
+//! ```
+
+// The machine and its plumbing are introduced here additively and wired into
+// `VmLifecycleManager` in a follow-up commit; until then the items are unused.
+#![allow(dead_code)]
+
+use statig::prelude::*;
+
+use super::types::VmLifecycleState;
+
+/// `statig` outcome specialized to this machine's state enum.
+type Outcome = statig::Outcome<State>;
+
+/// A lifecycle event fed to the state machine.
+///
+/// Replaces the previously-undispatched `types::VmEvent`. Every variant is
+/// produced by the actor (commands) or by a boot/stop sub-task (completions).
+#[derive(Debug, Clone)]
+pub(super) enum VmEvent {
+    /// `ensure_ready` on a VM that needs starting. `create` is precomputed by
+    /// the actor's `plan_boot` (drift/missing detection); it selects
+    /// `creating` vs `starting`.
+    Start {
+        /// Whether the machine must be (re)created before starting.
+        create: bool,
+        /// Startup budget in milliseconds, forwarded to the boot sub-task.
+        timeout_ms: u64,
+    },
+    /// Activity observed on an already-ready VM (new request, Kubernetes hold).
+    /// Exits `idle`.
+    Activity,
+    /// Boot sub-task: the guest agent reported ready.
+    AgentReady,
+    /// Boot or stop sub-task: terminal failure (reason carried for the actor).
+    Failure(String),
+    /// Idle ticker fired and the idle threshold was exceeded.
+    IdleTimeout,
+    /// Graceful shutdown request.
+    Stop,
+    /// Stop sub-task: the machine stopped.
+    Stopped,
+    /// Force-stop request (preempts any in-flight boot/stop).
+    ForceStop,
+}
+
+/// Balloon target requested by a transition; the actor applies it idempotently.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum BalloonTarget {
+    /// Shrink to the idle reservation to return memory to the host.
+    Idle,
+    /// Restore to the VM's full configured memory.
+    Full,
+}
+
+/// Lifecycle notification a transition asks the actor to publish on the bus.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum Notify {
+    /// VM reached `running` (`Event::MachineStarted`).
+    Started,
+    /// VM entered `idle` (`Event::MachineIdle`).
+    Idle,
+    /// VM stopped or was force-stopped (`Event::MachineStopped`).
+    Stopped,
+}
+
+/// A side effect emitted by a transition, executed by the lifecycle actor.
+///
+/// The machine only *describes* what should happen; the actor owns the
+/// hypervisor handle, the task join handles, the waiter list, and the event
+/// bus, and is the sole executor.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) enum Effect {
+    /// Spawn the boot sub-task. `create` ⇒ (re)create the machine first.
+    SpawnBoot {
+        /// Whether to create the machine before starting it.
+        create: bool,
+        /// Startup budget in milliseconds.
+        timeout_ms: u64,
+    },
+    /// Spawn the graceful-stop sub-task.
+    SpawnStop,
+    /// Abort the in-flight boot/stop sub-task (force path).
+    AbortInflight,
+    /// Remove the machine record (force path).
+    RemoveMachine,
+    /// Apply a balloon target.
+    Balloon(BalloonTarget),
+    /// Publish a lifecycle notification on the event bus.
+    Publish(Notify),
+    /// Resolve all parked `ensure_ready` callers with the agent CID.
+    ReadyWaiters,
+    /// Fail all parked `ensure_ready` callers with this reason.
+    FailWaiters(String),
+}
+
+/// External context: the effect sink a dispatch writes into.
+///
+/// Owned by the actor and passed by `&mut` to every `handle_with_context`, so
+/// the actor reads back the transition's effects without needing mutable access
+/// to the (zero-sized) state-machine storage.
+#[derive(Debug, Default)]
+pub(super) struct Effects {
+    items: Vec<Effect>,
+}
+
+impl Effects {
+    /// Records an effect for the actor to execute.
+    fn emit(&mut self, effect: Effect) {
+        self.items.push(effect);
+    }
+
+    /// Drains the effects accumulated since the last call.
+    pub(super) fn take(&mut self) -> Vec<Effect> {
+        std::mem::take(&mut self.items)
+    }
+
+    /// Shared `ForceStop` handling: tear everything down and fail any waiters.
+    fn force_stop(&mut self) -> Outcome {
+        self.emit(Effect::AbortInflight);
+        self.emit(Effect::RemoveMachine);
+        self.emit(Effect::Publish(Notify::Stopped));
+        self.emit(Effect::FailWaiters("force stopped".to_owned()));
+        Transition(State::not_exist())
+    }
+}
+
+/// Zero-sized `statig` shared storage. All durable lifecycle data lives in the
+/// actor; transition outputs flow through the [`Effects`] context.
+#[derive(Debug, Default)]
+pub(super) struct VmLifecycle;
+
+#[state_machine(
+    initial = "State::not_exist()",
+    state(derive(Debug, Clone, Copy, PartialEq, Eq)),
+    superstate(derive(Debug))
+)]
+impl VmLifecycle {
+    // ----- managed (root): ForceStop / Failure, anywhere -----
+
+    #[superstate]
+    async fn managed(event: &VmEvent, context: &mut Effects) -> Outcome {
+        match event {
+            VmEvent::ForceStop => context.force_stop(),
+            VmEvent::Failure(_) => Transition(State::failed()),
+            _ => Handled,
+        }
+    }
+
+    // ----- resting leaves: Start kicks off a boot -----
+
+    #[superstate(superstate = "managed")]
+    async fn resting(event: &VmEvent, context: &mut Effects) -> Outcome {
+        match event {
+            VmEvent::Start { create, timeout_ms } => {
+                context.emit(Effect::SpawnBoot {
+                    create: *create,
+                    timeout_ms: *timeout_ms,
+                });
+                Transition(if *create {
+                    State::creating()
+                } else {
+                    State::starting()
+                })
+            }
+            _ => Super,
+        }
+    }
+
+    #[state(superstate = "resting")]
+    async fn not_exist() -> Outcome {
+        Super
+    }
+
+    #[state(superstate = "resting")]
+    async fn created() -> Outcome {
+        Super
+    }
+
+    #[state(superstate = "resting")]
+    async fn stopped() -> Outcome {
+        Super
+    }
+
+    #[state(superstate = "resting")]
+    async fn failed() -> Outcome {
+        Super
+    }
+
+    // ----- booting leaves: AgentReady promotes to running -----
+
+    #[superstate(superstate = "managed")]
+    async fn booting(event: &VmEvent, context: &mut Effects) -> Outcome {
+        match event {
+            VmEvent::AgentReady => {
+                context.emit(Effect::Publish(Notify::Started));
+                context.emit(Effect::ReadyWaiters);
+                Transition(State::running())
+            }
+            _ => Super,
+        }
+    }
+
+    #[state(superstate = "booting")]
+    async fn creating() -> Outcome {
+        Super
+    }
+
+    #[state(superstate = "booting")]
+    async fn starting(event: &VmEvent, context: &mut Effects) -> Outcome {
+        match event {
+            VmEvent::Stop => {
+                context.emit(Effect::SpawnStop);
+                Transition(State::stopping())
+            }
+            _ => Super,
+        }
+    }
+
+    // ----- active leaves: running / idle -----
+
+    #[superstate(superstate = "managed")]
+    async fn active(event: &VmEvent, context: &mut Effects) -> Outcome {
+        match event {
+            VmEvent::Stop => {
+                context.emit(Effect::SpawnStop);
+                Transition(State::stopping())
+            }
+            _ => Super,
+        }
+    }
+
+    #[state(superstate = "active")]
+    async fn running(event: &VmEvent, context: &mut Effects) -> Outcome {
+        match event {
+            VmEvent::IdleTimeout => {
+                context.emit(Effect::Balloon(BalloonTarget::Idle));
+                context.emit(Effect::Publish(Notify::Idle));
+                Transition(State::idle())
+            }
+            // Already ready; the actor replies to the caller directly.
+            VmEvent::Activity | VmEvent::Start { .. } => Handled,
+            _ => Super,
+        }
+    }
+
+    #[state(superstate = "active")]
+    async fn idle(event: &VmEvent, context: &mut Effects) -> Outcome {
+        match event {
+            VmEvent::Activity | VmEvent::Start { .. } => {
+                context.emit(Effect::Balloon(BalloonTarget::Full));
+                Transition(State::running())
+            }
+            _ => Super,
+        }
+    }
+
+    // ----- stopping leaf -----
+
+    #[state(superstate = "managed")]
+    async fn stopping(event: &VmEvent, context: &mut Effects) -> Outcome {
+        match event {
+            VmEvent::Stopped => {
+                context.emit(Effect::Publish(Notify::Stopped));
+                Transition(State::stopped())
+            }
+            _ => Super,
+        }
+    }
+}
+
+impl State {
+    /// Projects the internal `statig` state onto the public lifecycle enum.
+    pub(super) fn to_public(self) -> VmLifecycleState {
+        match self {
+            Self::NotExist {} => VmLifecycleState::NotExist,
+            Self::Creating {} => VmLifecycleState::Creating,
+            Self::Created {} => VmLifecycleState::Created,
+            Self::Starting {} => VmLifecycleState::Starting,
+            Self::Running {} => VmLifecycleState::Running,
+            Self::Idle {} => VmLifecycleState::Idle,
+            Self::Stopping {} => VmLifecycleState::Stopping,
+            Self::Stopped {} => VmLifecycleState::Stopped,
+            Self::Failed {} => VmLifecycleState::Failed,
+        }
+    }
+}
+
+#[cfg(test)]
+mod machine_tests {
+    use super::*;
+
+    type Machine = statig::awaitable::InitializedStateMachine<VmLifecycle>;
+
+    /// Builds an initialized machine starting from `not_exist`.
+    async fn machine(fx: &mut Effects) -> Machine {
+        VmLifecycle
+            .uninitialized_state_machine()
+            .init_with_context(fx)
+            .await
+    }
+
+    /// Dispatches `event`, returning the resulting public state and the effects
+    /// the transition emitted.
+    async fn step(
+        sm: &mut Machine,
+        fx: &mut Effects,
+        event: VmEvent,
+    ) -> (VmLifecycleState, Vec<Effect>) {
+        sm.handle_with_context(&event, fx).await;
+        (sm.state().to_public(), fx.take())
+    }
+
+    const T: u64 = 90_000;
+
+    fn start(create: bool) -> VmEvent {
+        VmEvent::Start {
+            create,
+            timeout_ms: T,
+        }
+    }
+
+    #[tokio::test]
+    async fn start_from_not_exist_creates_then_boots_to_running() {
+        let mut fx = Effects::default();
+        let mut sm = machine(&mut fx).await;
+        assert_eq!(sm.state().to_public(), VmLifecycleState::NotExist);
+
+        let (state, effects) = step(&mut sm, &mut fx, start(true)).await;
+        assert_eq!(state, VmLifecycleState::Creating);
+        assert_eq!(
+            effects,
+            vec![Effect::SpawnBoot {
+                create: true,
+                timeout_ms: T
+            }]
+        );
+
+        let (state, effects) = step(&mut sm, &mut fx, VmEvent::AgentReady).await;
+        assert_eq!(state, VmLifecycleState::Running);
+        assert_eq!(
+            effects,
+            vec![Effect::Publish(Notify::Started), Effect::ReadyWaiters]
+        );
+    }
+
+    #[tokio::test]
+    async fn start_without_create_goes_straight_to_starting() {
+        let mut fx = Effects::default();
+        let mut sm = machine(&mut fx).await;
+        let (state, effects) = step(&mut sm, &mut fx, start(false)).await;
+        assert_eq!(state, VmLifecycleState::Starting);
+        assert_eq!(
+            effects,
+            vec![Effect::SpawnBoot {
+                create: false,
+                timeout_ms: T
+            }]
+        );
+    }
+
+    #[tokio::test]
+    async fn boot_failure_lands_in_failed() {
+        let mut fx = Effects::default();
+        let mut sm = machine(&mut fx).await;
+        step(&mut sm, &mut fx, start(true)).await;
+        let (state, effects) = step(&mut sm, &mut fx, VmEvent::Failure("boom".into())).await;
+        assert_eq!(state, VmLifecycleState::Failed);
+        assert!(effects.is_empty());
+    }
+
+    #[tokio::test]
+    async fn idle_round_trip_shrinks_then_restores_balloon() {
+        let mut fx = Effects::default();
+        let mut sm = running_machine(&mut fx).await;
+
+        let (state, effects) = step(&mut sm, &mut fx, VmEvent::IdleTimeout).await;
+        assert_eq!(state, VmLifecycleState::Idle);
+        assert_eq!(
+            effects,
+            vec![
+                Effect::Balloon(BalloonTarget::Idle),
+                Effect::Publish(Notify::Idle)
+            ]
+        );
+
+        let (state, effects) = step(&mut sm, &mut fx, VmEvent::Activity).await;
+        assert_eq!(state, VmLifecycleState::Running);
+        assert_eq!(effects, vec![Effect::Balloon(BalloonTarget::Full)]);
+    }
+
+    #[tokio::test]
+    async fn activity_while_running_is_a_noop() {
+        let mut fx = Effects::default();
+        let mut sm = running_machine(&mut fx).await;
+        let (state, effects) = step(&mut sm, &mut fx, VmEvent::Activity).await;
+        assert_eq!(state, VmLifecycleState::Running);
+        assert!(effects.is_empty());
+    }
+
+    #[tokio::test]
+    async fn stop_from_running_drains_through_stopping() {
+        let mut fx = Effects::default();
+        let mut sm = running_machine(&mut fx).await;
+
+        let (state, effects) = step(&mut sm, &mut fx, VmEvent::Stop).await;
+        assert_eq!(state, VmLifecycleState::Stopping);
+        assert_eq!(effects, vec![Effect::SpawnStop]);
+
+        let (state, effects) = step(&mut sm, &mut fx, VmEvent::Stopped).await;
+        assert_eq!(state, VmLifecycleState::Stopped);
+        assert_eq!(effects, vec![Effect::Publish(Notify::Stopped)]);
+    }
+
+    #[tokio::test]
+    async fn stop_is_accepted_while_starting() {
+        let mut fx = Effects::default();
+        let mut sm = machine(&mut fx).await;
+        step(&mut sm, &mut fx, start(false)).await;
+        let (state, effects) = step(&mut sm, &mut fx, VmEvent::Stop).await;
+        assert_eq!(state, VmLifecycleState::Stopping);
+        assert_eq!(effects, vec![Effect::SpawnStop]);
+    }
+
+    #[tokio::test]
+    async fn force_stop_preempts_from_every_phase() {
+        for reach in [
+            ReachState::Creating,
+            ReachState::Running,
+            ReachState::Idle,
+            ReachState::Stopping,
+        ] {
+            let mut fx = Effects::default();
+            let mut sm = machine(&mut fx).await;
+            reach.drive(&mut sm, &mut fx).await;
+
+            let (state, effects) = step(&mut sm, &mut fx, VmEvent::ForceStop).await;
+            assert_eq!(
+                state,
+                VmLifecycleState::NotExist,
+                "force stop from {reach:?} must reach NotExist"
+            );
+            assert_eq!(
+                effects,
+                vec![
+                    Effect::AbortInflight,
+                    Effect::RemoveMachine,
+                    Effect::Publish(Notify::Stopped),
+                    Effect::FailWaiters("force stopped".to_owned()),
+                ]
+            );
+        }
+    }
+
+    async fn running_machine(fx: &mut Effects) -> Machine {
+        let mut sm = machine(fx).await;
+        sm.handle_with_context(&start(true), fx).await;
+        sm.handle_with_context(&VmEvent::AgentReady, fx).await;
+        fx.take();
+        sm
+    }
+
+    #[derive(Debug, Clone, Copy)]
+    enum ReachState {
+        Creating,
+        Running,
+        Idle,
+        Stopping,
+    }
+
+    impl ReachState {
+        async fn drive(self, sm: &mut Machine, fx: &mut Effects) {
+            sm.handle_with_context(&start(true), fx).await;
+            match self {
+                Self::Creating => {}
+                Self::Running => {
+                    sm.handle_with_context(&VmEvent::AgentReady, fx).await;
+                }
+                Self::Idle => {
+                    sm.handle_with_context(&VmEvent::AgentReady, fx).await;
+                    sm.handle_with_context(&VmEvent::IdleTimeout, fx).await;
+                }
+                Self::Stopping => {
+                    sm.handle_with_context(&VmEvent::AgentReady, fx).await;
+                    sm.handle_with_context(&VmEvent::Stop, fx).await;
+                }
+            }
+            fx.take();
+        }
+    }
+}

--- a/app/arcbox-core/src/vm_lifecycle/mod.rs
+++ b/app/arcbox-core/src/vm_lifecycle/mod.rs
@@ -28,6 +28,7 @@
 //! ```
 
 mod health;
+mod machine;
 mod recovery;
 #[cfg(target_os = "macos")]
 mod serial;

--- a/app/arcbox-core/src/vm_lifecycle/mod.rs
+++ b/app/arcbox-core/src/vm_lifecycle/mod.rs
@@ -13,20 +13,23 @@
 //!
 //! ## Architecture
 //!
+//! The lifecycle is an event-driven hierarchical state machine (`machine.rs`,
+//! built on `statig`) owned by a single actor task (`actor.rs`). The facade
+//! ([`VmLifecycleManager`]) translates public calls into actor commands over an
+//! `mpsc` channel and serves reads from a lock-free `watch` channel; slow I/O
+//! (create/start/agent-wait/stop) runs in sub-tasks (`boot.rs`) so a force stop
+//! can always preempt.
+//!
 //! ```text
-//! ┌─────────────────────────────────────────────────────┐
-//! │              VmLifecycleManager                      │
-//! │  ┌─────────────┐ ┌─────────────┐ ┌───────────────┐  │
-//! │  │StateManager │ │HealthMonitor│ │BootAssetProv │  │
-//! │  └─────────────┘ └─────────────┘ └───────────────┘  │
-//! └─────────────────────────────────────────────────────┘
-//!                        │
-//!                        ▼
-//!              ┌─────────────────┐
-//!              │  MachineManager │
-//!              └─────────────────┘
+//! VmLifecycleManager ──commands──▶ LifecycleActor ⟳ statig VmLifecycle
+//!         ▲                          │        │
+//!         └────── watch state ───────┘        └──spawn──▶ boot/stop sub-task
+//!                                                              │
+//!                                          MachineManager ◀────┘
 //! ```
 
+mod actor;
+mod boot;
 mod health;
 mod machine;
 mod recovery;
@@ -38,16 +41,15 @@ mod types;
 
 use crate::boot_assets::BootAssetProvider;
 use crate::error::{CoreError, Result};
-use crate::event::{Event, EventBus};
-use crate::machine::{MachineConfig, MachineInfo, MachineManager};
-use arcbox_constants::cmdline::{GUEST_DOCKER_VSOCK_PORT_KEY, HV_EARLYCON_DIRECTIVE};
-use arcbox_error::CommonError;
-use std::fs::OpenOptions;
+use crate::event::EventBus;
+use crate::machine::{MachineInfo, MachineManager};
 use std::path::PathBuf;
-use std::sync::Arc;
-use std::sync::atomic::{AtomicU8, AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU8, AtomicU64};
+use std::sync::{Arc, Mutex, OnceLock};
 use std::time::Duration;
-use tokio::sync::{Mutex, RwLock};
+use tokio::sync::{mpsc, oneshot, watch};
+
+use actor::{Command, LifecycleActor, LifecycleShared};
 
 /// Default machine name used for container operations.
 pub const DEFAULT_MACHINE_NAME: &str = "default";
@@ -72,7 +74,8 @@ const DEFAULT_MAX_RETRIES: u32 = 3;
 /// Below this, the guest may become unstable.
 const IDLE_BALLOON_TARGET_MB: u64 = 128;
 
-/// Delay before shrinking balloon after entering idle state.
+/// Interval of the actor's idle ticker, and thereby the delay before the
+/// balloon shrinks once the idle timeout has elapsed.
 const BALLOON_SHRINK_DELAY_SECS: u64 = 10;
 
 /// Persistent guest dockerd data image name.
@@ -84,12 +87,21 @@ const DOCKER_DATA_IMAGE_NAME: &str = "docker.img";
 /// and prevents users from hitting artificial limits.
 const DOCKER_DATA_IMAGE_SIZE_BYTES: u64 = 8 * 1024 * 1024 * 1024 * 1024;
 
-// Note: BootAssetProvider and BootAssets are now in crate::boot_assets module.
-
 pub use health::HealthMonitor;
 pub use recovery::{BackoffStrategy, RecoveryAction, RecoveryPolicy};
-pub use types::{DefaultVmConfig, VmEvent, VmLifecycleConfig, VmLifecycleState};
-use types::{DesiredBoot, machine_drift_reason};
+pub use types::{DefaultVmConfig, VmLifecycleConfig, VmLifecycleState};
+
+/// Deferred actor state, consumed when the actor is first started.
+///
+/// The constructors are synchronous and may run outside a tokio runtime (e.g.
+/// `Runtime::new` in tests), where `tokio::spawn` would panic — so the actor is
+/// spawned lazily from the first async facade call instead.
+struct ActorSeed {
+    /// Receiving half of the facade's command channel.
+    commands: mpsc::UnboundedReceiver<Command>,
+    /// Publishing half of the state channel.
+    state_tx: watch::Sender<VmLifecycleState>,
+}
 
 /// VM lifecycle manager.
 ///
@@ -102,166 +114,22 @@ use types::{DesiredBoot, machine_drift_reason};
 /// let manager = VmLifecycleManager::new(machine_manager, event_bus, data_dir, config)?;
 ///
 /// // Ensure VM is ready before any container operation
-/// let agent = manager.ensure_ready().await?;
-///
-/// // Use agent for container operations
-/// agent.create_container(...).await?;
+/// let cid = manager.ensure_ready().await?;
 /// ```
 pub struct VmLifecycleManager {
-    /// Machine name this manager operates on. Set at construction time.
-    /// Defaults to [`DEFAULT_MACHINE_NAME`] for the native utility VM;
-    /// dual-VM setups override it (e.g. `"rosetta"`).
-    machine_name: String,
-    /// Filename used for this machine's persistent dockerd data image,
-    /// relative to `<data_dir>/<DATA>/`. Defaults to `docker.img`; the
-    /// rosetta lifecycle uses `docker-rosetta.img` to keep its image
-    /// strictly separate.
-    data_image_filename: String,
-    /// Machine manager for VM operations.
-    machine_manager: Arc<MachineManager>,
-    /// Event bus.
-    event_bus: EventBus,
-    /// Current lifecycle state.
-    state: RwLock<VmLifecycleState>,
-    /// Health monitor.
-    health_monitor: Arc<HealthMonitor>,
-    /// Boot asset provider.
-    boot_assets: Arc<BootAssetProvider>,
-    /// Recovery policy.
-    recovery: RecoveryPolicy,
-    /// Configuration.
-    config: VmLifecycleConfig,
-    /// Live, switchable hypervisor backend for the System VM, encoded as
-    /// `VmBackend as u8`. Seeded from the persisted machine (falling back to
-    /// `config.backend`); updated by [`Self::set_backend`] when the backend is
-    /// switched at runtime so the next (re)boot picks it up. Read via
-    /// [`Self::backend`].
-    backend: AtomicU8,
-    /// Monotonic counter bumped on every System VM stop. Identifies the current
-    /// VM incarnation so the Docker proxy can detect a restart and reset its
-    /// cached readiness + pooled connections. Read via [`Self::restart_generation`].
-    restart_generation: AtomicU64,
-    /// Data directory.
-    data_dir: PathBuf,
-    /// Mutex for serializing state transitions.
-    transition_lock: Mutex<()>,
-    /// Timestamp of last activity (epoch millis, for idle detection).
-    last_activity_ms: AtomicU64,
-    /// Whether balloon is currently shrunk for idle state.
-    balloon_shrunk: std::sync::atomic::AtomicBool,
-    /// Whether Kubernetes is holding the VM in the active state.
-    kubernetes_hold: std::sync::atomic::AtomicBool,
-}
-
-/// Ensures an explicit `earlycon=` directive on the custom-HV backend.
-///
-/// A bare `earlycon` relies on the device-tree `stdout-path` and produces nothing
-/// on the custom-HV PL011 emulator, so on `Hv` it is upgraded to the pinned
-/// `earlycon=pl011,<base>` form. The `Vz` backend has no PL011 MMIO device (it
-/// uses a VirtIO console), so pointing the kernel at that address would break VZ
-/// early boot — its cmdline is left untouched. An explicit operator `earlycon=`
-/// is always respected.
-fn ensure_earlycon(cmdline: String, backend: arcbox_vmm::VmBackend) -> String {
-    if !matches!(backend, arcbox_vmm::VmBackend::Hv) {
-        return cmdline;
-    }
-    if cmdline
-        .split_whitespace()
-        .any(|t| t.starts_with("earlycon="))
-    {
-        return cmdline;
-    }
-    let mut tokens: Vec<&str> = cmdline
-        .split_whitespace()
-        .filter(|t| *t != "earlycon")
-        .collect();
-    tokens.push(HV_EARLYCON_DIRECTIVE);
-    tokens.join(" ")
-}
-
-/// Builds the "timeout waiting for agent" error, folding in the last observed
-/// readiness error so a genuine guest-reported failure isn't masked as a plain
-/// timeout (per-iteration errors are otherwise only logged at debug level).
-fn agent_timeout_error(last_error: Option<&str>) -> CoreError {
-    match last_error {
-        Some(e) => CoreError::Vm(format!("timeout waiting for agent (last error: {e})")),
-        None => CoreError::Vm("timeout waiting for agent".to_string()),
-    }
+    /// State shared with the lifecycle actor and its boot/stop sub-tasks.
+    shared: Arc<LifecycleShared>,
+    /// Commands to the lifecycle actor.
+    cmd_tx: mpsc::UnboundedSender<Command>,
+    /// Public lifecycle state, published by the actor after every transition.
+    state_rx: watch::Receiver<VmLifecycleState>,
+    /// One-shot actor startup latch; see [`ActorSeed`].
+    actor: OnceLock<()>,
+    /// Actor state handed to `tokio::spawn` on first use.
+    seed: Mutex<Option<ActorSeed>>,
 }
 
 impl VmLifecycleManager {
-    /// Ensures a sparse, thin-provisioned block image of `size_bytes` virtual
-    /// size exists at `path`, creating parent directories as needed.
-    ///
-    /// `set_len` extends only the logical size (EOF); it reserves no physical
-    /// blocks, so the host file stays sparse and consumes disk only for blocks
-    /// the guest actually writes — matching OrbStack's thin data image.
-    ///
-    /// We deliberately do NOT pre-allocate physical space. An upfront macOS
-    /// `F_PREALLOCATE` reservation (previously capped at 64 GiB) made a fresh
-    /// install report tens of GiB of disk usage with zero containers — wasteful
-    /// and a regression against OrbStack on idle footprint. APFS/Btrfs allocate
-    /// on write lazily, so the working set still benefits from CoW without the
-    /// upfront cost. An existing image is never shrunk.
-    fn ensure_sparse_block_image(path: &std::path::Path, size_bytes: u64) -> Result<()> {
-        if let Some(parent) = path.parent() {
-            std::fs::create_dir_all(parent).map_err(|e| {
-                CoreError::config(format!(
-                    "failed to create block image directory '{}': {}",
-                    parent.display(),
-                    e
-                ))
-            })?;
-        }
-
-        let file_exists = path.exists();
-        let file = OpenOptions::new()
-            .read(true)
-            .write(true)
-            .create(true)
-            .truncate(false)
-            .open(path)
-            .map_err(|e| {
-                CoreError::config(format!(
-                    "failed to open block image '{}': {}",
-                    path.display(),
-                    e
-                ))
-            })?;
-
-        let current_len = file.metadata().map_err(|e| {
-            CoreError::config(format!(
-                "failed to stat block image '{}': {}",
-                path.display(),
-                e
-            ))
-        })?;
-
-        // Extend the logical size only — `set_len` leaves the file sparse, so
-        // no physical disk is consumed until the guest writes. Never shrink an
-        // existing image (guards against a smaller `size_bytes` truncating
-        // user data).
-        if current_len.len() < size_bytes {
-            file.set_len(size_bytes).map_err(|e| {
-                CoreError::config(format!(
-                    "failed to resize block image '{}': {}",
-                    path.display(),
-                    e
-                ))
-            })?;
-        }
-
-        if !file_exists {
-            tracing::info!(
-                path = %path.display(),
-                size_bytes,
-                "created persistent docker data image"
-            );
-        }
-
-        Ok(())
-    }
-
     /// Creates a new VM lifecycle manager for the default native machine.
     pub fn new(
         machine_manager: Arc<MachineManager>,
@@ -303,46 +171,91 @@ impl VmLifecycleManager {
 
         let recovery = RecoveryPolicy::new(config.max_retries, BackoffStrategy::default());
 
-        let existing = machine_manager.get(&machine_name);
-        let initial_state = existing
-            .as_ref()
-            .map_or(VmLifecycleState::NotExist, |info| {
-                VmLifecycleState::from(info.state)
-            });
+        // Seed the backend from the persisted machine so a prior switch survives
+        // daemon restarts; fall back to the config default on first boot.
+        let seeded_backend = machine_manager
+            .get(&machine_name)
+            .map_or(config.backend, |info| info.backend);
 
         let now_ms = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .unwrap_or_default()
             .as_millis() as u64;
 
-        // Seed the backend from the persisted machine so a prior switch survives
-        // daemon restarts; fall back to the config default on first boot.
-        let seeded_backend = existing.map_or(config.backend, |info| info.backend);
-
-        Ok(Self {
+        let shared = Arc::new(LifecycleShared {
             machine_name,
             data_image_filename,
+            data_dir,
             machine_manager,
             event_bus,
-            state: RwLock::new(initial_state),
-            health_monitor,
             boot_assets,
             recovery,
+            health_monitor,
             config,
             backend: AtomicU8::new(seeded_backend as u8),
             restart_generation: AtomicU64::new(0),
-            data_dir,
-            transition_lock: Mutex::new(()),
             last_activity_ms: AtomicU64::new(now_ms),
-            balloon_shrunk: std::sync::atomic::AtomicBool::new(false),
-            kubernetes_hold: std::sync::atomic::AtomicBool::new(false),
+            balloon_shrunk: AtomicBool::new(false),
+            kubernetes_hold: AtomicBool::new(false),
+        });
+
+        // The machine always boots its state graph from `NotExist`; whether a
+        // boot must (re)create the machine is derived from the machine
+        // registry at boot time, so no persisted-state seeding is needed (all
+        // persisted states map to non-ready states after crash recovery).
+        let (cmd_tx, cmd_rx) = mpsc::unbounded_channel();
+        let (state_tx, state_rx) = watch::channel(VmLifecycleState::NotExist);
+
+        Ok(Self {
+            shared,
+            cmd_tx,
+            state_rx,
+            actor: OnceLock::new(),
+            seed: Mutex::new(Some(ActorSeed {
+                commands: cmd_rx,
+                state_tx,
+            })),
         })
+    }
+
+    /// Spawns the lifecycle actor on first use.
+    ///
+    /// Must be called from a tokio runtime context; every caller is an async
+    /// facade method, which guarantees that.
+    fn ensure_actor(&self) {
+        self.actor.get_or_init(|| {
+            let seed = self
+                .seed
+                .lock()
+                .expect("lifecycle actor seed lock poisoned")
+                .take();
+            if let Some(seed) = seed {
+                let actor =
+                    LifecycleActor::new(Arc::clone(&self.shared), seed.commands, seed.state_tx);
+                drop(tokio::spawn(actor.run()));
+            }
+        });
+    }
+
+    /// Sends `command` to the actor and awaits its reply.
+    async fn request<T>(
+        &self,
+        command: Command,
+        reply_rx: oneshot::Receiver<Result<T>>,
+    ) -> Result<T> {
+        self.ensure_actor();
+        self.cmd_tx
+            .send(command)
+            .map_err(|_| CoreError::Vm("VM lifecycle actor terminated".to_string()))?;
+        reply_rx
+            .await
+            .map_err(|_| CoreError::Vm("VM lifecycle actor terminated".to_string()))?
     }
 
     /// Returns the machine name this lifecycle manager owns.
     #[must_use]
     pub fn machine_name(&self) -> &str {
-        &self.machine_name
+        &self.shared.machine_name
     }
 
     /// Returns the current VM incarnation counter, bumped on every stop.
@@ -352,26 +265,31 @@ impl VmLifecycleManager {
     /// its cached readiness + pooled connections before the next request.
     #[must_use]
     pub fn restart_generation(&self) -> u64 {
-        self.restart_generation.load(Ordering::Acquire)
+        self.shared
+            .restart_generation
+            .load(std::sync::atomic::Ordering::Acquire)
     }
 
     /// Returns the absolute path of this machine's persistent dockerd
     /// data image.
     #[must_use]
     pub fn data_image_path(&self) -> PathBuf {
-        self.data_dir
+        self.shared
+            .data_dir
             .join(arcbox_constants::paths::host::DATA)
-            .join(&self.data_image_filename)
+            .join(&self.shared.data_image_filename)
     }
 
     /// Returns the current lifecycle state.
+    #[allow(clippy::unused_async, reason = "public API compatibility")]
     pub async fn state(&self) -> VmLifecycleState {
-        *self.state.read().await
+        *self.state_rx.borrow()
     }
 
     /// Returns true if the VM is running and ready.
+    #[allow(clippy::unused_async, reason = "public API compatibility")]
     pub async fn is_running(&self) -> bool {
-        self.state.read().await.is_ready()
+        self.state_rx.borrow().is_ready()
     }
 
     /// Ensures a VM is ready for container operations.
@@ -389,611 +307,43 @@ impl VmLifecycleManager {
     /// # Errors
     /// Returns an error if VM cannot be started or agent is not ready.
     pub async fn ensure_ready(&self) -> Result<u32> {
-        self.ensure_ready_with_timeout(self.config.startup_timeout)
+        self.ensure_ready_with_timeout(self.shared.config.startup_timeout)
             .await
     }
 
     /// Ensures VM is ready with custom timeout.
     pub async fn ensure_ready_with_timeout(&self, timeout: Duration) -> Result<u32> {
         // Skip VM check for testing.
-        if self.config.skip_vm_check {
+        if self.shared.config.skip_vm_check {
             tracing::debug!("ensure_ready: skipping VM check (test mode)");
             // Register a mock machine so that container operations work.
             let mock_cid = 3;
-            self.machine_manager
-                .register_mock_machine(&self.machine_name, mock_cid)?;
+            self.shared
+                .machine_manager
+                .register_mock_machine(&self.shared.machine_name, mock_cid)?;
             // Return a mock CID for testing.
             return Ok(mock_cid);
         }
 
-        // Serialize state transitions
-        let _lock = self.transition_lock.lock().await;
-
-        let current_state = *self.state.read().await;
-
-        tracing::debug!("ensure_ready: current state = {:?}", current_state);
-
-        // If already running, just return CID
-        if current_state.is_ready() {
-            // Record activity timestamp.
-            self.record_activity();
-
-            // Exit idle state and restore balloon if shrunk.
-            if current_state == VmLifecycleState::Idle {
-                *self.state.write().await = VmLifecycleState::Running;
-                self.restore_balloon();
-            }
-
-            return self.get_cid().await;
-        }
-
-        // Need to start VM
-        if current_state.needs_start() {
-            self.start_default_vm(timeout).await?;
-        }
-
-        // Wait for agent to be ready
-        self.wait_for_agent(timeout).await?;
-
-        // Reset recovery counter on success
-        self.recovery.reset();
-        self.health_monitor.reset();
-
-        self.get_cid().await
-    }
-
-    /// Gets the CID for the default machine.
-    async fn get_cid(&self) -> Result<u32> {
-        self.machine_manager
-            .get_cid(&self.machine_name)
-            .ok_or_else(|| CoreError::Machine("default machine has no CID".to_string()))
-    }
-
-    /// Starts the default VM.
-    async fn start_default_vm(&self, timeout: Duration) -> Result<()> {
-        let current_state = *self.state.read().await;
-        let existing_machine = self.machine_manager.get(&self.machine_name);
-        let machine_exists = existing_machine.is_some();
-
-        // Recreate the persisted machine if any daemon-overridable field has
-        // drifted from the desired config. The desired kernel + cmdline are
-        // resolved through the same `resolve_desired_boot` path that
-        // `create_default_machine` uses, so drift detection can never disagree
-        // with what would actually be created. (An earlier version compared
-        // only cpus/memory plus a kernel-version substring, which silently
-        // reused a stale VM when `--kernel` or the cmdline changed.)
-        let desired_boot = match self.resolve_desired_boot().await {
-            Ok(boot) => Some(boot),
-            Err(e) => {
-                tracing::warn!(error = %e, "could not resolve desired boot params; skipping drift check");
-                None
-            }
-        };
-        let drift_reason = match (existing_machine.as_ref(), desired_boot.as_ref()) {
-            (Some(m), Some(boot)) => machine_drift_reason(m, &self.config.default_vm, boot),
-            _ => None,
-        };
-        if let Some(field) = drift_reason {
-            let m = existing_machine.as_ref().unwrap();
-            tracing::warn!(
-                drifted_field = field,
-                persisted_cpus = m.cpus,
-                persisted_memory = m.memory_mb,
-                persisted_kernel = m.kernel.as_deref().unwrap_or("none"),
-                desired_cpus = self.config.default_vm.cpus,
-                desired_memory = self.config.default_vm.memory_mb,
-                "default machine config drifted from desired defaults; recreating"
-            );
-            let _ = self.machine_manager.remove(&self.machine_name, true);
-        }
-        let config_drifted = drift_reason.is_some();
-
-        // Recreate if state says "not exist", machine record is missing, or
-        // the persisted config drifted from desired defaults.
-        if current_state == VmLifecycleState::NotExist || !machine_exists || config_drifted {
-            if current_state != VmLifecycleState::NotExist && !machine_exists {
-                tracing::warn!(
-                    state = current_state.as_str(),
-                    "default machine missing while lifecycle state indicates existing VM; recreating"
-                );
-            }
-            *self.state.write().await = VmLifecycleState::Creating;
-
-            match self.create_default_machine().await {
-                Ok(()) => {
-                    *self.state.write().await = VmLifecycleState::Created;
-                    self.event_bus.publish(Event::MachineCreated {
-                        name: self.machine_name.clone(),
-                    });
-                }
-                Err(e) => {
-                    *self.state.write().await = VmLifecycleState::Failed;
-                    return Err(e);
-                }
-            }
-        }
-
-        // Start VM
-        *self.state.write().await = VmLifecycleState::Starting;
-
-        let deadline = tokio::time::Instant::now() + timeout;
-
-        loop {
-            match self.machine_manager.start(&self.machine_name).await {
-                Ok(()) => {
-                    tracing::info!("Default VM started successfully");
-                    *self.state.write().await = VmLifecycleState::Running;
-                    self.event_bus.publish(Event::MachineStarted {
-                        name: self.machine_name.clone(),
-                    });
-
-                    // Install host route for container subnets via bridge NIC.
-                    // Non-blocking: retries transient failures (helper not ready,
-                    // bridge FDB not populated) but does not gate VM readiness.
-                    #[cfg(all(target_os = "macos", feature = "vmnet"))]
-                    if let Some(bridge) = self.machine_manager.vmnet_bridge_name(&self.machine_name)
-                    {
-                        // vmnet path: bridge name is known instantly, only need
-                        // helper retry (1-2 attempts for XPC readiness).
-                        let event_bus = self.event_bus.clone();
-                        let name = self.machine_name.clone();
-                        drop(tokio::spawn(async move {
-                            match crate::route_reconciler::ensure_route_for_bridge(&bridge).await {
-                                Ok(()) => {
-                                    event_bus.publish(Event::ContainerRouteInstalled { name });
-                                }
-                                Err(e) => {
-                                    tracing::warn!(error = %e, "failed to install container route (vmnet)");
-                                }
-                            }
-                        }));
-                    }
-
-                    #[cfg(all(target_os = "macos", not(feature = "vmnet")))]
-                    if let Some(mac) = self.machine_manager.bridge_mac(&self.machine_name) {
-                        // Non-vmnet path: scan kernel FDB to discover bridge
-                        // (retries up to ~10s for FDB learning).
-                        let event_bus = self.event_bus.clone();
-                        let name = self.machine_name.clone();
-                        drop(tokio::spawn(async move {
-                            match crate::route_reconciler::ensure_route_with_retry(&mac).await {
-                                Ok(()) => {
-                                    event_bus.publish(Event::ContainerRouteInstalled { name });
-                                }
-                                Err(e) => {
-                                    tracing::warn!(error = %e, "failed to install container route");
-                                }
-                            }
-                        }));
-                    }
-
-                    return Ok(());
-                }
-                Err(e) => {
-                    if is_not_found_error(&e) {
-                        tracing::warn!(
-                            "default machine disappeared before start; recreating and retrying"
-                        );
-                        *self.state.write().await = VmLifecycleState::Creating;
-                        match self.create_default_machine().await {
-                            Ok(()) => {
-                                *self.state.write().await = VmLifecycleState::Created;
-                                self.event_bus.publish(Event::MachineCreated {
-                                    name: self.machine_name.clone(),
-                                });
-                                continue;
-                            }
-                            Err(create_err) => {
-                                *self.state.write().await = VmLifecycleState::Failed;
-                                return Err(create_err);
-                            }
-                        }
-                    }
-
-                    tracing::warn!("Failed to start VM: {}", e);
-
-                    // Check if we should retry.
-                    // Avoid wrapping "VM error: ..." multiple times when propagating.
-                    let recovery_error = match &e {
-                        CoreError::Vm(msg) => msg.as_str(),
-                        _ => &e.to_string(),
-                    };
-                    match self.recovery.handle_failure(recovery_error) {
-                        RecoveryAction::RetryAfter(delay) => {
-                            if tokio::time::Instant::now() + delay > deadline {
-                                *self.state.write().await = VmLifecycleState::Failed;
-                                return Err(CoreError::Vm(format!(
-                                    "VM startup timeout after {} retries",
-                                    self.recovery.retry_count()
-                                )));
-                            }
-
-                            tracing::info!("Retrying VM start in {:?}", delay);
-                            tokio::time::sleep(delay).await;
-                        }
-                        RecoveryAction::GiveUp(err) => {
-                            *self.state.write().await = VmLifecycleState::Failed;
-                            return Err(CoreError::Vm(err));
-                        }
-                    }
-                }
-            }
-        }
-    }
-
-    /// Creates the default machine with EROFS rootfs and no initramfs.
-    ///
-    /// Block devices:
-    /// - vda: rootfs.erofs (read-only)
-    /// - vdb: docker-data.img (read-write)
-    async fn create_default_machine(&self) -> Result<()> {
-        let boot = self.resolve_desired_boot().await?;
-        let rootfs_path = boot.rootfs_image.to_string_lossy().to_string();
-
-        // Block devices: vda = EROFS rootfs (read-only), vdb = Docker data (read-write).
-        let mut block_devices = vec![crate::vm::BlockDeviceConfig {
-            path: rootfs_path.clone(),
-            read_only: true,
-        }];
-
-        // Attach persistent Docker data disk.
-        let docker_data_image = self.data_image_path();
-        Self::ensure_sparse_block_image(&docker_data_image, DOCKER_DATA_IMAGE_SIZE_BYTES)?;
-
-        // Don't inject docker_data_device into cmdline — let the agent
-        // auto-detect. It prefers /dev/arcboxhvc1 (HVC fast path) when
-        // available, falling back to /dev/vdb (VirtIO block).
-        block_devices.push(crate::vm::BlockDeviceConfig {
-            path: docker_data_image.to_string_lossy().to_string(),
-            read_only: false,
-        });
-
-        let config = MachineConfig {
-            name: self.machine_name.clone(),
-            cpus: self.config.default_vm.cpus,
-            memory_mb: self.config.default_vm.memory_mb,
-            disk_gb: self.config.default_vm.disk_gb,
-            kernel: Some(boot.kernel),
-            cmdline: Some(boot.cmdline),
-            block_devices,
-            distro: None,
-            distro_version: None,
-            backend: self.backend(),
-            // Host Rosetta capability. Whether the Rosetta share is actually
-            // wired is decided per-backend at VM build time (VZ only), so the
-            // value stays correct across a backend switch — see
-            // `VmManager::build_vmm_config`.
-            enable_rosetta: self.config.default_vm.rosetta,
-        };
-
-        tracing::info!(
-            "Creating default machine: cpus={}, memory={}MB, kernel={}, rootfs={}",
-            config.cpus,
-            config.memory_mb,
-            config.kernel.as_deref().unwrap_or("default"),
-            rootfs_path,
-        );
-
-        self.machine_manager.create(config).await?;
-
-        Ok(())
-    }
-
-    /// Resolves the default VM's boot parameters (kernel image, final kernel
-    /// command line, and rootfs image) from config + boot assets.
-    ///
-    /// Shared by [`Self::create_default_machine`] and the drift check in
-    /// [`Self::start_default_vm`] so machine creation and drift detection
-    /// always agree on the desired kernel and cmdline. The cmdline is the base
-    /// (explicit override or the boot manifest default) with `quiet` stripped,
-    /// `earlycon` ensured, and the guest docker vsock port injected.
-    async fn resolve_desired_boot(&self) -> Result<DesiredBoot> {
-        let assets = self.boot_assets.get_assets().await?;
-        let mut cmdline = self
-            .config
-            .default_vm
-            .cmdline
-            .clone()
-            .unwrap_or(assets.cmdline);
-
-        // Strip "quiet" so kernel boot messages are visible on the serial console.
-        cmdline = cmdline
-            .split_whitespace()
-            .filter(|t| *t != "quiet")
-            .collect::<Vec<_>>()
-            .join(" ");
-
-        // Ensure an explicit earlycon directive so early boot output reaches the
-        // host `guest_serial` log — but only on the custom-HV backend, whose PL011
-        // emulator the directive targets (VZ has no such device). See
-        // `ensure_earlycon`.
-        cmdline = ensure_earlycon(cmdline, self.backend());
-
-        // Inject guest docker vsock port if configured.
-        if let Some(port) = self.config.guest_docker_vsock_port {
-            if !cmdline
-                .split_whitespace()
-                .any(|token| token.starts_with(GUEST_DOCKER_VSOCK_PORT_KEY))
-            {
-                cmdline.push(' ');
-                cmdline.push_str(GUEST_DOCKER_VSOCK_PORT_KEY);
-                cmdline.push_str(&port.to_string());
-            }
-        }
-
-        Ok(DesiredBoot {
-            kernel: assets.kernel.to_string_lossy().to_string(),
-            cmdline,
-            rootfs_image: assets.rootfs_image,
-        })
-    }
-
-    /// Waits for the agent to become ready.
-    async fn wait_for_agent(&self, timeout: Duration) -> Result<()> {
-        tracing::debug!("Waiting for agent to become ready...");
-
-        enum AgentProbe {
-            Ready,
-            Watch(crate::agent_client::AgentClient),
-        }
-
-        let mm = Arc::clone(&self.machine_manager);
-        let machine_name = self.machine_name.clone();
-
-        // Run the entire probe loop on a blocking thread. On macOS HV backend,
-        // the agent transport is AF_UNIX socketpair → BlockingVsockTransport.
-        // Rapid connect/teardown of these fds stalls the tokio kqueue reactor's
-        // timer wheel, so neither tokio::time::sleep nor tokio::time::timeout
-        // can be used reliably inside this loop. spawn_blocking isolates the
-        // probe from the async runtime entirely.
-        let probe_result = tokio::task::spawn_blocking(move || {
-            let deadline = std::time::Instant::now() + timeout;
-            // Failed probes are ~1ms (vsock RST via the event-driven RX
-            // path), so a tight interval costs little and bounds the
-            // discovery overshoot once the agent starts listening.
-            let poll_interval = Duration::from_millis(25);
-            // Remember the last genuine readiness error so an exhausted deadline
-            // surfaces it instead of a bare "timeout" (a guest-reported failure
-            // also arrives here as an Err).
-            let mut last_readiness_err: Option<String> = None;
-
-            while std::time::Instant::now() < deadline {
-                // Console output (best-effort, non-blocking).
-                #[cfg(target_os = "macos")]
-                if let Ok(output) = mm.read_console_output(&machine_name) {
-                    let trimmed = output.trim_matches('\0');
-                    if !trimmed.is_empty() {
-                        tracing::info!("{}", trimmed.trim_end());
-                    }
-                }
-
-                // connect_agent discovers when the guest starts listening on
-                // the agent vsock port, then the readiness event stream waits
-                // for the guest to report a terminal state.
-                //
-                // On the HV AF_UNIX socketpair, connect_agent can succeed
-                // optimistically *before* the guest agent is actually listening
-                // (the guest's /sbin/init has not even run yet at this point),
-                // so the readiness read then fails with EOF. That is a normal
-                // "not ready yet" race, not a fatal protocol error — keep
-                // polling until a genuine readiness event arrives or the
-                // deadline elapses. HV's AF_UNIX transport stays on this
-                // blocking thread; async transports are handed back to tokio.
-                match mm.connect_agent(&machine_name) {
-                    Ok(agent) if agent.is_blocking() => {
-                        let remaining =
-                            deadline.saturating_duration_since(std::time::Instant::now());
-                        if remaining.is_zero() {
-                            return Err(agent_timeout_error(last_readiness_err.as_deref()));
-                        }
-                        match agent.watch_readiness_blocking(false, remaining) {
-                            Ok(_) => return Ok(AgentProbe::Ready),
-                            Err(e) => {
-                                tracing::debug!("agent not ready yet: {e}");
-                                last_readiness_err = Some(e.to_string());
-                            }
-                        }
-                    }
-                    Ok(agent) => return Ok(AgentProbe::Watch(agent)),
-                    Err(e) => tracing::debug!("Agent connection failed: {e}"),
-                }
-
-                std::thread::sleep(poll_interval);
-            }
-
-            Err(agent_timeout_error(last_readiness_err.as_deref()))
-        })
-        .await
-        .map_err(|e| CoreError::Vm(format!("probe task panicked: {e}")))?;
-
-        match probe_result? {
-            AgentProbe::Ready => {}
-            AgentProbe::Watch(first_agent) => {
-                // Mirror the blocking path's tolerance: an async transport may
-                // also connect before the guest agent is listening, so retry
-                // both the connect and the readiness watch (reconnecting each
-                // round) until it yields a genuine event or the timeout elapses.
-                let deadline = tokio::time::Instant::now() + timeout;
-                let mut next_agent = Some(first_agent);
-                let mut last_readiness_err: Option<String> = None;
-                loop {
-                    let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
-                    if remaining.is_zero() {
-                        return Err(agent_timeout_error(last_readiness_err.as_deref()));
-                    }
-                    // Reuse the connection from the probe loop on the first
-                    // iteration, then reconnect on each retry.
-                    let agent = match next_agent.take() {
-                        Some(agent) => agent,
-                        None => match self.machine_manager.connect_agent(&self.machine_name) {
-                            Ok(agent) => agent,
-                            Err(e) => {
-                                tracing::debug!("agent reconnect failed: {e}");
-                                tokio::time::sleep(Duration::from_millis(25)).await;
-                                continue;
-                            }
-                        },
-                    };
-                    // Recompute the budget after a potentially slow reconnect so
-                    // watch_readiness doesn't block past the deadline.
-                    let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
-                    if remaining.is_zero() {
-                        return Err(agent_timeout_error(last_readiness_err.as_deref()));
-                    }
-                    match agent.watch_readiness(false, remaining).await {
-                        Ok(_) => break,
-                        Err(e) => {
-                            tracing::debug!("agent not ready yet: {e}");
-                            last_readiness_err = Some(e.to_string());
-                            tokio::time::sleep(Duration::from_millis(25)).await;
-                        }
-                    }
-                }
-            }
-        }
-
-        // Back on async context — do async follow-up work.
-        tracing::info!("Agent is ready");
-        self.health_monitor.record_success();
-        #[cfg(target_os = "macos")]
-        {
-            let mm = Arc::clone(&self.machine_manager);
-            tokio::spawn(serial::serial_read_adaptive(mm));
-        }
-
-        Ok(())
-    }
-
-    /// Records activity, updating the last-activity timestamp.
-    fn record_activity(&self) {
-        let now_ms = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap_or_default()
-            .as_millis() as u64;
-        self.last_activity_ms.store(now_ms, Ordering::Relaxed);
+        let (reply, reply_rx) = oneshot::channel();
+        self.request(Command::EnsureReady { timeout, reply }, reply_rx)
+            .await
     }
 
     /// Enables or disables the Kubernetes lifecycle hold.
+    #[allow(clippy::unused_async, reason = "public API compatibility")]
     pub async fn set_kubernetes_hold(&self, active: bool) {
-        self.kubernetes_hold.store(active, Ordering::Relaxed);
-        self.record_activity();
+        self.shared
+            .kubernetes_hold
+            .store(active, std::sync::atomic::Ordering::Relaxed);
+        self.shared.record_activity();
 
         if active {
-            self.restore_balloon();
-            let mut state = self.state.write().await;
-            if *state == VmLifecycleState::Idle {
-                *state = VmLifecycleState::Running;
-            }
+            // Exit idle (restoring the balloon) so the hold takes effect
+            // immediately.
+            self.ensure_actor();
+            let _ = self.cmd_tx.send(Command::Activity);
         }
-    }
-
-    /// Returns seconds since last activity.
-    fn idle_seconds(&self) -> u64 {
-        let now_ms = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap_or_default()
-            .as_millis() as u64;
-        let last = self.last_activity_ms.load(Ordering::Relaxed);
-        now_ms.saturating_sub(last) / 1000
-    }
-
-    /// Shrinks the balloon to reclaim guest memory during idle.
-    ///
-    /// Sets the balloon target to `IDLE_BALLOON_TARGET_MB` so the guest
-    /// returns memory to the host, reducing idle footprint.
-    #[cfg(target_os = "macos")]
-    fn shrink_balloon(&self) {
-        if self.balloon_shrunk.load(Ordering::Relaxed) {
-            return;
-        }
-
-        let target_bytes = IDLE_BALLOON_TARGET_MB * 1024 * 1024;
-        if let Some(info) = self.machine_manager.get(&self.machine_name) {
-            match self
-                .machine_manager
-                .vm_manager()
-                .set_balloon_target(&info.vm_id, target_bytes)
-            {
-                Ok(()) => {
-                    self.balloon_shrunk.store(true, Ordering::Relaxed);
-                    tracing::info!("Balloon shrunk to {}MB for idle VM", IDLE_BALLOON_TARGET_MB);
-                }
-                Err(e) => {
-                    tracing::debug!("Failed to shrink balloon: {}", e);
-                }
-            }
-        }
-    }
-
-    /// Restores the balloon to the full configured memory size.
-    ///
-    /// Called when the VM exits idle state (new container activity).
-    #[cfg(target_os = "macos")]
-    fn restore_balloon(&self) {
-        if !self.balloon_shrunk.load(Ordering::Relaxed) {
-            return;
-        }
-
-        if let Some(info) = self.machine_manager.get(&self.machine_name) {
-            let full_bytes = info.memory_mb * 1024 * 1024;
-            match self
-                .machine_manager
-                .vm_manager()
-                .set_balloon_target(&info.vm_id, full_bytes)
-            {
-                Ok(()) => {
-                    self.balloon_shrunk.store(false, Ordering::Relaxed);
-                    tracing::info!("Balloon restored to {}MB", info.memory_mb);
-                }
-                Err(e) => {
-                    tracing::debug!("Failed to restore balloon: {}", e);
-                }
-            }
-        }
-    }
-
-    #[cfg(not(target_os = "macos"))]
-    fn shrink_balloon(&self) {}
-
-    #[cfg(not(target_os = "macos"))]
-    fn restore_balloon(&self) {}
-
-    /// Starts the idle monitor background task.
-    ///
-    /// This task periodically checks if the VM has been idle for longer than
-    /// `idle_timeout` and transitions to Idle state, shrinking the balloon.
-    pub fn start_idle_monitor(self: &Arc<Self>) {
-        let this = Arc::clone(self);
-        let idle_timeout = this.config.idle_timeout;
-        let shutdown = this.health_monitor.shutdown_token();
-
-        tokio::spawn(async move {
-            let check_interval = Duration::from_secs(BALLOON_SHRINK_DELAY_SECS);
-            loop {
-                tokio::select! {
-                    () = shutdown.cancelled() => break,
-                    () = tokio::time::sleep(check_interval) => {}
-                }
-
-                let state = *this.state.read().await;
-                if state != VmLifecycleState::Running {
-                    continue;
-                }
-
-                let idle_secs = this.idle_seconds();
-                if this.kubernetes_hold.load(Ordering::Relaxed) {
-                    continue;
-                }
-                if idle_secs >= idle_timeout.as_secs() {
-                    *this.state.write().await = VmLifecycleState::Idle;
-                    this.shrink_balloon();
-                    tracing::info!("VM entered idle state after {}s of inactivity", idle_secs);
-                    this.event_bus.publish(Event::MachineIdle {
-                        name: this.machine_name.clone(),
-                    });
-                }
-            }
-        });
     }
 
     /// Gracefully stops the VM.
@@ -1001,89 +351,23 @@ impl VmLifecycleManager {
     /// # Errors
     /// Returns an error if the VM cannot be stopped.
     pub async fn shutdown(&self) -> Result<()> {
-        let _lock = self.transition_lock.lock().await;
-
-        let current_state = *self.state.read().await;
-
-        if !current_state.is_ready() && current_state != VmLifecycleState::Starting {
-            // VM is not running, nothing to do
-            return Ok(());
-        }
-
-        *self.state.write().await = VmLifecycleState::Stopping;
-
-        // Stop health monitor
-        self.health_monitor.stop();
-
-        // Stop the machine (graceful first, then force-stop fallback).
-        let stop_result = match self.machine_manager.graceful_stop(
-            DEFAULT_MACHINE_NAME,
-            Duration::from_secs(arcbox_constants::timeouts::HOST_SHUTDOWN_TIMEOUT_SECS),
-        ) {
-            Ok(true) => Ok(()),
-            Ok(false) => {
-                tracing::warn!(
-                    "Graceful stop timed out for '{}', falling back to force stop",
-                    DEFAULT_MACHINE_NAME
-                );
-                self.machine_manager.stop(&self.machine_name)
-            }
-            Err(e) => {
-                tracing::warn!(
-                    "Graceful stop failed for '{}': {}, falling back to force stop",
-                    DEFAULT_MACHINE_NAME,
-                    e
-                );
-                self.machine_manager.stop(&self.machine_name)
-            }
-        };
-
-        match stop_result {
-            Ok(()) => {
-                *self.state.write().await = VmLifecycleState::Stopped;
-                self.restart_generation.fetch_add(1, Ordering::Release);
-                tracing::info!("Default VM stopped");
-                self.event_bus.publish(Event::MachineStopped {
-                    name: self.machine_name.clone(),
-                });
-                Ok(())
-            }
-            Err(e) => {
-                *self.state.write().await = VmLifecycleState::Failed;
-                Err(e)
-            }
-        }
+        let (reply, reply_rx) = oneshot::channel();
+        self.request(Command::Shutdown { reply }, reply_rx).await
     }
 
-    /// Forces VM termination.
-    ///
-    /// Does not take `transition_lock` — force stop must succeed even when
-    /// a graceful shutdown holds the lock (blocked in a sync VM stop call).
+    /// Forces VM termination, preempting any in-flight boot or graceful stop.
     ///
     /// # Errors
     /// Returns an error if the VM cannot be terminated.
     pub async fn force_stop(&self) -> Result<()> {
-        self.health_monitor.stop();
-
-        let _ = self.machine_manager.remove(&self.machine_name, true);
-
-        *self.state.write().await = VmLifecycleState::NotExist;
-        self.restart_generation.fetch_add(1, Ordering::Release);
-        self.event_bus.publish(Event::MachineStopped {
-            name: self.machine_name.clone(),
-        });
-
-        Ok(())
+        let (reply, reply_rx) = oneshot::channel();
+        self.request(Command::ForceStop { reply }, reply_rx).await
     }
 
     /// Returns the System VM's current hypervisor backend.
     #[must_use]
     pub fn backend(&self) -> arcbox_vmm::VmBackend {
-        // Encoded as `VmBackend as u8` (Hv = 0, Vz = 1).
-        match self.backend.load(Ordering::Acquire) {
-            0 => arcbox_vmm::VmBackend::Hv,
-            _ => arcbox_vmm::VmBackend::Vz,
-        }
+        self.shared.backend()
     }
 
     /// Sets the hypervisor backend used on the next (re)boot of the System VM.
@@ -1091,36 +375,37 @@ impl VmLifecycleManager {
     /// Does not stop or restart a running VM; to apply immediately the caller
     /// must force a recreate (see `Runtime::switch_system_vm_backend`).
     pub fn set_backend(&self, backend: arcbox_vmm::VmBackend) {
-        self.backend.store(backend as u8, Ordering::Release);
+        self.shared
+            .backend
+            .store(backend as u8, std::sync::atomic::Ordering::Release);
     }
 
     /// Returns the configuration.
-    pub const fn config(&self) -> &VmLifecycleConfig {
-        &self.config
+    #[must_use]
+    pub fn config(&self) -> &VmLifecycleConfig {
+        &self.shared.config
     }
 
     /// Returns the boot asset provider.
-    pub const fn boot_assets(&self) -> &Arc<BootAssetProvider> {
-        &self.boot_assets
+    #[must_use]
+    pub fn boot_assets(&self) -> &Arc<BootAssetProvider> {
+        &self.shared.boot_assets
     }
 
     /// Returns the resolved default VM configuration used by lifecycle.
     #[must_use]
     pub fn default_vm_config(&self) -> DefaultVmConfig {
-        self.config.default_vm.clone()
+        self.shared.config.default_vm.clone()
     }
 
     /// Returns the health monitor.
-    pub const fn health_monitor(&self) -> &Arc<HealthMonitor> {
-        &self.health_monitor
+    #[must_use]
+    pub fn health_monitor(&self) -> &Arc<HealthMonitor> {
+        &self.shared.health_monitor
     }
 
     /// Returns the machine info for the default machine.
     pub fn default_machine_info(&self) -> Option<MachineInfo> {
-        self.machine_manager.get(&self.machine_name)
+        self.shared.machine_manager.get(&self.shared.machine_name)
     }
-}
-
-const fn is_not_found_error(err: &CoreError) -> bool {
-    matches!(err, CoreError::Common(CommonError::NotFound(_)))
 }

--- a/app/arcbox-core/src/vm_lifecycle/tests.rs
+++ b/app/arcbox-core/src/vm_lifecycle/tests.rs
@@ -1,5 +1,8 @@
+use super::boot::{agent_timeout_error, ensure_earlycon, ensure_sparse_block_image};
+use super::types::{DesiredBoot, machine_drift_reason};
 use super::*;
 use crate::machine::MachineState;
+use arcbox_constants::cmdline::HV_EARLYCON_DIRECTIVE;
 
 #[test]
 fn test_lifecycle_state_is_ready() {
@@ -83,7 +86,7 @@ fn ensure_sparse_block_image_is_thin_provisioned() {
     let path = dir.path().join("data").join("docker.img");
     let size_bytes = DOCKER_DATA_IMAGE_SIZE_BYTES; // 8 TiB virtual size
 
-    VmLifecycleManager::ensure_sparse_block_image(&path, size_bytes).unwrap();
+    ensure_sparse_block_image(&path, size_bytes).unwrap();
 
     let meta = std::fs::metadata(&path).unwrap();
     assert_eq!(
@@ -113,16 +116,16 @@ fn ensure_sparse_block_image_never_shrinks() {
     let dir = tempfile::tempdir().unwrap();
     let path = dir.path().join("docker.img");
 
-    VmLifecycleManager::ensure_sparse_block_image(&path, 8192).unwrap();
+    ensure_sparse_block_image(&path, 8192).unwrap();
     assert_eq!(std::fs::metadata(&path).unwrap().len(), 8192);
 
     // A call with a smaller virtual size must not truncate the existing
     // image — that would discard guest data.
-    VmLifecycleManager::ensure_sparse_block_image(&path, 4096).unwrap();
+    ensure_sparse_block_image(&path, 4096).unwrap();
     assert_eq!(std::fs::metadata(&path).unwrap().len(), 8192);
 
     // A larger size grows it.
-    VmLifecycleManager::ensure_sparse_block_image(&path, 16384).unwrap();
+    ensure_sparse_block_image(&path, 16384).unwrap();
     assert_eq!(std::fs::metadata(&path).unwrap().len(), 16384);
 }
 

--- a/app/arcbox-core/src/vm_lifecycle/types.rs
+++ b/app/arcbox-core/src/vm_lifecycle/types.rs
@@ -78,33 +78,6 @@ impl From<MachineState> for VmLifecycleState {
     }
 }
 
-/// State transition events.
-#[derive(Debug, Clone)]
-pub enum VmEvent {
-    /// Request to create VM.
-    Create,
-    /// VM creation completed.
-    Created,
-    /// Request to start VM.
-    Start,
-    /// Agent became ready.
-    AgentReady,
-    /// VM became idle (no activity for `idle_timeout`).
-    IdleTimeout,
-    /// Activity detected, exit idle state.
-    Activity,
-    /// Request to stop VM.
-    Stop,
-    /// VM stopped successfully.
-    Stopped,
-    /// Force stop VM.
-    ForceStop,
-    /// VM crashed or failed.
-    Failure(String),
-    /// Retry after failure.
-    Retry,
-}
-
 /// VM lifecycle configuration.
 #[derive(Debug, Clone)]
 pub struct VmLifecycleConfig {


### PR DESCRIPTION
## Summary

Rewrites `vm_lifecycle` from a `RwLock<VmLifecycleState>` + `transition_lock` + ~15 scattered state writes into an event-driven hierarchical state machine ([statig](https://crates.io/crates/statig) 0.4.1, blocking engine) owned by a single lifecycle actor.

Full design, transition table, and rationale: **Linear ABX-387**.

## Architecture

```
VmLifecycleManager ──commands (mpsc)──▶ LifecycleActor ⟳ statig VmLifecycle (pure decision core → Effects)
        ▲                                  │       │
        └───── state (watch, lock-free) ───┘       └──spawn──▶ boot/stop sub-tasks (boot.rs)
```

- **`machine.rs`** — the statig HSM: `managed → {booting{creating,starting}, active{running,idle}, stopping, resting{not_exist,created,stopped,failed}}`. Handlers are pure transition logic emitting `Effect`s into an externally-owned context; the full transition table is unit-tested with zero runtime dependencies.
- **`actor.rs`** — sole owner of the machine. Commands arrive over `mpsc`; boot/stop completions come back epoch-tagged; effects (spawn boot/stop, balloon, publish, generation bump, waiter resolution) execute here. The actor never blocks, so `ForceStop` can always preempt by aborting the in-flight sub-task — the role the old `transition_lock` bypass played, without the race.
- **`boot.rs`** — the slow I/O, ported verbatim from the old `start_default_vm` / `wait_for_agent` / `shutdown` (drift detection, recovery retries, the HV `spawn_blocking` agent probe, graceful→force stop fallback).
- **`mod.rs`** — thin facade, public API signatures unchanged. `is_running()`/`state()` now read a lock-free `watch` channel and can no longer be blocked by a 90s cold boot. The actor spawns lazily on the first async call, so constructors stay runtime-free (`skip_vm_check` test paths never spawn it).

The previously dead `VmEvent` enum (defined, never dispatched) is deleted; its replacement is actually driven. The dormant idle balloon reclaim is now live: an actor-internal ticker dispatches `IdleTimeout` (gated by `config.auto_stop`, `kubernetes_hold`), shrinking the balloon to 128 MB after 5 min idle and restoring it on the next activity.

## 0.4.15 semantics preserved

- `backend` atomic (runtime-switchable HV/VZ, seeded from the persisted machine); `switch_system_vm_backend`'s recreate-via-drift path still works (drift check lives in the boot sub-task).
- `restart_generation` bumps are an explicit `BumpGeneration` effect on graceful stop and force stop.

## Behavior notes (intentional)

- `MachineStarted` / `Running` now happen at **agent-ready** rather than machine-start; `is_running()` therefore means "agent reachable", matching the state's documented meaning. `ensure_ready` return timing is unchanged.
- `shutdown()` during an in-flight boot parks (`pending_stop`) and stops right after the boot resolves — the old code reached the same outcome by waiting on `transition_lock`. If the boot fails, the shutdown resolves `Ok` (nothing to stop).
- `force_stop()` fails parked `ensure_ready` waiters immediately with "force stopped" instead of letting them poll into a timeout.
- Bug fix: graceful stop was hard-coded to `DEFAULT_MACHINE_NAME`; a rosetta lifecycle would have stopped the wrong machine.

## Review

A 3-dimension adversarial review (behavior equivalence / concurrency & liveness / transition-table completeness, 11 agents, per-finding refutation) confirmed 4 findings — all fixed in the last commit:
- stale sub-task completions after `ForceStop`+reboot could clobber the new boot's tracking or drive the machine from the wrong epoch → completions are now epoch-tagged and stale ones dropped;
- `Effect::RemoveMachine` ran a synchronous hypervisor teardown inline on the actor task → moved to `spawn_blocking`, force-stop reply joins it.

## Testing

- 71 arcbox-core tests pass, including 24 vm_lifecycle tests (full transition-table coverage: create/boot/ready, idle balloon round-trip, graceful stop drain, force-stop preemption from every phase).
- Workspace compiles clean; clippy zero warnings; rustfmt clean.

## Remaining before ready-for-review

- [ ] Actor-level tests: concurrent `ensure_ready` waiter semantics, `force_stop` preemption latency, `pending_stop` sequencing (planned `test(core)` commit).
- [ ] Real-machine gate (Apple Silicon, signed daemon via `cargo xtask macos dev`): cold boot < 1.5s, `docker run hello-world`, 10× start/stop without "timeout waiting for agent", idle balloon shrink/restore with dockerd surviving.
- [ ] Note: local dev toolchain is rustc 1.95 vs workspace MSRV 1.96; local runs used `--ignore-rust-version`. CI runs the real toolchain and gates authoritatively.