### PR TITLE
feat: disposable macOS guests with pre-baked pulled base images

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -321,6 +321,7 @@ dependencies = [
  "arcbox-transport",
  "arcbox-virtio",
  "arcbox-vmm",
+ "arcbox-vz",
  "async-trait",
  "bytes",
  "chrono",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -253,6 +253,7 @@ dependencies = [
  "arcbox-grpc",
  "arcbox-helper",
  "arcbox-protocol",
+ "chrono",
  "clap",
  "clap_complete",
  "crossterm",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -323,6 +323,7 @@ dependencies = [
  "arcbox-vmm",
  "arcbox-vz",
  "async-trait",
+ "base64",
  "bytes",
  "chrono",
  "dirs",
@@ -344,6 +345,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "uuid",
+ "zstd",
 ]
 
 [[package]]

--- a/app/arcbox-api/src/grpc/machine.rs
+++ b/app/arcbox-api/src/grpc/machine.rs
@@ -5,16 +5,13 @@ use std::pin::Pin;
 use arcbox_grpc::v1::machine_service_server;
 use arcbox_protocol::v1::{
     CreateMachineRequest, CreateMachineResponse, Empty, InspectMachineRequest, ListMachinesRequest,
-    ListMachinesResponse, MacImageListResponse, MacImagePullRequest, MacImageRemoveRequest,
-    MacImageSummary, MachineAgentRequest, MachineExecOutput, MachineExecRequest, MachineInfo,
+    ListMachinesResponse, MachineAgentRequest, MachineExecOutput, MachineExecRequest, MachineInfo,
     MachineNetwork, MachinePingResponse, MachineSummary, MachineSystemInfo, RemoveMachineRequest,
     StartMachineRequest, StopMachineRequest,
 };
 use tokio_stream::Stream;
 use tonic::{Request, Response, Status};
 
-#[cfg(target_os = "macos")]
-use super::run_macos_blocking;
 use super::{SharedRuntime, SharedRuntimeExt};
 
 /// Machine service implementation.
@@ -38,27 +35,6 @@ impl machine_service_server::MachineService for MachineServiceImpl {
     ) -> Result<Response<CreateMachineResponse>, Status> {
         let req = request.into_inner();
         let runtime = self.runtime.ready()?;
-
-        if req.guest_os == "macos" {
-            #[cfg(target_os = "macos")]
-            {
-                self.runtime
-                    .ready()?
-                    .mac_machine_manager()
-                    .create(arcbox_core::MacMachineConfig {
-                        name: req.name.clone(),
-                        image: req.macos_image,
-                        cpus: req.cpus,
-                        memory_mib: req.memory / (1024 * 1024),
-                    })
-                    .map_err(|e| Status::internal(e.to_string()))?;
-                return Ok(Response::new(CreateMachineResponse { id: req.name }));
-            }
-            #[cfg(not(target_os = "macos"))]
-            return Err(Status::unimplemented(
-                "macOS guests require an Apple Silicon host",
-            ));
-        }
 
         // Convert bytes to MB for internal config.
         let memory_mb = req.memory / (1024 * 1024);
@@ -115,14 +91,6 @@ impl machine_service_server::MachineService for MachineServiceImpl {
         let id = request.into_inner().id;
         let runtime = self.runtime.ready()?;
 
-        #[cfg(target_os = "macos")]
-        if runtime.mac_machine_manager().get(&id).is_some() {
-            let mgr = std::sync::Arc::clone(runtime.mac_machine_manager());
-            let name = id.clone();
-            run_macos_blocking(move || async move { mgr.start(&name).await }).await?;
-            return Ok(Response::new(Empty {}));
-        }
-
         runtime
             .machine_manager()
             .start(&id)
@@ -135,14 +103,6 @@ impl machine_service_server::MachineService for MachineServiceImpl {
     async fn stop(&self, request: Request<StopMachineRequest>) -> Result<Response<Empty>, Status> {
         let id = request.into_inner().id;
         let runtime = self.runtime.ready()?;
-
-        #[cfg(target_os = "macos")]
-        if runtime.mac_machine_manager().get(&id).is_some() {
-            let mgr = std::sync::Arc::clone(runtime.mac_machine_manager());
-            let name = id.clone();
-            run_macos_blocking(move || async move { mgr.stop(&name).await }).await?;
-            return Ok(Response::new(Empty {}));
-        }
 
         runtime
             .machine_manager()
@@ -159,15 +119,6 @@ impl machine_service_server::MachineService for MachineServiceImpl {
         let req = request.into_inner();
         let runtime = self.runtime.ready()?;
 
-        #[cfg(target_os = "macos")]
-        if runtime.mac_machine_manager().get(&req.id).is_some() {
-            let mgr = std::sync::Arc::clone(runtime.mac_machine_manager());
-            let name = req.id.clone();
-            let force = req.force;
-            run_macos_blocking(move || async move { mgr.remove(&name, force).await }).await?;
-            return Ok(Response::new(Empty {}));
-        }
-
         runtime
             .machine_manager()
             .remove(&req.id, req.force)
@@ -182,26 +133,6 @@ impl machine_service_server::MachineService for MachineServiceImpl {
     ) -> Result<Response<ListMachinesResponse>, Status> {
         let runtime = self.runtime.ready()?;
 
-        #[cfg(target_os = "macos")]
-        let mac: Vec<MachineSummary> = runtime
-            .mac_machine_manager()
-            .list()
-            .into_iter()
-            .map(|m| MachineSummary {
-                id: m.name.clone(),
-                name: m.name,
-                state: format!("{:?}", m.state).to_lowercase(),
-                cpus: m.cpus,
-                memory: m.memory_mib * 1024 * 1024,
-                disk_size: 0,
-                ip_address: String::new(),
-                created: m.created_at.timestamp(),
-                guest_os: "macos".to_string(),
-            })
-            .collect();
-        #[cfg(not(target_os = "macos"))]
-        let mac: Vec<MachineSummary> = Vec::new();
-
         let summaries: Vec<MachineSummary> = runtime
             .machine_manager()
             .list()
@@ -215,9 +146,7 @@ impl machine_service_server::MachineService for MachineServiceImpl {
                 disk_size: m.disk_gb * 1024 * 1024 * 1024,
                 ip_address: m.ip_address.unwrap_or_default(),
                 created: m.created_at.timestamp(),
-                guest_os: "linux".to_string(),
             })
-            .chain(mac)
             .collect();
 
         Ok(Response::new(ListMachinesResponse {
@@ -231,30 +160,6 @@ impl machine_service_server::MachineService for MachineServiceImpl {
     ) -> Result<Response<MachineInfo>, Status> {
         let id = request.into_inner().id;
         let runtime = self.runtime.ready()?;
-
-        #[cfg(target_os = "macos")]
-        if let Some(machine) = runtime.mac_machine_manager().get(&id) {
-            return Ok(Response::new(MachineInfo {
-                id: machine.name.clone(),
-                name: machine.name,
-                state: format!("{:?}", machine.state).to_lowercase(),
-                hardware: Some(arcbox_protocol::v1::MachineHardware {
-                    cpus: machine.cpus,
-                    memory: machine.memory_mib * 1024 * 1024,
-                    arch: std::env::consts::ARCH.to_string(),
-                }),
-                network: None,
-                storage: None,
-                os: Some(arcbox_protocol::v1::MachineOs {
-                    distro: "macos".to_string(),
-                    version: machine.image,
-                    kernel: String::new(),
-                }),
-                created: None,
-                started_at: None,
-                mounts: vec![],
-            }));
-        }
 
         let machine = runtime
             .machine_manager()
@@ -394,91 +299,5 @@ impl machine_service_server::MachineService for MachineServiceImpl {
     ) -> Result<Response<arcbox_protocol::v1::SshInfoResponse>, Status> {
         // TODO: Implement SSH info.
         Err(Status::unimplemented("ssh_info not implemented"))
-    }
-
-    async fn mac_image_pull(
-        &self,
-        request: Request<MacImagePullRequest>,
-    ) -> Result<Response<Empty>, Status> {
-        let req = request.into_inner();
-        #[cfg(target_os = "macos")]
-        {
-            let mgr = std::sync::Arc::clone(self.runtime.ready()?.mac_machine_manager());
-            let name = req.name.clone();
-            let ipsw = req.ipsw_path.clone();
-            let disk_gb = (req.disk_size / (1024 * 1024 * 1024)).max(64);
-            run_macos_blocking(move || async move {
-                let mut last = String::new();
-                mgr.images()
-                    .install_from_ipsw(std::path::Path::new(&ipsw), &name, disk_gb, |frac| {
-                        let pct = format!("{:.0}", frac * 100.0);
-                        if pct != last {
-                            tracing::info!("macOS image install: {pct}%");
-                            last = pct;
-                        }
-                    })
-                    .await
-            })
-            .await?;
-            Ok(Response::new(Empty {}))
-        }
-        #[cfg(not(target_os = "macos"))]
-        {
-            let _ = req;
-            Err(Status::unimplemented(
-                "macOS images require an Apple Silicon host",
-            ))
-        }
-    }
-
-    async fn mac_image_list(
-        &self,
-        _request: Request<Empty>,
-    ) -> Result<Response<MacImageListResponse>, Status> {
-        #[cfg(target_os = "macos")]
-        let images: Vec<MacImageSummary> = self
-            .runtime
-            .ready()?
-            .mac_machine_manager()
-            .images()
-            .list()
-            .into_iter()
-            .map(|i| MacImageSummary {
-                name: i.meta.name,
-                minimum_cpu_count: i.meta.minimum_cpu_count,
-                minimum_memory_mib: i.meta.minimum_memory_mib,
-                disk_gb: i.meta.disk_gb,
-                created: i.meta.created_at.timestamp(),
-                source: i.meta.source.unwrap_or_default(),
-            })
-            .collect();
-        #[cfg(not(target_os = "macos"))]
-        let images: Vec<MacImageSummary> = Vec::new();
-
-        Ok(Response::new(MacImageListResponse { images }))
-    }
-
-    async fn mac_image_remove(
-        &self,
-        request: Request<MacImageRemoveRequest>,
-    ) -> Result<Response<Empty>, Status> {
-        let name = request.into_inner().name;
-        #[cfg(target_os = "macos")]
-        {
-            self.runtime
-                .ready()?
-                .mac_machine_manager()
-                .images()
-                .remove(&name)
-                .map_err(|e| Status::internal(e.to_string()))?;
-            Ok(Response::new(Empty {}))
-        }
-        #[cfg(not(target_os = "macos"))]
-        {
-            let _ = name;
-            Err(Status::unimplemented(
-                "macOS images require an Apple Silicon host",
-            ))
-        }
     }
 }

--- a/app/arcbox-api/src/grpc/machine.rs
+++ b/app/arcbox-api/src/grpc/machine.rs
@@ -254,10 +254,33 @@ impl machine_service_server::MachineService for MachineServiceImpl {
         request: Request<InspectMachineRequest>,
     ) -> Result<Response<MachineInfo>, Status> {
         let id = request.into_inner().id;
+        let runtime = self.runtime.ready()?;
 
-        let machine = self
-            .runtime
-            .ready()?
+        #[cfg(target_os = "macos")]
+        if let Some(machine) = runtime.mac_machine_manager().get(&id) {
+            return Ok(Response::new(MachineInfo {
+                id: machine.name.clone(),
+                name: machine.name,
+                state: format!("{:?}", machine.state).to_lowercase(),
+                hardware: Some(arcbox_protocol::v1::MachineHardware {
+                    cpus: machine.cpus,
+                    memory: machine.memory_mib * 1024 * 1024,
+                    arch: std::env::consts::ARCH.to_string(),
+                }),
+                network: None,
+                storage: None,
+                os: Some(arcbox_protocol::v1::MachineOs {
+                    distro: "macos".to_string(),
+                    version: machine.image,
+                    kernel: String::new(),
+                }),
+                created: None,
+                started_at: None,
+                mounts: vec![],
+            }));
+        }
+
+        let machine = runtime
             .machine_manager()
             .get(&id)
             .ok_or_else(|| Status::not_found("machine not found"))?;

--- a/app/arcbox-api/src/grpc/machine.rs
+++ b/app/arcbox-api/src/grpc/machine.rs
@@ -5,7 +5,8 @@ use std::pin::Pin;
 use arcbox_grpc::v1::machine_service_server;
 use arcbox_protocol::v1::{
     CreateMachineRequest, CreateMachineResponse, Empty, InspectMachineRequest, ListMachinesRequest,
-    ListMachinesResponse, MachineAgentRequest, MachineExecOutput, MachineExecRequest, MachineInfo,
+    ListMachinesResponse, MacImageListResponse, MacImagePullRequest, MacImageRemoveRequest,
+    MacImageSummary, MachineAgentRequest, MachineExecOutput, MachineExecRequest, MachineInfo,
     MachineNetwork, MachinePingResponse, MachineSummary, MachineSystemInfo, RemoveMachineRequest,
     StartMachineRequest, StopMachineRequest,
 };
@@ -13,6 +14,32 @@ use tokio_stream::Stream;
 use tonic::{Request, Response, Status};
 
 use super::{SharedRuntime, SharedRuntimeExt};
+
+/// Drives a `!Send` macOS VM future to completion on a dedicated blocking thread.
+///
+/// Virtualization.framework operations hold ObjC handles (and the VM's dispatch
+/// queue) across await and are not `Send`, but tonic requires handler futures to be
+/// `Send`. Running the future via a transient current-thread runtime inside
+/// `spawn_blocking` keeps that `!Send` state off the gRPC worker threads; the booted
+/// VM (which is `Send + Sync`) outlives the transient runtime.
+#[cfg(target_os = "macos")]
+async fn run_macos_blocking<T, Fut, F>(f: F) -> Result<T, Status>
+where
+    T: Send + 'static,
+    Fut: std::future::Future<Output = arcbox_core::Result<T>>,
+    F: FnOnce() -> Fut + Send + 'static,
+{
+    tokio::task::spawn_blocking(move || {
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .map_err(|e| Status::internal(format!("macOS runtime: {e}")))?
+            .block_on(f())
+            .map_err(|e| Status::internal(e.to_string()))
+    })
+    .await
+    .map_err(|e| Status::internal(format!("macOS task join: {e}")))?
+}
 
 /// Machine service implementation.
 pub struct MachineServiceImpl {
@@ -35,6 +62,27 @@ impl machine_service_server::MachineService for MachineServiceImpl {
     ) -> Result<Response<CreateMachineResponse>, Status> {
         let req = request.into_inner();
         let runtime = self.runtime.ready()?;
+
+        if req.guest_os == "macos" {
+            #[cfg(target_os = "macos")]
+            {
+                self.runtime
+                    .ready()?
+                    .mac_machine_manager()
+                    .create(arcbox_core::MacMachineConfig {
+                        name: req.name.clone(),
+                        image: req.macos_image,
+                        cpus: req.cpus,
+                        memory_mib: req.memory / (1024 * 1024),
+                    })
+                    .map_err(|e| Status::internal(e.to_string()))?;
+                return Ok(Response::new(CreateMachineResponse { id: req.name }));
+            }
+            #[cfg(not(target_os = "macos"))]
+            return Err(Status::unimplemented(
+                "macOS guests require an Apple Silicon host",
+            ));
+        }
 
         // Convert bytes to MB for internal config.
         let memory_mb = req.memory / (1024 * 1024);
@@ -89,9 +137,17 @@ impl machine_service_server::MachineService for MachineServiceImpl {
         request: Request<StartMachineRequest>,
     ) -> Result<Response<Empty>, Status> {
         let id = request.into_inner().id;
+        let runtime = self.runtime.ready()?;
 
-        self.runtime
-            .ready()?
+        #[cfg(target_os = "macos")]
+        if runtime.mac_machine_manager().get(&id).is_some() {
+            let mgr = std::sync::Arc::clone(runtime.mac_machine_manager());
+            let name = id.clone();
+            run_macos_blocking(move || async move { mgr.start(&name).await }).await?;
+            return Ok(Response::new(Empty {}));
+        }
+
+        runtime
             .machine_manager()
             .start(&id)
             .await
@@ -102,9 +158,17 @@ impl machine_service_server::MachineService for MachineServiceImpl {
 
     async fn stop(&self, request: Request<StopMachineRequest>) -> Result<Response<Empty>, Status> {
         let id = request.into_inner().id;
+        let runtime = self.runtime.ready()?;
 
-        self.runtime
-            .ready()?
+        #[cfg(target_os = "macos")]
+        if runtime.mac_machine_manager().get(&id).is_some() {
+            let mgr = std::sync::Arc::clone(runtime.mac_machine_manager());
+            let name = id.clone();
+            run_macos_blocking(move || async move { mgr.stop(&name).await }).await?;
+            return Ok(Response::new(Empty {}));
+        }
+
+        runtime
             .machine_manager()
             .stop(&id)
             .map_err(|e| Status::internal(e.to_string()))?;
@@ -117,9 +181,18 @@ impl machine_service_server::MachineService for MachineServiceImpl {
         request: Request<RemoveMachineRequest>,
     ) -> Result<Response<Empty>, Status> {
         let req = request.into_inner();
+        let runtime = self.runtime.ready()?;
 
-        self.runtime
-            .ready()?
+        #[cfg(target_os = "macos")]
+        if runtime.mac_machine_manager().get(&req.id).is_some() {
+            let mgr = std::sync::Arc::clone(runtime.mac_machine_manager());
+            let name = req.id.clone();
+            let force = req.force;
+            run_macos_blocking(move || async move { mgr.remove(&name, force).await }).await?;
+            return Ok(Response::new(Empty {}));
+        }
+
+        runtime
             .machine_manager()
             .remove(&req.id, req.force)
             .map_err(|e| Status::internal(e.to_string()))?;
@@ -131,9 +204,31 @@ impl machine_service_server::MachineService for MachineServiceImpl {
         &self,
         _request: Request<ListMachinesRequest>,
     ) -> Result<Response<ListMachinesResponse>, Status> {
-        let machines = self.runtime.ready()?.machine_manager().list();
+        let runtime = self.runtime.ready()?;
 
-        let summaries: Vec<_> = machines
+        #[cfg(target_os = "macos")]
+        let mac: Vec<MachineSummary> = runtime
+            .mac_machine_manager()
+            .list()
+            .into_iter()
+            .map(|m| MachineSummary {
+                id: m.name.clone(),
+                name: m.name,
+                state: format!("{:?}", m.state).to_lowercase(),
+                cpus: m.cpus,
+                memory: m.memory_mib * 1024 * 1024,
+                disk_size: 0,
+                ip_address: String::new(),
+                created: m.created_at.timestamp(),
+                guest_os: "macos".to_string(),
+            })
+            .collect();
+        #[cfg(not(target_os = "macos"))]
+        let mac: Vec<MachineSummary> = Vec::new();
+
+        let summaries: Vec<MachineSummary> = runtime
+            .machine_manager()
+            .list()
             .into_iter()
             .map(|m| MachineSummary {
                 id: m.name.clone(),
@@ -144,7 +239,9 @@ impl machine_service_server::MachineService for MachineServiceImpl {
                 disk_size: m.disk_gb * 1024 * 1024 * 1024,
                 ip_address: m.ip_address.unwrap_or_default(),
                 created: m.created_at.timestamp(),
+                guest_os: "linux".to_string(),
             })
+            .chain(mac)
             .collect();
 
         Ok(Response::new(ListMachinesResponse {
@@ -298,5 +395,91 @@ impl machine_service_server::MachineService for MachineServiceImpl {
     ) -> Result<Response<arcbox_protocol::v1::SshInfoResponse>, Status> {
         // TODO: Implement SSH info.
         Err(Status::unimplemented("ssh_info not implemented"))
+    }
+
+    async fn mac_image_pull(
+        &self,
+        request: Request<MacImagePullRequest>,
+    ) -> Result<Response<Empty>, Status> {
+        let req = request.into_inner();
+        #[cfg(target_os = "macos")]
+        {
+            let mgr = std::sync::Arc::clone(self.runtime.ready()?.mac_machine_manager());
+            let name = req.name.clone();
+            let ipsw = req.ipsw_path.clone();
+            let disk_gb = (req.disk_size / (1024 * 1024 * 1024)).max(64);
+            run_macos_blocking(move || async move {
+                let mut last = String::new();
+                mgr.images()
+                    .install_from_ipsw(std::path::Path::new(&ipsw), &name, disk_gb, |frac| {
+                        let pct = format!("{:.0}", frac * 100.0);
+                        if pct != last {
+                            tracing::info!("macOS image install: {pct}%");
+                            last = pct;
+                        }
+                    })
+                    .await
+            })
+            .await?;
+            Ok(Response::new(Empty {}))
+        }
+        #[cfg(not(target_os = "macos"))]
+        {
+            let _ = req;
+            Err(Status::unimplemented(
+                "macOS images require an Apple Silicon host",
+            ))
+        }
+    }
+
+    async fn mac_image_list(
+        &self,
+        _request: Request<Empty>,
+    ) -> Result<Response<MacImageListResponse>, Status> {
+        #[cfg(target_os = "macos")]
+        let images: Vec<MacImageSummary> = self
+            .runtime
+            .ready()?
+            .mac_machine_manager()
+            .images()
+            .list()
+            .into_iter()
+            .map(|i| MacImageSummary {
+                name: i.meta.name,
+                minimum_cpu_count: i.meta.minimum_cpu_count,
+                minimum_memory_mib: i.meta.minimum_memory_mib,
+                disk_gb: i.meta.disk_gb,
+                created: i.meta.created_at.timestamp(),
+                source: i.meta.source.unwrap_or_default(),
+            })
+            .collect();
+        #[cfg(not(target_os = "macos"))]
+        let images: Vec<MacImageSummary> = Vec::new();
+
+        Ok(Response::new(MacImageListResponse { images }))
+    }
+
+    async fn mac_image_remove(
+        &self,
+        request: Request<MacImageRemoveRequest>,
+    ) -> Result<Response<Empty>, Status> {
+        let name = request.into_inner().name;
+        #[cfg(target_os = "macos")]
+        {
+            self.runtime
+                .ready()?
+                .mac_machine_manager()
+                .images()
+                .remove(&name)
+                .map_err(|e| Status::internal(e.to_string()))?;
+            Ok(Response::new(Empty {}))
+        }
+        #[cfg(not(target_os = "macos"))]
+        {
+            let _ = name;
+            Err(Status::unimplemented(
+                "macOS images require an Apple Silicon host",
+            ))
+        }
     }
 }

--- a/app/arcbox-api/src/grpc/machine.rs
+++ b/app/arcbox-api/src/grpc/machine.rs
@@ -13,33 +13,9 @@ use arcbox_protocol::v1::{
 use tokio_stream::Stream;
 use tonic::{Request, Response, Status};
 
-use super::{SharedRuntime, SharedRuntimeExt};
-
-/// Drives a `!Send` macOS VM future to completion on a dedicated blocking thread.
-///
-/// Virtualization.framework operations hold ObjC handles (and the VM's dispatch
-/// queue) across await and are not `Send`, but tonic requires handler futures to be
-/// `Send`. Running the future via a transient current-thread runtime inside
-/// `spawn_blocking` keeps that `!Send` state off the gRPC worker threads; the booted
-/// VM (which is `Send + Sync`) outlives the transient runtime.
 #[cfg(target_os = "macos")]
-async fn run_macos_blocking<T, Fut, F>(f: F) -> Result<T, Status>
-where
-    T: Send + 'static,
-    Fut: std::future::Future<Output = arcbox_core::Result<T>>,
-    F: FnOnce() -> Fut + Send + 'static,
-{
-    tokio::task::spawn_blocking(move || {
-        tokio::runtime::Builder::new_current_thread()
-            .enable_all()
-            .build()
-            .map_err(|e| Status::internal(format!("macOS runtime: {e}")))?
-            .block_on(f())
-            .map_err(|e| Status::internal(e.to_string()))
-    })
-    .await
-    .map_err(|e| Status::internal(format!("macOS task join: {e}")))?
-}
+use super::run_macos_blocking;
+use super::{SharedRuntime, SharedRuntimeExt};
 
 /// Machine service implementation.
 pub struct MachineServiceImpl {

--- a/app/arcbox-api/src/grpc/macos.rs
+++ b/app/arcbox-api/src/grpc/macos.rs
@@ -138,14 +138,24 @@ impl macos_service_server::MacosService for MacosServiceImpl {
         let name = req.name;
         let ipsw = req.ipsw_path;
         let disk_gb = req.disk_gb.max(MIN_IMAGE_DISK_GB);
+        // An empty ipsw_path means "download the latest from Apple".
+        let source = if ipsw.is_empty() {
+            arcbox_core::PullSource::Latest
+        } else {
+            arcbox_core::PullSource::LocalIpsw(std::path::PathBuf::from(ipsw))
+        };
         run_macos_blocking(move || async move {
             let mut last = String::new();
             mgr.images()
-                .install_from_ipsw(std::path::Path::new(&ipsw), &name, disk_gb, |frac| {
-                    let pct = format!("{:.0}", frac * 100.0);
-                    if pct != last {
-                        tracing::info!("macOS image install: {pct}%");
-                        last = pct;
+                .pull(source, &name, disk_gb, |phase, frac| {
+                    let label = match phase {
+                        arcbox_core::PullPhase::Download => "download",
+                        arcbox_core::PullPhase::Install => "install",
+                    };
+                    let msg = format!("macOS image {label}: {:.0}%", frac * 100.0);
+                    if msg != last {
+                        tracing::info!("{msg}");
+                        last = msg;
                     }
                 })
                 .await

--- a/app/arcbox-api/src/grpc/macos.rs
+++ b/app/arcbox-api/src/grpc/macos.rs
@@ -1,0 +1,193 @@
+//! macOS guest service gRPC implementation (Apple Silicon only).
+//!
+//! Disposable macOS VMs and their base images. The whole surface delegates to
+//! [`arcbox_core::MacMachineManager`]; lifecycle operations hold `!Send`
+//! Virtualization.framework handles across await, so they run through
+//! [`super::run_macos_blocking`].
+
+use std::sync::Arc;
+
+use arcbox_grpc::v1::macos_service_server;
+use arcbox_protocol::v1::{
+    CreateMacosMachineRequest, Empty, InspectMacosMachineRequest, MacosImageListResponse,
+    MacosImagePullRequest, MacosImageRemoveRequest, MacosImageSummary, MacosMachineInfo,
+    MacosMachineListResponse, MacosMachineSummary, RemoveMacosMachineRequest,
+    StartMacosMachineRequest, StopMacosMachineRequest,
+};
+use tonic::{Request, Response, Status};
+
+use super::{SharedRuntime, SharedRuntimeExt, run_macos_blocking};
+
+/// Minimum system disk size for a base image, in GiB.
+const MIN_IMAGE_DISK_GB: u64 = 64;
+
+/// macOS guest service implementation.
+pub struct MacosServiceImpl {
+    runtime: SharedRuntime,
+}
+
+impl MacosServiceImpl {
+    /// Creates a new macOS guest service with a deferred runtime.
+    #[must_use]
+    pub fn new(runtime: SharedRuntime) -> Self {
+        Self { runtime }
+    }
+}
+
+#[tonic::async_trait]
+impl macos_service_server::MacosService for MacosServiceImpl {
+    async fn create(
+        &self,
+        request: Request<CreateMacosMachineRequest>,
+    ) -> Result<Response<Empty>, Status> {
+        let req = request.into_inner();
+        self.runtime
+            .ready()?
+            .mac_machine_manager()
+            .create(arcbox_core::MacMachineConfig {
+                name: req.name,
+                image: req.image,
+                cpus: req.cpus,
+                memory_mib: req.memory_mib,
+            })
+            .map_err(|e| Status::internal(e.to_string()))?;
+        Ok(Response::new(Empty {}))
+    }
+
+    async fn start(
+        &self,
+        request: Request<StartMacosMachineRequest>,
+    ) -> Result<Response<Empty>, Status> {
+        let name = request.into_inner().name;
+        let mgr = Arc::clone(self.runtime.ready()?.mac_machine_manager());
+        run_macos_blocking(move || async move { mgr.start(&name).await }).await?;
+        Ok(Response::new(Empty {}))
+    }
+
+    async fn stop(
+        &self,
+        request: Request<StopMacosMachineRequest>,
+    ) -> Result<Response<Empty>, Status> {
+        let name = request.into_inner().name;
+        let mgr = Arc::clone(self.runtime.ready()?.mac_machine_manager());
+        run_macos_blocking(move || async move { mgr.stop(&name).await }).await?;
+        Ok(Response::new(Empty {}))
+    }
+
+    async fn remove(
+        &self,
+        request: Request<RemoveMacosMachineRequest>,
+    ) -> Result<Response<Empty>, Status> {
+        let req = request.into_inner();
+        let mgr = Arc::clone(self.runtime.ready()?.mac_machine_manager());
+        let name = req.name;
+        let force = req.force;
+        run_macos_blocking(move || async move { mgr.remove(&name, force).await }).await?;
+        Ok(Response::new(Empty {}))
+    }
+
+    async fn list(
+        &self,
+        _request: Request<Empty>,
+    ) -> Result<Response<MacosMachineListResponse>, Status> {
+        let machines = self
+            .runtime
+            .ready()?
+            .mac_machine_manager()
+            .list()
+            .into_iter()
+            .map(|m| MacosMachineSummary {
+                name: m.name,
+                state: format!("{:?}", m.state).to_lowercase(),
+                cpus: m.cpus,
+                memory_mib: m.memory_mib,
+                image: m.image,
+                created: m.created_at.timestamp(),
+            })
+            .collect();
+        Ok(Response::new(MacosMachineListResponse { machines }))
+    }
+
+    async fn inspect(
+        &self,
+        request: Request<InspectMacosMachineRequest>,
+    ) -> Result<Response<MacosMachineInfo>, Status> {
+        let name = request.into_inner().name;
+        let machine = self
+            .runtime
+            .ready()?
+            .mac_machine_manager()
+            .get(&name)
+            .ok_or_else(|| Status::not_found("macOS guest not found"))?;
+        Ok(Response::new(MacosMachineInfo {
+            name: machine.name,
+            state: format!("{:?}", machine.state).to_lowercase(),
+            cpus: machine.cpus,
+            memory_mib: machine.memory_mib,
+            image: machine.image,
+            created: machine.created_at.timestamp(),
+        }))
+    }
+
+    async fn image_pull(
+        &self,
+        request: Request<MacosImagePullRequest>,
+    ) -> Result<Response<Empty>, Status> {
+        let req = request.into_inner();
+        let mgr = Arc::clone(self.runtime.ready()?.mac_machine_manager());
+        let name = req.name;
+        let ipsw = req.ipsw_path;
+        let disk_gb = req.disk_gb.max(MIN_IMAGE_DISK_GB);
+        run_macos_blocking(move || async move {
+            let mut last = String::new();
+            mgr.images()
+                .install_from_ipsw(std::path::Path::new(&ipsw), &name, disk_gb, |frac| {
+                    let pct = format!("{:.0}", frac * 100.0);
+                    if pct != last {
+                        tracing::info!("macOS image install: {pct}%");
+                        last = pct;
+                    }
+                })
+                .await
+        })
+        .await?;
+        Ok(Response::new(Empty {}))
+    }
+
+    async fn image_list(
+        &self,
+        _request: Request<Empty>,
+    ) -> Result<Response<MacosImageListResponse>, Status> {
+        let images = self
+            .runtime
+            .ready()?
+            .mac_machine_manager()
+            .images()
+            .list()
+            .into_iter()
+            .map(|i| MacosImageSummary {
+                name: i.meta.name,
+                minimum_cpu_count: i.meta.minimum_cpu_count,
+                minimum_memory_mib: i.meta.minimum_memory_mib,
+                disk_gb: i.meta.disk_gb,
+                created: i.meta.created_at.timestamp(),
+                source: i.meta.source.unwrap_or_default(),
+            })
+            .collect();
+        Ok(Response::new(MacosImageListResponse { images }))
+    }
+
+    async fn image_remove(
+        &self,
+        request: Request<MacosImageRemoveRequest>,
+    ) -> Result<Response<Empty>, Status> {
+        let name = request.into_inner().name;
+        self.runtime
+            .ready()?
+            .mac_machine_manager()
+            .images()
+            .remove(&name)
+            .map_err(|e| Status::internal(e.to_string()))?;
+        Ok(Response::new(Empty {}))
+    }
+}

--- a/app/arcbox-api/src/grpc/macos.rs
+++ b/app/arcbox-api/src/grpc/macos.rs
@@ -169,26 +169,32 @@ impl macos_service_server::MacosService for MacosServiceImpl {
             // doesn't emit an event per network chunk.
             let progress = tx.clone();
             let mut last = (PullStage::Resolve, u32::MAX);
-            let result = mgr
-                .images()
-                .pull_remote(source, move |stage, fraction| {
-                    #[allow(
-                        clippy::cast_possible_truncation,
-                        clippy::cast_sign_loss,
-                        reason = "fraction is clamped to 0.0..=1.0 by the producer"
-                    )]
-                    let percent = (fraction * 100.0) as u32;
-                    if last != (stage, percent) {
-                        last = (stage, percent);
-                        let _ = progress.send(Ok(MacosImagePullEvent {
-                            stage: stage_name(stage).to_string(),
-                            fraction,
-                        }));
+            let pull = mgr.images().pull_remote(source, move |stage, fraction| {
+                #[allow(
+                    clippy::cast_possible_truncation,
+                    clippy::cast_sign_loss,
+                    reason = "fraction is clamped to 0.0..=1.0 by the producer"
+                )]
+                let percent = (fraction * 100.0) as u32;
+                if last != (stage, percent) {
+                    last = (stage, percent);
+                    let _ = progress.send(Ok(MacosImagePullEvent {
+                        stage: stage_name(stage).to_string(),
+                        fraction,
+                    }));
+                }
+            });
+            // A dropped client stream closes the channel; cancel the pull by
+            // dropping its future (its staging guard cleans up the partials).
+            tokio::select! {
+                result = pull => {
+                    if let Err(e) = result {
+                        let _ = tx.send(Err(Status::internal(e.to_string())));
                     }
-                })
-                .await;
-            if let Err(e) = result {
-                let _ = tx.send(Err(Status::internal(e.to_string())));
+                }
+                () = tx.closed() => {
+                    tracing::info!("macOS image pull canceled: client disconnected");
+                }
             }
         });
         Ok(Response::new(Box::pin(UnboundedReceiverStream::new(rx))))

--- a/app/arcbox-api/src/grpc/macos.rs
+++ b/app/arcbox-api/src/grpc/macos.rs
@@ -169,6 +169,8 @@ impl macos_service_server::MacosService for MacosServiceImpl {
             memory_mib: machine.memory_mib,
             image: machine.image,
             created: machine.created_at.timestamp(),
+            mac_address: machine.mac_address.unwrap_or_default(),
+            ip_address: machine.ip_address.unwrap_or_default(),
         }))
     }
 

--- a/app/arcbox-api/src/grpc/macos.rs
+++ b/app/arcbox-api/src/grpc/macos.rs
@@ -3,23 +3,36 @@
 //! Disposable macOS VMs and their base images. The whole surface delegates to
 //! [`arcbox_core::MacMachineManager`]; lifecycle operations hold `!Send`
 //! Virtualization.framework handles across await, so they run through
-//! [`super::run_macos_blocking`].
+//! [`super::run_macos_blocking`]. Image pulls are plain `Send` futures and
+//! stream progress from an ordinary spawned task.
 
+use std::pin::Pin;
 use std::sync::Arc;
 
+use arcbox_core::{PullStage, RemoteLocation, RemoteSource};
 use arcbox_grpc::v1::macos_service_server;
 use arcbox_protocol::v1::{
     CreateMacosMachineRequest, Empty, InspectMacosMachineRequest, MacosImageListResponse,
-    MacosImagePullRequest, MacosImageRemoveRequest, MacosImageSummary, MacosMachineInfo,
-    MacosMachineListResponse, MacosMachineSummary, RemoveMacosMachineRequest,
+    MacosImagePullEvent, MacosImagePullRequest, MacosImageRemoveRequest, MacosImageSummary,
+    MacosMachineInfo, MacosMachineListResponse, MacosMachineSummary, RemoveMacosMachineRequest,
     StartMacosMachineRequest, StopMacosMachineRequest,
 };
+use tokio_stream::Stream;
+use tokio_stream::wrappers::UnboundedReceiverStream;
 use tonic::{Request, Response, Status};
 
 use super::{SharedRuntime, SharedRuntimeExt, run_macos_blocking};
 
-/// Minimum system disk size for a base image, in GiB.
-const MIN_IMAGE_DISK_GB: u64 = 64;
+/// Wire name of a pull stage.
+const fn stage_name(stage: PullStage) -> &'static str {
+    match stage {
+        PullStage::Resolve => "resolving",
+        PullStage::Validate => "validating",
+        PullStage::Disk => "disk",
+        PullStage::Aux => "aux",
+        PullStage::Verify => "verifying",
+    }
+}
 
 /// macOS guest service implementation.
 pub struct MacosServiceImpl {
@@ -129,39 +142,56 @@ impl macos_service_server::MacosService for MacosServiceImpl {
         }))
     }
 
+    type ImagePullStream = Pin<Box<dyn Stream<Item = Result<MacosImagePullEvent, Status>> + Send>>;
+
     async fn image_pull(
         &self,
         request: Request<MacosImagePullRequest>,
-    ) -> Result<Response<Empty>, Status> {
+    ) -> Result<Response<Self::ImagePullStream>, Status> {
         let req = request.into_inner();
+        let source =
+            match (req.reference.is_empty(), req.manifest_url.is_empty()) {
+                (false, true) => RemoteSource::Reference(req.reference.parse().map_err(
+                    |e: arcbox_core::CoreError| Status::invalid_argument(e.to_string()),
+                )?),
+                (true, false) => RemoteSource::Manifest(RemoteLocation::parse(&req.manifest_url)),
+                _ => {
+                    return Err(Status::invalid_argument(
+                        "exactly one of reference / manifest_url must be set",
+                    ));
+                }
+            };
+
         let mgr = Arc::clone(self.runtime.ready()?.mac_machine_manager());
-        let name = req.name;
-        let ipsw = req.ipsw_path;
-        let disk_gb = req.disk_gb.max(MIN_IMAGE_DISK_GB);
-        // An empty ipsw_path means "download the latest from Apple".
-        let source = if ipsw.is_empty() {
-            arcbox_core::PullSource::Latest
-        } else {
-            arcbox_core::PullSource::LocalIpsw(std::path::PathBuf::from(ipsw))
-        };
-        run_macos_blocking(move || async move {
-            let mut last = String::new();
-            mgr.images()
-                .pull(source, &name, disk_gb, |phase, frac| {
-                    let label = match phase {
-                        arcbox_core::PullPhase::Download => "download",
-                        arcbox_core::PullPhase::Install => "install",
-                    };
-                    let msg = format!("macOS image {label}: {:.0}%", frac * 100.0);
-                    if msg != last {
-                        tracing::info!("{msg}");
-                        last = msg;
+        let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
+        tokio::spawn(async move {
+            // Throttle to whole-percent changes so a multi-gigabyte download
+            // doesn't emit an event per network chunk.
+            let progress = tx.clone();
+            let mut last = (PullStage::Resolve, u32::MAX);
+            let result = mgr
+                .images()
+                .pull_remote(source, move |stage, fraction| {
+                    #[allow(
+                        clippy::cast_possible_truncation,
+                        clippy::cast_sign_loss,
+                        reason = "fraction is clamped to 0.0..=1.0 by the producer"
+                    )]
+                    let percent = (fraction * 100.0) as u32;
+                    if last != (stage, percent) {
+                        last = (stage, percent);
+                        let _ = progress.send(Ok(MacosImagePullEvent {
+                            stage: stage_name(stage).to_string(),
+                            fraction,
+                        }));
                     }
                 })
-                .await
-        })
-        .await?;
-        Ok(Response::new(Empty {}))
+                .await;
+            if let Err(e) = result {
+                let _ = tx.send(Err(Status::internal(e.to_string())));
+            }
+        });
+        Ok(Response::new(Box::pin(UnboundedReceiverStream::new(rx))))
     }
 
     async fn image_list(
@@ -182,6 +212,8 @@ impl macos_service_server::MacosService for MacosServiceImpl {
                 disk_gb: i.meta.disk_gb,
                 created: i.meta.created_at.timestamp(),
                 source: i.meta.source.unwrap_or_default(),
+                version: i.meta.version.unwrap_or_default(),
+                os_version: i.meta.os_version.unwrap_or_default(),
             })
             .collect();
         Ok(Response::new(MacosImageListResponse { images }))

--- a/app/arcbox-api/src/grpc/macos.rs
+++ b/app/arcbox-api/src/grpc/macos.rs
@@ -9,13 +9,14 @@
 use std::pin::Pin;
 use std::sync::Arc;
 
-use arcbox_core::{PullStage, RemoteLocation, RemoteSource};
+use arcbox_core::{MacImage, PullStage, RemoteLocation, RemoteSource};
 use arcbox_grpc::v1::macos_service_server;
 use arcbox_protocol::v1::{
     CreateMacosMachineRequest, Empty, InspectMacosMachineRequest, MacosImageListResponse,
-    MacosImagePullEvent, MacosImagePullRequest, MacosImageRemoveRequest, MacosImageSummary,
-    MacosMachineInfo, MacosMachineListResponse, MacosMachineSummary, RemoveMacosMachineRequest,
-    StartMacosMachineRequest, StopMacosMachineRequest,
+    MacosImagePullEvent, MacosImagePullRequest, MacosImageRemoveRequest, MacosImageResolveRequest,
+    MacosImageResolveResponse, MacosImageSummary, MacosMachineInfo, MacosMachineListResponse,
+    MacosMachineSummary, RemoveMacosMachineRequest, StartMacosMachineRequest,
+    StopMacosMachineRequest,
 };
 use tokio_stream::Stream;
 use tokio_stream::wrappers::UnboundedReceiverStream;
@@ -31,6 +32,35 @@ const fn stage_name(stage: PullStage) -> &'static str {
         PullStage::Disk => "disk",
         PullStage::Aux => "aux",
         PullStage::Verify => "verifying",
+    }
+}
+
+/// Parses an image source: exactly one of `reference` / `manifest_url`.
+/// Shared by `ImagePull` and `ImageResolve`, which take the same source.
+fn parse_source(reference: &str, manifest_url: &str) -> Result<RemoteSource, Status> {
+    match (reference.is_empty(), manifest_url.is_empty()) {
+        (false, true) => Ok(RemoteSource::Reference(reference.parse().map_err(
+            |e: arcbox_core::CoreError| Status::invalid_argument(e.to_string()),
+        )?)),
+        (true, false) => Ok(RemoteSource::Manifest(RemoteLocation::parse(manifest_url))),
+        _ => Err(Status::invalid_argument(
+            "exactly one of reference / manifest_url must be set",
+        )),
+    }
+}
+
+/// Wire summary of a registered image. Shared by `ImageList` and
+/// `ImagePull`'s terminal event.
+fn image_summary(image: MacImage) -> MacosImageSummary {
+    MacosImageSummary {
+        name: image.meta.name,
+        minimum_cpu_count: image.meta.minimum_cpu_count,
+        minimum_memory_mib: image.meta.minimum_memory_mib,
+        disk_gb: image.meta.disk_gb,
+        created: image.meta.created_at.timestamp(),
+        source: image.meta.source.unwrap_or_default(),
+        version: image.meta.version.unwrap_or_default(),
+        os_version: image.meta.os_version.unwrap_or_default(),
     }
 }
 
@@ -149,18 +179,7 @@ impl macos_service_server::MacosService for MacosServiceImpl {
         request: Request<MacosImagePullRequest>,
     ) -> Result<Response<Self::ImagePullStream>, Status> {
         let req = request.into_inner();
-        let source =
-            match (req.reference.is_empty(), req.manifest_url.is_empty()) {
-                (false, true) => RemoteSource::Reference(req.reference.parse().map_err(
-                    |e: arcbox_core::CoreError| Status::invalid_argument(e.to_string()),
-                )?),
-                (true, false) => RemoteSource::Manifest(RemoteLocation::parse(&req.manifest_url)),
-                _ => {
-                    return Err(Status::invalid_argument(
-                        "exactly one of reference / manifest_url must be set",
-                    ));
-                }
-            };
+        let source = parse_source(&req.reference, &req.manifest_url)?;
 
         let mgr = Arc::clone(self.runtime.ready()?.mac_machine_manager());
         let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
@@ -181,23 +200,57 @@ impl macos_service_server::MacosService for MacosServiceImpl {
                     let _ = progress.send(Ok(MacosImagePullEvent {
                         stage: stage_name(stage).to_string(),
                         fraction,
+                        image: None,
                     }));
                 }
             });
             // A dropped client stream closes the channel; cancel the pull by
             // dropping its future (its staging guard cleans up the partials).
             tokio::select! {
-                result = pull => {
-                    if let Err(e) = result {
+                result = pull => match result {
+                    // Terminal event: what actually landed (or was already
+                    // present), so the caller learns the concrete version a
+                    // floating reference resolved to.
+                    Ok(image) => {
+                        let _ = tx.send(Ok(MacosImagePullEvent {
+                            stage: "done".to_string(),
+                            fraction: 1.0,
+                            image: Some(image_summary(image)),
+                        }));
+                    }
+                    Err(e) => {
                         let _ = tx.send(Err(Status::internal(e.to_string())));
                     }
-                }
+                },
                 () = tx.closed() => {
                     tracing::info!("macOS image pull canceled: client disconnected");
                 }
             }
         });
         Ok(Response::new(Box::pin(UnboundedReceiverStream::new(rx))))
+    }
+
+    async fn image_resolve(
+        &self,
+        request: Request<MacosImageResolveRequest>,
+    ) -> Result<Response<MacosImageResolveResponse>, Status> {
+        let req = request.into_inner();
+        let source = parse_source(&req.reference, &req.manifest_url)?;
+        let mgr = Arc::clone(self.runtime.ready()?.mac_machine_manager());
+        let resolved = mgr
+            .images()
+            .resolve_remote(&source)
+            .await
+            .map_err(|e| Status::internal(e.to_string()))?;
+        Ok(Response::new(MacosImageResolveResponse {
+            name: resolved.name,
+            version: resolved.version,
+            os_version: resolved.os_version,
+            minimum_cpu_count: resolved.minimum_cpu_count,
+            minimum_memory_mib: resolved.minimum_memory_mib,
+            disk_gb: resolved.disk_gb,
+            installed_version: resolved.installed_version.unwrap_or_default(),
+        }))
     }
 
     async fn image_list(
@@ -211,16 +264,7 @@ impl macos_service_server::MacosService for MacosServiceImpl {
             .images()
             .list()
             .into_iter()
-            .map(|i| MacosImageSummary {
-                name: i.meta.name,
-                minimum_cpu_count: i.meta.minimum_cpu_count,
-                minimum_memory_mib: i.meta.minimum_memory_mib,
-                disk_gb: i.meta.disk_gb,
-                created: i.meta.created_at.timestamp(),
-                source: i.meta.source.unwrap_or_default(),
-                version: i.meta.version.unwrap_or_default(),
-                os_version: i.meta.os_version.unwrap_or_default(),
-            })
+            .map(image_summary)
             .collect();
         Ok(Response::new(MacosImageListResponse { images }))
     }

--- a/app/arcbox-api/src/grpc/mod.rs
+++ b/app/arcbox-api/src/grpc/mod.rs
@@ -9,12 +9,16 @@
 mod icon;
 mod kubernetes;
 mod machine;
+#[cfg(target_os = "macos")]
+mod macos;
 mod sandbox;
 mod snapshot;
 
 pub use icon::IconServiceImpl;
 pub use kubernetes::KubernetesServiceImpl;
 pub use machine::MachineServiceImpl;
+#[cfg(target_os = "macos")]
+pub use macos::MacosServiceImpl;
 pub use sandbox::SandboxServiceImpl;
 pub use snapshot::SandboxSnapshotServiceImpl;
 
@@ -22,6 +26,32 @@ use std::sync::{Arc, OnceLock};
 
 use arcbox_core::Runtime;
 use tonic::Status;
+
+/// Drives a `!Send` macOS VM future to completion on a dedicated blocking thread.
+///
+/// Virtualization.framework operations hold ObjC handles (and the VM's dispatch
+/// queue) across await and are not `Send`, but tonic requires handler futures to be
+/// `Send`. Running the future via a transient current-thread runtime inside
+/// `spawn_blocking` keeps that `!Send` state off the gRPC worker threads; the booted
+/// VM (which is `Send + Sync`) outlives the transient runtime.
+#[cfg(target_os = "macos")]
+async fn run_macos_blocking<T, Fut, F>(f: F) -> Result<T, Status>
+where
+    T: Send + 'static,
+    Fut: std::future::Future<Output = arcbox_core::Result<T>>,
+    F: FnOnce() -> Fut + Send + 'static,
+{
+    tokio::task::spawn_blocking(move || {
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .map_err(|e| Status::internal(format!("macOS runtime: {e}")))?
+            .block_on(f())
+            .map_err(|e| Status::internal(e.to_string()))
+    })
+    .await
+    .map_err(|e| Status::internal(format!("macOS task join: {e}")))?
+}
 
 /// Shared handle to a runtime that may not be initialized yet.
 ///

--- a/app/arcbox-api/src/lib.rs
+++ b/app/arcbox-api/src/lib.rs
@@ -18,6 +18,8 @@ pub use arcbox_grpc::v1::{
     kubernetes_service_client, kubernetes_service_server, machine_service_client,
     machine_service_server, migration_service_client, migration_service_server,
 };
+#[cfg(target_os = "macos")]
+pub use arcbox_grpc::v1::{macos_service_client, macos_service_server};
 pub use arcbox_grpc::{
     IconService, IconServiceServer, MigrationService, MigrationServiceServer, SandboxService,
     SandboxServiceServer, SandboxSnapshotService, SandboxSnapshotServiceServer, SystemService,
@@ -26,6 +28,8 @@ pub use arcbox_grpc::{
 
 pub use arcbox_protocol::v1::setup_status::Phase as SetupPhase;
 pub use error::{ApiError, Result};
+#[cfg(target_os = "macos")]
+pub use grpc::MacosServiceImpl;
 pub use grpc::{
     IconServiceImpl, KubernetesServiceImpl, MachineServiceImpl, SandboxServiceImpl,
     SandboxSnapshotServiceImpl, SharedRuntime,

--- a/app/arcbox-cli/Cargo.toml
+++ b/app/arcbox-cli/Cargo.toml
@@ -48,6 +48,7 @@ sha2 = "0.10"
 hex = "0.4"
 tokio-stream.workspace = true
 arcbox-helper.workspace = true
+chrono.workspace = true
 
 [target.'cfg(target_os = "macos")'.dependencies]
 macos-resolver = { workspace = true }

--- a/app/arcbox-cli/src/commands/daemon.rs
+++ b/app/arcbox-cli/src/commands/daemon.rs
@@ -56,6 +56,12 @@ pub struct DaemonArgs {
     #[arg(long)]
     pub docker_integration: bool,
 
+    /// Run as a VM host only: do not boot the default Linux VM, and disable the
+    /// Docker API, Docker CLI integration, and Kubernetes proxy. macOS guest
+    /// management is unaffected.
+    #[arg(long)]
+    pub no_linux_vm: bool,
+
     /// Guest dockerd API vsock port.
     #[arg(long)]
     pub guest_docker_vsock_port: Option<u32>,
@@ -409,6 +415,9 @@ fn build_daemon_args(args: &DaemonArgs) -> Vec<OsString> {
     }
     if args.docker_integration {
         daemon_args.push(OsString::from("--docker-integration"));
+    }
+    if args.no_linux_vm {
+        daemon_args.push(OsString::from("--no-linux-vm"));
     }
     if let Some(port) = args.guest_docker_vsock_port {
         daemon_args.push(OsString::from("--guest-docker-vsock-port"));

--- a/app/arcbox-cli/src/commands/machine.rs
+++ b/app/arcbox-cli/src/commands/machine.rs
@@ -156,6 +156,12 @@ pub struct CreateArgs {
     /// Custom kernel command line (for advanced users / testing)
     #[arg(long)]
     pub cmdline: Option<String>,
+    /// Guest OS: "linux" (default) or "macos" (Apple Silicon only).
+    #[arg(long, default_value = "linux")]
+    pub os: String,
+    /// macOS base image to clone (required when --os macos).
+    #[arg(long)]
+    pub image: Option<String>,
 }
 
 #[derive(Args)]
@@ -255,6 +261,10 @@ pub async fn execute(cmd: MachineCommands) -> Result<()> {
 }
 
 async fn execute_create(args: CreateArgs) -> Result<()> {
+    if args.os == "macos" && args.image.is_none() {
+        anyhow::bail!("--image <base> is required when --os macos");
+    }
+
     let mut client = machine_client().await?;
     let mounts = args
         .mount
@@ -276,6 +286,8 @@ async fn execute_create(args: CreateArgs) -> Result<()> {
             ssh_public_key: String::new(),
             kernel: args.kernel.clone().unwrap_or_default(),
             cmdline: args.cmdline.clone().unwrap_or_default(),
+            guest_os: args.os.clone(),
+            macos_image: args.image.clone().unwrap_or_default(),
         }))
         .await
         .context("Failed to create machine")?;
@@ -405,15 +417,21 @@ async fn execute_list(args: ListArgs) -> Result<()> {
 
     // Print header
     println!(
-        "{:<20} {:<12} {:<6} {:<12} {:<10}",
-        "NAME", "STATE", "CPUS", "MEMORY", "DISK"
+        "{:<20} {:<7} {:<12} {:<6} {:<12} {:<10}",
+        "NAME", "OS", "STATE", "CPUS", "MEMORY", "DISK"
     );
 
     // Print machines
     for machine in &machines {
+        let os = if machine.guest_os.is_empty() {
+            "linux"
+        } else {
+            machine.guest_os.as_str()
+        };
         println!(
-            "{:<20} {:<12} {:<6} {:<12} {:<10}",
+            "{:<20} {:<7} {:<12} {:<6} {:<12} {:<10}",
             machine.name,
+            os,
             title_case_state(&machine.state),
             machine.cpus,
             format!("{} MB", machine.memory / (1024 * 1024)),

--- a/app/arcbox-cli/src/commands/machine.rs
+++ b/app/arcbox-cli/src/commands/machine.rs
@@ -156,12 +156,6 @@ pub struct CreateArgs {
     /// Custom kernel command line (for advanced users / testing)
     #[arg(long)]
     pub cmdline: Option<String>,
-    /// Guest OS: "linux" (default) or "macos" (Apple Silicon only).
-    #[arg(long, default_value = "linux")]
-    pub os: String,
-    /// macOS base image to clone (required when --os macos).
-    #[arg(long)]
-    pub image: Option<String>,
 }
 
 #[derive(Args)]
@@ -261,10 +255,6 @@ pub async fn execute(cmd: MachineCommands) -> Result<()> {
 }
 
 async fn execute_create(args: CreateArgs) -> Result<()> {
-    if args.os == "macos" && args.image.is_none() {
-        anyhow::bail!("--image <base> is required when --os macos");
-    }
-
     let mut client = machine_client().await?;
     let mounts = args
         .mount
@@ -286,8 +276,6 @@ async fn execute_create(args: CreateArgs) -> Result<()> {
             ssh_public_key: String::new(),
             kernel: args.kernel.clone().unwrap_or_default(),
             cmdline: args.cmdline.clone().unwrap_or_default(),
-            guest_os: args.os.clone(),
-            macos_image: args.image.clone().unwrap_or_default(),
         }))
         .await
         .context("Failed to create machine")?;
@@ -417,21 +405,15 @@ async fn execute_list(args: ListArgs) -> Result<()> {
 
     // Print header
     println!(
-        "{:<20} {:<7} {:<12} {:<6} {:<12} {:<10}",
-        "NAME", "OS", "STATE", "CPUS", "MEMORY", "DISK"
+        "{:<20} {:<12} {:<6} {:<12} {:<10}",
+        "NAME", "STATE", "CPUS", "MEMORY", "DISK"
     );
 
     // Print machines
     for machine in &machines {
-        let os = if machine.guest_os.is_empty() {
-            "linux"
-        } else {
-            machine.guest_os.as_str()
-        };
         println!(
-            "{:<20} {:<7} {:<12} {:<6} {:<12} {:<10}",
+            "{:<20} {:<12} {:<6} {:<12} {:<10}",
             machine.name,
-            os,
             title_case_state(&machine.state),
             machine.cpus,
             format!("{} MB", machine.memory / (1024 * 1024)),

--- a/app/arcbox-cli/src/commands/macos.rs
+++ b/app/arcbox-cli/src/commands/macos.rs
@@ -103,7 +103,8 @@ pub enum ImageCommands {
 
 #[derive(Args)]
 pub struct PullArgs {
-    /// Base image name.
+    /// Local name to give the base image.
+    #[arg(long)]
     pub name: String,
     /// Path to a local IPSW restore image. Omit to download the latest from Apple.
     #[arg(long)]
@@ -264,7 +265,7 @@ async fn execute_image(cmd: ImageCommands) -> Result<()> {
                 println!("No macOS images found.");
                 println!();
                 println!("To install one, run:");
-                println!("  arcbox macos image pull <name> --ipsw <path>");
+                println!("  arcbox macos image pull --name <name> [--ipsw <path>]");
                 return Ok(());
             }
 

--- a/app/arcbox-cli/src/commands/macos.rs
+++ b/app/arcbox-cli/src/commands/macos.rs
@@ -1,7 +1,7 @@
 //! macOS guest management commands (Apple Silicon only).
 //!
-//! Disposable, single-purpose macOS VMs: install a base image once from an
-//! IPSW, then copy-on-write clone it to boot clean, throwaway guests. This is a
+//! Disposable, single-purpose macOS VMs: pull a pre-baked base image once,
+//! then copy-on-write clone it to boot clean, throwaway guests. This is a
 //! distinct noun from `arcbox machine` (Linux) and talks to its own
 //! `MacosService`.
 
@@ -91,7 +91,7 @@ pub struct RemoveArgs {
 /// macOS base image commands.
 #[derive(Subcommand)]
 pub enum ImageCommands {
-    /// Install a base image from a local IPSW (long-running)
+    /// Pull a published base image (e.g. tahoe-base or tahoe-base@2026.07.02)
     Pull(PullArgs),
     /// List base images
     #[command(name = "ls", alias = "list")]
@@ -103,15 +103,14 @@ pub enum ImageCommands {
 
 #[derive(Args)]
 pub struct PullArgs {
-    /// Local name to give the base image.
+    /// Image reference: stream name with optional pinned version
+    /// (e.g. "tahoe-base" or "tahoe-base@2026.07.02").
+    #[arg(required_unless_present = "manifest", conflicts_with = "manifest")]
+    pub reference: Option<String>,
+    /// Pull directly from a manifest (URL or daemon-local path), bypassing
+    /// the published index.
     #[arg(long)]
-    pub name: String,
-    /// Path to a local IPSW restore image. Omit to download the latest from Apple.
-    #[arg(long)]
-    pub ipsw: Option<String>,
-    /// System disk size in GB.
-    #[arg(long, default_value = "64")]
-    pub disk: u64,
+    pub manifest: Option<String>,
 }
 
 #[derive(Args)]
@@ -232,24 +231,38 @@ async fn execute_list() -> Result<()> {
 async fn execute_image(cmd: ImageCommands) -> Result<()> {
     match cmd {
         ImageCommands::Pull(args) => {
+            use std::io::Write as _;
+
             let mut client = macos_client().await?;
-            let source = args
-                .ipsw
-                .as_deref()
-                .unwrap_or("latest (download from Apple)");
-            println!(
-                "Installing macOS image '{}' from {source} (this can take 10-20 minutes)...",
-                args.name
-            );
-            client
+            let what = args
+                .reference
+                .clone()
+                .or_else(|| args.manifest.clone())
+                .unwrap_or_default();
+            let mut stream = client
                 .image_pull(tonic::Request::new(MacosImagePullRequest {
-                    name: args.name.clone(),
-                    ipsw_path: args.ipsw.unwrap_or_default(),
-                    disk_gb: args.disk,
+                    reference: args.reference.unwrap_or_default(),
+                    manifest_url: args.manifest.unwrap_or_default(),
                 }))
                 .await
-                .context("Failed to install macOS image")?;
-            println!("macOS image '{}' installed", args.name);
+                .context("Failed to pull macOS image")?
+                .into_inner();
+
+            let mut last_stage = String::new();
+            while let Some(event) = stream
+                .message()
+                .await
+                .context("Failed to pull macOS image")?
+            {
+                if event.stage != last_stage && !last_stage.is_empty() {
+                    println!();
+                }
+                last_stage.clone_from(&event.stage);
+                print!("\r{}: {:>3.0}%", event.stage, event.fraction * 100.0);
+                let _ = std::io::stdout().flush();
+            }
+            println!();
+            println!("macOS image '{what}' pulled");
             Ok(())
         }
         ImageCommands::List => {
@@ -264,22 +277,34 @@ async fn execute_image(cmd: ImageCommands) -> Result<()> {
             if images.is_empty() {
                 println!("No macOS images found.");
                 println!();
-                println!("To install one, run:");
-                println!("  arcbox macos image pull --name <name> [--ipsw <path>]");
+                println!("To pull one, run:");
+                println!("  arcbox macos image pull tahoe-base");
                 return Ok(());
             }
 
             println!(
-                "{:<20} {:<6} {:<10} {:<8}",
-                "NAME", "CPUS", "MEMORY", "DISK"
+                "{:<20} {:<14} {:<8} {:<8} {:<12}",
+                "NAME", "VERSION", "OS", "DISK", "CREATED"
             );
             for image in &images {
+                let created = chrono::DateTime::from_timestamp(image.created, 0)
+                    .map(|t| t.format("%Y-%m-%d").to_string())
+                    .unwrap_or_default();
                 println!(
-                    "{:<20} {:<6} {:<10} {:<8}",
+                    "{:<20} {:<14} {:<8} {:<8} {:<12}",
                     image.name,
-                    image.minimum_cpu_count,
-                    format!("{} MB", image.minimum_memory_mib),
+                    if image.version.is_empty() {
+                        "-"
+                    } else {
+                        &image.version
+                    },
+                    if image.os_version.is_empty() {
+                        "-"
+                    } else {
+                        &image.os_version
+                    },
                     format!("{} GB", image.disk_gb),
+                    created,
                 );
             }
             Ok(())

--- a/app/arcbox-cli/src/commands/macos.rs
+++ b/app/arcbox-cli/src/commands/macos.rs
@@ -9,7 +9,8 @@ use anyhow::{Context, Result};
 use arcbox_grpc::v1::macos_service_client::MacosServiceClient;
 use arcbox_protocol::v1::{
     CreateMacosMachineRequest, Empty, MacosImagePullRequest, MacosImageRemoveRequest,
-    RemoveMacosMachineRequest, StartMacosMachineRequest, StopMacosMachineRequest,
+    MacosImageResolveRequest, RemoveMacosMachineRequest, StartMacosMachineRequest,
+    StopMacosMachineRequest,
 };
 use clap::{Args, Subcommand};
 use tonic::transport::{Channel, Endpoint};
@@ -92,7 +93,10 @@ pub struct RemoveArgs {
 #[derive(Subcommand)]
 pub enum ImageCommands {
     /// Pull a published base image (e.g. tahoe-base or tahoe-base@2026.07.02)
-    Pull(PullArgs),
+    Pull(SourceArgs),
+    /// Resolve a reference against the published index without downloading:
+    /// what version a pull would land, and what is installed locally
+    Resolve(SourceArgs),
     /// List base images
     #[command(name = "ls", alias = "list")]
     List,
@@ -101,14 +105,16 @@ pub enum ImageCommands {
     Remove(ImageRemoveArgs),
 }
 
+/// Where an image comes from — shared by `pull` and `resolve`, which take
+/// the same source.
 #[derive(Args)]
-pub struct PullArgs {
+pub struct SourceArgs {
     /// Image reference: stream name with optional pinned version
     /// (e.g. "tahoe-base" or "tahoe-base@2026.07.02").
     #[arg(required_unless_present = "manifest", conflicts_with = "manifest")]
     pub reference: Option<String>,
-    /// Pull directly from a manifest (URL or daemon-local path), bypassing
-    /// the published index.
+    /// Use a manifest directly (URL or daemon-local path), bypassing the
+    /// published index.
     #[arg(long)]
     pub manifest: Option<String>,
 }
@@ -249,11 +255,18 @@ async fn execute_image(cmd: ImageCommands) -> Result<()> {
                 .into_inner();
 
             let mut last_stage = String::new();
+            let mut landed = None;
             while let Some(event) = stream
                 .message()
                 .await
                 .context("Failed to pull macOS image")?
             {
+                // The terminal event carries the landed image instead of
+                // progress; report it as the outcome, not as a stage line.
+                if let Some(image) = event.image {
+                    landed = Some(image);
+                    continue;
+                }
                 if event.stage != last_stage && !last_stage.is_empty() {
                     println!();
                 }
@@ -262,7 +275,35 @@ async fn execute_image(cmd: ImageCommands) -> Result<()> {
                 let _ = std::io::stdout().flush();
             }
             println!();
-            println!("macOS image '{what}' pulled");
+            match landed {
+                Some(image) => println!("macOS image '{}@{}' pulled", image.name, image.version),
+                None => println!("macOS image '{what}' pulled"),
+            }
+            Ok(())
+        }
+        ImageCommands::Resolve(args) => {
+            let mut client = macos_client().await?;
+            let info = client
+                .image_resolve(tonic::Request::new(MacosImageResolveRequest {
+                    reference: args.reference.unwrap_or_default(),
+                    manifest_url: args.manifest.unwrap_or_default(),
+                }))
+                .await
+                .context("Failed to resolve macOS image")?
+                .into_inner();
+            println!("{}@{}", info.name, info.version);
+            println!("os: macOS {}", info.os_version);
+            println!(
+                "requires: {} CPUs, {} MiB memory, {} GB disk",
+                info.minimum_cpu_count, info.minimum_memory_mib, info.disk_gb
+            );
+            if info.installed_version.is_empty() {
+                println!("installed: (none)");
+            } else if info.installed_version == info.version {
+                println!("installed: {} (up to date)", info.installed_version);
+            } else {
+                println!("installed: {} (update available)", info.installed_version);
+            }
             Ok(())
         }
         ImageCommands::List => {

--- a/app/arcbox-cli/src/commands/macos.rs
+++ b/app/arcbox-cli/src/commands/macos.rs
@@ -8,9 +8,9 @@
 use anyhow::{Context, Result};
 use arcbox_grpc::v1::macos_service_client::MacosServiceClient;
 use arcbox_protocol::v1::{
-    CreateMacosMachineRequest, Empty, MacosImagePullRequest, MacosImageRemoveRequest,
-    MacosImageResolveRequest, RemoveMacosMachineRequest, StartMacosMachineRequest,
-    StopMacosMachineRequest,
+    CreateMacosMachineRequest, Empty, InspectMacosMachineRequest, MacosImagePullRequest,
+    MacosImageRemoveRequest, MacosImageResolveRequest, RemoveMacosMachineRequest,
+    StartMacosMachineRequest, StopMacosMachineRequest,
 };
 use clap::{Args, Subcommand};
 use tonic::transport::{Channel, Endpoint};
@@ -54,6 +54,8 @@ pub enum MacosCommands {
     /// List guests
     #[command(name = "ls", alias = "list")]
     List,
+    /// Print a running guest's IP address (from its DHCP lease)
+    Ip(IpArgs),
     /// Manage macOS base images
     #[command(subcommand)]
     Image(ImageCommands),
@@ -78,6 +80,16 @@ pub struct CreateArgs {
 pub struct NameArgs {
     /// Guest name.
     pub name: String,
+}
+
+#[derive(Args)]
+pub struct IpArgs {
+    /// Guest name.
+    pub name: String,
+    /// Keep retrying for up to this many seconds — a freshly started guest
+    /// takes a few seconds to acquire its DHCP lease.
+    #[arg(long, default_value = "0")]
+    pub wait: u16,
 }
 
 #[derive(Args)]
@@ -133,7 +145,35 @@ pub async fn execute(cmd: MacosCommands) -> Result<()> {
         MacosCommands::Stop(args) => execute_stop(args).await,
         MacosCommands::Remove(args) => execute_remove(args).await,
         MacosCommands::List => execute_list().await,
+        MacosCommands::Ip(args) => execute_ip(args).await,
         MacosCommands::Image(c) => execute_image(c).await,
+    }
+}
+
+async fn execute_ip(args: IpArgs) -> Result<()> {
+    let mut client = macos_client().await?;
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(args.wait.into());
+    loop {
+        let info = client
+            .inspect(tonic::Request::new(InspectMacosMachineRequest {
+                name: args.name.clone(),
+            }))
+            .await
+            .context("Failed to inspect macOS guest")?
+            .into_inner();
+        if !info.ip_address.is_empty() {
+            println!("{}", info.ip_address);
+            return Ok(());
+        }
+        if std::time::Instant::now() >= deadline {
+            let hint = if info.state == "running" {
+                "the guest has not acquired a DHCP lease yet — try --wait 30"
+            } else {
+                "is the guest running?"
+            };
+            anyhow::bail!("no IP address found for '{}' ({hint})", args.name);
+        }
+        tokio::time::sleep(std::time::Duration::from_secs(1)).await;
     }
 }
 

--- a/app/arcbox-cli/src/commands/macos.rs
+++ b/app/arcbox-cli/src/commands/macos.rs
@@ -1,17 +1,91 @@
-//! macOS guest image management commands.
+//! macOS guest management commands (Apple Silicon only).
+//!
+//! Disposable, single-purpose macOS VMs: install a base image once from an
+//! IPSW, then copy-on-write clone it to boot clean, throwaway guests. This is a
+//! distinct noun from `arcbox machine` (Linux) and talks to its own
+//! `MacosService`.
 
 use anyhow::{Context, Result};
-use arcbox_protocol::v1::{Empty, MacImagePullRequest, MacImageRemoveRequest};
+use arcbox_grpc::v1::macos_service_client::MacosServiceClient;
+use arcbox_protocol::v1::{
+    CreateMacosMachineRequest, Empty, MacosImagePullRequest, MacosImageRemoveRequest,
+    RemoveMacosMachineRequest, StartMacosMachineRequest, StopMacosMachineRequest,
+};
 use clap::{Args, Subcommand};
+use tonic::transport::{Channel, Endpoint};
 
-use super::machine::machine_client;
+use super::machine::UnixConnector;
+
+async fn macos_client() -> Result<MacosServiceClient<Channel>> {
+    let socket_path = super::resolve_grpc_socket_path();
+    let channel = Endpoint::from_static("http://[::]:50051")
+        .connect_with_connector(UnixConnector::new(socket_path.clone()))
+        .await
+        .with_context(|| {
+            format!(
+                "Failed to connect to ArcBox gRPC daemon at {}",
+                socket_path.display()
+            )
+        })?;
+    Ok(MacosServiceClient::new(channel))
+}
+
+fn title_case(state: &str) -> String {
+    let mut chars = state.chars();
+    match chars.next() {
+        Some(first) => format!("{}{}", first.to_ascii_uppercase(), chars.as_str()),
+        None => String::new(),
+    }
+}
 
 /// macOS guest management commands (Apple Silicon only).
 #[derive(Subcommand)]
 pub enum MacosCommands {
+    /// Create a guest by copy-on-write cloning a base image
+    Create(CreateArgs),
+    /// Start a guest
+    Start(NameArgs),
+    /// Stop a guest
+    Stop(NameArgs),
+    /// Remove a guest
+    #[command(alias = "rm")]
+    Remove(RemoveArgs),
+    /// List guests
+    #[command(name = "ls", alias = "list")]
+    List,
     /// Manage macOS base images
     #[command(subcommand)]
     Image(ImageCommands),
+}
+
+#[derive(Args)]
+pub struct CreateArgs {
+    /// Guest name.
+    pub name: String,
+    /// Base image to clone.
+    #[arg(long)]
+    pub image: String,
+    /// Number of CPUs.
+    #[arg(long, default_value = "4", value_parser = clap::value_parser!(u32).range(1..))]
+    pub cpus: u32,
+    /// Memory in MiB.
+    #[arg(long, default_value = "8192")]
+    pub memory: u64,
+}
+
+#[derive(Args)]
+pub struct NameArgs {
+    /// Guest name.
+    pub name: String,
+}
+
+#[derive(Args)]
+pub struct RemoveArgs {
+    /// Guest name.
+    pub name: String,
+    /// Remove even if running (stops it first).
+    #[arg(short, long)]
+    pub force: bool,
 }
 
 /// macOS base image commands.
@@ -24,7 +98,7 @@ pub enum ImageCommands {
     List,
     /// Remove a base image
     #[command(alias = "rm")]
-    Remove(RemoveArgs),
+    Remove(ImageRemoveArgs),
 }
 
 #[derive(Args)]
@@ -34,19 +108,13 @@ pub struct PullArgs {
     /// Path to a local IPSW restore image.
     #[arg(long)]
     pub ipsw: String,
-    /// CPUs for the install VM.
-    #[arg(long, default_value = "4")]
-    pub cpus: u32,
-    /// Memory in MB for the install VM.
-    #[arg(long, default_value = "8192")]
-    pub memory: u64,
     /// System disk size in GB.
     #[arg(long, default_value = "64")]
     pub disk: u64,
 }
 
 #[derive(Args)]
-pub struct RemoveArgs {
+pub struct ImageRemoveArgs {
     /// Base image name.
     pub name: String,
 }
@@ -54,25 +122,125 @@ pub struct RemoveArgs {
 /// Executes a macOS command.
 pub async fn execute(cmd: MacosCommands) -> Result<()> {
     match cmd {
+        MacosCommands::Create(args) => execute_create(args).await,
+        MacosCommands::Start(args) => execute_start(args).await,
+        MacosCommands::Stop(args) => execute_stop(args).await,
+        MacosCommands::Remove(args) => execute_remove(args).await,
+        MacosCommands::List => execute_list().await,
         MacosCommands::Image(c) => execute_image(c).await,
     }
+}
+
+async fn execute_create(args: CreateArgs) -> Result<()> {
+    let mut client = macos_client().await?;
+    client
+        .create(tonic::Request::new(CreateMacosMachineRequest {
+            name: args.name.clone(),
+            image: args.image.clone(),
+            cpus: args.cpus,
+            memory_mib: args.memory,
+        }))
+        .await
+        .context("Failed to create macOS guest")?;
+
+    println!(
+        "macOS guest '{}' created from image '{}'",
+        args.name, args.image
+    );
+    println!("  CPUs:   {}", args.cpus);
+    println!("  Memory: {} MiB", args.memory);
+    println!();
+    println!("To start it, run:");
+    println!("  arcbox macos start {}", args.name);
+    Ok(())
+}
+
+async fn execute_start(args: NameArgs) -> Result<()> {
+    let mut client = macos_client().await?;
+    println!("Starting macOS guest '{}'...", args.name);
+    client
+        .start(tonic::Request::new(StartMacosMachineRequest {
+            name: args.name.clone(),
+        }))
+        .await
+        .context("Failed to start macOS guest")?;
+    println!("macOS guest '{}' started", args.name);
+    Ok(())
+}
+
+async fn execute_stop(args: NameArgs) -> Result<()> {
+    let mut client = macos_client().await?;
+    println!("Stopping macOS guest '{}'...", args.name);
+    client
+        .stop(tonic::Request::new(StopMacosMachineRequest {
+            name: args.name.clone(),
+        }))
+        .await
+        .context("Failed to stop macOS guest")?;
+    println!("macOS guest '{}' stopped", args.name);
+    Ok(())
+}
+
+async fn execute_remove(args: RemoveArgs) -> Result<()> {
+    let mut client = macos_client().await?;
+    client
+        .remove(tonic::Request::new(RemoveMacosMachineRequest {
+            name: args.name.clone(),
+            force: args.force,
+        }))
+        .await
+        .context("Failed to remove macOS guest")?;
+    println!("macOS guest '{}' removed", args.name);
+    Ok(())
+}
+
+async fn execute_list() -> Result<()> {
+    let mut client = macos_client().await?;
+    let machines = client
+        .list(tonic::Request::new(Empty {}))
+        .await
+        .context("Failed to list macOS guests")?
+        .into_inner()
+        .machines;
+
+    if machines.is_empty() {
+        println!("No macOS guests found.");
+        println!();
+        println!("To create one, run:");
+        println!("  arcbox macos create <name> --image <base>");
+        return Ok(());
+    }
+
+    println!(
+        "{:<20} {:<12} {:<6} {:<12} {:<16}",
+        "NAME", "STATE", "CPUS", "MEMORY", "IMAGE"
+    );
+    for m in &machines {
+        println!(
+            "{:<20} {:<12} {:<6} {:<12} {:<16}",
+            m.name,
+            title_case(&m.state),
+            m.cpus,
+            format!("{} MiB", m.memory_mib),
+            m.image,
+        );
+    }
+    Ok(())
 }
 
 async fn execute_image(cmd: ImageCommands) -> Result<()> {
     match cmd {
         ImageCommands::Pull(args) => {
-            let mut client = machine_client().await?;
+            let mut client = macos_client().await?;
             println!(
                 "Installing macOS image '{}' from {} (this can take 10-20 minutes)...",
                 args.name, args.ipsw
             );
             client
-                .mac_image_pull(tonic::Request::new(MacImagePullRequest {
+                .image_pull(tonic::Request::new(MacosImagePullRequest {
                     name: args.name.clone(),
                     ipsw_path: args.ipsw,
-                    cpus: args.cpus,
-                    memory: args.memory.saturating_mul(1024 * 1024),
-                    disk_size: args.disk.saturating_mul(1024 * 1024 * 1024),
+                    disk_gb: args.disk,
                 }))
                 .await
                 .context("Failed to install macOS image")?;
@@ -80,9 +248,9 @@ async fn execute_image(cmd: ImageCommands) -> Result<()> {
             Ok(())
         }
         ImageCommands::List => {
-            let mut client = machine_client().await?;
+            let mut client = macos_client().await?;
             let images = client
-                .mac_image_list(tonic::Request::new(Empty {}))
+                .image_list(tonic::Request::new(Empty {}))
                 .await
                 .context("Failed to list macOS images")?
                 .into_inner()
@@ -112,9 +280,9 @@ async fn execute_image(cmd: ImageCommands) -> Result<()> {
             Ok(())
         }
         ImageCommands::Remove(args) => {
-            let mut client = machine_client().await?;
+            let mut client = macos_client().await?;
             client
-                .mac_image_remove(tonic::Request::new(MacImageRemoveRequest {
+                .image_remove(tonic::Request::new(MacosImageRemoveRequest {
                     name: args.name.clone(),
                 }))
                 .await

--- a/app/arcbox-cli/src/commands/macos.rs
+++ b/app/arcbox-cli/src/commands/macos.rs
@@ -1,0 +1,126 @@
+//! macOS guest image management commands.
+
+use anyhow::{Context, Result};
+use arcbox_protocol::v1::{Empty, MacImagePullRequest, MacImageRemoveRequest};
+use clap::{Args, Subcommand};
+
+use super::machine::machine_client;
+
+/// macOS guest management commands (Apple Silicon only).
+#[derive(Subcommand)]
+pub enum MacosCommands {
+    /// Manage macOS base images
+    #[command(subcommand)]
+    Image(ImageCommands),
+}
+
+/// macOS base image commands.
+#[derive(Subcommand)]
+pub enum ImageCommands {
+    /// Install a base image from a local IPSW (long-running)
+    Pull(PullArgs),
+    /// List base images
+    #[command(name = "ls", alias = "list")]
+    List,
+    /// Remove a base image
+    #[command(alias = "rm")]
+    Remove(RemoveArgs),
+}
+
+#[derive(Args)]
+pub struct PullArgs {
+    /// Base image name.
+    pub name: String,
+    /// Path to a local IPSW restore image.
+    #[arg(long)]
+    pub ipsw: String,
+    /// CPUs for the install VM.
+    #[arg(long, default_value = "4")]
+    pub cpus: u32,
+    /// Memory in MB for the install VM.
+    #[arg(long, default_value = "8192")]
+    pub memory: u64,
+    /// System disk size in GB.
+    #[arg(long, default_value = "64")]
+    pub disk: u64,
+}
+
+#[derive(Args)]
+pub struct RemoveArgs {
+    /// Base image name.
+    pub name: String,
+}
+
+/// Executes a macOS command.
+pub async fn execute(cmd: MacosCommands) -> Result<()> {
+    match cmd {
+        MacosCommands::Image(c) => execute_image(c).await,
+    }
+}
+
+async fn execute_image(cmd: ImageCommands) -> Result<()> {
+    match cmd {
+        ImageCommands::Pull(args) => {
+            let mut client = machine_client().await?;
+            println!(
+                "Installing macOS image '{}' from {} (this can take 10-20 minutes)...",
+                args.name, args.ipsw
+            );
+            client
+                .mac_image_pull(tonic::Request::new(MacImagePullRequest {
+                    name: args.name.clone(),
+                    ipsw_path: args.ipsw,
+                    cpus: args.cpus,
+                    memory: args.memory.saturating_mul(1024 * 1024),
+                    disk_size: args.disk.saturating_mul(1024 * 1024 * 1024),
+                }))
+                .await
+                .context("Failed to install macOS image")?;
+            println!("macOS image '{}' installed", args.name);
+            Ok(())
+        }
+        ImageCommands::List => {
+            let mut client = machine_client().await?;
+            let images = client
+                .mac_image_list(tonic::Request::new(Empty {}))
+                .await
+                .context("Failed to list macOS images")?
+                .into_inner()
+                .images;
+
+            if images.is_empty() {
+                println!("No macOS images found.");
+                println!();
+                println!("To install one, run:");
+                println!("  arcbox macos image pull <name> --ipsw <path>");
+                return Ok(());
+            }
+
+            println!(
+                "{:<20} {:<6} {:<10} {:<8}",
+                "NAME", "CPUS", "MEMORY", "DISK"
+            );
+            for image in &images {
+                println!(
+                    "{:<20} {:<6} {:<10} {:<8}",
+                    image.name,
+                    image.minimum_cpu_count,
+                    format!("{} MB", image.minimum_memory_mib),
+                    format!("{} GB", image.disk_gb),
+                );
+            }
+            Ok(())
+        }
+        ImageCommands::Remove(args) => {
+            let mut client = machine_client().await?;
+            client
+                .mac_image_remove(tonic::Request::new(MacImageRemoveRequest {
+                    name: args.name.clone(),
+                }))
+                .await
+                .context("Failed to remove macOS image")?;
+            println!("macOS image '{}' removed", args.name);
+            Ok(())
+        }
+    }
+}

--- a/app/arcbox-cli/src/commands/macos.rs
+++ b/app/arcbox-cli/src/commands/macos.rs
@@ -105,9 +105,9 @@ pub enum ImageCommands {
 pub struct PullArgs {
     /// Base image name.
     pub name: String,
-    /// Path to a local IPSW restore image.
+    /// Path to a local IPSW restore image. Omit to download the latest from Apple.
     #[arg(long)]
-    pub ipsw: String,
+    pub ipsw: Option<String>,
     /// System disk size in GB.
     #[arg(long, default_value = "64")]
     pub disk: u64,
@@ -232,14 +232,18 @@ async fn execute_image(cmd: ImageCommands) -> Result<()> {
     match cmd {
         ImageCommands::Pull(args) => {
             let mut client = macos_client().await?;
+            let source = args
+                .ipsw
+                .as_deref()
+                .unwrap_or("latest (download from Apple)");
             println!(
-                "Installing macOS image '{}' from {} (this can take 10-20 minutes)...",
-                args.name, args.ipsw
+                "Installing macOS image '{}' from {source} (this can take 10-20 minutes)...",
+                args.name
             );
             client
                 .image_pull(tonic::Request::new(MacosImagePullRequest {
                     name: args.name.clone(),
-                    ipsw_path: args.ipsw,
+                    ipsw_path: args.ipsw.unwrap_or_default(),
                     disk_gb: args.disk,
                 }))
                 .await

--- a/app/arcbox-cli/src/commands/mod.rs
+++ b/app/arcbox-cli/src/commands/mod.rs
@@ -57,6 +57,8 @@ pub mod internal;
 pub mod kubernetes;
 pub mod logs;
 pub mod machine;
+#[cfg(target_os = "macos")]
+pub mod macos;
 pub mod migrate;
 pub mod sandbox;
 pub mod setup;
@@ -113,6 +115,11 @@ pub enum Commands {
     /// Manage Linux machines
     #[command(subcommand)]
     Machine(machine::MachineCommands),
+
+    /// Manage macOS guests (Apple Silicon only)
+    #[cfg(target_os = "macos")]
+    #[command(subcommand)]
+    Macos(macos::MacosCommands),
 
     /// Import workloads from Docker Desktop or OrbStack
     #[command(subcommand)]

--- a/app/arcbox-cli/src/main.rs
+++ b/app/arcbox-cli/src/main.rs
@@ -67,6 +67,8 @@ fn main() -> Result<()> {
         .block_on(async {
             match cli.command {
                 Commands::Machine(cmd) => commands::machine::execute(cmd).await,
+                #[cfg(target_os = "macos")]
+                Commands::Macos(cmd) => commands::macos::execute(cmd).await,
                 Commands::Migrate(cmd) => commands::migrate::execute(cmd).await,
                 Commands::Sandbox(cmd) => commands::sandbox::execute(cmd).await,
                 Commands::Docker(cmd) => commands::docker::execute(cmd, cli.format).await,

--- a/app/arcbox-core/Cargo.toml
+++ b/app/arcbox-core/Cargo.toml
@@ -44,6 +44,7 @@ tempfile = "3"
 statig = "0.4.1"
 
 [target.'cfg(target_os = "macos")'.dependencies]
+arcbox-vz.workspace = true
 ifbridge = { workspace = true }
 
 [dev-dependencies]

--- a/app/arcbox-core/Cargo.toml
+++ b/app/arcbox-core/Cargo.toml
@@ -42,6 +42,8 @@ arcbox-migration = { workspace = true }
 libc = { workspace = true }
 tempfile = "3"
 statig = "0.4.1"
+zstd = "0.13.3"
+base64 = "0.22.1"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 arcbox-vz.workspace = true

--- a/app/arcbox-core/Cargo.toml
+++ b/app/arcbox-core/Cargo.toml
@@ -62,6 +62,10 @@ provision-bundled = []
 provision-distro = []
 vmnet = ["arcbox-vmm/vmnet"]
 gic = ["arcbox-vmm/gic"]
+# Retained-but-unshipped macOS IPSW installer (install_from_ipsw + Apple IPSW
+# download). The product acquires images via `pull` only; this stays compiled
+# under the feature so the code cannot rot. Not part of any default build.
+macos-ipsw-install = []
 
 [lints]
 workspace = true

--- a/app/arcbox-core/src/config.rs
+++ b/app/arcbox-core/src/config.rs
@@ -15,6 +15,7 @@
 //! [vm]
 //! # cpus = 8         # default: host core count
 //! # memory_mb = 8192  # default: half of host RAM (512–16384)
+//! # autostart = true  # boot the default Linux VM (Docker/K8s); false = VM-host only
 //!
 //! [machine]
 //! disk_gb = 50
@@ -197,6 +198,12 @@ pub struct VmDefaults {
     /// non-interactively via `ARCBOX_VM_BACKEND` or `config.toml` — the
     /// entry point for the dual-backend e2e matrix.
     pub backend: arcbox_vmm::VmBackend,
+    /// Whether to boot the default Linux VM (the Docker/Kubernetes system VM)
+    /// on daemon startup. When `false`, the daemon runs as a VM host only:
+    /// the Linux VM never starts and the Docker API, Docker CLI integration,
+    /// and Kubernetes proxy are all disabled. macOS guest management is
+    /// unaffected. Overridden to `false` by the daemon's `--no-linux-vm` flag.
+    pub autostart: bool,
 }
 
 impl VmDefaults {
@@ -223,6 +230,7 @@ impl Default for VmDefaults {
             memory_mb: arcbox_hypervisor::default_vm_memory_size() / (1024 * 1024),
             kernel_path: None,
             backend: arcbox_vmm::VmBackend::default(),
+            autostart: true,
         }
     }
 }

--- a/app/arcbox-core/src/error.rs
+++ b/app/arcbox-core/src/error.rs
@@ -56,9 +56,16 @@ pub enum CoreError {
     #[error("network error: {0}")]
     Net(#[from] arcbox_net::NetError),
 
-    /// macOS guest image / clone error.
+    /// macOS guest image / clone error (a message that does not originate from
+    /// Virtualization.framework — e.g. a path or serialization failure).
+    #[cfg(target_os = "macos")]
     #[error("macOS image error: {0}")]
     Macos(String),
+
+    /// Virtualization.framework error from the `arcbox-vz` layer.
+    #[cfg(target_os = "macos")]
+    #[error("macOS virtualization error: {0}")]
+    Vz(#[from] arcbox_vz::VZError),
 }
 
 impl CoreError {
@@ -87,6 +94,7 @@ impl CoreError {
     }
 
     /// Creates a new macOS image error.
+    #[cfg(target_os = "macos")]
     #[must_use]
     pub fn macos(msg: impl Into<String>) -> Self {
         Self::Macos(msg.into())

--- a/app/arcbox-core/src/error.rs
+++ b/app/arcbox-core/src/error.rs
@@ -55,6 +55,10 @@ pub enum CoreError {
     /// Network error.
     #[error("network error: {0}")]
     Net(#[from] arcbox_net::NetError),
+
+    /// macOS guest image / clone error.
+    #[error("macOS image error: {0}")]
+    Macos(String),
 }
 
 impl CoreError {
@@ -80,6 +84,12 @@ impl CoreError {
     #[must_use]
     pub fn invalid_state(msg: impl Into<String>) -> Self {
         Self::Common(CommonError::invalid_state(msg))
+    }
+
+    /// Creates a new macOS image error.
+    #[must_use]
+    pub fn macos(msg: impl Into<String>) -> Self {
+        Self::Macos(msg.into())
     }
 }
 

--- a/app/arcbox-core/src/lib.rs
+++ b/app/arcbox-core/src/lib.rs
@@ -59,8 +59,9 @@ pub use error::{CoreError, Result};
 pub use machine::MachineManager;
 #[cfg(target_os = "macos")]
 pub use macos::{
-    MacImage, MacImageManager, MacImageMeta, MacInstanceDisks, MacMachineConfig, MacMachineInfo,
-    MacMachineManager, MacVm, PullPhase, PullSource,
+    ImageReference, MacImage, MacImageManager, MacImageMeta, MacInstanceDisks, MacMachineConfig,
+    MacMachineInfo, MacMachineManager, MacVm, PullPhase, PullSource, PullStage, RemoteLocation,
+    RemoteSource,
 };
 pub use migration::MigrationManager;
 pub use runtime::{Runtime, SandboxPortExposure};

--- a/app/arcbox-core/src/lib.rs
+++ b/app/arcbox-core/src/lib.rs
@@ -58,7 +58,10 @@ pub use config::{Config, ContainerRuntimeConfig};
 pub use error::{CoreError, Result};
 pub use machine::MachineManager;
 #[cfg(target_os = "macos")]
-pub use macos::{MacImage, MacImageManager, MacImageMeta, MacInstanceDisks};
+pub use macos::{
+    MacImage, MacImageManager, MacImageMeta, MacInstanceDisks, MacMachineConfig, MacMachineInfo,
+    MacMachineManager, MacVm,
+};
 pub use migration::MigrationManager;
 pub use runtime::{Runtime, SandboxPortExposure};
 pub use vm::{SharedDirConfig, VmConfig, VmManager};

--- a/app/arcbox-core/src/lib.rs
+++ b/app/arcbox-core/src/lib.rs
@@ -60,9 +60,10 @@ pub use machine::MachineManager;
 #[cfg(target_os = "macos")]
 pub use macos::{
     ImageReference, MacImage, MacImageManager, MacImageMeta, MacInstanceDisks, MacMachineConfig,
-    MacMachineInfo, MacMachineManager, MacVm, PullPhase, PullSource, PullStage, RemoteLocation,
-    RemoteSource,
+    MacMachineInfo, MacMachineManager, MacVm, PullStage, RemoteLocation, RemoteSource,
 };
+#[cfg(feature = "macos-ipsw-install")]
+pub use macos::{PullPhase, PullSource};
 pub use migration::MigrationManager;
 pub use runtime::{Runtime, SandboxPortExposure};
 pub use vm::{SharedDirConfig, VmConfig, VmManager};

--- a/app/arcbox-core/src/lib.rs
+++ b/app/arcbox-core/src/lib.rs
@@ -60,7 +60,7 @@ pub use machine::MachineManager;
 #[cfg(target_os = "macos")]
 pub use macos::{
     MacImage, MacImageManager, MacImageMeta, MacInstanceDisks, MacMachineConfig, MacMachineInfo,
-    MacMachineManager, MacVm,
+    MacMachineManager, MacVm, PullPhase, PullSource,
 };
 pub use migration::MigrationManager;
 pub use runtime::{Runtime, SandboxPortExposure};

--- a/app/arcbox-core/src/lib.rs
+++ b/app/arcbox-core/src/lib.rs
@@ -61,6 +61,7 @@ pub use machine::MachineManager;
 pub use macos::{
     ImageReference, MacImage, MacImageManager, MacImageMeta, MacInstanceDisks, MacMachineConfig,
     MacMachineInfo, MacMachineManager, MacVm, PullStage, RemoteLocation, RemoteSource,
+    ResolvedImage,
 };
 #[cfg(feature = "macos-ipsw-install")]
 pub use macos::{PullPhase, PullSource};

--- a/app/arcbox-core/src/lib.rs
+++ b/app/arcbox-core/src/lib.rs
@@ -37,6 +37,8 @@ pub mod container_backend;
 pub mod error;
 pub mod event;
 pub mod machine;
+#[cfg(target_os = "macos")]
+pub mod macos;
 pub mod migration;
 pub mod persistence;
 #[cfg(target_os = "macos")]
@@ -55,6 +57,8 @@ pub use boot_assets::{
 pub use config::{Config, ContainerRuntimeConfig};
 pub use error::{CoreError, Result};
 pub use machine::MachineManager;
+#[cfg(target_os = "macos")]
+pub use macos::{MacImage, MacImageManager, MacImageMeta, MacInstanceDisks};
 pub use migration::MigrationManager;
 pub use runtime::{Runtime, SandboxPortExposure};
 pub use vm::{SharedDirConfig, VmConfig, VmManager};

--- a/app/arcbox-core/src/macos/disk.rs
+++ b/app/arcbox-core/src/macos/disk.rs
@@ -1,0 +1,498 @@
+//! Chunked restore of a published macOS system disk.
+//!
+//! A manifest splits the disk into fixed-size, independently decompressible
+//! zstd frames (`disk.NNN.zst`). [`fetch_disk`] downloads them with bounded
+//! parallelism, verifies each stored object against its manifest hash,
+//! decompresses each frame, and sparse-writes it at its fixed offset — the
+//! compressed bytes are streamed through decompression and never staged on
+//! disk. Per-chunk integrity (compressed hash + exact decompressed length,
+//! plus zstd's own per-frame content checksum) combined with deterministic
+//! offset placement makes the assembled image correct without an end-to-end
+//! re-read of the multi-gigabyte result.
+
+use std::io::Write;
+use std::path::Path;
+use std::sync::Arc;
+
+use sha2::{Digest, Sha256};
+use tokio::io::AsyncReadExt;
+use tokio::sync::Semaphore;
+use tokio::task::JoinSet;
+
+use super::remote::{DiskChunk, DiskManifest, RemoteLocation};
+use crate::error::{CoreError, Result};
+
+/// Concurrent chunk downloads: enough to keep a fast link busy and overlap
+/// decompression across cores without flooding the CDN or the runtime.
+const DOWNLOAD_CONCURRENCY: usize = 4;
+
+/// Per-chunk transient-failure budget. A chunk is small enough (≤ ~480 MiB
+/// compressed) that a failed attempt simply re-downloads it from the start —
+/// no byte-range resume, which keeps the streaming decoder state trivial.
+const DOWNLOAD_RETRIES: u32 = 4;
+const DOWNLOAD_RETRY_DELAY: std::time::Duration = std::time::Duration::from_secs(2);
+
+/// Block granularity for zero detection; a multiple of the APFS block size.
+const SPARSE_BLOCK: usize = 64 * 1024;
+static ZERO_BLOCK: [u8; SPARSE_BLOCK] = [0u8; SPARSE_BLOCK];
+
+/// Zero-skipping positioned block writer: writes decompressed bytes at
+/// `base + offset` into a pre-sized file, never writing all-zero blocks (so
+/// skipped ranges stay holes). One writer per chunk; `base` is the chunk's
+/// absolute disk offset. Both `base` (a multiple of `chunk_size`) and the
+/// block size are aligned to the block grid, so chunks written in parallel
+/// never share a block and their positioned writes never overlap.
+///
+/// Alignment comes from buffering to fixed-size blocks; the `Write::flush`
+/// impl deliberately does not drain a partial block (the decompressor flushes
+/// mid-stream), the tail is written by [`SparseWriter::finish`].
+struct SparseWriter {
+    file: Arc<std::fs::File>,
+    base: u64,
+    offset: u64,
+    buf: Vec<u8>,
+}
+
+impl SparseWriter {
+    fn new(file: Arc<std::fs::File>, base: u64) -> Self {
+        Self {
+            file,
+            base,
+            offset: 0,
+            buf: Vec::with_capacity(SPARSE_BLOCK),
+        }
+    }
+
+    fn flush_block(&mut self) -> std::io::Result<()> {
+        use std::os::unix::fs::FileExt;
+        // Slice equality is a memcmp — much faster than a per-byte scan.
+        if self.buf.as_slice() != &ZERO_BLOCK[..self.buf.len()] {
+            self.file.write_all_at(&self.buf, self.base + self.offset)?;
+        }
+        self.offset += self.buf.len() as u64;
+        self.buf.clear();
+        Ok(())
+    }
+
+    /// Drains the partial tail block and returns the bytes this chunk covered.
+    fn finish(mut self) -> std::io::Result<u64> {
+        if !self.buf.is_empty() {
+            self.flush_block()?;
+        }
+        Ok(self.offset)
+    }
+}
+
+impl Write for SparseWriter {
+    fn write(&mut self, data: &[u8]) -> std::io::Result<usize> {
+        let take = (SPARSE_BLOCK - self.buf.len()).min(data.len());
+        self.buf.extend_from_slice(&data[..take]);
+        if self.buf.len() == SPARSE_BLOCK {
+            self.flush_block()?;
+        }
+        Ok(take)
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
+/// Hex-encodes bytes (lowercase).
+pub(super) fn hex(bytes: &[u8]) -> String {
+    use std::fmt::Write as _;
+    bytes.iter().fold(String::new(), |mut s, b| {
+        let _ = write!(s, "{b:02x}");
+        s
+    })
+}
+
+/// Verifies a hex SHA-256 against an expected manifest value.
+pub(super) fn verify_sha256(what: &str, actual: &[u8], expected: &str) -> Result<()> {
+    let actual = hex(actual);
+    if !actual.eq_ignore_ascii_case(expected) {
+        return Err(CoreError::macos(format!(
+            "{what}: checksum mismatch (expected {expected}, got {actual})"
+        )));
+    }
+    Ok(())
+}
+
+/// Hash + decompress + sparse-write sink for one chunk's compressed stream.
+struct ChunkSink {
+    decoder: zstd::stream::write::Decoder<'static, SparseWriter>,
+    hasher: Sha256,
+    received: u64,
+}
+
+impl ChunkSink {
+    fn new(file: Arc<std::fs::File>, base: u64) -> Result<Self> {
+        Ok(Self {
+            decoder: zstd::stream::write::Decoder::new(SparseWriter::new(file, base))
+                .map_err(|e| CoreError::macos(format!("zstd init: {e}")))?,
+            hasher: Sha256::new(),
+            received: 0,
+        })
+    }
+
+    fn consume(&mut self, bytes: &[u8], path: &str) -> Result<()> {
+        self.hasher.update(bytes);
+        self.decoder
+            .write_all(bytes)
+            .map_err(|e| CoreError::macos(format!("decompress {path}: {e}")))?;
+        self.received += bytes.len() as u64;
+        Ok(())
+    }
+
+    /// Finalizes decompression and verifies the chunk: exact compressed size,
+    /// compressed SHA-256, and exact decompressed length.
+    fn finish(mut self, chunk: &DiskChunk, expected_len: u64) -> Result<()> {
+        self.decoder
+            .flush()
+            .map_err(|e| CoreError::macos(format!("decompress {}: {e}", chunk.path)))?;
+        let written = self
+            .decoder
+            .into_inner()
+            .finish()
+            .map_err(|e| CoreError::macos(format!("write {}: {e}", chunk.path)))?;
+        if self.received != chunk.size {
+            return Err(CoreError::macos(format!(
+                "{}: truncated download (expected {} compressed bytes, got {})",
+                chunk.path, chunk.size, self.received
+            )));
+        }
+        verify_sha256(&chunk.path, &self.hasher.finalize(), &chunk.sha256)?;
+        if written != expected_len {
+            return Err(CoreError::macos(format!(
+                "{}: decompressed to {written} bytes, expected {expected_len}",
+                chunk.path
+            )));
+        }
+        Ok(())
+    }
+}
+
+/// Downloads, verifies, and sparse-writes every disk chunk into `dst`.
+///
+/// `location` is the manifest's own location; chunk paths resolve relative to
+/// it. Chunks download with bounded parallelism; `on_progress` receives the
+/// downloaded fraction (weighted by compressed bytes) as each chunk completes.
+///
+/// # Errors
+/// Returns an error on any download, integrity, or write failure. The whole
+/// operation is cancellable: dropping the returned future aborts every
+/// in-flight chunk at its next await point.
+pub(super) async fn fetch_disk(
+    location: &RemoteLocation,
+    disk: &DiskManifest,
+    dst: &Path,
+    mut on_progress: impl FnMut(f64),
+) -> Result<()> {
+    let file = Arc::new(std::fs::File::create(dst)?);
+    file.set_len(disk.uncompressed_size)?;
+    let total_compressed: u64 = disk.chunks.iter().map(|c| c.size).sum();
+
+    let client = reqwest::Client::new();
+    let semaphore = Arc::new(Semaphore::new(DOWNLOAD_CONCURRENCY));
+    let mut tasks = JoinSet::new();
+    for (index, chunk) in disk.chunks.iter().enumerate() {
+        let base = index as u64 * disk.chunk_size;
+        let expected_len = (disk.uncompressed_size - base).min(disk.chunk_size);
+        let chunk_location = location.join(&chunk.path)?;
+        let client = client.clone();
+        let file = Arc::clone(&file);
+        let chunk = chunk.clone();
+        let semaphore = Arc::clone(&semaphore);
+        tasks.spawn(async move {
+            // The permit bounds concurrent downloads; the remaining tasks park
+            // here cheaply until a slot frees.
+            let _permit = semaphore
+                .acquire_owned()
+                .await
+                .map_err(|_| CoreError::macos("disk download canceled"))?;
+            fetch_chunk(&client, &chunk_location, &chunk, base, expected_len, file).await?;
+            Ok::<u64, CoreError>(chunk.size)
+        });
+    }
+
+    on_progress(0.0);
+    let mut downloaded = 0u64;
+    while let Some(joined) = tasks.join_next().await {
+        downloaded += joined.map_err(|e| CoreError::macos(format!("disk chunk task: {e}")))??;
+        if total_compressed > 0 {
+            on_progress((downloaded as f64 / total_compressed as f64).min(1.0));
+        }
+    }
+    Ok(())
+}
+
+/// Fetches one chunk from its resolved location into the shared disk file.
+async fn fetch_chunk(
+    client: &reqwest::Client,
+    location: &RemoteLocation,
+    chunk: &DiskChunk,
+    base: u64,
+    expected_len: u64,
+    file: Arc<std::fs::File>,
+) -> Result<()> {
+    match location {
+        RemoteLocation::Http(url) => {
+            let mut attempt = 0u32;
+            loop {
+                match download_chunk_http(client, url, chunk, base, expected_len, Arc::clone(&file))
+                    .await
+                {
+                    Ok(()) => return Ok(()),
+                    Err(e) => {
+                        attempt += 1;
+                        if attempt > DOWNLOAD_RETRIES {
+                            return Err(CoreError::macos(format!(
+                                "{}: giving up after {DOWNLOAD_RETRIES} attempts: {e}",
+                                chunk.path
+                            )));
+                        }
+                        tracing::warn!(
+                            "chunk {}: {e}; retrying ({attempt}/{DOWNLOAD_RETRIES})",
+                            chunk.path
+                        );
+                        tokio::time::sleep(DOWNLOAD_RETRY_DELAY).await;
+                    }
+                }
+            }
+        }
+        RemoteLocation::File(path) => {
+            download_chunk_file(path, chunk, base, expected_len, file).await
+        }
+    }
+}
+
+/// Streams a chunk over HTTP through decompression into the sparse file.
+async fn download_chunk_http(
+    client: &reqwest::Client,
+    url: &reqwest::Url,
+    chunk: &DiskChunk,
+    base: u64,
+    expected_len: u64,
+    file: Arc<std::fs::File>,
+) -> Result<()> {
+    let mut sink = ChunkSink::new(file, base)?;
+    let mut resp = client
+        .get(url.clone())
+        .send()
+        .await
+        .and_then(reqwest::Response::error_for_status)
+        .map_err(|e| CoreError::macos(format!("download {url}: {e}")))?;
+    while let Some(bytes) = resp
+        .chunk()
+        .await
+        .map_err(|e| CoreError::macos(format!("download {url}: {e}")))?
+    {
+        sink.consume(&bytes, &chunk.path)?;
+    }
+    sink.finish(chunk, expected_len)
+}
+
+/// Reads a chunk from a local file through decompression into the sparse file.
+///
+/// Uses `tokio::fs` (not `std`): every read is an await point, which keeps the
+/// decompression cancellable rather than running to completion inside a single
+/// poll and pinning a runtime worker.
+async fn download_chunk_file(
+    path: &Path,
+    chunk: &DiskChunk,
+    base: u64,
+    expected_len: u64,
+    file: Arc<std::fs::File>,
+) -> Result<()> {
+    let mut sink = ChunkSink::new(file, base)?;
+    let mut src = tokio::fs::File::open(path).await?;
+    let mut buf = vec![0u8; 1024 * 1024];
+    loop {
+        let n = src.read(&mut buf).await?;
+        if n == 0 {
+            break;
+        }
+        sink.consume(&buf[..n], &chunk.path)?;
+    }
+    sink.finish(chunk, expected_len)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    /// Splits `raw` into `chunk_size` slices, zstd-compresses each into `dir`
+    /// as `disk.NNN.zst`, and returns the matching manifest.
+    fn publish_disk(dir: &Path, raw: &[u8], chunk_size: usize) -> DiskManifest {
+        let mut chunks = Vec::new();
+        for (i, slice) in raw.chunks(chunk_size).enumerate() {
+            let compressed = zstd::encode_all(slice, 3).unwrap();
+            let path = format!("disk.{i:03}.zst");
+            std::fs::write(dir.join(&path), &compressed).unwrap();
+            chunks.push(DiskChunk {
+                path,
+                size: compressed.len() as u64,
+                sha256: hex(&Sha256::digest(&compressed)),
+            });
+        }
+        DiskManifest {
+            disk_format: "raw".into(),
+            uncompressed_size: raw.len() as u64,
+            chunk_size: chunk_size as u64,
+            chunks,
+        }
+    }
+
+    #[test]
+    fn sparse_writer_skips_zero_blocks() {
+        // APFS only keeps holes in files above a size threshold (verified
+        // empirically: fully materialized at 16 MiB, sparse at 256 MiB), so
+        // this test must run at realistic scale. Data is streamed block-wise
+        // to keep the test memory-light.
+        const TOTAL: u64 = 256 * 1024 * 1024;
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("sparse.bin");
+
+        let file = std::fs::File::create(&path).unwrap();
+        file.set_len(TOTAL).unwrap();
+        let mut w = SparseWriter::new(Arc::new(file), 0);
+        let data = vec![7u8; SPARSE_BLOCK];
+        let zeros = vec![0u8; SPARSE_BLOCK];
+        let blocks = TOTAL / SPARSE_BLOCK as u64;
+        for i in 0..blocks {
+            // Non-zero first and last blocks, zeros everywhere between.
+            if i == 0 || i == blocks - 1 {
+                w.write_all(&data).unwrap();
+            } else {
+                w.write_all(&zeros).unwrap();
+            }
+        }
+        assert_eq!(w.finish().unwrap(), TOTAL);
+
+        // Content: first/last blocks hold data, an interior block reads zero.
+        use std::os::unix::fs::FileExt;
+        let f = std::fs::File::open(&path).unwrap();
+        let mut buf = vec![0u8; SPARSE_BLOCK];
+        f.read_exact_at(&mut buf, 0).unwrap();
+        assert_eq!(buf, data);
+        f.read_exact_at(&mut buf, TOTAL - SPARSE_BLOCK as u64)
+            .unwrap();
+        assert_eq!(buf, data);
+        f.read_exact_at(&mut buf, TOTAL / 2).unwrap();
+        assert_eq!(buf, zeros);
+
+        // Allocation: the zero interior must be holes, not written blocks.
+        let allocated = std::fs::metadata(&path)
+            .map(|m| std::os::unix::fs::MetadataExt::blocks(&m) * 512)
+            .unwrap();
+        assert!(
+            allocated < 8 * 1024 * 1024,
+            "expected sparse file, got {allocated} bytes allocated for {TOTAL}"
+        );
+    }
+
+    #[tokio::test]
+    async fn assembles_chunks_from_local_files() {
+        let dir = tempdir().unwrap();
+        let publish = dir.path().join("publish");
+        std::fs::create_dir_all(&publish).unwrap();
+
+        // Three full chunks (data, zero gap, data) plus a partial last chunk,
+        // exercising the remainder and the hole-skipping path.
+        let mut raw = vec![0u8; 5 * SPARSE_BLOCK + SPARSE_BLOCK / 2];
+        raw[0..SPARSE_BLOCK].fill(0xAB);
+        raw[4 * SPARSE_BLOCK..5 * SPARSE_BLOCK].fill(0xCD);
+        raw[5 * SPARSE_BLOCK..].fill(0xEE);
+        let disk = publish_disk(&publish, &raw, 2 * SPARSE_BLOCK);
+        assert_eq!(disk.chunks.len(), 3);
+
+        let location = RemoteLocation::File(publish.join("manifest.json"));
+        let dst = dir.path().join("disk.img");
+        fetch_disk(&location, &disk, &dst, |_| {}).await.unwrap();
+        assert_eq!(std::fs::read(&dst).unwrap(), raw);
+    }
+
+    #[tokio::test]
+    async fn rejects_chunk_with_wrong_hash() {
+        let dir = tempdir().unwrap();
+        let publish = dir.path().join("publish");
+        std::fs::create_dir_all(&publish).unwrap();
+
+        let raw = vec![0xABu8; SPARSE_BLOCK];
+        let mut disk = publish_disk(&publish, &raw, SPARSE_BLOCK);
+        disk.chunks[0].sha256 =
+            "0000000000000000000000000000000000000000000000000000000000000000".into();
+
+        let location = RemoteLocation::File(publish.join("manifest.json"));
+        let dst = dir.path().join("disk.img");
+        let err = fetch_disk(&location, &disk, &dst, |_| {})
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("checksum mismatch"), "{err}");
+    }
+
+    /// First GET on a connection sends only half the body then hangs up; every
+    /// later GET serves the whole body. Drives the chunk retry path.
+    async fn serve_flaky(listener: tokio::net::TcpListener, body: Vec<u8>) {
+        use std::sync::atomic::{AtomicBool, Ordering};
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+        let first = Arc::new(AtomicBool::new(true));
+        loop {
+            let Ok((mut sock, _)) = listener.accept().await else {
+                return;
+            };
+            let body = body.clone();
+            let first = Arc::clone(&first);
+            tokio::spawn(async move {
+                let mut req = Vec::new();
+                let mut buf = [0u8; 4096];
+                while !req.windows(4).any(|w| w == b"\r\n\r\n") {
+                    match sock.read(&mut buf).await {
+                        Ok(0) | Err(_) => return,
+                        Ok(n) => req.extend_from_slice(&buf[..n]),
+                    }
+                }
+                let head = format!(
+                    "HTTP/1.1 200 OK\r\ncontent-length: {}\r\nconnection: close\r\n\r\n",
+                    body.len()
+                );
+                let _ = sock.write_all(head.as_bytes()).await;
+                if first.swap(false, Ordering::SeqCst) {
+                    // Truncate mid-body then drop: a broken connection.
+                    let _ = sock.write_all(&body[..body.len() / 2]).await;
+                } else {
+                    let _ = sock.write_all(&body).await;
+                }
+            });
+        }
+    }
+
+    #[tokio::test]
+    async fn http_chunk_retries_after_connection_drop() {
+        let mut raw = vec![0xABu8; SPARSE_BLOCK];
+        raw.extend_from_slice(&vec![0u8; SPARSE_BLOCK]);
+        raw.extend_from_slice(&vec![0xCDu8; SPARSE_BLOCK]);
+        let body = zstd::encode_all(&raw[..], 3).unwrap();
+        let disk = DiskManifest {
+            disk_format: "raw".into(),
+            uncompressed_size: raw.len() as u64,
+            chunk_size: raw.len() as u64,
+            chunks: vec![DiskChunk {
+                path: "disk.000.zst".into(),
+                size: body.len() as u64,
+                sha256: hex(&Sha256::digest(&body)),
+            }],
+        };
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(serve_flaky(listener, body));
+
+        let location = RemoteLocation::parse(&format!("http://{addr}/manifest.json"));
+        let dir = tempdir().unwrap();
+        let dst = dir.path().join("disk.img");
+        fetch_disk(&location, &disk, &dst, |_| {}).await.unwrap();
+        assert_eq!(std::fs::read(&dst).unwrap(), raw);
+    }
+}

--- a/app/arcbox-core/src/macos/disk.rs
+++ b/app/arcbox-core/src/macos/disk.rs
@@ -1,34 +1,39 @@
 //! Chunked restore of a published macOS system disk.
 //!
 //! A manifest splits the disk into fixed-size, independently decompressible
-//! zstd frames (`disk.NNN.zst`). [`fetch_disk`] downloads them with bounded
-//! parallelism, verifies each stored object against its manifest hash,
-//! decompresses each frame, and sparse-writes it at its fixed offset — the
-//! compressed bytes are streamed through decompression and never staged on
-//! disk. Per-chunk integrity (compressed hash + exact decompressed length,
-//! plus zstd's own per-frame content checksum) combined with deterministic
-//! offset placement makes the assembled image correct without an end-to-end
-//! re-read of the multi-gigabyte result.
+//! zstd frames (`disk.NNN.zst`). [`fetch_disk`] downloads each chunk into
+//! memory, verifies it against its manifest hash *before* decoding, then
+//! decompresses the verified bytes and sparse-writes them at the chunk's fixed
+//! offset. Downloading and verifying up front is what makes the operation
+//! safe under retries: a truncated or corrupt attempt is rejected in memory
+//! and never touches `disk.img`, so the only bytes ever written to the disk
+//! come from a chunk proven correct — and those decode deterministically, so
+//! sparse-skipping a zero block can never leave stale data behind. Compressed
+//! bytes never touch disk, and a whole-disk re-read is unnecessary.
 
 use std::io::Write;
 use std::path::Path;
 use std::sync::Arc;
 
 use sha2::{Digest, Sha256};
-use tokio::io::AsyncReadExt;
 use tokio::sync::Semaphore;
 use tokio::task::JoinSet;
 
 use super::remote::{DiskChunk, DiskManifest, RemoteLocation};
 use crate::error::{CoreError, Result};
 
-/// Concurrent chunk downloads: enough to keep a fast link busy and overlap
-/// decompression across cores without flooding the CDN or the runtime.
-const DOWNLOAD_CONCURRENCY: usize = 4;
+/// Total compressed bytes buffered across in-flight chunks. Each chunk is
+/// downloaded and verified in memory before it is decoded into the disk, so
+/// this caps peak memory. It also caps concurrency: a chunk reserves at least
+/// [`MIN_SLOT`], so at most `BUFFER_BUDGET / MIN_SLOT` downloads run at once —
+/// enough connections to saturate a fast link without flooding the CDN.
+const BUFFER_BUDGET: u32 = 1 << 30; // 1 GiB
+/// Minimum budget a chunk reserves, capping concurrent downloads at 8.
+const MIN_SLOT: u32 = BUFFER_BUDGET / 8;
 
 /// Per-chunk transient-failure budget. A chunk is small enough (≤ ~480 MiB
 /// compressed) that a failed attempt simply re-downloads it from the start —
-/// no byte-range resume, which keeps the streaming decoder state trivial.
+/// no byte-range resume needed, and the retry re-verifies before decoding.
 const DOWNLOAD_RETRIES: u32 = 4;
 const DOWNLOAD_RETRY_DELAY: std::time::Duration = std::time::Duration::from_secs(2);
 
@@ -118,65 +123,12 @@ pub(super) fn verify_sha256(what: &str, actual: &[u8], expected: &str) -> Result
     Ok(())
 }
 
-/// Hash + decompress + sparse-write sink for one chunk's compressed stream.
-struct ChunkSink {
-    decoder: zstd::stream::write::Decoder<'static, SparseWriter>,
-    hasher: Sha256,
-    received: u64,
-}
-
-impl ChunkSink {
-    fn new(file: Arc<std::fs::File>, base: u64) -> Result<Self> {
-        Ok(Self {
-            decoder: zstd::stream::write::Decoder::new(SparseWriter::new(file, base))
-                .map_err(|e| CoreError::macos(format!("zstd init: {e}")))?,
-            hasher: Sha256::new(),
-            received: 0,
-        })
-    }
-
-    fn consume(&mut self, bytes: &[u8], path: &str) -> Result<()> {
-        self.hasher.update(bytes);
-        self.decoder
-            .write_all(bytes)
-            .map_err(|e| CoreError::macos(format!("decompress {path}: {e}")))?;
-        self.received += bytes.len() as u64;
-        Ok(())
-    }
-
-    /// Finalizes decompression and verifies the chunk: exact compressed size,
-    /// compressed SHA-256, and exact decompressed length.
-    fn finish(mut self, chunk: &DiskChunk, expected_len: u64) -> Result<()> {
-        self.decoder
-            .flush()
-            .map_err(|e| CoreError::macos(format!("decompress {}: {e}", chunk.path)))?;
-        let written = self
-            .decoder
-            .into_inner()
-            .finish()
-            .map_err(|e| CoreError::macos(format!("write {}: {e}", chunk.path)))?;
-        if self.received != chunk.size {
-            return Err(CoreError::macos(format!(
-                "{}: truncated download (expected {} compressed bytes, got {})",
-                chunk.path, chunk.size, self.received
-            )));
-        }
-        verify_sha256(&chunk.path, &self.hasher.finalize(), &chunk.sha256)?;
-        if written != expected_len {
-            return Err(CoreError::macos(format!(
-                "{}: decompressed to {written} bytes, expected {expected_len}",
-                chunk.path
-            )));
-        }
-        Ok(())
-    }
-}
-
 /// Downloads, verifies, and sparse-writes every disk chunk into `dst`.
 ///
 /// `location` is the manifest's own location; chunk paths resolve relative to
-/// it. Chunks download with bounded parallelism; `on_progress` receives the
-/// downloaded fraction (weighted by compressed bytes) as each chunk completes.
+/// it. Chunks are fetched with bounded parallelism (see [`BUFFER_BUDGET`]);
+/// `on_progress` receives the downloaded fraction (weighted by compressed
+/// bytes) as each chunk lands.
 ///
 /// # Errors
 /// Returns an error on any download, integrity, or write failure. The whole
@@ -193,24 +145,30 @@ pub(super) async fn fetch_disk(
     let total_compressed: u64 = disk.chunks.iter().map(|c| c.size).sum();
 
     let client = reqwest::Client::new();
-    let semaphore = Arc::new(Semaphore::new(DOWNLOAD_CONCURRENCY));
+    let budget = Arc::new(Semaphore::new(BUFFER_BUDGET as usize));
     let mut tasks = JoinSet::new();
     for (index, chunk) in disk.chunks.iter().enumerate() {
         let base = index as u64 * disk.chunk_size;
         let expected_len = (disk.uncompressed_size - base).min(disk.chunk_size);
         let chunk_location = location.join(&chunk.path)?;
+        // Reserve at least MIN_SLOT (caps connections) and at most the whole
+        // budget; a chunk larger than the budget still fits (it takes it all).
+        let cost = u32::try_from(chunk.size)
+            .unwrap_or(BUFFER_BUDGET)
+            .clamp(MIN_SLOT, BUFFER_BUDGET);
         let client = client.clone();
         let file = Arc::clone(&file);
         let chunk = chunk.clone();
-        let semaphore = Arc::clone(&semaphore);
+        let budget = Arc::clone(&budget);
         tasks.spawn(async move {
-            // The permit bounds concurrent downloads; the remaining tasks park
-            // here cheaply until a slot frees.
-            let _permit = semaphore
-                .acquire_owned()
+            // The permit bounds buffered memory and concurrent downloads; the
+            // remaining tasks park here cheaply until budget frees.
+            let _permit = budget
+                .acquire_many_owned(cost)
                 .await
                 .map_err(|_| CoreError::macos("disk download canceled"))?;
-            fetch_chunk(&client, &chunk_location, &chunk, base, expected_len, file).await?;
+            let compressed = fetch_verified(&client, &chunk_location, &chunk).await?;
+            decode_into(compressed, base, expected_len, chunk.path.clone(), file).await?;
             Ok::<u64, CoreError>(chunk.size)
         });
     }
@@ -226,23 +184,22 @@ pub(super) async fn fetch_disk(
     Ok(())
 }
 
-/// Fetches one chunk from its resolved location into the shared disk file.
-async fn fetch_chunk(
+/// Fetches a chunk's compressed bytes into memory and verifies them against
+/// the manifest (exact size + SHA-256), retrying transient HTTP failures.
+///
+/// Returns only once the bytes are proven correct, so the caller can decode
+/// them straight into the disk without any risk of writing bad data.
+async fn fetch_verified(
     client: &reqwest::Client,
     location: &RemoteLocation,
     chunk: &DiskChunk,
-    base: u64,
-    expected_len: u64,
-    file: Arc<std::fs::File>,
-) -> Result<()> {
+) -> Result<Vec<u8>> {
     match location {
         RemoteLocation::Http(url) => {
             let mut attempt = 0u32;
             loop {
-                match download_chunk_http(client, url, chunk, base, expected_len, Arc::clone(&file))
-                    .await
-                {
-                    Ok(()) => return Ok(()),
+                match download_http(client, url, chunk).await {
+                    Ok(bytes) => return Ok(bytes),
                     Err(e) => {
                         attempt += 1;
                         if attempt > DOWNLOAD_RETRIES {
@@ -261,60 +218,88 @@ async fn fetch_chunk(
             }
         }
         RemoteLocation::File(path) => {
-            download_chunk_file(path, chunk, base, expected_len, file).await
+            let bytes = tokio::fs::read(path).await?;
+            verify_chunk(chunk, bytes)
         }
     }
 }
 
-/// Streams a chunk over HTTP through decompression into the sparse file.
-async fn download_chunk_http(
+/// One HTTP GET collecting a chunk into memory, capped at its manifest size so
+/// a runaway response can't exhaust memory, then verified.
+async fn download_http(
     client: &reqwest::Client,
     url: &reqwest::Url,
     chunk: &DiskChunk,
-    base: u64,
-    expected_len: u64,
-    file: Arc<std::fs::File>,
-) -> Result<()> {
-    let mut sink = ChunkSink::new(file, base)?;
+) -> Result<Vec<u8>> {
     let mut resp = client
         .get(url.clone())
         .send()
         .await
         .and_then(reqwest::Response::error_for_status)
         .map_err(|e| CoreError::macos(format!("download {url}: {e}")))?;
+    let mut buf = Vec::with_capacity(usize::try_from(chunk.size).unwrap_or(0));
     while let Some(bytes) = resp
         .chunk()
         .await
         .map_err(|e| CoreError::macos(format!("download {url}: {e}")))?
     {
-        sink.consume(&bytes, &chunk.path)?;
+        if buf.len() as u64 + bytes.len() as u64 > chunk.size {
+            return Err(CoreError::macos(format!(
+                "{}: response exceeds manifest size {}",
+                chunk.path, chunk.size
+            )));
+        }
+        buf.extend_from_slice(&bytes);
     }
-    sink.finish(chunk, expected_len)
+    verify_chunk(chunk, buf)
 }
 
-/// Reads a chunk from a local file through decompression into the sparse file.
-///
-/// Uses `tokio::fs` (not `std`): every read is an await point, which keeps the
-/// decompression cancellable rather than running to completion inside a single
-/// poll and pinning a runtime worker.
-async fn download_chunk_file(
-    path: &Path,
-    chunk: &DiskChunk,
+/// Verifies buffered compressed bytes against the manifest, consuming them.
+fn verify_chunk(chunk: &DiskChunk, bytes: Vec<u8>) -> Result<Vec<u8>> {
+    if bytes.len() as u64 != chunk.size {
+        return Err(CoreError::macos(format!(
+            "{}: expected {} compressed bytes, got {}",
+            chunk.path,
+            chunk.size,
+            bytes.len()
+        )));
+    }
+    verify_sha256(&chunk.path, &Sha256::digest(&bytes), &chunk.sha256)?;
+    Ok(bytes)
+}
+
+/// Decodes verified compressed bytes into the sparse file at `base`, on a
+/// blocking thread (decompression is CPU-bound). Because the input is already
+/// proven correct, the output is the exact expected data — sparse-skipping a
+/// zero block is always safe.
+async fn decode_into(
+    compressed: Vec<u8>,
     base: u64,
     expected_len: u64,
+    path: String,
     file: Arc<std::fs::File>,
 ) -> Result<()> {
-    let mut sink = ChunkSink::new(file, base)?;
-    let mut src = tokio::fs::File::open(path).await?;
-    let mut buf = vec![0u8; 1024 * 1024];
-    loop {
-        let n = src.read(&mut buf).await?;
-        if n == 0 {
-            break;
+    let label = path.clone();
+    tokio::task::spawn_blocking(move || {
+        let mut decoder = zstd::stream::write::Decoder::new(SparseWriter::new(file, base))
+            .map_err(|e| CoreError::macos(format!("zstd init {path}: {e}")))?;
+        decoder
+            .write_all(&compressed)
+            .and_then(|()| decoder.flush())
+            .map_err(|e| CoreError::macos(format!("decompress {path}: {e}")))?;
+        let written = decoder
+            .into_inner()
+            .finish()
+            .map_err(|e| CoreError::macos(format!("write {path}: {e}")))?;
+        if written != expected_len {
+            return Err(CoreError::macos(format!(
+                "{path}: decompressed to {written} bytes, expected {expected_len}"
+            )));
         }
-        sink.consume(&buf[..n], &chunk.path)?;
-    }
-    sink.finish(chunk, expected_len)
+        Ok(())
+    })
+    .await
+    .map_err(|e| CoreError::macos(format!("decode task {label}: {e}")))?
 }
 
 #[cfg(test)]
@@ -488,6 +473,78 @@ mod tests {
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
         let addr = listener.local_addr().unwrap();
         tokio::spawn(serve_flaky(listener, body));
+
+        let location = RemoteLocation::parse(&format!("http://{addr}/manifest.json"));
+        let dir = tempdir().unwrap();
+        let dst = dir.path().join("disk.img");
+        fetch_disk(&location, &disk, &dst, |_| {}).await.unwrap();
+        assert_eq!(std::fs::read(&dst).unwrap(), raw);
+    }
+
+    /// First GET serves `bad` in full; every later GET serves `good`. Drives
+    /// the retry path with a *complete but wrong* first response.
+    async fn serve_bad_then_good(listener: tokio::net::TcpListener, bad: Vec<u8>, good: Vec<u8>) {
+        use std::sync::atomic::{AtomicBool, Ordering};
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+        let first = Arc::new(AtomicBool::new(true));
+        loop {
+            let Ok((mut sock, _)) = listener.accept().await else {
+                return;
+            };
+            let (bad, good, first) = (bad.clone(), good.clone(), Arc::clone(&first));
+            tokio::spawn(async move {
+                let mut req = Vec::new();
+                let mut buf = [0u8; 4096];
+                while !req.windows(4).any(|w| w == b"\r\n\r\n") {
+                    match sock.read(&mut buf).await {
+                        Ok(0) | Err(_) => return,
+                        Ok(n) => req.extend_from_slice(&buf[..n]),
+                    }
+                }
+                let body = if first.swap(false, Ordering::SeqCst) {
+                    bad
+                } else {
+                    good
+                };
+                let head = format!(
+                    "HTTP/1.1 200 OK\r\ncontent-length: {}\r\nconnection: close\r\n\r\n",
+                    body.len()
+                );
+                let _ = sock.write_all(head.as_bytes()).await;
+                let _ = sock.write_all(&body).await;
+            });
+        }
+    }
+
+    /// A corrupt-but-complete first attempt must be rejected in memory, never
+    /// written to the disk. The corrupt chunk decodes to non-zero data exactly
+    /// where the correct chunk is zero, so if a rejected attempt could reach
+    /// the disk, the retry's zero-block skip would leave the stale non-zero
+    /// bytes behind. Verifying before decoding makes that impossible.
+    #[tokio::test]
+    async fn corrupt_attempt_never_reaches_disk() {
+        let mut raw = vec![0xABu8; SPARSE_BLOCK];
+        raw.extend_from_slice(&vec![0u8; SPARSE_BLOCK]); // correct: second block is zero
+        let good = zstd::encode_all(&raw[..], 3).unwrap();
+
+        let mut wrong = vec![0xABu8; SPARSE_BLOCK];
+        wrong.extend_from_slice(&vec![0xCDu8; SPARSE_BLOCK]); // wrong: second block non-zero
+        let bad = zstd::encode_all(&wrong[..], 3).unwrap();
+
+        let disk = DiskManifest {
+            disk_format: "raw".into(),
+            uncompressed_size: raw.len() as u64,
+            chunk_size: raw.len() as u64,
+            chunks: vec![DiskChunk {
+                path: "disk.000.zst".into(),
+                size: good.len() as u64,
+                sha256: hex(&Sha256::digest(&good)),
+            }],
+        };
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(serve_bad_then_good(listener, bad, good));
 
         let location = RemoteLocation::parse(&format!("http://{addr}/manifest.json"));
         let dir = tempdir().unwrap();

--- a/app/arcbox-core/src/macos/download.rs
+++ b/app/arcbox-core/src/macos/download.rs
@@ -1,0 +1,127 @@
+//! Downloading macOS restore images (IPSWs) to a local cache.
+//!
+//! Apple's API yields a remote IPSW URL but not the bytes; the installer needs a
+//! local file. This streams the URL into a cache directory: the download is written
+//! to a sibling `.part` file and atomically renamed on success, so an interrupted
+//! download never looks like a valid cache entry. SHA-256 is computed for integrity
+//! and verified against `expected` when known (version resolution will supply one;
+//! `latest` has no published digest, so the size check + atomic rename guard it).
+
+use std::io::{Read, Write};
+use std::path::{Path, PathBuf};
+
+use sha2::{Digest, Sha256};
+
+use crate::error::{CoreError, Result};
+
+/// Streams `url` into `cache_dir`, returning the path to the cached IPSW.
+///
+/// The cache file name is the URL's last path segment. A complete cache hit is
+/// reused (re-verified against `expected_sha256` when provided, otherwise trusted).
+/// `on_progress` receives the downloaded fraction in `0.0..=1.0`, best-effort — only
+/// when the server reports a content length.
+pub(super) async fn download_ipsw(
+    url: &str,
+    cache_dir: &Path,
+    expected_sha256: Option<&str>,
+    mut on_progress: impl FnMut(f64),
+) -> Result<PathBuf> {
+    let file_name = url
+        .rsplit('/')
+        .next()
+        .filter(|s| !s.is_empty())
+        .ok_or_else(|| CoreError::macos(format!("cannot derive a file name from URL: {url}")))?;
+    if file_name.contains("..") || file_name.contains('/') {
+        return Err(CoreError::macos(format!(
+            "unsafe IPSW file name: {file_name}"
+        )));
+    }
+
+    std::fs::create_dir_all(cache_dir)?;
+    let dest = cache_dir.join(file_name);
+
+    if dest.exists() {
+        match expected_sha256 {
+            Some(expected) if !sha256_file(&dest)?.eq_ignore_ascii_case(expected) => {
+                tracing::warn!(
+                    "cached IPSW {} failed checksum, re-downloading",
+                    dest.display()
+                );
+                std::fs::remove_file(&dest)?;
+            }
+            _ => return Ok(dest),
+        }
+    }
+
+    let part = dest.with_extension("part");
+    let _ = std::fs::remove_file(&part);
+
+    let mut resp = reqwest::get(url)
+        .await
+        .and_then(reqwest::Response::error_for_status)
+        .map_err(|e| CoreError::macos(format!("download {url}: {e}")))?;
+
+    let total = resp.content_length();
+    let mut file = std::fs::File::create(&part)?;
+    let mut hasher = Sha256::new();
+    let mut downloaded: u64 = 0;
+    let mut last_msg = String::new();
+
+    while let Some(chunk) = resp
+        .chunk()
+        .await
+        .map_err(|e| CoreError::macos(format!("download {url}: {e}")))?
+    {
+        let bytes = chunk.as_ref();
+        file.write_all(bytes)?;
+        hasher.update(bytes);
+        downloaded += bytes.len() as u64;
+        if let Some(total) = total.filter(|t| *t > 0) {
+            let frac = (downloaded as f64 / total as f64).min(1.0);
+            let msg = format!("{:.0}", frac * 100.0);
+            if msg != last_msg {
+                last_msg = msg;
+                on_progress(frac);
+            }
+        }
+    }
+    file.flush()?;
+    drop(file);
+
+    if let Some(total) = total {
+        if downloaded != total {
+            let _ = std::fs::remove_file(&part);
+            return Err(CoreError::macos(format!(
+                "download {url}: truncated (expected {total} bytes, got {downloaded})"
+            )));
+        }
+    }
+
+    let actual = format!("{:x}", hasher.finalize());
+    if let Some(expected) = expected_sha256 {
+        if !actual.eq_ignore_ascii_case(expected) {
+            let _ = std::fs::remove_file(&part);
+            return Err(CoreError::macos(format!(
+                "download {url}: checksum mismatch (expected {expected}, got {actual})"
+            )));
+        }
+    }
+
+    std::fs::rename(&part, &dest)?;
+    Ok(dest)
+}
+
+/// Computes the hex SHA-256 of a file, reading it in chunks.
+fn sha256_file(path: &Path) -> Result<String> {
+    let mut file = std::fs::File::open(path)?;
+    let mut hasher = Sha256::new();
+    let mut buf = vec![0u8; 64 * 1024];
+    loop {
+        let n = file.read(&mut buf)?;
+        if n == 0 {
+            break;
+        }
+        hasher.update(&buf[..n]);
+    }
+    Ok(format!("{:x}", hasher.finalize()))
+}

--- a/app/arcbox-core/src/macos/image.rs
+++ b/app/arcbox-core/src/macos/image.rs
@@ -103,6 +103,14 @@ impl MacImageManager {
         self.images_dir.join(name)
     }
 
+    /// Directory holding downloaded IPSWs (a sibling of the images dir).
+    #[must_use]
+    pub fn cache_dir(&self) -> PathBuf {
+        self.images_dir
+            .parent()
+            .map_or_else(|| self.images_dir.join("cache"), |p| p.join("cache"))
+    }
+
     /// Loads a base image by name.
     ///
     /// # Errors

--- a/app/arcbox-core/src/macos/image.rs
+++ b/app/arcbox-core/src/macos/image.rs
@@ -179,9 +179,10 @@ impl MacImageManager {
     /// copied, so the clone boots the same installed system. Off APFS the disk falls
     /// back to a full copy (logged).
     ///
-    /// The base machine identifier is reused, which is correct for running a single
-    /// clone at a time; concurrent clones should be given distinct identifiers (done
-    /// with the VM lifecycle).
+    /// The base machine identifier is copied into the instance and reused on every
+    /// boot. It is the identifier the base's auxiliary storage was created with at
+    /// install, so reusing it gives the clone a stable identity that pairs with the
+    /// cloned NVRAM.
     ///
     /// # Errors
     /// Returns an error if the base image is missing or any clone/copy step fails.

--- a/app/arcbox-core/src/macos/image.rs
+++ b/app/arcbox-core/src/macos/image.rs
@@ -2,17 +2,21 @@
 //!
 //! A base image is a directory under `data_dir/macos/images/<name>/` holding an
 //! installed macOS system disk plus the auxiliary storage and identity needed to
-//! boot it. [`MacImageManager::clone_base`] produces a per-VM instance from a base
-//! by copy-on-write cloning the (large) system disk via `clonefile(2)` — instant
+//! boot it. [`MacImage::clone_into`] produces a per-VM instance from a base by
+//! copy-on-write cloning the (large) system disk via `clonefile(2)` — instant
 //! and space-shared on APFS — so every VM is a clean, disposable copy.
 
+use std::collections::HashMap;
 use std::ffi::CString;
 use std::os::unix::ffi::OsStrExt;
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
+use tokio::sync::Mutex;
 
+use super::validate_name;
 use crate::error::{CoreError, Result};
 
 pub(super) const META_FILE: &str = "meta.json";
@@ -83,6 +87,41 @@ impl MacImage {
     pub fn machine_id_path(&self) -> PathBuf {
         self.dir.join(MACHINE_ID_FILE)
     }
+
+    /// Clones this base image into `dst_dir`, producing per-VM disks ready to boot.
+    ///
+    /// The (large) system disk is copy-on-write cloned via `clonefile(2)` — instant
+    /// and space-shared on APFS — while the small auxiliary storage and identity are
+    /// copied, so the clone boots the same installed system. Off APFS the disk falls
+    /// back to a full copy (logged).
+    ///
+    /// The base machine identifier is copied into the instance and reused on every
+    /// boot. It is the identifier the base's auxiliary storage was created with at
+    /// install, so reusing it gives the clone a stable identity that pairs with the
+    /// cloned NVRAM.
+    ///
+    /// # Errors
+    /// Returns an error if any clone/copy step fails.
+    pub fn clone_into(&self, dst_dir: &Path) -> Result<MacInstanceDisks> {
+        std::fs::create_dir_all(dst_dir)?;
+
+        let dst_disk = dst_dir.join(DISK_FILE);
+        cow_clone(&self.disk_path(), &dst_disk)?;
+
+        let dst_aux = dst_dir.join(AUX_FILE);
+        let _ = std::fs::remove_file(&dst_aux);
+        std::fs::copy(self.aux_path(), &dst_aux)?;
+
+        let hardware_model = std::fs::read(self.hardware_model_path())?;
+        let machine_id = std::fs::read(self.machine_id_path())?;
+
+        Ok(MacInstanceDisks {
+            disk: dst_disk,
+            aux: dst_aux,
+            hardware_model,
+            machine_id,
+        })
+    }
 }
 
 /// Disk artifacts of a cloned per-VM instance, ready to assemble into a VM.
@@ -101,6 +140,10 @@ pub struct MacInstanceDisks {
 /// Manages macOS base image templates and their copy-on-write clones.
 pub struct MacImageManager {
     images_dir: PathBuf,
+    /// Per-image-name locks serializing concurrent pulls of the same image so
+    /// they cannot corrupt the shared staging directory. Bounded by the number
+    /// of distinct image names ever pulled.
+    pull_locks: Mutex<HashMap<String, Arc<Mutex<()>>>>,
 }
 
 impl MacImageManager {
@@ -109,13 +152,18 @@ impl MacImageManager {
     pub fn new(data_dir: &Path) -> Self {
         Self {
             images_dir: data_dir.join("macos").join("images"),
+            pull_locks: Mutex::new(HashMap::new()),
         }
     }
 
     /// Directory holding a named image's artifacts.
-    #[must_use]
-    pub fn image_dir(&self, name: &str) -> PathBuf {
-        self.images_dir.join(name)
+    ///
+    /// # Errors
+    /// Returns an error if `name` is not a single safe path component (see
+    /// [`validate_name`]).
+    pub(super) fn image_dir(&self, name: &str) -> Result<PathBuf> {
+        validate_name(name)?;
+        Ok(self.images_dir.join(name))
     }
 
     /// Directory holding downloaded IPSWs (a sibling of the images dir).
@@ -126,13 +174,25 @@ impl MacImageManager {
             .map_or_else(|| self.images_dir.join("cache"), |p| p.join("cache"))
     }
 
+    /// Returns the lock serializing pulls of image `name` (creating it on first use).
+    pub(super) async fn pull_lock(&self, name: &str) -> Arc<Mutex<()>> {
+        Arc::clone(
+            self.pull_locks
+                .lock()
+                .await
+                .entry(name.to_string())
+                .or_default(),
+        )
+    }
+
     /// Loads a base image by name.
     ///
     /// # Errors
-    /// Returns a not-found error if no such image exists, or a macOS error if its
-    /// metadata cannot be parsed.
+    /// Returns a not-found error if no such image exists, an invalid-name error
+    /// if `name` is not a safe path component, or a macOS error if its metadata
+    /// cannot be parsed.
     pub fn get(&self, name: &str) -> Result<MacImage> {
-        let dir = self.image_dir(name);
+        let dir = self.image_dir(name)?;
         let meta_path = dir.join(META_FILE);
         if !meta_path.exists() {
             return Err(CoreError::not_found(format!("macOS image '{name}'")));
@@ -168,10 +228,11 @@ impl MacImageManager {
     /// Removes a base image and all its artifacts.
     ///
     /// # Errors
-    /// Returns a not-found error if the image does not exist, or an I/O error if
-    /// removal fails.
+    /// Returns a not-found error if the image does not exist, an invalid-name
+    /// error if `name` is not a safe path component, or an I/O error if removal
+    /// fails.
     pub fn remove(&self, name: &str) -> Result<()> {
-        let dir = self.image_dir(name);
+        let dir = self.image_dir(name)?;
         if !dir.exists() {
             return Err(CoreError::not_found(format!("macOS image '{name}'")));
         }
@@ -185,9 +246,10 @@ impl MacImageManager {
     /// flow; this records the accompanying `meta.json`.
     ///
     /// # Errors
-    /// Returns an error if the metadata cannot be serialized or written.
+    /// Returns an error if the name is invalid or the metadata cannot be
+    /// serialized or written.
     pub fn write_meta(&self, meta: &MacImageMeta) -> Result<()> {
-        Self::write_meta_in(&self.image_dir(&meta.name), meta)
+        Self::write_meta_in(&self.image_dir(&meta.name)?, meta)
     }
 
     /// Persists metadata into an explicit directory (used by the pull flow to
@@ -201,42 +263,6 @@ impl MacImageManager {
             .map_err(|e| CoreError::macos(format!("serialize image metadata: {e}")))?;
         std::fs::write(dir.join(META_FILE), json)?;
         Ok(())
-    }
-
-    /// Clones a base image into `dst_dir`, producing per-VM disks ready to boot.
-    ///
-    /// The (large) system disk is copy-on-write cloned via `clonefile(2)` — instant
-    /// and space-shared on APFS — while the small auxiliary storage and identity are
-    /// copied, so the clone boots the same installed system. Off APFS the disk falls
-    /// back to a full copy (logged).
-    ///
-    /// The base machine identifier is copied into the instance and reused on every
-    /// boot. It is the identifier the base's auxiliary storage was created with at
-    /// install, so reusing it gives the clone a stable identity that pairs with the
-    /// cloned NVRAM.
-    ///
-    /// # Errors
-    /// Returns an error if the base image is missing or any clone/copy step fails.
-    pub fn clone_base(&self, base: &str, dst_dir: &Path) -> Result<MacInstanceDisks> {
-        let image = self.get(base)?;
-        std::fs::create_dir_all(dst_dir)?;
-
-        let dst_disk = dst_dir.join(DISK_FILE);
-        cow_clone(&image.disk_path(), &dst_disk)?;
-
-        let dst_aux = dst_dir.join(AUX_FILE);
-        let _ = std::fs::remove_file(&dst_aux);
-        std::fs::copy(image.aux_path(), &dst_aux)?;
-
-        let hardware_model = std::fs::read(image.hardware_model_path())?;
-        let machine_id = std::fs::read(image.machine_id_path())?;
-
-        Ok(MacInstanceDisks {
-            disk: dst_disk,
-            aux: dst_aux,
-            hardware_model,
-            machine_id,
-        })
     }
 }
 
@@ -301,7 +327,10 @@ mod tests {
 
         let loaded = mgr.get("base").unwrap();
         assert_eq!(loaded.meta, meta);
-        assert_eq!(loaded.disk_path(), mgr.image_dir("base").join("disk.img"));
+        assert_eq!(
+            loaded.disk_path(),
+            mgr.image_dir("base").unwrap().join("disk.img")
+        );
         assert_eq!(mgr.list().len(), 1);
     }
 
@@ -311,5 +340,20 @@ mod tests {
         let mgr = MacImageManager::new(dir.path());
         assert!(mgr.get("nope").is_err());
         assert!(mgr.list().is_empty());
+    }
+
+    #[test]
+    fn traversal_names_are_rejected_before_touching_the_fs() {
+        let dir = tempdir().unwrap();
+        // A sibling directory that a traversal name would try to escape into.
+        let victim = dir.path().join("victim");
+        std::fs::create_dir_all(&victim).unwrap();
+        let mgr = MacImageManager::new(dir.path());
+
+        assert!(mgr.get("../victim").is_err());
+        assert!(mgr.remove("../victim").is_err());
+        assert!(mgr.image_dir("a/b").is_err());
+        // The rejected names never reached the filesystem.
+        assert!(victim.exists());
     }
 }

--- a/app/arcbox-core/src/macos/image.rs
+++ b/app/arcbox-core/src/macos/image.rs
@@ -15,26 +15,41 @@ use serde::{Deserialize, Serialize};
 
 use crate::error::{CoreError, Result};
 
-const META_FILE: &str = "meta.json";
-const DISK_FILE: &str = "disk.img";
-const AUX_FILE: &str = "aux.img";
-const HARDWARE_MODEL_FILE: &str = "hwmodel.bin";
-const MACHINE_ID_FILE: &str = "machine-id.bin";
+pub(super) const META_FILE: &str = "meta.json";
+pub(super) const DISK_FILE: &str = "disk.img";
+pub(super) const AUX_FILE: &str = "aux.img";
+pub(super) const HARDWARE_MODEL_FILE: &str = "hwmodel.bin";
+pub(super) const MACHINE_ID_FILE: &str = "machine-id.bin";
 
 /// Persisted metadata describing a macOS base image template.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct MacImageMeta {
     /// Image name (unique within the registry).
     pub name: String,
-    /// Source the image was installed from (IPSW path or "latest"), if known.
+    /// Where the image came from (manifest location or IPSW path), if known.
     pub source: Option<String>,
-    /// Minimum CPU count reported by the restore image.
+    /// Stream the image was pulled from (e.g. `tahoe-base`), if pulled.
+    #[serde(default)]
+    pub stream: Option<String>,
+    /// Published version label (e.g. `2026.07.02`), if pulled.
+    #[serde(default)]
+    pub version: Option<String>,
+    /// Guest macOS product version (e.g. `26.5`), if known.
+    #[serde(default)]
+    pub os_version: Option<String>,
+    /// Guest macOS build number (e.g. `25F71`), if known.
+    #[serde(default)]
+    pub os_build: Option<String>,
+    /// Preinstalled GitHub Actions runner version, if known.
+    #[serde(default)]
+    pub runner_version: Option<String>,
+    /// Minimum CPU count required by the guest.
     pub minimum_cpu_count: u64,
-    /// Minimum guest memory in MiB reported by the restore image.
+    /// Minimum guest memory in MiB required by the guest.
     pub minimum_memory_mib: u64,
-    /// System disk size in GiB.
+    /// System disk size in GB (decimal, logical size).
     pub disk_gb: u64,
-    /// When the image was created.
+    /// When the image was created locally.
     pub created_at: DateTime<Utc>,
 }
 
@@ -172,8 +187,16 @@ impl MacImageManager {
     /// # Errors
     /// Returns an error if the metadata cannot be serialized or written.
     pub fn write_meta(&self, meta: &MacImageMeta) -> Result<()> {
-        let dir = self.image_dir(&meta.name);
-        std::fs::create_dir_all(&dir)?;
+        Self::write_meta_in(&self.image_dir(&meta.name), meta)
+    }
+
+    /// Persists metadata into an explicit directory (used by the pull flow to
+    /// assemble an image in a staging directory before renaming it live).
+    ///
+    /// # Errors
+    /// Returns an error if the metadata cannot be serialized or written.
+    pub(super) fn write_meta_in(dir: &Path, meta: &MacImageMeta) -> Result<()> {
+        std::fs::create_dir_all(dir)?;
         let json = serde_json::to_string_pretty(meta)
             .map_err(|e| CoreError::macos(format!("serialize image metadata: {e}")))?;
         std::fs::write(dir.join(META_FILE), json)?;
@@ -257,6 +280,11 @@ mod tests {
         MacImageMeta {
             name: "base".into(),
             source: Some("/tmp/UniversalMac.ipsw".into()),
+            stream: None,
+            version: None,
+            os_version: None,
+            os_build: None,
+            runner_version: None,
             minimum_cpu_count: 2,
             minimum_memory_mib: 4096,
             disk_gb: 64,

--- a/app/arcbox-core/src/macos/image.rs
+++ b/app/arcbox-core/src/macos/image.rs
@@ -1,0 +1,278 @@
+//! macOS guest base images and their copy-on-write clones.
+//!
+//! A base image is a directory under `data_dir/macos/images/<name>/` holding an
+//! installed macOS system disk plus the auxiliary storage and identity needed to
+//! boot it. [`MacImageManager::clone_base`] produces a per-VM instance from a base
+//! by copy-on-write cloning the (large) system disk via `clonefile(2)` — instant
+//! and space-shared on APFS — so every VM is a clean, disposable copy.
+
+use std::ffi::CString;
+use std::os::unix::ffi::OsStrExt;
+use std::path::{Path, PathBuf};
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+use crate::error::{CoreError, Result};
+
+const META_FILE: &str = "meta.json";
+const DISK_FILE: &str = "disk.img";
+const AUX_FILE: &str = "aux.img";
+const HARDWARE_MODEL_FILE: &str = "hwmodel.bin";
+const MACHINE_ID_FILE: &str = "machine-id.bin";
+
+/// Persisted metadata describing a macOS base image template.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MacImageMeta {
+    /// Image name (unique within the registry).
+    pub name: String,
+    /// Source the image was installed from (IPSW path or "latest"), if known.
+    pub source: Option<String>,
+    /// Minimum CPU count reported by the restore image.
+    pub minimum_cpu_count: u64,
+    /// Minimum guest memory in MiB reported by the restore image.
+    pub minimum_memory_mib: u64,
+    /// System disk size in GiB.
+    pub disk_gb: u64,
+    /// When the image was created.
+    pub created_at: DateTime<Utc>,
+}
+
+/// A macOS base image template on disk.
+#[derive(Debug, Clone)]
+pub struct MacImage {
+    /// Image metadata.
+    pub meta: MacImageMeta,
+    /// Directory holding the image artifacts.
+    pub dir: PathBuf,
+}
+
+impl MacImage {
+    /// Path to the installed system disk image.
+    #[must_use]
+    pub fn disk_path(&self) -> PathBuf {
+        self.dir.join(DISK_FILE)
+    }
+    /// Path to the auxiliary (NVRAM) storage.
+    #[must_use]
+    pub fn aux_path(&self) -> PathBuf {
+        self.dir.join(AUX_FILE)
+    }
+    /// Path to the hardware-model data representation.
+    #[must_use]
+    pub fn hardware_model_path(&self) -> PathBuf {
+        self.dir.join(HARDWARE_MODEL_FILE)
+    }
+    /// Path to the base machine-identifier data representation.
+    #[must_use]
+    pub fn machine_id_path(&self) -> PathBuf {
+        self.dir.join(MACHINE_ID_FILE)
+    }
+}
+
+/// Disk artifacts of a cloned per-VM instance, ready to assemble into a VM.
+#[derive(Debug, Clone)]
+pub struct MacInstanceDisks {
+    /// Per-VM system disk (a copy-on-write clone of the base disk).
+    pub disk: PathBuf,
+    /// Per-VM auxiliary storage.
+    pub aux: PathBuf,
+    /// Hardware-model data representation (shared with the base).
+    pub hardware_model: Vec<u8>,
+    /// Machine-identifier data representation for this instance.
+    pub machine_id: Vec<u8>,
+}
+
+/// Manages macOS base image templates and their copy-on-write clones.
+pub struct MacImageManager {
+    images_dir: PathBuf,
+}
+
+impl MacImageManager {
+    /// Creates a manager rooted at `data_dir/macos/images`.
+    #[must_use]
+    pub fn new(data_dir: &Path) -> Self {
+        Self {
+            images_dir: data_dir.join("macos").join("images"),
+        }
+    }
+
+    /// Directory holding a named image's artifacts.
+    #[must_use]
+    pub fn image_dir(&self, name: &str) -> PathBuf {
+        self.images_dir.join(name)
+    }
+
+    /// Loads a base image by name.
+    ///
+    /// # Errors
+    /// Returns a not-found error if no such image exists, or a macOS error if its
+    /// metadata cannot be parsed.
+    pub fn get(&self, name: &str) -> Result<MacImage> {
+        let dir = self.image_dir(name);
+        let meta_path = dir.join(META_FILE);
+        if !meta_path.exists() {
+            return Err(CoreError::not_found(format!("macOS image '{name}'")));
+        }
+        let raw = std::fs::read_to_string(&meta_path)?;
+        let meta: MacImageMeta = serde_json::from_str(&raw)
+            .map_err(|e| CoreError::macos(format!("parse {}: {e}", meta_path.display())))?;
+        Ok(MacImage { meta, dir })
+    }
+
+    /// Lists all base images. Unreadable entries are skipped with a warning.
+    #[must_use]
+    pub fn list(&self) -> Vec<MacImage> {
+        let Ok(entries) = std::fs::read_dir(&self.images_dir) else {
+            return Vec::new();
+        };
+        let mut images = Vec::new();
+        for entry in entries.flatten() {
+            if !entry.path().is_dir() {
+                continue;
+            }
+            let Some(name) = entry.file_name().to_str().map(String::from) else {
+                continue;
+            };
+            match self.get(&name) {
+                Ok(image) => images.push(image),
+                Err(e) => tracing::warn!("skipping macOS image '{name}': {e}"),
+            }
+        }
+        images
+    }
+
+    /// Removes a base image and all its artifacts.
+    ///
+    /// # Errors
+    /// Returns a not-found error if the image does not exist, or an I/O error if
+    /// removal fails.
+    pub fn remove(&self, name: &str) -> Result<()> {
+        let dir = self.image_dir(name);
+        if !dir.exists() {
+            return Err(CoreError::not_found(format!("macOS image '{name}'")));
+        }
+        std::fs::remove_dir_all(&dir)?;
+        Ok(())
+    }
+
+    /// Persists the metadata for a base image.
+    ///
+    /// The disk, auxiliary storage, and identity files are written by the install
+    /// flow; this records the accompanying `meta.json`.
+    ///
+    /// # Errors
+    /// Returns an error if the metadata cannot be serialized or written.
+    pub fn write_meta(&self, meta: &MacImageMeta) -> Result<()> {
+        let dir = self.image_dir(&meta.name);
+        std::fs::create_dir_all(&dir)?;
+        let json = serde_json::to_string_pretty(meta)
+            .map_err(|e| CoreError::macos(format!("serialize image metadata: {e}")))?;
+        std::fs::write(dir.join(META_FILE), json)?;
+        Ok(())
+    }
+
+    /// Clones a base image into `dst_dir`, producing per-VM disks ready to boot.
+    ///
+    /// The (large) system disk is copy-on-write cloned via `clonefile(2)` — instant
+    /// and space-shared on APFS — while the small auxiliary storage and identity are
+    /// copied, so the clone boots the same installed system. Off APFS the disk falls
+    /// back to a full copy (logged).
+    ///
+    /// The base machine identifier is reused, which is correct for running a single
+    /// clone at a time; concurrent clones should be given distinct identifiers (done
+    /// with the VM lifecycle).
+    ///
+    /// # Errors
+    /// Returns an error if the base image is missing or any clone/copy step fails.
+    pub fn clone_base(&self, base: &str, dst_dir: &Path) -> Result<MacInstanceDisks> {
+        let image = self.get(base)?;
+        std::fs::create_dir_all(dst_dir)?;
+
+        let dst_disk = dst_dir.join(DISK_FILE);
+        cow_clone(&image.disk_path(), &dst_disk)?;
+
+        let dst_aux = dst_dir.join(AUX_FILE);
+        let _ = std::fs::remove_file(&dst_aux);
+        std::fs::copy(image.aux_path(), &dst_aux)?;
+
+        let hardware_model = std::fs::read(image.hardware_model_path())?;
+        let machine_id = std::fs::read(image.machine_id_path())?;
+
+        Ok(MacInstanceDisks {
+            disk: dst_disk,
+            aux: dst_aux,
+            hardware_model,
+            machine_id,
+        })
+    }
+}
+
+/// Copy-on-write clones `src` to `dst` via `clonefile(2)`, falling back to a full
+/// copy when the destination is not on the same APFS volume.
+fn cow_clone(src: &Path, dst: &Path) -> Result<()> {
+    let _ = std::fs::remove_file(dst); // clonefile fails if the destination exists.
+    let src_c = CString::new(src.as_os_str().as_bytes())
+        .map_err(|e| CoreError::macos(format!("path {}: {e}", src.display())))?;
+    let dst_c = CString::new(dst.as_os_str().as_bytes())
+        .map_err(|e| CoreError::macos(format!("path {}: {e}", dst.display())))?;
+    // SAFETY: clonefile takes two valid NUL-terminated C paths and a flags word.
+    let rc = unsafe { libc::clonefile(src_c.as_ptr(), dst_c.as_ptr(), 0) };
+    if rc == 0 {
+        return Ok(());
+    }
+    let err = std::io::Error::last_os_error();
+    match err.raw_os_error() {
+        Some(libc::ENOTSUP | libc::EXDEV) => {
+            tracing::warn!(
+                "clonefile unsupported for {} ({err}); falling back to a full copy",
+                dst.display()
+            );
+            std::fs::copy(src, dst)?;
+            Ok(())
+        }
+        _ => Err(CoreError::macos(format!(
+            "clonefile {} -> {}: {err}",
+            src.display(),
+            dst.display()
+        ))),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    fn sample_meta() -> MacImageMeta {
+        MacImageMeta {
+            name: "base".into(),
+            source: Some("/tmp/UniversalMac.ipsw".into()),
+            minimum_cpu_count: 2,
+            minimum_memory_mib: 4096,
+            disk_gb: 64,
+            created_at: Utc::now(),
+        }
+    }
+
+    #[test]
+    fn meta_round_trips_through_registry() {
+        let dir = tempdir().unwrap();
+        let mgr = MacImageManager::new(dir.path());
+        let meta = sample_meta();
+        mgr.write_meta(&meta).unwrap();
+
+        let loaded = mgr.get("base").unwrap();
+        assert_eq!(loaded.meta, meta);
+        assert_eq!(loaded.disk_path(), mgr.image_dir("base").join("disk.img"));
+        assert_eq!(mgr.list().len(), 1);
+    }
+
+    #[test]
+    fn get_missing_image_is_not_found() {
+        let dir = tempdir().unwrap();
+        let mgr = MacImageManager::new(dir.path());
+        assert!(mgr.get("nope").is_err());
+        assert!(mgr.list().is_empty());
+    }
+}

--- a/app/arcbox-core/src/macos/install.rs
+++ b/app/arcbox-core/src/macos/install.rs
@@ -4,7 +4,7 @@
 //! complete base image — `disk.img`, `aux.img`, `hwmodel.bin`, `machine-id.bin`,
 //! `meta.json` — that [`MacImageManager::clone_base`] can copy-on-write clone.
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use arcbox_vz::{
     MacAuxiliaryStorage, MacGraphicsDeviceConfiguration, MacMachineIdentifier, MacOSBootLoader,
@@ -13,8 +13,27 @@ use arcbox_vz::{
 };
 use chrono::Utc;
 
+use super::download::download_ipsw;
 use super::image::{MacImage, MacImageManager, MacImageMeta};
 use crate::error::{CoreError, Result};
+
+/// Where a [`MacImageManager::pull`] obtains its IPSW.
+#[derive(Debug, Clone)]
+pub enum PullSource {
+    /// Restore from a local IPSW file.
+    LocalIpsw(PathBuf),
+    /// Download the latest Apple-published restore image.
+    Latest,
+}
+
+/// The phase a [`MacImageManager::pull`] is in, for progress reporting.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PullPhase {
+    /// Downloading the IPSW from Apple.
+    Download,
+    /// Restoring macOS onto the base image (the long phase).
+    Install,
+}
 
 /// macOS installation is memory-hungry; floor the install VM at 8 GiB.
 const INSTALL_MIN_MEMORY: u64 = 8 * GIB;
@@ -109,5 +128,45 @@ impl MacImageManager {
         };
         self.write_meta(&meta)?;
         self.get(name)
+    }
+
+    /// Pulls a base image: obtain an IPSW (downloading the latest when needed), then
+    /// restore it into a base image named `name`.
+    ///
+    /// `on_progress` is invoked with the current phase and its fraction
+    /// (`0.0..=1.0`). Apple Silicon only.
+    ///
+    /// # Errors
+    /// Returns an error if the download fails, the latest restore image has no URL,
+    /// or any restore/persist step fails.
+    #[allow(
+        clippy::future_not_send,
+        reason = "drives Virtualization.framework through !Send ObjC pointers held across await; the caller drives it on a single thread"
+    )]
+    pub async fn pull(
+        &self,
+        source: PullSource,
+        name: &str,
+        disk_gb: u64,
+        mut on_progress: impl FnMut(PullPhase, f64),
+    ) -> Result<MacImage> {
+        let ipsw = match source {
+            PullSource::LocalIpsw(path) => path,
+            PullSource::Latest => {
+                let restore = MacOSRestoreImage::latest_supported().await?;
+                let url = restore
+                    .url()
+                    .ok_or_else(|| CoreError::macos("latest restore image has no download URL"))?;
+                drop(restore);
+                download_ipsw(&url, &self.cache_dir(), None, |frac| {
+                    on_progress(PullPhase::Download, frac);
+                })
+                .await?
+            }
+        };
+        self.install_from_ipsw(&ipsw, name, disk_gb, |frac| {
+            on_progress(PullPhase::Install, frac);
+        })
+        .await
     }
 }

--- a/app/arcbox-core/src/macos/install.rs
+++ b/app/arcbox-core/src/macos/install.rs
@@ -1,0 +1,124 @@
+//! Installing macOS from an IPSW into a base image template.
+//!
+//! Drives the arcbox-vz installer (the same flow proven by Gate B) and persists a
+//! complete base image — `disk.img`, `aux.img`, `hwmodel.bin`, `machine-id.bin`,
+//! `meta.json` — that [`MacImageManager::clone_base`] can copy-on-write clone.
+
+use std::path::Path;
+
+use arcbox_vz::{
+    MacAuxiliaryStorage, MacGraphicsDeviceConfiguration, MacMachineIdentifier, MacOSBootLoader,
+    MacOSInstaller, MacOSRestoreImage, MacPlatform, StorageDeviceConfiguration, VZError,
+    VirtualMachineConfiguration, min_cpu_count, min_memory_size,
+};
+use chrono::Utc;
+
+use super::image::{MacImage, MacImageManager, MacImageMeta};
+use crate::error::{CoreError, Result};
+
+/// macOS installation is memory-hungry; floor the install VM at 8 GiB.
+const INSTALL_MIN_MEMORY: u64 = 8 * GIB;
+const GIB: u64 = 1024 * 1024 * 1024;
+
+fn vz_err(e: VZError) -> CoreError {
+    CoreError::macos(e.to_string())
+}
+
+impl MacImageManager {
+    /// Installs macOS from a local IPSW into a new base image named `name`.
+    ///
+    /// Writes `disk.img` + `aux.img` + `hwmodel.bin` + `machine-id.bin` + `meta.json`
+    /// under the image directory and returns the resulting [`MacImage`]. This is a
+    /// long-running operation (tens of minutes); `on_progress` is invoked with the
+    /// installation fraction (`0.0..=1.0`) as it proceeds. Apple Silicon only.
+    ///
+    /// # Errors
+    /// Returns an error if the image already exists, the restore image's hardware
+    /// model is unsupported on this host, or any install/persist step fails.
+    #[allow(
+        clippy::future_not_send,
+        reason = "drives Virtualization.framework through ObjC pointers and the VM's dispatch queue, which are inherently !Send and held across await; the caller drives it on a single thread"
+    )]
+    pub async fn install_from_ipsw(
+        &self,
+        ipsw: &Path,
+        name: &str,
+        disk_gb: u64,
+        on_progress: impl FnMut(f64),
+    ) -> Result<MacImage> {
+        let dir = self.image_dir(name);
+        if dir.join("meta.json").exists() {
+            return Err(CoreError::already_exists(format!("macOS image '{name}'")));
+        }
+
+        let restore = MacOSRestoreImage::load_from_url(ipsw)
+            .await
+            .map_err(vz_err)?;
+        let reqs = restore.requirements().map_err(vz_err)?;
+        if !reqs.hardware_model.is_supported() {
+            return Err(CoreError::macos(
+                "restore image hardware model is not supported on this host",
+            ));
+        }
+
+        std::fs::create_dir_all(&dir)?;
+        let disk_path = dir.join("disk.img");
+        let aux_path = dir.join("aux.img");
+
+        // Persist the identity so clones can reproduce a bootable configuration.
+        std::fs::write(
+            dir.join("hwmodel.bin"),
+            reqs.hardware_model.data_representation(),
+        )?;
+        let machine_id = MacMachineIdentifier::new().map_err(vz_err)?;
+        std::fs::write(dir.join("machine-id.bin"), machine_id.data_representation())?;
+
+        // Allocate the (sparse) system disk and fresh auxiliary storage.
+        let disk = std::fs::File::create(&disk_path)?;
+        disk.set_len(disk_gb * GIB)?;
+        drop(disk);
+        let _ = std::fs::remove_file(&aux_path);
+        let aux =
+            MacAuxiliaryStorage::create(&aux_path, &reqs.hardware_model, true).map_err(vz_err)?;
+
+        let platform = MacPlatform::new(&reqs.hardware_model, &machine_id, &aux).map_err(vz_err)?;
+        let cpus = usize::try_from(reqs.minimum_cpu_count.max(min_cpu_count())).unwrap_or(1);
+        let memory = reqs
+            .minimum_memory_size
+            .max(INSTALL_MIN_MEMORY)
+            .max(min_memory_size());
+
+        let mut config = VirtualMachineConfiguration::new().map_err(vz_err)?;
+        config
+            .set_cpu_count(cpus)
+            .set_memory_size(memory)
+            .set_platform(platform)
+            .set_boot_loader(MacOSBootLoader::new().map_err(vz_err)?)
+            .add_storage_device(
+                StorageDeviceConfiguration::disk_image(&disk_path, false).map_err(vz_err)?,
+            )
+            .add_graphics_device(
+                MacGraphicsDeviceConfiguration::new(1920, 1080, 80).map_err(vz_err)?,
+            );
+        config.validate().map_err(vz_err)?;
+        let vm = config.build().map_err(vz_err)?;
+
+        let installer = MacOSInstaller::new(&vm, ipsw).map_err(vz_err)?;
+        installer.install(&vm, on_progress).await.map_err(vz_err)?;
+
+        // The installer leaves the VM running; power it off so the base is captured
+        // at rest. Best-effort — ignore an error if it is already stopped.
+        let _ = vm.stop().await;
+
+        let meta = MacImageMeta {
+            name: name.to_string(),
+            source: Some(ipsw.display().to_string()),
+            minimum_cpu_count: reqs.minimum_cpu_count,
+            minimum_memory_mib: memory / (1024 * 1024),
+            disk_gb,
+            created_at: Utc::now(),
+        };
+        self.write_meta(&meta)?;
+        self.get(name)
+    }
+}

--- a/app/arcbox-core/src/macos/install.rs
+++ b/app/arcbox-core/src/macos/install.rs
@@ -121,6 +121,11 @@ impl MacImageManager {
         let meta = MacImageMeta {
             name: name.to_string(),
             source: Some(ipsw.display().to_string()),
+            stream: None,
+            version: None,
+            os_version: None,
+            os_build: None,
+            runner_version: None,
             minimum_cpu_count: reqs.minimum_cpu_count,
             minimum_memory_mib: memory / (1024 * 1024),
             disk_gb,

--- a/app/arcbox-core/src/macos/install.rs
+++ b/app/arcbox-core/src/macos/install.rs
@@ -8,7 +8,7 @@ use std::path::Path;
 
 use arcbox_vz::{
     MacAuxiliaryStorage, MacGraphicsDeviceConfiguration, MacMachineIdentifier, MacOSBootLoader,
-    MacOSInstaller, MacOSRestoreImage, MacPlatform, StorageDeviceConfiguration, VZError,
+    MacOSInstaller, MacOSRestoreImage, MacPlatform, StorageDeviceConfiguration,
     VirtualMachineConfiguration, min_cpu_count, min_memory_size,
 };
 use chrono::Utc;
@@ -19,10 +19,6 @@ use crate::error::{CoreError, Result};
 /// macOS installation is memory-hungry; floor the install VM at 8 GiB.
 const INSTALL_MIN_MEMORY: u64 = 8 * GIB;
 const GIB: u64 = 1024 * 1024 * 1024;
-
-fn vz_err(e: VZError) -> CoreError {
-    CoreError::macos(e.to_string())
-}
 
 impl MacImageManager {
     /// Installs macOS from a local IPSW into a new base image named `name`.
@@ -51,10 +47,8 @@ impl MacImageManager {
             return Err(CoreError::already_exists(format!("macOS image '{name}'")));
         }
 
-        let restore = MacOSRestoreImage::load_from_url(ipsw)
-            .await
-            .map_err(vz_err)?;
-        let reqs = restore.requirements().map_err(vz_err)?;
+        let restore = MacOSRestoreImage::load_from_url(ipsw).await?;
+        let reqs = restore.requirements()?;
         if !reqs.hardware_model.is_supported() {
             return Err(CoreError::macos(
                 "restore image hardware model is not supported on this host",
@@ -70,7 +64,7 @@ impl MacImageManager {
             dir.join("hwmodel.bin"),
             reqs.hardware_model.data_representation(),
         )?;
-        let machine_id = MacMachineIdentifier::new().map_err(vz_err)?;
+        let machine_id = MacMachineIdentifier::new()?;
         std::fs::write(dir.join("machine-id.bin"), machine_id.data_representation())?;
 
         // Allocate the (sparse) system disk and fresh auxiliary storage.
@@ -78,33 +72,28 @@ impl MacImageManager {
         disk.set_len(disk_gb * GIB)?;
         drop(disk);
         let _ = std::fs::remove_file(&aux_path);
-        let aux =
-            MacAuxiliaryStorage::create(&aux_path, &reqs.hardware_model, true).map_err(vz_err)?;
+        let aux = MacAuxiliaryStorage::create(&aux_path, &reqs.hardware_model, true)?;
 
-        let platform = MacPlatform::new(&reqs.hardware_model, &machine_id, &aux).map_err(vz_err)?;
+        let platform = MacPlatform::new(&reqs.hardware_model, &machine_id, &aux)?;
         let cpus = usize::try_from(reqs.minimum_cpu_count.max(min_cpu_count())).unwrap_or(1);
         let memory = reqs
             .minimum_memory_size
             .max(INSTALL_MIN_MEMORY)
             .max(min_memory_size());
 
-        let mut config = VirtualMachineConfiguration::new().map_err(vz_err)?;
+        let mut config = VirtualMachineConfiguration::new()?;
         config
             .set_cpu_count(cpus)
             .set_memory_size(memory)
             .set_platform(platform)
-            .set_boot_loader(MacOSBootLoader::new().map_err(vz_err)?)
-            .add_storage_device(
-                StorageDeviceConfiguration::disk_image(&disk_path, false).map_err(vz_err)?,
-            )
-            .add_graphics_device(
-                MacGraphicsDeviceConfiguration::new(1920, 1080, 80).map_err(vz_err)?,
-            );
-        config.validate().map_err(vz_err)?;
-        let vm = config.build().map_err(vz_err)?;
+            .set_boot_loader(MacOSBootLoader::new()?)
+            .add_storage_device(StorageDeviceConfiguration::disk_image(&disk_path, false)?)
+            .add_graphics_device(MacGraphicsDeviceConfiguration::new(1920, 1080, 80)?);
+        config.validate()?;
+        let vm = config.build()?;
 
-        let installer = MacOSInstaller::new(&vm, ipsw).map_err(vz_err)?;
-        installer.install(&vm, on_progress).await.map_err(vz_err)?;
+        let installer = MacOSInstaller::new(&vm, ipsw)?;
+        installer.install(&vm, on_progress).await?;
 
         // The installer leaves the VM running; power it off so the base is captured
         // at rest. Best-effort — ignore an error if it is already stopped.

--- a/app/arcbox-core/src/macos/install.rs
+++ b/app/arcbox-core/src/macos/install.rs
@@ -3,6 +3,11 @@
 //! Drives the arcbox-vz installer (the same flow proven by Gate B) and persists a
 //! complete base image — `disk.img`, `aux.img`, `hwmodel.bin`, `machine-id.bin`,
 //! `meta.json` — that [`MacImageManager::clone_base`] can copy-on-write clone.
+//!
+//! Retained but unshipped: the product acquires base images exclusively via
+//! [`MacImageManager::pull_remote`](super::pull); this module is compiled only
+//! under the `macos-ipsw-install` feature so the installer flow stays
+//! compiler-verified without being product surface.
 
 use std::path::{Path, PathBuf};
 

--- a/app/arcbox-core/src/macos/install.rs
+++ b/app/arcbox-core/src/macos/install.rs
@@ -2,7 +2,8 @@
 //!
 //! Drives the arcbox-vz installer (the same flow proven by Gate B) and persists a
 //! complete base image — `disk.img`, `aux.img`, `hwmodel.bin`, `machine-id.bin`,
-//! `meta.json` — that [`MacImageManager::clone_base`] can copy-on-write clone.
+//! `meta.json` — that [`MacImage::clone_into`](super::image::MacImage::clone_into)
+//! can copy-on-write clone.
 //!
 //! Retained but unshipped: the product acquires base images exclusively via
 //! [`MacImageManager::pull_remote`](super::pull); this module is compiled only
@@ -66,7 +67,7 @@ impl MacImageManager {
         disk_gb: u64,
         on_progress: impl FnMut(f64),
     ) -> Result<MacImage> {
-        let dir = self.image_dir(name);
+        let dir = self.image_dir(name)?;
         if dir.join("meta.json").exists() {
             return Err(CoreError::already_exists(format!("macOS image '{name}'")));
         }

--- a/app/arcbox-core/src/macos/lease.rs
+++ b/app/arcbox-core/src/macos/lease.rs
@@ -1,0 +1,209 @@
+//! Guest IP discovery from the host's DHCP lease table.
+//!
+//! macOS guests use NAT (vmnet shared) networking, whose DHCP server is the
+//! system's `bootpd`. It records every lease in `/var/db/dhcpd_leases` as
+//! plain-text `{ key=value ... }` blocks (bootp's `PLCache` format). A guest
+//! is found by the MAC address pinned to its network device at boot: the
+//! lease whose `hw_address` matches is the guest's current address.
+
+use std::path::Path;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+/// The system DHCP lease table written by `bootpd`.
+const DHCPD_LEASES: &str = "/var/db/dhcpd_leases";
+
+/// A single unexpired DHCP lease.
+struct Lease {
+    mac: [u8; 6],
+    ip: String,
+    expires_at: u64,
+}
+
+/// A lease block mid-parse: fields arrive line by line and any may be
+/// missing or malformed.
+#[derive(Default)]
+struct RawLease {
+    mac: Option<[u8; 6]>,
+    ip: Option<String>,
+    expires_at: Option<u64>,
+}
+
+/// Resolves the IPv4 address leased to `mac`, or `None` when the guest has
+/// no current lease (not yet booted far enough to DHCP, or expired).
+pub(super) fn resolve_ip(mac: &str) -> Option<String> {
+    resolve_ip_in(Path::new(DHCPD_LEASES), mac)
+}
+
+fn resolve_ip_in(leases_path: &Path, mac: &str) -> Option<String> {
+    let mac = parse_mac(mac)?;
+    let contents = std::fs::read_to_string(leases_path).ok()?;
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_or(0, |d| d.as_secs());
+    parse_leases(&contents, now)
+        .into_iter()
+        .filter(|lease| lease.mac == mac)
+        // Duplicate leases for one MAC: the newest is the live one.
+        .max_by_key(|lease| lease.expires_at)
+        .map(|lease| lease.ip)
+}
+
+/// Parses a MAC address in colon-separated hex. `bootpd` strips leading
+/// zeros from octets (`0e` is written `e`), so octets are parsed as hex
+/// values rather than compared textually.
+fn parse_mac(mac: &str) -> Option<[u8; 6]> {
+    let mut bytes = [0u8; 6];
+    let mut octets = mac.split(':');
+    for byte in &mut bytes {
+        *byte = u8::from_str_radix(octets.next()?, 16).ok()?;
+    }
+    octets.next().is_none().then_some(bytes)
+}
+
+/// Parses the lease table, keeping only unexpired Ethernet leases.
+///
+/// Blocks are `{`, `key=value` lines, `}`. Individually malformed blocks or
+/// fields are skipped: the file belongs to `bootpd` and holds entries for
+/// every vmnet consumer on the host, so one odd entry must not hide the
+/// guest's.
+fn parse_leases(contents: &str, now_epoch: u64) -> Vec<Lease> {
+    let mut leases = Vec::new();
+    let mut current: Option<RawLease> = None;
+
+    for line in contents.lines() {
+        let line = line.trim();
+        match line {
+            "{" => current = Some(RawLease::default()),
+            "}" => {
+                if let Some(RawLease {
+                    mac: Some(mac),
+                    ip: Some(ip),
+                    expires_at: Some(expires_at),
+                }) = current.take()
+                    && expires_at > now_epoch
+                {
+                    leases.push(Lease {
+                        mac,
+                        ip,
+                        expires_at,
+                    });
+                }
+            }
+            _ => {
+                let (Some(entry), Some((key, value))) = (current.as_mut(), line.split_once('='))
+                else {
+                    continue;
+                };
+                match key {
+                    // "1,aa:bb:c:dd:ee:ff" — 1 is ARPHRD_ETHER.
+                    "hw_address" => {
+                        entry.mac = value.strip_prefix("1,").and_then(parse_mac);
+                    }
+                    "ip_address" => entry.ip = Some(value.to_owned()),
+                    // Absolute expiry as hex epoch seconds, e.g. "0x686bb84a".
+                    "lease" => {
+                        entry.expires_at = value
+                            .strip_prefix("0x")
+                            .and_then(|hex| u64::from_str_radix(hex, 16).ok());
+                    }
+                    _ => {}
+                }
+            }
+        }
+    }
+    leases
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const FAR_FUTURE: u64 = 0xffff_ffff;
+
+    fn table() -> String {
+        format!(
+            "{{\n\
+             \tname=ci-runner\n\
+             \tip_address=192.168.64.7\n\
+             \thw_address=1,6:aa:bb:cc:dd:e\n\
+             \tidentifier=1,6:aa:bb:cc:dd:e\n\
+             \tlease=0x{FAR_FUTURE:x}\n\
+             }}\n\
+             {{\n\
+             \tname=other\n\
+             \tip_address=192.168.64.3\n\
+             \thw_address=1,86:66:3e:78:c9:e5\n\
+             \tlease=0x{FAR_FUTURE:x}\n\
+             }}\n"
+        )
+    }
+
+    #[test]
+    fn matches_mac_with_stripped_leading_zeros() {
+        // The pinned MAC is zero-padded; bootpd writes "6:aa:bb:cc:dd:e".
+        let leases = parse_leases(&table(), 0);
+        let mac = parse_mac("06:aa:bb:cc:dd:0e").unwrap();
+        let lease = leases.iter().find(|l| l.mac == mac).unwrap();
+        assert_eq!(lease.ip, "192.168.64.7");
+    }
+
+    #[test]
+    fn expired_leases_are_dropped() {
+        assert_eq!(parse_leases(&table(), FAR_FUTURE + 1).len(), 0);
+        assert_eq!(parse_leases(&table(), 0).len(), 2);
+    }
+
+    #[test]
+    fn newest_duplicate_lease_wins() {
+        let contents = "{\n\
+             ip_address=192.168.64.2\n\
+             hw_address=1,aa:aa:aa:aa:aa:aa\n\
+             lease=0x10\n\
+             }\n\
+             {\n\
+             ip_address=192.168.64.9\n\
+             hw_address=1,aa:aa:aa:aa:aa:aa\n\
+             lease=0x20\n\
+             }\n";
+        let newest = parse_leases(contents, 0)
+            .into_iter()
+            .max_by_key(|l| l.expires_at)
+            .unwrap();
+        assert_eq!(newest.ip, "192.168.64.9");
+    }
+
+    #[test]
+    fn malformed_blocks_are_skipped() {
+        let contents = "{\n\
+             garbage line without equals\n\
+             hw_address=not-a-mac\n\
+             }\n\
+             stray line\n\
+             {\n\
+             ip_address=192.168.64.5\n\
+             hw_address=1,bb:bb:bb:bb:bb:bb\n\
+             lease=0xffffffff\n\
+             }\n";
+        let leases = parse_leases(contents, 0);
+        assert_eq!(leases.len(), 1);
+        assert_eq!(leases[0].ip, "192.168.64.5");
+    }
+
+    #[test]
+    fn non_ethernet_hw_address_is_ignored() {
+        let contents = "{\n\
+             ip_address=192.168.64.5\n\
+             hw_address=6,cc:cc:cc:cc:cc:cc\n\
+             lease=0xffffffff\n\
+             }\n";
+        assert!(parse_leases(contents, 0).is_empty());
+    }
+
+    #[test]
+    fn mac_parsing_rejects_wrong_shapes() {
+        assert!(parse_mac("aa:bb:cc:dd:ee").is_none());
+        assert!(parse_mac("aa:bb:cc:dd:ee:ff:00").is_none());
+        assert!(parse_mac("zz:bb:cc:dd:ee:ff").is_none());
+        assert_eq!(parse_mac("6:AA:bb:CC:dd:e"), parse_mac("06:aa:bb:cc:dd:0e"));
+    }
+}

--- a/app/arcbox-core/src/macos/machine.rs
+++ b/app/arcbox-core/src/macos/machine.rs
@@ -29,6 +29,7 @@ const MACHINE_RECORD_FILE: &str = "machine.json";
 const DISK_FILE: &str = "disk.img";
 const AUX_FILE: &str = "aux.img";
 const HARDWARE_MODEL_FILE: &str = "hwmodel.bin";
+const MACHINE_ID_FILE: &str = "machine-id.bin";
 
 /// Persisted record describing a macOS machine.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -70,12 +71,22 @@ pub struct MacMachineInfo {
     pub created_at: DateTime<Utc>,
 }
 
+/// A machine's runtime slot. A slot is reserved (`Starting`) before the VM boots so
+/// the per-host guest cap is enforced atomically across the multi-second boot, then
+/// replaced by the live VM (`Running`).
+enum RunningSlot {
+    /// Reserved while booting: occupies a guest slot but has no live VM yet.
+    Starting,
+    /// A booted, running VM.
+    Running(MacVm),
+}
+
 /// Manages macOS guest machines: clone-from-base, boot, stop, remove.
 pub struct MacMachineManager {
     images: MacImageManager,
     machines_dir: PathBuf,
     records: RwLock<HashMap<String, MacMachineRecord>>,
-    running: RwLock<HashMap<String, MacVm>>,
+    running: RwLock<HashMap<String, RunningSlot>>,
 }
 
 impl MacMachineManager {
@@ -143,8 +154,14 @@ impl MacMachineManager {
     /// Returns an error if a machine with the name exists, the base image is missing,
     /// or the clone/persist fails.
     pub fn create(&self, config: MacMachineConfig) -> Result<()> {
-        let mut records = self.records.write().map_err(|_| CoreError::LockPoisoned)?;
-        if records.contains_key(&config.name) {
+        // Pre-check under a short read lock, then clone (slow file I/O) without holding
+        // any lock, then re-check on insert to settle a lost create/create race.
+        if self
+            .records
+            .read()
+            .map_err(|_| CoreError::LockPoisoned)?
+            .contains_key(&config.name)
+        {
             return Err(CoreError::already_exists(format!(
                 "macOS machine '{}'",
                 config.name
@@ -153,8 +170,10 @@ impl MacMachineManager {
 
         let dir = self.machine_dir(&config.name);
         let disks = self.images.clone_base(&config.image, &dir)?;
-        // Keep the hardware model with the machine so it boots without the base image.
+        // Keep the hardware model and machine identifier with the machine so it boots
+        // without the base image and with a stable identity across reboots.
         std::fs::write(dir.join(HARDWARE_MODEL_FILE), &disks.hardware_model)?;
+        std::fs::write(dir.join(MACHINE_ID_FILE), &disks.machine_id)?;
 
         let record = MacMachineRecord {
             name: config.name.clone(),
@@ -164,6 +183,16 @@ impl MacMachineManager {
             created_at: Utc::now(),
         };
         self.write_record(&record)?;
+
+        let mut records = self.records.write().map_err(|_| CoreError::LockPoisoned)?;
+        if records.contains_key(&config.name) {
+            drop(records);
+            let _ = std::fs::remove_dir_all(&dir);
+            return Err(CoreError::already_exists(format!(
+                "macOS machine '{}'",
+                config.name
+            )));
+        }
         records.insert(config.name, record);
         Ok(())
     }
@@ -187,8 +216,11 @@ impl MacMachineManager {
                 .cloned()
                 .ok_or_else(|| CoreError::not_found(format!("macOS machine '{name}'")))?
         };
+
+        // Atomically check the cap and reserve a slot before the multi-second boot, so
+        // concurrent starts cannot both pass the check and exceed the cap.
         {
-            let running = self.running.read().map_err(|_| CoreError::LockPoisoned)?;
+            let mut running = self.running.write().map_err(|_| CoreError::LockPoisoned)?;
             if running.contains_key(name) {
                 return Err(CoreError::invalid_state(format!(
                     "macOS machine '{name}' is already running"
@@ -199,23 +231,38 @@ impl MacMachineManager {
                     "at most {MAX_RUNNING_MACOS_GUESTS} macOS guests may run concurrently per host (Apple license)"
                 )));
             }
+            running.insert(name.to_string(), RunningSlot::Starting);
         }
 
         let dir = self.machine_dir(name);
-        let hardware_model = std::fs::read(dir.join(HARDWARE_MODEL_FILE))?;
         // The framework rejects a third macOS guest, so it backstops the cap above.
-        let vm = MacVm::boot(
-            &dir.join(DISK_FILE),
-            &dir.join(AUX_FILE),
-            &hardware_model,
-            record.cpus,
-            record.memory_mib,
-        )
-        .await?;
+        let booted = async {
+            let hardware_model = std::fs::read(dir.join(HARDWARE_MODEL_FILE))?;
+            let machine_id = std::fs::read(dir.join(MACHINE_ID_FILE))?;
+            MacVm::boot(
+                &dir.join(DISK_FILE),
+                &dir.join(AUX_FILE),
+                &hardware_model,
+                &machine_id,
+                record.cpus,
+                record.memory_mib,
+            )
+            .await
+        }
+        .await;
 
         let mut running = self.running.write().map_err(|_| CoreError::LockPoisoned)?;
-        running.insert(name.to_string(), vm);
-        Ok(())
+        match booted {
+            Ok(vm) => {
+                running.insert(name.to_string(), RunningSlot::Running(vm));
+                Ok(())
+            }
+            Err(e) => {
+                // Release the reservation so a retry (and the cap) are not wedged.
+                running.remove(name);
+                Err(e)
+            }
+        }
     }
 
     /// Stops a running macOS machine.
@@ -229,9 +276,21 @@ impl MacMachineManager {
     pub async fn stop(&self, name: &str) -> Result<()> {
         let vm = {
             let mut running = self.running.write().map_err(|_| CoreError::LockPoisoned)?;
-            running.remove(name).ok_or_else(|| {
-                CoreError::invalid_state(format!("macOS machine '{name}' is not running"))
-            })?
+            match running.remove(name) {
+                Some(RunningSlot::Running(vm)) => vm,
+                Some(slot @ RunningSlot::Starting) => {
+                    // Mid-boot: keep the reservation; start() will finalize it.
+                    running.insert(name.to_string(), slot);
+                    return Err(CoreError::invalid_state(format!(
+                        "macOS machine '{name}' is still starting"
+                    )));
+                }
+                None => {
+                    return Err(CoreError::invalid_state(format!(
+                        "macOS machine '{name}' is not running"
+                    )));
+                }
+            }
         };
         vm.stop().await
     }
@@ -271,10 +330,35 @@ impl MacMachineManager {
         Ok(())
     }
 
-    /// Returns whether a machine is currently running.
+    /// Returns whether a machine currently occupies a runtime slot (starting or
+    /// running).
     #[must_use]
     pub fn is_running(&self, name: &str) -> bool {
         self.running.read().is_ok_and(|r| r.contains_key(name))
+    }
+
+    /// Maps a machine's runtime slot to its reported state.
+    fn state_of(&self, name: &str) -> MachineState {
+        let Ok(running) = self.running.read() else {
+            return MachineState::Stopped;
+        };
+        match running.get(name) {
+            Some(RunningSlot::Running(_)) => MachineState::Running,
+            Some(RunningSlot::Starting) => MachineState::Starting,
+            None => MachineState::Stopped,
+        }
+    }
+
+    /// Builds the public view of a record, resolving its current runtime state.
+    fn info(&self, record: &MacMachineRecord) -> MacMachineInfo {
+        MacMachineInfo {
+            name: record.name.clone(),
+            image: record.image.clone(),
+            cpus: record.cpus,
+            memory_mib: record.memory_mib,
+            state: self.state_of(&record.name),
+            created_at: record.created_at,
+        }
     }
 
     /// Lists all macOS machines.
@@ -283,27 +367,45 @@ impl MacMachineManager {
         let Ok(records) = self.records.read() else {
             return Vec::new();
         };
-        records
-            .values()
-            .map(|r| MacMachineInfo {
-                name: r.name.clone(),
-                image: r.image.clone(),
-                cpus: r.cpus,
-                memory_mib: r.memory_mib,
-                state: if self.is_running(&r.name) {
-                    MachineState::Running
-                } else {
-                    MachineState::Stopped
-                },
-                created_at: r.created_at,
-            })
-            .collect()
+        records.values().map(|r| self.info(r)).collect()
     }
 
     /// Returns one macOS machine by name.
     #[must_use]
     pub fn get(&self, name: &str) -> Option<MacMachineInfo> {
-        self.list().into_iter().find(|m| m.name == name)
+        let records = self.records.read().ok()?;
+        records.get(name).map(|r| self.info(r))
+    }
+
+    /// Stops every running macOS guest, returning the per-machine errors that occur.
+    ///
+    /// Used on daemon shutdown so framework VMs are stopped cleanly rather than dropped
+    /// while still running. Reserved (still-starting) slots have no live VM and are
+    /// simply discarded.
+    #[allow(
+        clippy::future_not_send,
+        reason = "stops Virtualization.framework VMs (!Send ObjC handles across await); driven on a single thread"
+    )]
+    pub async fn stop_all(&self) -> Vec<(String, CoreError)> {
+        let vms: Vec<(String, MacVm)> = {
+            let Ok(mut running) = self.running.write() else {
+                return vec![(String::from("<all>"), CoreError::LockPoisoned)];
+            };
+            running
+                .drain()
+                .filter_map(|(name, slot)| match slot {
+                    RunningSlot::Running(vm) => Some((name, vm)),
+                    RunningSlot::Starting => None,
+                })
+                .collect()
+        };
+        let mut errors = Vec::new();
+        for (name, vm) in vms {
+            if let Err(e) = vm.stop().await {
+                errors.push((name, e));
+            }
+        }
+        errors
     }
 }
 

--- a/app/arcbox-core/src/macos/machine.rs
+++ b/app/arcbox-core/src/macos/machine.rs
@@ -1,0 +1,327 @@
+//! macOS guest machine lifecycle.
+//!
+//! A macOS machine is a copy-on-write clone of a base image (see
+//! [`MacImageManager`]) plus a small persisted record. [`MacMachineManager`] creates
+//! (clones), starts (boots a [`MacVm`]), stops, and removes them, holding live VMs
+//! in memory.
+//!
+//! The Apple macOS license permits at most two concurrently-running macOS guests per
+//! host; `start` enforces that count for macOS machines only (Linux VMs are not
+//! subject to it). Virtualization.framework itself rejects a third macOS guest, so
+//! that is the hard backstop.
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::RwLock;
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+use super::image::MacImageManager;
+use super::vm::MacVm;
+use crate::error::{CoreError, Result};
+use crate::machine::MachineState;
+
+/// Apple licenses at most two concurrently-running macOS guests per host.
+const MAX_RUNNING_MACOS_GUESTS: usize = 2;
+
+const MACHINE_RECORD_FILE: &str = "machine.json";
+const DISK_FILE: &str = "disk.img";
+const AUX_FILE: &str = "aux.img";
+const HARDWARE_MODEL_FILE: &str = "hwmodel.bin";
+
+/// Persisted record describing a macOS machine.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+struct MacMachineRecord {
+    name: String,
+    image: String,
+    cpus: u32,
+    memory_mib: u64,
+    created_at: DateTime<Utc>,
+}
+
+/// Configuration for creating a macOS machine from a base image.
+#[derive(Debug, Clone)]
+pub struct MacMachineConfig {
+    /// Machine name (unique).
+    pub name: String,
+    /// Base image to clone.
+    pub image: String,
+    /// Number of CPUs.
+    pub cpus: u32,
+    /// Memory in MiB.
+    pub memory_mib: u64,
+}
+
+/// Public view of a macOS machine.
+#[derive(Debug, Clone)]
+pub struct MacMachineInfo {
+    /// Machine name.
+    pub name: String,
+    /// Base image it was cloned from.
+    pub image: String,
+    /// Number of CPUs.
+    pub cpus: u32,
+    /// Memory in MiB.
+    pub memory_mib: u64,
+    /// Current state (Running if a live VM is held, else Stopped).
+    pub state: MachineState,
+    /// Creation time.
+    pub created_at: DateTime<Utc>,
+}
+
+/// Manages macOS guest machines: clone-from-base, boot, stop, remove.
+pub struct MacMachineManager {
+    images: MacImageManager,
+    machines_dir: PathBuf,
+    records: RwLock<HashMap<String, MacMachineRecord>>,
+    running: RwLock<HashMap<String, MacVm>>,
+}
+
+impl MacMachineManager {
+    /// Creates a manager rooted at `data_dir`.
+    #[must_use]
+    pub fn new(data_dir: &Path) -> Self {
+        let machines_dir = data_dir.join("macos").join("machines");
+        let records = Self::load_records(&machines_dir);
+        Self {
+            images: MacImageManager::new(data_dir),
+            machines_dir,
+            records: RwLock::new(records),
+            running: RwLock::new(HashMap::new()),
+        }
+    }
+
+    /// Returns the base-image manager.
+    #[must_use]
+    pub fn images(&self) -> &MacImageManager {
+        &self.images
+    }
+
+    fn machine_dir(&self, name: &str) -> PathBuf {
+        self.machines_dir.join(name)
+    }
+
+    fn load_records(machines_dir: &Path) -> HashMap<String, MacMachineRecord> {
+        let mut records = HashMap::new();
+        let Ok(entries) = std::fs::read_dir(machines_dir) else {
+            return records;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path().join(MACHINE_RECORD_FILE);
+            if !path.is_file() {
+                continue;
+            }
+            match std::fs::read_to_string(&path)
+                .ok()
+                .and_then(|raw| serde_json::from_str::<MacMachineRecord>(&raw).ok())
+            {
+                Some(record) => {
+                    records.insert(record.name.clone(), record);
+                }
+                None => tracing::warn!(
+                    "skipping unreadable macOS machine record {}",
+                    path.display()
+                ),
+            }
+        }
+        records
+    }
+
+    fn write_record(&self, record: &MacMachineRecord) -> Result<()> {
+        let dir = self.machine_dir(&record.name);
+        std::fs::create_dir_all(&dir)?;
+        let json = serde_json::to_string_pretty(record)
+            .map_err(|e| CoreError::macos(format!("serialize machine record: {e}")))?;
+        std::fs::write(dir.join(MACHINE_RECORD_FILE), json)?;
+        Ok(())
+    }
+
+    /// Creates a macOS machine by copy-on-write cloning `config.image`.
+    ///
+    /// # Errors
+    /// Returns an error if a machine with the name exists, the base image is missing,
+    /// or the clone/persist fails.
+    pub fn create(&self, config: MacMachineConfig) -> Result<()> {
+        let mut records = self.records.write().map_err(|_| CoreError::LockPoisoned)?;
+        if records.contains_key(&config.name) {
+            return Err(CoreError::already_exists(format!(
+                "macOS machine '{}'",
+                config.name
+            )));
+        }
+
+        let dir = self.machine_dir(&config.name);
+        let disks = self.images.clone_base(&config.image, &dir)?;
+        // Keep the hardware model with the machine so it boots without the base image.
+        std::fs::write(dir.join(HARDWARE_MODEL_FILE), &disks.hardware_model)?;
+
+        let record = MacMachineRecord {
+            name: config.name.clone(),
+            image: config.image,
+            cpus: config.cpus,
+            memory_mib: config.memory_mib,
+            created_at: Utc::now(),
+        };
+        self.write_record(&record)?;
+        records.insert(config.name, record);
+        Ok(())
+    }
+
+    /// Boots a macOS machine and waits until it is running.
+    ///
+    /// Enforces the per-host macOS-guest cap (counting only running macOS machines).
+    ///
+    /// # Errors
+    /// Returns an error if the machine is unknown, already running, the cap is
+    /// reached, or the VM fails to start.
+    #[allow(
+        clippy::future_not_send,
+        reason = "boots a Virtualization.framework VM (!Send ObjC handles across await); driven on a single thread"
+    )]
+    pub async fn start(&self, name: &str) -> Result<()> {
+        let record = {
+            let records = self.records.read().map_err(|_| CoreError::LockPoisoned)?;
+            records
+                .get(name)
+                .cloned()
+                .ok_or_else(|| CoreError::not_found(format!("macOS machine '{name}'")))?
+        };
+        {
+            let running = self.running.read().map_err(|_| CoreError::LockPoisoned)?;
+            if running.contains_key(name) {
+                return Err(CoreError::invalid_state(format!(
+                    "macOS machine '{name}' is already running"
+                )));
+            }
+            if running.len() >= MAX_RUNNING_MACOS_GUESTS {
+                return Err(CoreError::macos(format!(
+                    "at most {MAX_RUNNING_MACOS_GUESTS} macOS guests may run concurrently per host (Apple license)"
+                )));
+            }
+        }
+
+        let dir = self.machine_dir(name);
+        let hardware_model = std::fs::read(dir.join(HARDWARE_MODEL_FILE))?;
+        // The framework rejects a third macOS guest, so it backstops the cap above.
+        let vm = MacVm::boot(
+            &dir.join(DISK_FILE),
+            &dir.join(AUX_FILE),
+            &hardware_model,
+            record.cpus,
+            record.memory_mib,
+        )
+        .await?;
+
+        let mut running = self.running.write().map_err(|_| CoreError::LockPoisoned)?;
+        running.insert(name.to_string(), vm);
+        Ok(())
+    }
+
+    /// Stops a running macOS machine.
+    ///
+    /// # Errors
+    /// Returns an error if the machine is not running or cannot be stopped.
+    #[allow(
+        clippy::future_not_send,
+        reason = "stops a Virtualization.framework VM (!Send ObjC handles across await); driven on a single thread"
+    )]
+    pub async fn stop(&self, name: &str) -> Result<()> {
+        let vm = {
+            let mut running = self.running.write().map_err(|_| CoreError::LockPoisoned)?;
+            running.remove(name).ok_or_else(|| {
+                CoreError::invalid_state(format!("macOS machine '{name}' is not running"))
+            })?
+        };
+        vm.stop().await
+    }
+
+    /// Removes a macOS machine and its disks.
+    ///
+    /// # Errors
+    /// Returns an error if the machine is running and `force` is false, or if
+    /// stopping/removal fails.
+    #[allow(
+        clippy::future_not_send,
+        reason = "may stop a Virtualization.framework VM (!Send ObjC handles across await); driven on a single thread"
+    )]
+    pub async fn remove(&self, name: &str, force: bool) -> Result<()> {
+        let is_running = self
+            .running
+            .read()
+            .map_err(|_| CoreError::LockPoisoned)?
+            .contains_key(name);
+        if is_running {
+            if !force {
+                return Err(CoreError::invalid_state(format!(
+                    "macOS machine '{name}' is running (use force to remove)"
+                )));
+            }
+            self.stop(name).await?;
+        }
+
+        let dir = self.machine_dir(name);
+        if dir.exists() {
+            std::fs::remove_dir_all(&dir)?;
+        }
+        self.records
+            .write()
+            .map_err(|_| CoreError::LockPoisoned)?
+            .remove(name);
+        Ok(())
+    }
+
+    /// Returns whether a machine is currently running.
+    #[must_use]
+    pub fn is_running(&self, name: &str) -> bool {
+        self.running.read().is_ok_and(|r| r.contains_key(name))
+    }
+
+    /// Lists all macOS machines.
+    #[must_use]
+    pub fn list(&self) -> Vec<MacMachineInfo> {
+        let Ok(records) = self.records.read() else {
+            return Vec::new();
+        };
+        records
+            .values()
+            .map(|r| MacMachineInfo {
+                name: r.name.clone(),
+                image: r.image.clone(),
+                cpus: r.cpus,
+                memory_mib: r.memory_mib,
+                state: if self.is_running(&r.name) {
+                    MachineState::Running
+                } else {
+                    MachineState::Stopped
+                },
+                created_at: r.created_at,
+            })
+            .collect()
+    }
+
+    /// Returns one macOS machine by name.
+    #[must_use]
+    pub fn get(&self, name: &str) -> Option<MacMachineInfo> {
+        self.list().into_iter().find(|m| m.name == name)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn record_round_trips() {
+        let record = MacMachineRecord {
+            name: "ci-runner".into(),
+            image: "sequoia".into(),
+            cpus: 4,
+            memory_mib: 8192,
+            created_at: Utc::now(),
+        };
+        let json = serde_json::to_string(&record).unwrap();
+        let back: MacMachineRecord = serde_json::from_str(&json).unwrap();
+        assert_eq!(record, back);
+    }
+}

--- a/app/arcbox-core/src/macos/machine.rs
+++ b/app/arcbox-core/src/macos/machine.rs
@@ -18,8 +18,8 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
 use super::image::MacImageManager;
-use super::lease;
 use super::vm::MacVm;
+use super::{StagingGuard, lease, validate_name};
 use crate::error::{CoreError, Result};
 use crate::machine::MachineState;
 
@@ -135,8 +135,13 @@ impl MacMachineManager {
         &self.images
     }
 
-    fn machine_dir(&self, name: &str) -> PathBuf {
-        self.machines_dir.join(name)
+    /// Directory holding a named machine's artifacts.
+    ///
+    /// # Errors
+    /// Returns an error if `name` is not a single safe path component.
+    fn machine_dir(&self, name: &str) -> Result<PathBuf> {
+        validate_name(name)?;
+        Ok(self.machines_dir.join(name))
     }
 
     fn load_records(machines_dir: &Path) -> HashMap<String, MacMachineRecord> {
@@ -166,8 +171,13 @@ impl MacMachineManager {
     }
 
     fn write_record(&self, record: &MacMachineRecord) -> Result<()> {
-        let dir = self.machine_dir(&record.name);
-        std::fs::create_dir_all(&dir)?;
+        Self::write_record_in(&self.machine_dir(&record.name)?, record)
+    }
+
+    /// Serializes a machine record into an explicit directory (used by `create`
+    /// to assemble a machine in a staging directory before renaming it live).
+    fn write_record_in(dir: &Path, record: &MacMachineRecord) -> Result<()> {
+        std::fs::create_dir_all(dir)?;
         let json = serde_json::to_string_pretty(record)
             .map_err(|e| CoreError::macos(format!("serialize machine record: {e}")))?;
         std::fs::write(dir.join(MACHINE_RECORD_FILE), json)?;
@@ -176,12 +186,19 @@ impl MacMachineManager {
 
     /// Creates a macOS machine by copy-on-write cloning `config.image`.
     ///
+    /// The instance is assembled in a unique staging directory and renamed into
+    /// place atomically under the records lock, so concurrent creates of the same
+    /// name cannot corrupt each other. `config.cpus`/`config.memory_mib` must meet
+    /// the image's published minimums.
+    ///
     /// # Errors
-    /// Returns an error if a machine with the name exists, the base image is missing,
+    /// Returns an error if the name is invalid, a machine with the name exists, the
+    /// base image is missing, the requested resources are below the image minimums,
     /// or the clone/persist fails.
     pub fn create(&self, config: MacMachineConfig) -> Result<()> {
-        // Pre-check under a short read lock, then clone (slow file I/O) without holding
-        // any lock, then re-check on insert to settle a lost create/create race.
+        let final_dir = self.machine_dir(&config.name)?;
+
+        // Fast pre-check; the authoritative check happens under the write lock below.
         if self
             .records
             .read()
@@ -194,13 +211,34 @@ impl MacMachineManager {
             )));
         }
 
-        let dir = self.machine_dir(&config.name);
-        let disks = self.images.clone_base(&config.image, &dir)?;
+        // Enforce the image's published resource minimums before the slow clone.
+        let image = self.images.get(&config.image)?;
+        if u64::from(config.cpus) < image.meta.minimum_cpu_count {
+            return Err(CoreError::macos(format!(
+                "image '{}' requires at least {} CPUs",
+                config.image, image.meta.minimum_cpu_count
+            )));
+        }
+        if config.memory_mib < image.meta.minimum_memory_mib {
+            return Err(CoreError::macos(format!(
+                "image '{}' requires at least {} MiB of memory",
+                config.image, image.meta.minimum_memory_mib
+            )));
+        }
+
+        // Assemble in a unique staging directory. Two concurrent creates of the
+        // same name each stage independently, so the loser only ever removes its
+        // own staging directory — never the winner's cloned disks. The guard
+        // removes staging on any early return.
+        let staging =
+            self.machines_dir
+                .join(format!(".create-{}-{}", config.name, uuid::Uuid::new_v4()));
+        let mut guard = StagingGuard::new(staging.clone());
+        let disks = image.clone_into(&staging)?;
         // Keep the hardware model and machine identifier with the machine so it boots
         // without the base image and with a stable identity across reboots.
-        std::fs::write(dir.join(HARDWARE_MODEL_FILE), &disks.hardware_model)?;
-        std::fs::write(dir.join(MACHINE_ID_FILE), &disks.machine_id)?;
-
+        std::fs::write(staging.join(HARDWARE_MODEL_FILE), &disks.hardware_model)?;
+        std::fs::write(staging.join(MACHINE_ID_FILE), &disks.machine_id)?;
         let record = MacMachineRecord {
             name: config.name.clone(),
             image: config.image,
@@ -209,17 +247,22 @@ impl MacMachineManager {
             created_at: Utc::now(),
             mac_address: Some(generate_mac()),
         };
-        self.write_record(&record)?;
+        Self::write_record_in(&staging, &record)?;
 
+        // Land under the write lock: re-check, clear any stale orphan, rename, insert.
         let mut records = self.records.write().map_err(|_| CoreError::LockPoisoned)?;
         if records.contains_key(&config.name) {
-            drop(records);
-            let _ = std::fs::remove_dir_all(&dir);
             return Err(CoreError::already_exists(format!(
                 "macOS machine '{}'",
                 config.name
             )));
         }
+        if final_dir.exists() {
+            // An orphan from an earlier create that crashed before inserting.
+            std::fs::remove_dir_all(&final_dir)?;
+        }
+        std::fs::rename(&staging, &final_dir)?;
+        guard.disarm();
         records.insert(config.name, record);
         Ok(())
     }
@@ -280,7 +323,7 @@ impl MacMachineManager {
             running.insert(name.to_string(), RunningSlot::Starting);
         }
 
-        let dir = self.machine_dir(name);
+        let dir = self.machine_dir(name)?;
         // The framework rejects a third macOS guest, so it backstops the cap above.
         let booted = async {
             let hardware_model = std::fs::read(dir.join(HARDWARE_MODEL_FILE))?;
@@ -314,6 +357,9 @@ impl MacMachineManager {
 
     /// Stops a running macOS machine.
     ///
+    /// If the stop fails, the machine stays tracked as running (the VZ guest may
+    /// still be live), so the guest cap and [`list`](Self::list) remain accurate.
+    ///
     /// # Errors
     /// Returns an error if the machine is not running or cannot be stopped.
     #[allow(
@@ -339,7 +385,16 @@ impl MacMachineManager {
                 }
             }
         };
-        vm.stop().await
+        if let Err(e) = vm.stop().await {
+            // Stop failed: the VZ guest may still hold a framework slot. Re-insert
+            // so the guest cap and list() reflect that it is still running.
+            self.running
+                .write()
+                .map_err(|_| CoreError::LockPoisoned)?
+                .insert(name.to_string(), RunningSlot::Running(vm));
+            return Err(e);
+        }
+        Ok(())
     }
 
     /// Removes a macOS machine and its disks.
@@ -366,7 +421,7 @@ impl MacMachineManager {
             self.stop(name).await?;
         }
 
-        let dir = self.machine_dir(name);
+        let dir = self.machine_dir(name)?;
         if dir.exists() {
             std::fs::remove_dir_all(&dir)?;
         }
@@ -466,7 +521,76 @@ impl MacMachineManager {
 
 #[cfg(test)]
 mod tests {
+    use super::super::MacImageMeta;
     use super::*;
+    use tempfile::tempdir;
+
+    /// Writes a minimal but clonable base image into the manager's registry.
+    fn write_base_image(mgr: &MacMachineManager, name: &str, min_cpu: u64, min_mem: u64) {
+        mgr.images()
+            .write_meta(&MacImageMeta {
+                name: name.into(),
+                source: None,
+                stream: None,
+                version: None,
+                os_version: None,
+                os_build: None,
+                runner_version: None,
+                minimum_cpu_count: min_cpu,
+                minimum_memory_mib: min_mem,
+                disk_gb: 1,
+                created_at: Utc::now(),
+            })
+            .unwrap();
+        let dir = mgr.images().image_dir(name).unwrap();
+        std::fs::write(dir.join("disk.img"), b"disk").unwrap();
+        std::fs::write(dir.join("aux.img"), b"aux").unwrap();
+        std::fs::write(dir.join("hwmodel.bin"), b"hw").unwrap();
+        std::fs::write(dir.join("machine-id.bin"), b"id").unwrap();
+    }
+
+    fn config(name: &str, cpus: u32, memory_mib: u64) -> MacMachineConfig {
+        MacMachineConfig {
+            name: name.into(),
+            image: "base".into(),
+            cpus,
+            memory_mib,
+        }
+    }
+
+    #[test]
+    fn create_rejects_resources_below_image_minimums() {
+        let dir = tempdir().unwrap();
+        let mgr = MacMachineManager::new(dir.path());
+        write_base_image(&mgr, "base", 2, 4096);
+
+        assert!(mgr.create(config("ci", 1, 8192)).is_err()); // too few CPUs
+        assert!(mgr.create(config("ci", 4, 1024)).is_err()); // too little memory
+        assert!(mgr.get("ci").is_none()); // nothing recorded
+    }
+
+    #[test]
+    fn create_conflict_keeps_the_existing_machine_disks() {
+        let dir = tempdir().unwrap();
+        let mgr = MacMachineManager::new(dir.path());
+        write_base_image(&mgr, "base", 2, 4096);
+
+        mgr.create(config("ci", 4, 8192)).unwrap();
+        let disk = mgr.machine_dir("ci").unwrap().join(DISK_FILE);
+        assert!(disk.exists());
+
+        // A second create for the same name must fail without destroying the first.
+        assert!(mgr.create(config("ci", 4, 8192)).is_err());
+        assert!(disk.exists());
+    }
+
+    #[test]
+    fn create_rejects_invalid_names() {
+        let dir = tempdir().unwrap();
+        let mgr = MacMachineManager::new(dir.path());
+        write_base_image(&mgr, "base", 2, 4096);
+        assert!(mgr.create(config("../escape", 4, 8192)).is_err());
+    }
 
     #[test]
     fn record_round_trips() {

--- a/app/arcbox-core/src/macos/machine.rs
+++ b/app/arcbox-core/src/macos/machine.rs
@@ -18,6 +18,7 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
 use super::image::MacImageManager;
+use super::lease;
 use super::vm::MacVm;
 use crate::error::{CoreError, Result};
 use crate::machine::MachineState;
@@ -39,6 +40,25 @@ struct MacMachineRecord {
     cpus: u32,
     memory_mib: u64,
     created_at: DateTime<Utc>,
+    /// MAC address pinned to the guest's NAT interface. Stable across
+    /// reboots so the guest's DHCP lease identifies it (see [`lease`]).
+    /// `None` only for records written before the field existed; `start`
+    /// backfills it.
+    #[serde(default)]
+    mac_address: Option<String>,
+}
+
+/// Generates a random locally-administered unicast MAC address.
+fn generate_mac() -> String {
+    let mut b: [u8; 6] = uuid::Uuid::new_v4().into_bytes()[..6]
+        .try_into()
+        .expect("slice of length 6");
+    // Locally administered (bit 1), unicast (bit 0 clear).
+    b[0] = (b[0] | 0x02) & 0xFE;
+    format!(
+        "{:02x}:{:02x}:{:02x}:{:02x}:{:02x}:{:02x}",
+        b[0], b[1], b[2], b[3], b[4], b[5]
+    )
 }
 
 /// Configuration for creating a macOS machine from a base image.
@@ -69,6 +89,12 @@ pub struct MacMachineInfo {
     pub state: MachineState,
     /// Creation time.
     pub created_at: DateTime<Utc>,
+    /// MAC address of the guest's NAT interface. `None` only for machines
+    /// created before MAC pinning that have not been started since.
+    pub mac_address: Option<String>,
+    /// IPv4 address from the guest's DHCP lease. `None` unless the machine
+    /// is running and has acquired a lease.
+    pub ip_address: Option<String>,
 }
 
 /// A machine's runtime slot. A slot is reserved (`Starting`) before the VM boots so
@@ -181,6 +207,7 @@ impl MacMachineManager {
             cpus: config.cpus,
             memory_mib: config.memory_mib,
             created_at: Utc::now(),
+            mac_address: Some(generate_mac()),
         };
         self.write_record(&record)?;
 
@@ -217,6 +244,25 @@ impl MacMachineManager {
                 .ok_or_else(|| CoreError::not_found(format!("macOS machine '{name}'")))?
         };
 
+        // Records written before MAC pinning have none persisted: mint one now
+        // so the boot below can pin it and the machine keeps it from then on.
+        let mac_address = match record.mac_address.clone() {
+            Some(mac) => mac,
+            None => {
+                let mac = generate_mac();
+                let record = MacMachineRecord {
+                    mac_address: Some(mac.clone()),
+                    ..record.clone()
+                };
+                self.write_record(&record)?;
+                self.records
+                    .write()
+                    .map_err(|_| CoreError::LockPoisoned)?
+                    .insert(name.to_owned(), record);
+                mac
+            }
+        };
+
         // Atomically check the cap and reserve a slot before the multi-second boot, so
         // concurrent starts cannot both pass the check and exceed the cap.
         {
@@ -244,6 +290,7 @@ impl MacMachineManager {
                 &dir.join(AUX_FILE),
                 &hardware_model,
                 &machine_id,
+                &mac_address,
                 record.cpus,
                 record.memory_mib,
             )
@@ -349,15 +396,23 @@ impl MacMachineManager {
         }
     }
 
-    /// Builds the public view of a record, resolving its current runtime state.
+    /// Builds the public view of a record, resolving its current runtime state
+    /// and — for a running guest — the IP of its DHCP lease.
     fn info(&self, record: &MacMachineRecord) -> MacMachineInfo {
+        let state = self.state_of(&record.name);
+        let ip_address = match (&record.mac_address, state) {
+            (Some(mac), MachineState::Running) => lease::resolve_ip(mac),
+            _ => None,
+        };
         MacMachineInfo {
             name: record.name.clone(),
             image: record.image.clone(),
             cpus: record.cpus,
             memory_mib: record.memory_mib,
-            state: self.state_of(&record.name),
+            state,
             created_at: record.created_at,
+            mac_address: record.mac_address.clone(),
+            ip_address,
         }
     }
 
@@ -421,9 +476,30 @@ mod tests {
             cpus: 4,
             memory_mib: 8192,
             created_at: Utc::now(),
+            mac_address: Some("06:aa:bb:cc:dd:0e".into()),
         };
         let json = serde_json::to_string(&record).unwrap();
         let back: MacMachineRecord = serde_json::from_str(&json).unwrap();
         assert_eq!(record, back);
+    }
+
+    #[test]
+    fn record_without_mac_still_loads() {
+        // Records persisted before MAC pinning have no mac_address field.
+        let json = r#"{"name":"old","image":"sequoia","cpus":2,"memory_mib":4096,
+                       "created_at":"2026-07-01T00:00:00Z"}"#;
+        let record: MacMachineRecord = serde_json::from_str(json).unwrap();
+        assert_eq!(record.mac_address, None);
+    }
+
+    #[test]
+    fn generated_mac_is_locally_administered_unicast() {
+        for _ in 0..64 {
+            let mac = generate_mac();
+            assert_eq!(mac.len(), 17);
+            let first = u8::from_str_radix(&mac[..2], 16).unwrap();
+            assert_eq!(first & 0x02, 0x02, "locally administered bit: {mac}");
+            assert_eq!(first & 0x01, 0x00, "unicast bit: {mac}");
+        }
     }
 }

--- a/app/arcbox-core/src/macos/machine.rs
+++ b/app/arcbox-core/src/macos/machine.rs
@@ -97,14 +97,38 @@ pub struct MacMachineInfo {
     pub ip_address: Option<String>,
 }
 
-/// A machine's runtime slot. A slot is reserved (`Starting`) before the VM boots so
-/// the per-host guest cap is enforced atomically across the multi-second boot, then
-/// replaced by the live VM (`Running`).
+/// A machine's runtime slot.
+///
+/// The slot map is the single serialization point for machine lifecycles: every
+/// transition (start, stop, remove) reserves the machine's slot before touching
+/// its disks or record, so the per-host guest cap and mutual exclusion are both
+/// enforced here. While a slot is held no other lifecycle operation can act on
+/// the machine. Only [`MacMachineManager::stop_all`] (daemon shutdown) sweeps
+/// held slots away; in-flight operations re-check their slot before finalizing
+/// so a post-sweep state is never clobbered.
 enum RunningSlot {
     /// Reserved while booting: occupies a guest slot but has no live VM yet.
     Starting,
     /// A booted, running VM.
     Running(MacVm),
+    /// Reserved while an in-flight stop runs. The VZ guest may still be live,
+    /// so the slot keeps occupying the guest cap and blocks a concurrent start
+    /// from booting a second VM on the same disks.
+    Stopping,
+    /// Reserved while the machine's disks and record are being deleted.
+    Removing,
+}
+
+impl RunningSlot {
+    /// How this slot reads in a "cannot do that now" error.
+    const fn describe(&self) -> &'static str {
+        match self {
+            Self::Starting => "still starting",
+            Self::Running(_) => "running",
+            Self::Stopping => "stopping",
+            Self::Removing => "being removed",
+        }
+    }
 }
 
 /// Manages macOS guest machines: clone-from-base, boot, stop, remove.
@@ -272,13 +296,80 @@ impl MacMachineManager {
     /// Enforces the per-host macOS-guest cap (counting only running macOS machines).
     ///
     /// # Errors
-    /// Returns an error if the machine is unknown, already running, the cap is
-    /// reached, or the VM fails to start.
+    /// Returns an error if the machine is unknown, its slot is held (running,
+    /// or an in-flight start/stop/remove), the cap is reached, or the VM fails
+    /// to start.
     #[allow(
         clippy::future_not_send,
         reason = "boots a Virtualization.framework VM (!Send ObjC handles across await); driven on a single thread"
     )]
     pub async fn start(&self, name: &str) -> Result<()> {
+        // Fast not-found before touching the slot map; the authoritative
+        // re-check happens under the reservation below.
+        if !self
+            .records
+            .read()
+            .map_err(|_| CoreError::LockPoisoned)?
+            .contains_key(name)
+        {
+            return Err(CoreError::not_found(format!("macOS machine '{name}'")));
+        }
+
+        // Atomically check the cap and reserve the slot before the multi-second
+        // boot, so concurrent starts cannot exceed the cap and no concurrent
+        // stop/remove can act on the machine while it boots.
+        {
+            let mut running = self.running.write().map_err(|_| CoreError::LockPoisoned)?;
+            if let Some(slot) = running.get(name) {
+                return Err(CoreError::invalid_state(format!(
+                    "macOS machine '{name}' is {}",
+                    slot.describe()
+                )));
+            }
+            if running.len() >= MAX_RUNNING_MACOS_GUESTS {
+                return Err(CoreError::macos(format!(
+                    "at most {MAX_RUNNING_MACOS_GUESTS} macOS guests may run concurrently per host (Apple license)"
+                )));
+            }
+            running.insert(name.to_string(), RunningSlot::Starting);
+        }
+
+        let booted = self.boot_reserved(name).await;
+
+        let mut running = self.running.write().map_err(|_| CoreError::LockPoisoned)?;
+        match booted {
+            Ok(vm) => match running.get_mut(name) {
+                Some(slot @ RunningSlot::Starting) => {
+                    *slot = RunningSlot::Running(vm);
+                    Ok(())
+                }
+                // Only stop_all (daemon shutdown) sweeps a held reservation:
+                // the fresh VM dies with the process, and whatever occupies
+                // the slot now belongs to a newer operation.
+                _ => Err(CoreError::invalid_state(format!(
+                    "macOS machine '{name}': daemon is shutting down"
+                ))),
+            },
+            Err(e) => {
+                // Release the reservation so a retry (and the cap) are not
+                // wedged — unless stop_all already swept it.
+                if matches!(running.get(name), Some(RunningSlot::Starting)) {
+                    running.remove(name);
+                }
+                Err(e)
+            }
+        }
+    }
+
+    /// Re-validates the record and boots the VM for a machine whose `Starting`
+    /// slot the caller holds. The reservation is what makes the re-read
+    /// authoritative: a concurrent remove cannot delete the record or the
+    /// machine directory while the slot is held.
+    #[allow(
+        clippy::future_not_send,
+        reason = "boots a Virtualization.framework VM (!Send ObjC handles across await); driven on a single thread"
+    )]
+    async fn boot_reserved(&self, name: &str) -> Result<MacVm> {
         let record = {
             let records = self.records.read().map_err(|_| CoreError::LockPoisoned)?;
             records
@@ -289,6 +380,8 @@ impl MacMachineManager {
 
         // Records written before MAC pinning have none persisted: mint one now
         // so the boot below can pin it and the machine keeps it from then on.
+        // Runs under the reservation, so it cannot resurrect a directory a
+        // concurrent remove is deleting.
         let mac_address = match record.mac_address.clone() {
             Some(mac) => mac,
             None => {
@@ -306,53 +399,21 @@ impl MacMachineManager {
             }
         };
 
-        // Atomically check the cap and reserve a slot before the multi-second boot, so
-        // concurrent starts cannot both pass the check and exceed the cap.
-        {
-            let mut running = self.running.write().map_err(|_| CoreError::LockPoisoned)?;
-            if running.contains_key(name) {
-                return Err(CoreError::invalid_state(format!(
-                    "macOS machine '{name}' is already running"
-                )));
-            }
-            if running.len() >= MAX_RUNNING_MACOS_GUESTS {
-                return Err(CoreError::macos(format!(
-                    "at most {MAX_RUNNING_MACOS_GUESTS} macOS guests may run concurrently per host (Apple license)"
-                )));
-            }
-            running.insert(name.to_string(), RunningSlot::Starting);
-        }
-
         let dir = self.machine_dir(name)?;
-        // The framework rejects a third macOS guest, so it backstops the cap above.
-        let booted = async {
-            let hardware_model = std::fs::read(dir.join(HARDWARE_MODEL_FILE))?;
-            let machine_id = std::fs::read(dir.join(MACHINE_ID_FILE))?;
-            MacVm::boot(
-                &dir.join(DISK_FILE),
-                &dir.join(AUX_FILE),
-                &hardware_model,
-                &machine_id,
-                &mac_address,
-                record.cpus,
-                record.memory_mib,
-            )
-            .await
-        }
-        .await;
-
-        let mut running = self.running.write().map_err(|_| CoreError::LockPoisoned)?;
-        match booted {
-            Ok(vm) => {
-                running.insert(name.to_string(), RunningSlot::Running(vm));
-                Ok(())
-            }
-            Err(e) => {
-                // Release the reservation so a retry (and the cap) are not wedged.
-                running.remove(name);
-                Err(e)
-            }
-        }
+        // The framework rejects a third macOS guest, so it backstops the cap
+        // enforced by the caller's reservation.
+        let hardware_model = std::fs::read(dir.join(HARDWARE_MODEL_FILE))?;
+        let machine_id = std::fs::read(dir.join(MACHINE_ID_FILE))?;
+        MacVm::boot(
+            &dir.join(DISK_FILE),
+            &dir.join(AUX_FILE),
+            &hardware_model,
+            &machine_id,
+            &mac_address,
+            record.cpus,
+            record.memory_mib,
+        )
+        .await
     }
 
     /// Stops a running macOS machine.
@@ -370,12 +431,20 @@ impl MacMachineManager {
         let vm = {
             let mut running = self.running.write().map_err(|_| CoreError::LockPoisoned)?;
             match running.remove(name) {
-                Some(RunningSlot::Running(vm)) => vm,
-                Some(slot @ RunningSlot::Starting) => {
-                    // Mid-boot: keep the reservation; start() will finalize it.
-                    running.insert(name.to_string(), slot);
+                Some(RunningSlot::Running(vm)) => {
+                    // Leave a placeholder: the machine keeps occupying its
+                    // guest slot while the stop is in flight, so the cap stays
+                    // accurate and a concurrent start cannot boot a second VM
+                    // on the same disks while the VZ guest may still be live.
+                    running.insert(name.to_string(), RunningSlot::Stopping);
+                    vm
+                }
+                Some(other) => {
+                    // An in-flight operation owns the slot; keep its state.
+                    let state = other.describe();
+                    running.insert(name.to_string(), other);
                     return Err(CoreError::invalid_state(format!(
-                        "macOS machine '{name}' is still starting"
+                        "macOS machine '{name}' is {state}"
                     )));
                 }
                 None => {
@@ -385,16 +454,29 @@ impl MacMachineManager {
                 }
             }
         };
-        if let Err(e) = vm.stop().await {
-            // Stop failed: the VZ guest may still hold a framework slot. Re-insert
-            // so the guest cap and list() reflect that it is still running.
-            self.running
-                .write()
-                .map_err(|_| CoreError::LockPoisoned)?
-                .insert(name.to_string(), RunningSlot::Running(vm));
-            return Err(e);
+
+        let stopped = vm.stop().await;
+
+        let mut running = self.running.write().map_err(|_| CoreError::LockPoisoned)?;
+        match stopped {
+            Ok(()) => {
+                // Clear our placeholder — unless stop_all already swept it.
+                if matches!(running.get(name), Some(RunningSlot::Stopping)) {
+                    running.remove(name);
+                }
+                Ok(())
+            }
+            Err(e) => {
+                // Stop failed: the VZ guest may still hold a framework slot.
+                // Restore the live slot so the guest cap and list() reflect it
+                // — unless stop_all already swept the placeholder (the daemon
+                // is exiting and the guest dies with the process).
+                if matches!(running.get(name), Some(RunningSlot::Stopping)) {
+                    running.insert(name.to_string(), RunningSlot::Running(vm));
+                }
+                Err(e)
+            }
         }
-        Ok(())
     }
 
     /// Removes a macOS machine and its disks.
@@ -407,20 +489,59 @@ impl MacMachineManager {
         reason = "may stop a Virtualization.framework VM (!Send ObjC handles across await); driven on a single thread"
     )]
     pub async fn remove(&self, name: &str, force: bool) -> Result<()> {
-        let is_running = self
-            .running
-            .read()
-            .map_err(|_| CoreError::LockPoisoned)?
-            .contains_key(name);
-        if is_running {
-            if !force {
+        // Reserve the machine's slot before touching disk, so a concurrent
+        // start cannot boot from files that are mid-deletion.
+        let occupied = {
+            let mut running = self.running.write().map_err(|_| CoreError::LockPoisoned)?;
+            match running.get(name) {
+                Some(slot) if !force => {
+                    let hint = if matches!(slot, RunningSlot::Running(_)) {
+                        " (use force to remove)"
+                    } else {
+                        ""
+                    };
+                    return Err(CoreError::invalid_state(format!(
+                        "macOS machine '{name}' is {}{hint}",
+                        slot.describe()
+                    )));
+                }
+                Some(_) => true,
+                None => {
+                    running.insert(name.to_string(), RunningSlot::Removing);
+                    false
+                }
+            }
+        };
+        if occupied {
+            // Force: stop the guest first (fails cleanly if the machine is
+            // still starting, stopping, or being removed), then claim the
+            // freed slot.
+            self.stop(name).await?;
+            let mut running = self.running.write().map_err(|_| CoreError::LockPoisoned)?;
+            if let Some(slot) = running.get(name) {
+                // A concurrent start won the slot between the stop and here.
                 return Err(CoreError::invalid_state(format!(
-                    "macOS machine '{name}' is running (use force to remove)"
+                    "macOS machine '{name}' is {}",
+                    slot.describe()
                 )));
             }
-            self.stop(name).await?;
+            running.insert(name.to_string(), RunningSlot::Removing);
         }
 
+        let removed = self.delete_machine(name);
+
+        // Release the reservation on success and failure alike — unless
+        // stop_all already swept it.
+        let mut running = self.running.write().map_err(|_| CoreError::LockPoisoned)?;
+        if matches!(running.get(name), Some(RunningSlot::Removing)) {
+            running.remove(name);
+        }
+        removed
+    }
+
+    /// Deletes a machine's directory and record. The caller must hold the
+    /// machine's `Removing` slot.
+    fn delete_machine(&self, name: &str) -> Result<()> {
         let dir = self.machine_dir(name)?;
         if dir.exists() {
             std::fs::remove_dir_all(&dir)?;
@@ -432,8 +553,8 @@ impl MacMachineManager {
         Ok(())
     }
 
-    /// Returns whether a machine currently occupies a runtime slot (starting or
-    /// running).
+    /// Returns whether a machine currently occupies a runtime slot (starting,
+    /// running, stopping, or being removed).
     #[must_use]
     pub fn is_running(&self, name: &str) -> bool {
         self.running.read().is_ok_and(|r| r.contains_key(name))
@@ -447,7 +568,10 @@ impl MacMachineManager {
         match running.get(name) {
             Some(RunningSlot::Running(_)) => MachineState::Running,
             Some(RunningSlot::Starting) => MachineState::Starting,
-            None => MachineState::Stopped,
+            Some(RunningSlot::Stopping) => MachineState::Stopping,
+            // Between disk deletion and record pruning, list() can still see
+            // the record; the machine is no longer running.
+            Some(RunningSlot::Removing) | None => MachineState::Stopped,
         }
     }
 
@@ -490,8 +614,9 @@ impl MacMachineManager {
     /// Stops every running macOS guest, returning the per-machine errors that occur.
     ///
     /// Used on daemon shutdown so framework VMs are stopped cleanly rather than dropped
-    /// while still running. Reserved (still-starting) slots have no live VM and are
-    /// simply discarded.
+    /// while still running. Placeholder slots (starting/stopping/removing) have no live
+    /// VM here and are simply discarded; their in-flight owners re-check the slot
+    /// before finalizing, so the sweep cannot be clobbered.
     #[allow(
         clippy::future_not_send,
         reason = "stops Virtualization.framework VMs (!Send ObjC handles across await); driven on a single thread"
@@ -505,7 +630,7 @@ impl MacMachineManager {
                 .drain()
                 .filter_map(|(name, slot)| match slot {
                     RunningSlot::Running(vm) => Some((name, vm)),
-                    RunningSlot::Starting => None,
+                    _ => None,
                 })
                 .collect()
         };
@@ -558,6 +683,21 @@ mod tests {
         }
     }
 
+    /// Drives a `!Send` lifecycle future on a transient current-thread runtime
+    /// (the same pattern the gRPC handlers use).
+    fn block_on<F: std::future::Future>(f: F) -> F::Output {
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap()
+            .block_on(f)
+    }
+
+    /// Reserves `name`'s runtime slot as if an operation were in flight.
+    fn hold_slot(mgr: &MacMachineManager, name: &str, slot: RunningSlot) {
+        mgr.running.write().unwrap().insert(name.to_string(), slot);
+    }
+
     #[test]
     fn create_rejects_resources_below_image_minimums() {
         let dir = tempdir().unwrap();
@@ -590,6 +730,87 @@ mod tests {
         let mgr = MacMachineManager::new(dir.path());
         write_base_image(&mgr, "base", 2, 4096);
         assert!(mgr.create(config("../escape", 4, 8192)).is_err());
+    }
+
+    #[test]
+    fn lifecycle_refuses_a_machine_whose_slot_is_held() {
+        let dir = tempdir().unwrap();
+        let mgr = MacMachineManager::new(dir.path());
+        write_base_image(&mgr, "base", 2, 4096);
+        mgr.create(config("ci", 4, 8192)).unwrap();
+
+        // A held slot blocks start, stop, and non-force remove, and the
+        // holder's state survives the refused call.
+        hold_slot(&mgr, "ci", RunningSlot::Removing);
+        let err = block_on(mgr.start("ci")).unwrap_err().to_string();
+        assert!(err.contains("being removed"), "{err}");
+        let err = block_on(mgr.stop("ci")).unwrap_err().to_string();
+        assert!(err.contains("being removed"), "{err}");
+        let err = block_on(mgr.remove("ci", false)).unwrap_err().to_string();
+        assert!(err.contains("being removed"), "{err}");
+        assert!(mgr.is_running("ci"));
+
+        // Force-remove of a still-starting machine fails through stop()
+        // without deleting anything.
+        hold_slot(&mgr, "ci", RunningSlot::Starting);
+        let err = block_on(mgr.remove("ci", true)).unwrap_err().to_string();
+        assert!(err.contains("still starting"), "{err}");
+        assert!(mgr.machine_dir("ci").unwrap().join(DISK_FILE).exists());
+        assert!(mgr.is_running("ci"));
+
+        // A stop racing an in-flight stop is refused, not doubled.
+        hold_slot(&mgr, "ci", RunningSlot::Stopping);
+        let err = block_on(mgr.stop("ci")).unwrap_err().to_string();
+        assert!(err.contains("stopping"), "{err}");
+        assert!(mgr.is_running("ci"));
+    }
+
+    #[test]
+    fn remove_releases_its_reservation() {
+        let dir = tempdir().unwrap();
+        let mgr = MacMachineManager::new(dir.path());
+        write_base_image(&mgr, "base", 2, 4096);
+        mgr.create(config("ci", 4, 8192)).unwrap();
+
+        block_on(mgr.remove("ci", false)).unwrap();
+        assert!(mgr.get("ci").is_none());
+        assert!(!mgr.machine_dir("ci").unwrap().exists());
+        // The Removing placeholder must not leak into the slot map.
+        assert!(!mgr.is_running("ci"));
+
+        // Removing an unknown machine stays idempotent and leaks no slot.
+        block_on(mgr.remove("ghost", false)).unwrap();
+        assert!(!mgr.is_running("ghost"));
+    }
+
+    #[test]
+    fn failed_start_releases_the_reservation() {
+        let dir = tempdir().unwrap();
+        let mgr = MacMachineManager::new(dir.path());
+        write_base_image(&mgr, "base", 2, 4096);
+        mgr.create(config("ci", 4, 8192)).unwrap();
+
+        // The fixture's hardware model is garbage, so the boot fails after
+        // the slot is reserved; the reservation must be released so a retry
+        // is not refused as "still starting".
+        let err = block_on(mgr.start("ci")).unwrap_err().to_string();
+        assert!(!err.contains("still starting"), "{err}");
+        assert!(!mgr.is_running("ci"));
+        let retry = block_on(mgr.start("ci")).unwrap_err().to_string();
+        assert!(!retry.contains("still starting"), "{retry}");
+    }
+
+    #[test]
+    fn placeholder_slots_count_against_the_guest_cap() {
+        let dir = tempdir().unwrap();
+        let mgr = MacMachineManager::new(dir.path());
+        write_base_image(&mgr, "base", 2, 4096);
+        mgr.create(config("ci", 4, 8192)).unwrap();
+
+        hold_slot(&mgr, "other-a", RunningSlot::Starting);
+        hold_slot(&mgr, "other-b", RunningSlot::Stopping);
+        let err = block_on(mgr.start("ci")).unwrap_err().to_string();
+        assert!(err.contains("at most 2"), "{err}");
     }
 
     #[test]

--- a/app/arcbox-core/src/macos/mod.rs
+++ b/app/arcbox-core/src/macos/mod.rs
@@ -3,5 +3,9 @@
 
 mod image;
 mod install;
+mod machine;
+mod vm;
 
 pub use image::{MacImage, MacImageManager, MacImageMeta, MacInstanceDisks};
+pub use machine::{MacMachineConfig, MacMachineInfo, MacMachineManager};
+pub use vm::MacVm;

--- a/app/arcbox-core/src/macos/mod.rs
+++ b/app/arcbox-core/src/macos/mod.rs
@@ -15,6 +15,6 @@ pub use image::{MacImage, MacImageManager, MacImageMeta, MacInstanceDisks};
 #[cfg(feature = "macos-ipsw-install")]
 pub use install::{PullPhase, PullSource};
 pub use machine::{MacMachineConfig, MacMachineInfo, MacMachineManager};
-pub use pull::{PullStage, RemoteSource};
+pub use pull::{PullStage, RemoteSource, ResolvedImage};
 pub use remote::{ImageReference, RemoteLocation};
 pub use vm::MacVm;

--- a/app/arcbox-core/src/macos/mod.rs
+++ b/app/arcbox-core/src/macos/mod.rs
@@ -1,0 +1,6 @@
+//! macOS guest support: base images, copy-on-write clones, and (later) the macOS
+//! machine lifecycle. Apple Silicon only.
+
+mod image;
+
+pub use image::{MacImage, MacImageManager, MacImageMeta, MacInstanceDisks};

--- a/app/arcbox-core/src/macos/mod.rs
+++ b/app/arcbox-core/src/macos/mod.rs
@@ -1,5 +1,10 @@
-//! macOS guest support: base images, copy-on-write clones, and (later) the macOS
-//! machine lifecycle. Apple Silicon only.
+//! macOS guest support: base images, copy-on-write clones, and the macOS machine
+//! lifecycle. Apple Silicon only.
+
+use std::ffi::OsStr;
+use std::path::{Component, Path, PathBuf};
+
+use crate::error::{CoreError, Result};
 
 #[cfg(feature = "macos-ipsw-install")]
 mod download;
@@ -19,3 +24,76 @@ pub use machine::{MacMachineConfig, MacMachineInfo, MacMachineManager};
 pub use pull::{PullStage, RemoteSource, ResolvedImage};
 pub use remote::{ImageReference, RemoteLocation};
 pub use vm::MacVm;
+
+/// Validates that `name` is a single, safe path component.
+///
+/// Image and machine names are used verbatim as a directory under a managed
+/// root (`macos/images/<name>`, `macos/machines/<name>`). A name must therefore
+/// be exactly one normal path component: this rejects empty names, embedded NUL,
+/// absolute paths, path separators, and `.`/`..`, so a caller- or manifest-
+/// supplied name can never escape its root.
+pub(super) fn validate_name(name: &str) -> Result<()> {
+    let mut components = Path::new(name).components();
+    match (components.next(), components.next()) {
+        (Some(Component::Normal(only)), None)
+            if only == OsStr::new(name) && !name.contains('\0') =>
+        {
+            Ok(())
+        }
+        _ => Err(CoreError::macos(format!("invalid name '{name}'"))),
+    }
+}
+
+/// Removes a staging directory on drop unless disarmed.
+///
+/// Both the image pull and machine create flows assemble their artifacts in a
+/// staging directory and rename it into place only when complete. This guard is
+/// what makes those flows safe against early return and cancellation: if it is
+/// dropped before `disarm` (an error, or the future being dropped at an await
+/// point), the partial directory is removed rather than leaked.
+pub(super) struct StagingGuard {
+    path: Option<PathBuf>,
+}
+
+impl StagingGuard {
+    pub(super) fn new(path: PathBuf) -> Self {
+        Self { path: Some(path) }
+    }
+
+    /// Keeps the directory (it has been renamed into its final location).
+    pub(super) fn disarm(&mut self) {
+        self.path = None;
+    }
+}
+
+impl Drop for StagingGuard {
+    fn drop(&mut self) {
+        if let Some(path) = &self.path {
+            let _ = std::fs::remove_dir_all(path);
+        }
+    }
+}
+
+#[cfg(test)]
+mod name_tests {
+    use super::validate_name;
+
+    #[test]
+    fn accepts_plain_and_dotted_components() {
+        for ok in [
+            "tahoe-base",
+            "tahoe-base@2026.07.02",
+            ".pull-x",
+            ".create-ci-1",
+        ] {
+            assert!(validate_name(ok).is_ok(), "should accept {ok:?}");
+        }
+    }
+
+    #[test]
+    fn rejects_traversal_and_separators() {
+        for bad in ["", ".", "..", "a/b", "/abs", "a/../b", "a\0b", "sub/dir"] {
+            assert!(validate_name(bad).is_err(), "should reject {bad:?}");
+        }
+    }
+}

--- a/app/arcbox-core/src/macos/mod.rs
+++ b/app/arcbox-core/src/macos/mod.rs
@@ -2,5 +2,6 @@
 //! machine lifecycle. Apple Silicon only.
 
 mod image;
+mod install;
 
 pub use image::{MacImage, MacImageManager, MacImageMeta, MacInstanceDisks};

--- a/app/arcbox-core/src/macos/mod.rs
+++ b/app/arcbox-core/src/macos/mod.rs
@@ -1,11 +1,13 @@
 //! macOS guest support: base images, copy-on-write clones, and (later) the macOS
 //! machine lifecycle. Apple Silicon only.
 
+mod download;
 mod image;
 mod install;
 mod machine;
 mod vm;
 
 pub use image::{MacImage, MacImageManager, MacImageMeta, MacInstanceDisks};
+pub use install::{PullPhase, PullSource};
 pub use machine::{MacMachineConfig, MacMachineInfo, MacMachineManager};
 pub use vm::MacVm;

--- a/app/arcbox-core/src/macos/mod.rs
+++ b/app/arcbox-core/src/macos/mod.rs
@@ -6,6 +6,7 @@ mod download;
 mod image;
 #[cfg(feature = "macos-ipsw-install")]
 mod install;
+mod lease;
 mod machine;
 mod pull;
 mod remote;

--- a/app/arcbox-core/src/macos/mod.rs
+++ b/app/arcbox-core/src/macos/mod.rs
@@ -5,9 +5,13 @@ mod download;
 mod image;
 mod install;
 mod machine;
+mod pull;
+mod remote;
 mod vm;
 
 pub use image::{MacImage, MacImageManager, MacImageMeta, MacInstanceDisks};
 pub use install::{PullPhase, PullSource};
 pub use machine::{MacMachineConfig, MacMachineInfo, MacMachineManager};
+pub use pull::{PullStage, RemoteSource};
+pub use remote::{ImageReference, RemoteLocation};
 pub use vm::MacVm;

--- a/app/arcbox-core/src/macos/mod.rs
+++ b/app/arcbox-core/src/macos/mod.rs
@@ -6,6 +6,7 @@ use std::path::{Component, Path, PathBuf};
 
 use crate::error::{CoreError, Result};
 
+mod disk;
 #[cfg(feature = "macos-ipsw-install")]
 mod download;
 mod image;

--- a/app/arcbox-core/src/macos/mod.rs
+++ b/app/arcbox-core/src/macos/mod.rs
@@ -1,8 +1,10 @@
 //! macOS guest support: base images, copy-on-write clones, and (later) the macOS
 //! machine lifecycle. Apple Silicon only.
 
+#[cfg(feature = "macos-ipsw-install")]
 mod download;
 mod image;
+#[cfg(feature = "macos-ipsw-install")]
 mod install;
 mod machine;
 mod pull;
@@ -10,6 +12,7 @@ mod remote;
 mod vm;
 
 pub use image::{MacImage, MacImageManager, MacImageMeta, MacInstanceDisks};
+#[cfg(feature = "macos-ipsw-install")]
 pub use install::{PullPhase, PullSource};
 pub use machine::{MacMachineConfig, MacMachineInfo, MacMachineManager};
 pub use pull::{PullStage, RemoteSource};

--- a/app/arcbox-core/src/macos/pull.rs
+++ b/app/arcbox-core/src/macos/pull.rs
@@ -396,7 +396,6 @@ fn meta_from_manifest(manifest: &ImageManifest, location: &RemoteLocation) -> Ma
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::io::Write as _;
     use tempfile::tempdir;
 
     /// Real hardware-model data representation captured from a Tahoe base

--- a/app/arcbox-core/src/macos/pull.rs
+++ b/app/arcbox-core/src/macos/pull.rs
@@ -2,13 +2,13 @@
 //!
 //! [`MacImageManager::pull_remote`] resolves a reference against the published
 //! index (or consumes a manifest directly), validates host support *before*
-//! the multi-gigabyte download, then streams the zstd-compressed disk through
-//! decompression into a sparse `disk.img` — the compressed bytes never touch
-//! disk. The image is assembled in a staging directory and renamed live only
-//! after every integrity check passes, so a failed pull never leaves a broken
+//! the multi-gigabyte download, then restores the disk: its chunks download
+//! with bounded parallelism and stream through decompression into a sparse
+//! `disk.img` (the compressed bytes never touch disk — see [`super::disk`]).
+//! The image is assembled in a staging directory and renamed live only after
+//! every integrity check passes, so a failed pull never leaves a broken
 //! registry entry.
 
-use std::io::Write;
 use std::path::Path;
 
 use base64::Engine as _;
@@ -16,13 +16,19 @@ use base64::engine::general_purpose::STANDARD as BASE64;
 use chrono::Utc;
 use sha2::{Digest, Sha256};
 
+use super::disk::{fetch_disk, verify_sha256};
 use super::image::{
     AUX_FILE, DISK_FILE, HARDWARE_MODEL_FILE, MACHINE_ID_FILE, MacImage, MacImageManager,
     MacImageMeta,
 };
-use super::remote::{ImageManifest, ImageReference, RemoteFile, RemoteIndex, RemoteLocation};
+use super::remote::{ImageManifest, ImageReference, RemoteIndex, RemoteLocation};
 use super::{StagingGuard, validate_name};
 use crate::error::{CoreError, Result};
+
+/// Manifest schema this client consumes.
+const MANIFEST_SCHEMA_VERSION: u32 = 2;
+/// Index schema this client consumes.
+const INDEX_SCHEMA_VERSION: u32 = 1;
 
 /// Where a [`MacImageManager::pull_remote`] finds its manifest.
 #[derive(Debug, Clone)]
@@ -77,67 +83,6 @@ pub enum PullStage {
     Verify,
 }
 
-/// Zero-skipping block writer: keeps `disk.img` sparse by never writing
-/// all-zero blocks (the file is pre-sized, so skipped ranges become holes).
-///
-/// Alignment comes from buffering to fixed-size blocks; `flush` deliberately
-/// does not drain a partial block (the decompressor flushes mid-stream), the
-/// tail is written by [`SparseWriter::finish`].
-struct SparseWriter {
-    file: std::fs::File,
-    offset: u64,
-    buf: Vec<u8>,
-}
-
-/// Block granularity for zero detection; a multiple of the APFS block size.
-const SPARSE_BLOCK: usize = 64 * 1024;
-static ZERO_BLOCK: [u8; SPARSE_BLOCK] = [0u8; SPARSE_BLOCK];
-
-impl SparseWriter {
-    fn new(file: std::fs::File) -> Self {
-        Self {
-            file,
-            offset: 0,
-            buf: Vec::with_capacity(SPARSE_BLOCK),
-        }
-    }
-
-    fn flush_block(&mut self) -> std::io::Result<()> {
-        // Slice equality is a memcmp — much faster than a per-byte scan.
-        if self.buf.as_slice() != &ZERO_BLOCK[..self.buf.len()] {
-            use std::os::unix::fs::FileExt;
-            self.file.write_all_at(&self.buf, self.offset)?;
-        }
-        self.offset += self.buf.len() as u64;
-        self.buf.clear();
-        Ok(())
-    }
-
-    /// Drains the partial tail block and returns the total bytes written.
-    fn finish(mut self) -> std::io::Result<u64> {
-        if !self.buf.is_empty() {
-            self.flush_block()?;
-        }
-        self.file.flush()?;
-        Ok(self.offset)
-    }
-}
-
-impl Write for SparseWriter {
-    fn write(&mut self, data: &[u8]) -> std::io::Result<usize> {
-        let take = (SPARSE_BLOCK - self.buf.len()).min(data.len());
-        self.buf.extend_from_slice(&data[..take]);
-        if self.buf.len() == SPARSE_BLOCK {
-            self.flush_block()?;
-        }
-        Ok(take)
-    }
-
-    fn flush(&mut self) -> std::io::Result<()> {
-        Ok(())
-    }
-}
-
 /// Decodes a base64 manifest field.
 fn decode_field(field: &str, value: &str) -> Result<Vec<u8>> {
     BASE64
@@ -159,208 +104,9 @@ fn validate_hardware_model(data: &[u8]) -> Result<()> {
     Ok(())
 }
 
-/// Verifies a hex SHA-256 against an expected manifest value.
-fn verify_sha256(what: &str, actual: &[u8], expected: &str) -> Result<()> {
-    let actual = hex(actual);
-    if !actual.eq_ignore_ascii_case(expected) {
-        return Err(CoreError::macos(format!(
-            "{what}: checksum mismatch (expected {expected}, got {actual})"
-        )));
-    }
-    Ok(())
-}
-
-fn hex(bytes: &[u8]) -> String {
-    use std::fmt::Write as _;
-    bytes.iter().fold(String::new(), |mut s, b| {
-        let _ = write!(s, "{b:02x}");
-        s
-    })
-}
-
-/// Consecutive transient-failure budget for a streaming download; any received
-/// byte resets it, so a 20 GB pull tolerates many blips but not a dead link.
-const DOWNLOAD_RETRIES: u32 = 4;
-const DOWNLOAD_RETRY_DELAY: std::time::Duration = std::time::Duration::from_secs(2);
-
-/// Streams a compressed file from `location`, decompressing into a sparse,
-/// pre-sized `dst`. Verifies compressed size, SHA-256, and decompressed size
-/// against `spec`. `on_progress` receives the downloaded fraction.
-///
-/// HTTP downloads resume mid-stream on transient failures: the zstd decoder
-/// state lives in memory, so a dropped connection is re-requested with
-/// `Range: bytes=<received>-` and decoding continues where it left off. (A
-/// daemon restart still restarts the pull from zero — resume covers network
-/// blips within one attempt, which is the failure that matters at 20 GB.)
-/// Hash + decompress + sparse-write sink for a compressed download stream.
-///
-/// A struct rather than a closure so callers can read `received` between
-/// `consume` calls (the resume offset for `Range` re-requests).
-struct StreamSink<F: FnMut(f64)> {
-    decoder: zstd::stream::write::Decoder<'static, SparseWriter>,
-    hasher: Sha256,
-    received: u64,
-    compressed_size: u64,
-    path: String,
-    on_progress: F,
-}
-
-impl<F: FnMut(f64)> StreamSink<F> {
-    fn consume(&mut self, bytes: &[u8]) -> Result<()> {
-        self.hasher.update(bytes);
-        self.decoder
-            .write_all(bytes)
-            .map_err(|e| CoreError::macos(format!("decompress {}: {e}", self.path)))?;
-        self.received += bytes.len() as u64;
-        if self.compressed_size > 0 {
-            (self.on_progress)((self.received as f64 / self.compressed_size as f64).min(1.0));
-        }
-        Ok(())
-    }
-}
-
-/// Failure of a single download attempt: transient failures are retried from
-/// the current offset, fatal ones abort the pull.
-enum AttemptError {
-    Transient(CoreError),
-    Fatal(CoreError),
-}
-
-/// One HTTP request feeding the sink, resuming at `sink.received`.
-/// Returns the bytes this attempt contributed.
-async fn stream_http_once<F: FnMut(f64)>(
-    client: &reqwest::Client,
-    url: &reqwest::Url,
-    sink: &mut StreamSink<F>,
-) -> std::result::Result<u64, AttemptError> {
-    let mut request = client.get(url.clone());
-    if sink.received > 0 {
-        request = request.header(reqwest::header::RANGE, format!("bytes={}-", sink.received));
-    }
-    let mut resp = request
-        .send()
-        .await
-        .and_then(reqwest::Response::error_for_status)
-        .map_err(|e| AttemptError::Transient(CoreError::macos(format!("download {url}: {e}"))))?;
-    if sink.received > 0 && resp.status() != reqwest::StatusCode::PARTIAL_CONTENT {
-        // The server ignored the Range header; replaying the body from zero
-        // would corrupt the in-memory decoder state. Retrying cannot help.
-        return Err(AttemptError::Fatal(CoreError::macos(format!(
-            "download {url}: server does not honor Range requests; cannot resume"
-        ))));
-    }
-    let start = sink.received;
-    while let Some(chunk) = resp
-        .chunk()
-        .await
-        .map_err(|e| AttemptError::Transient(CoreError::macos(format!("download {url}: {e}"))))?
-    {
-        // A decode/write failure is local, not a network blip.
-        sink.consume(&chunk).map_err(AttemptError::Fatal)?;
-    }
-    Ok(sink.received - start)
-}
-
-async fn fetch_zstd_to_sparse(
-    location: &RemoteLocation,
-    spec: &RemoteFile,
-    dst: &Path,
-    on_progress: impl FnMut(f64),
-) -> Result<()> {
-    let file = std::fs::File::create(dst)?;
-    file.set_len(spec.uncompressed_size)?;
-    let mut sink = StreamSink {
-        decoder: zstd::stream::write::Decoder::new(SparseWriter::new(file))
-            .map_err(|e| CoreError::macos(format!("zstd init: {e}")))?,
-        hasher: Sha256::new(),
-        received: 0,
-        compressed_size: spec.compressed_size,
-        path: spec.path.clone(),
-        on_progress,
-    };
-
-    match location {
-        RemoteLocation::Http(url) => {
-            let client = reqwest::Client::new();
-            let mut failures: u32 = 0;
-            while sink.received < spec.compressed_size {
-                match stream_http_once(&client, url, &mut sink).await {
-                    Ok(_) if sink.received >= spec.compressed_size => break,
-                    // Progress resets the failure budget; a clean-but-short
-                    // body counts as a failure too (otherwise it would spin).
-                    Ok(progressed) => {
-                        failures = if progressed > 0 { 1 } else { failures + 1 };
-                        tracing::warn!(
-                            "download {url}: connection ended early; resuming at byte {}",
-                            sink.received
-                        );
-                    }
-                    Err(AttemptError::Fatal(e)) => return Err(e),
-                    Err(AttemptError::Transient(e)) => {
-                        failures += 1;
-                        tracing::warn!("{e}; resuming at byte {}", sink.received);
-                    }
-                }
-                if failures > DOWNLOAD_RETRIES {
-                    return Err(CoreError::macos(format!(
-                        "download {url}: giving up after {DOWNLOAD_RETRIES} consecutive failures at byte {}",
-                        sink.received
-                    )));
-                }
-                tokio::time::sleep(DOWNLOAD_RETRY_DELAY).await;
-            }
-        }
-        RemoteLocation::File(path) => {
-            // tokio::fs (not std): every read is an await point, which is what
-            // keeps this future cancellable — a sync loop here would run to
-            // completion inside a single poll, immune to `select!`/drop, while
-            // pinning a runtime worker for the whole decompression.
-            use tokio::io::AsyncReadExt;
-            let mut src = tokio::fs::File::open(path).await?;
-            let mut buf = vec![0u8; 1024 * 1024];
-            loop {
-                let n = src.read(&mut buf).await?;
-                if n == 0 {
-                    break;
-                }
-                sink.consume(&buf[..n])?;
-            }
-        }
-    }
-
-    let StreamSink {
-        mut decoder,
-        hasher,
-        received,
-        ..
-    } = sink;
-    decoder
-        .flush()
-        .map_err(|e| CoreError::macos(format!("decompress {}: {e}", spec.path)))?;
-    let written = decoder
-        .into_inner()
-        .finish()
-        .map_err(|e| CoreError::macos(format!("finalize {}: {e}", dst.display())))?;
-
-    if received != spec.compressed_size {
-        return Err(CoreError::macos(format!(
-            "{}: truncated download (expected {} compressed bytes, got {received})",
-            spec.path, spec.compressed_size
-        )));
-    }
-    verify_sha256(&spec.path, &hasher.finalize(), &spec.sha256)?;
-    if written != spec.uncompressed_size {
-        return Err(CoreError::macos(format!(
-            "{}: decompressed to {written} bytes, manifest says {}",
-            spec.path, spec.uncompressed_size
-        )));
-    }
-    Ok(())
-}
-
 /// Resolves `source` to the manifest a pull would consume: index resolution
-/// (for a reference), then schema, disk-format, and name-match checks.
-/// Shared by [`MacImageManager::pull_remote`] and
+/// (for a reference), then schema, disk-format, chunk-layout, and name-match
+/// checks. Shared by [`MacImageManager::pull_remote`] and
 /// [`MacImageManager::resolve_remote`], so "what resolve reported" and
 /// "what pull lands" can never drift.
 async fn resolve_source(source: &RemoteSource) -> Result<(RemoteLocation, ImageManifest)> {
@@ -369,7 +115,7 @@ async fn resolve_source(source: &RemoteSource) -> Result<(RemoteLocation, ImageM
         RemoteSource::Reference(reference) => {
             let base = super::remote::image_base().as_dir();
             let index: RemoteIndex = base.join("index.json")?.fetch_json().await?;
-            if index.schema_version != 1 {
+            if index.schema_version != INDEX_SCHEMA_VERSION {
                 return Err(CoreError::macos(format!(
                     "unsupported image index schema_version {}",
                     index.schema_version
@@ -380,7 +126,7 @@ async fn resolve_source(source: &RemoteSource) -> Result<(RemoteLocation, ImageM
         }
     };
     let manifest: ImageManifest = manifest_location.fetch_json().await?;
-    if manifest.schema_version != 1 {
+    if manifest.schema_version != MANIFEST_SCHEMA_VERSION {
         return Err(CoreError::macos(format!(
             "unsupported image manifest schema_version {}",
             manifest.schema_version
@@ -390,6 +136,23 @@ async fn resolve_source(source: &RemoteSource) -> Result<(RemoteLocation, ImageM
         return Err(CoreError::macos(format!(
             "unsupported disk format '{}'",
             manifest.disk.disk_format
+        )));
+    }
+    // The chunk list must exactly tile the declared disk size, so every
+    // uncompressed byte is covered by exactly one chunk at a known offset.
+    if manifest.disk.chunk_size == 0 || manifest.disk.chunks.is_empty() {
+        return Err(CoreError::macos("manifest disk has no chunks"));
+    }
+    let expected_chunks = manifest
+        .disk
+        .uncompressed_size
+        .div_ceil(manifest.disk.chunk_size);
+    if manifest.disk.chunks.len() as u64 != expected_chunks {
+        return Err(CoreError::macos(format!(
+            "manifest lists {} disk chunks but {expected_chunks} are needed for {} bytes at chunk_size {}",
+            manifest.disk.chunks.len(),
+            manifest.disk.uncompressed_size,
+            manifest.disk.chunk_size
         )));
     }
     // The name becomes a registry directory; reject anything that could escape it
@@ -433,7 +196,7 @@ impl MacImageManager {
             runner_version: manifest.runner_version,
             minimum_cpu_count: manifest.minimum_cpu_count,
             minimum_memory_mib: manifest.minimum_memory_mib,
-            disk_gb: manifest.disk.file.uncompressed_size / 1_000_000_000,
+            disk_gb: manifest.disk.uncompressed_size / 1_000_000_000,
             installed_version,
         })
     }
@@ -513,9 +276,9 @@ impl MacImageManager {
         on_progress: &mut impl FnMut(PullStage, f64),
     ) -> Result<()> {
         on_progress(PullStage::Disk, 0.0);
-        fetch_zstd_to_sparse(
-            &manifest_location.join(&manifest.disk.file.path)?,
-            &manifest.disk.file,
+        fetch_disk(
+            manifest_location,
+            &manifest.disk,
             &staging.join(DISK_FILE),
             |frac| on_progress(PullStage::Disk, frac),
         )
@@ -567,7 +330,7 @@ fn meta_from_manifest(manifest: &ImageManifest, location: &RemoteLocation) -> Ma
         runner_version: manifest.runner_version.clone(),
         minimum_cpu_count: manifest.minimum_cpu_count,
         minimum_memory_mib: manifest.minimum_memory_mib,
-        disk_gb: manifest.disk.file.uncompressed_size / 1_000_000_000,
+        disk_gb: manifest.disk.uncompressed_size / 1_000_000_000,
         created_at: Utc::now(),
     }
 }
@@ -575,99 +338,8 @@ fn meta_from_manifest(manifest: &ImageManifest, location: &RemoteLocation) -> Ma
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::macos::disk::hex;
     use tempfile::tempdir;
-
-    /// Minimal HTTP server for download tests. First plain GET: claims the
-    /// full length but sends only the first half, then hangs up (simulating a
-    /// dropped connection). `Range: bytes=N-` requests: served completely.
-    async fn serve_flaky_zst(listener: tokio::net::TcpListener, full: Vec<u8>) {
-        use tokio::io::{AsyncReadExt, AsyncWriteExt};
-        loop {
-            let Ok((mut sock, _)) = listener.accept().await else {
-                return;
-            };
-            let full = full.clone();
-            tokio::spawn(async move {
-                let mut req = Vec::new();
-                let mut buf = [0u8; 4096];
-                while !req.windows(4).any(|w| w == b"\r\n\r\n") {
-                    match sock.read(&mut buf).await {
-                        Ok(0) | Err(_) => return,
-                        Ok(n) => req.extend_from_slice(&buf[..n]),
-                    }
-                }
-                let req = String::from_utf8_lossy(&req).to_ascii_lowercase();
-                let range_start = req
-                    .lines()
-                    .find_map(|l| l.strip_prefix("range: bytes="))
-                    .and_then(|r| r.split('-').next())
-                    .and_then(|s| s.parse::<usize>().ok());
-                match range_start {
-                    None => {
-                        let head = format!(
-                            "HTTP/1.1 200 OK\r\ncontent-length: {}\r\nconnection: close\r\n\r\n",
-                            full.len()
-                        );
-                        let _ = sock.write_all(head.as_bytes()).await;
-                        let _ = sock.write_all(&full[..full.len() / 2]).await;
-                        // Drop mid-body: the client sees a broken connection.
-                    }
-                    Some(start) => {
-                        let rest = &full[start..];
-                        let head = format!(
-                            "HTTP/1.1 206 Partial Content\r\ncontent-length: {}\r\ncontent-range: bytes {start}-{}/{}\r\nconnection: close\r\n\r\n",
-                            rest.len(),
-                            full.len() - 1,
-                            full.len()
-                        );
-                        let _ = sock.write_all(head.as_bytes()).await;
-                        let _ = sock.write_all(rest).await;
-                    }
-                }
-            });
-        }
-    }
-
-    #[tokio::test]
-    async fn http_download_resumes_after_connection_drop() {
-        let mut raw = vec![0xABu8; SPARSE_BLOCK];
-        raw.extend_from_slice(&vec![0u8; SPARSE_BLOCK]);
-        raw.extend_from_slice(&vec![0xCDu8; SPARSE_BLOCK]);
-        let compressed = zstd::encode_all(&raw[..], 3).unwrap();
-        let spec = RemoteFile {
-            path: "disk.img.zst".into(),
-            uncompressed_size: raw.len() as u64,
-            compressed_size: compressed.len() as u64,
-            sha256: hex(&Sha256::digest(&compressed)),
-        };
-
-        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let url = format!("http://{}/disk.img.zst", listener.local_addr().unwrap());
-        tokio::spawn(serve_flaky_zst(listener, compressed));
-
-        let dir = tempdir().unwrap();
-        let dst = dir.path().join("disk.img");
-        fetch_zstd_to_sparse(&RemoteLocation::parse(&url), &spec, &dst, |_| {})
-            .await
-            .unwrap();
-        assert_eq!(std::fs::read(&dst).unwrap(), raw);
-    }
-
-    #[test]
-    fn staging_guard_removes_unless_disarmed() {
-        let dir = tempdir().unwrap();
-        let staging = dir.path().join("staging");
-
-        std::fs::create_dir_all(&staging).unwrap();
-        drop(StagingGuard::new(staging.clone()));
-        assert!(!staging.exists());
-
-        std::fs::create_dir_all(&staging).unwrap();
-        let mut guard = StagingGuard::new(staging.clone());
-        guard.disarm();
-        drop(guard);
-        assert!(staging.exists());
-    }
 
     /// Real hardware-model data representation captured from a Tahoe base
     /// image (`config.json .hardwareModel`); decodes on any host, and
@@ -675,58 +347,37 @@ mod tests {
     const REAL_HARDWARE_MODEL_B64: &str = "YnBsaXN0MDDTAQIDBAQFXxAZRGF0YVJlcHJlc2VudGF0aW9uVmVyc2lvbl8QD1BsYXRmb3JtVmVyc2lvbl8QEk1pbmltdW1TdXBwb3J0ZWRPUxACowYHBxANEAAIDys9UlRYWgAAAAAAAAEBAAAAAAAAAAgAAAAAAAAAAAAAAAAAAABc";
     const REAL_MACHINE_ID_B64: &str = "YnBsaXN0MDDRAQJURUNJRBQAAAAAAAAAAJzeRwpdz1o1CAsQAAAAAAAAAQEAAAAAAAAAAwAAAAAAAAAAAAAAAAAAACE=";
 
+    /// Block granularity the sparse writer uses; test chunk sizes are multiples
+    /// of it so chunk offsets stay block-aligned.
+    const BLOCK: usize = 64 * 1024;
+
+    /// Splits `raw` into `chunk_size` slices, writes each as a zstd-compressed
+    /// `disk.NNN.zst` under `dir`, and returns the manifest `disk` object.
+    fn publish_disk(dir: &Path, raw: &[u8], chunk_size: usize) -> serde_json::Value {
+        let mut chunks = Vec::new();
+        for (i, slice) in raw.chunks(chunk_size).enumerate() {
+            let compressed = zstd::encode_all(slice, 3).unwrap();
+            let path = format!("disk.{i:03}.zst");
+            std::fs::write(dir.join(&path), &compressed).unwrap();
+            chunks.push(serde_json::json!({
+                "path": path,
+                "size": compressed.len(),
+                "sha256": hex(&Sha256::digest(&compressed)),
+            }));
+        }
+        serde_json::json!({
+            "disk_format": "raw",
+            "uncompressed_size": raw.len(),
+            "uncompressed_sha256": hex(&Sha256::digest(raw)),
+            "chunk_size": chunk_size,
+            "chunks": chunks,
+        })
+    }
+
     fn write_zstd(path: &Path, raw: &[u8]) -> (u64, String) {
         let compressed = zstd::encode_all(raw, 3).unwrap();
         std::fs::write(path, &compressed).unwrap();
         (compressed.len() as u64, hex(&Sha256::digest(&compressed)))
-    }
-
-    #[test]
-    fn sparse_writer_skips_zero_blocks() {
-        // APFS only keeps holes in files above a size threshold (verified
-        // empirically: fully materialized at 16 MiB, sparse at 256 MiB), so
-        // this test must run at realistic scale. Data is streamed block-wise
-        // to keep the test memory-light.
-        const TOTAL: u64 = 256 * 1024 * 1024;
-        let dir = tempdir().unwrap();
-        let path = dir.path().join("sparse.bin");
-
-        let file = std::fs::File::create(&path).unwrap();
-        file.set_len(TOTAL).unwrap();
-        let mut w = SparseWriter::new(file);
-        let data = vec![7u8; SPARSE_BLOCK];
-        let zeros = vec![0u8; SPARSE_BLOCK];
-        let blocks = TOTAL / SPARSE_BLOCK as u64;
-        for i in 0..blocks {
-            // Non-zero first and last blocks, zeros everywhere between.
-            if i == 0 || i == blocks - 1 {
-                w.write_all(&data).unwrap();
-            } else {
-                w.write_all(&zeros).unwrap();
-            }
-        }
-        assert_eq!(w.finish().unwrap(), TOTAL);
-
-        // Content: first/last blocks hold data, an interior block reads zero.
-        use std::os::unix::fs::FileExt;
-        let f = std::fs::File::open(&path).unwrap();
-        let mut buf = vec![0u8; SPARSE_BLOCK];
-        f.read_exact_at(&mut buf, 0).unwrap();
-        assert_eq!(buf, data);
-        f.read_exact_at(&mut buf, TOTAL - SPARSE_BLOCK as u64)
-            .unwrap();
-        assert_eq!(buf, data);
-        f.read_exact_at(&mut buf, TOTAL / 2).unwrap();
-        assert_eq!(buf, zeros);
-
-        // Allocation: the zero interior must be holes, not written blocks.
-        let allocated = std::fs::metadata(&path)
-            .map(|m| std::os::unix::fs::MetadataExt::blocks(&m) * 512)
-            .unwrap();
-        assert!(
-            allocated < 8 * 1024 * 1024,
-            "expected sparse file, got {allocated} bytes allocated for {TOTAL}"
-        );
     }
 
     #[tokio::test]
@@ -734,21 +385,23 @@ mod tests {
         let images = tempdir().unwrap();
         let publish = tempdir().unwrap();
 
-        // Synthetic sparse disk: data, a zero gap, more data.
-        let mut disk = vec![0u8; 4 * SPARSE_BLOCK];
-        disk[0..SPARSE_BLOCK].fill(0xAB);
-        disk[3 * SPARSE_BLOCK..].fill(0xCD);
-        let (disk_csize, disk_sha) = write_zstd(&publish.path().join("disk.img.zst"), &disk);
+        // Synthetic sparse disk spanning several chunks, with a zero gap and a
+        // partial last chunk: data, zeros, data (partial).
+        let mut disk = vec![0u8; 5 * BLOCK];
+        disk[0..BLOCK].fill(0xAB);
+        disk[4 * BLOCK..].fill(0xCD);
+        let disk_json = publish_disk(publish.path(), &disk, 2 * BLOCK);
 
         let aux = vec![0x5Au8; 8192];
         let (aux_csize, aux_sha) = write_zstd(&publish.path().join("aux.img.zst"), &aux);
 
         let manifest = serde_json::json!({
-            "schema_version": 1,
+            "schema_version": 2,
             "name": "tahoe-base",
             "version": "2026.07.02",
             "variant": "base",
             "built_at": "2026-07-02T00:00:00Z",
+            "source_image": "ghcr.io/cirruslabs/macos-tahoe-base@sha256:abc",
             "os": { "product_version": "26.5", "build": "25F71" },
             "runner_version": "2.334.0",
             "xcode": [],
@@ -756,13 +409,7 @@ mod tests {
             "machine_id": REAL_MACHINE_ID_B64,
             "minimum_cpu_count": 2,
             "minimum_memory_mib": 4096,
-            "disk": {
-                "path": "disk.img.zst",
-                "disk_format": "raw",
-                "uncompressed_size": disk.len(),
-                "compressed_size": disk_csize,
-                "sha256": disk_sha
-            },
+            "disk": disk_json,
             "aux": {
                 "path": "aux.img.zst",
                 "uncompressed_size": aux.len(),
@@ -797,8 +444,9 @@ mod tests {
 
         // A `--manifest` source is not index-validated, so a hostile name must be
         // rejected during resolution — before anything is downloaded or landed.
+        // The disk is a minimal-but-valid layout so resolution reaches the name.
         let manifest = serde_json::json!({
-            "schema_version": 1,
+            "schema_version": 2,
             "name": "../evil",
             "version": "2026.07.02",
             "os": { "product_version": "26.5" },
@@ -807,8 +455,11 @@ mod tests {
             "minimum_cpu_count": 2,
             "minimum_memory_mib": 4096,
             "disk": {
-                "path": "disk.img.zst", "disk_format": "raw",
-                "uncompressed_size": 1, "compressed_size": 1, "sha256": "00"
+                "disk_format": "raw",
+                "uncompressed_size": 1,
+                "uncompressed_sha256": "00",
+                "chunk_size": 1,
+                "chunks": [{ "path": "disk.000.zst", "size": 1, "sha256": "00" }]
             },
             "aux": {
                 "path": "aux.img.zst",
@@ -824,6 +475,42 @@ mod tests {
         assert!(mgr.resolve_remote(&source).await.is_err());
     }
 
+    #[tokio::test]
+    async fn manifest_with_inconsistent_chunk_count_is_rejected() {
+        let images = tempdir().unwrap();
+        let publish = tempdir().unwrap();
+
+        // Declares a 3-chunk disk but lists only one chunk.
+        let manifest = serde_json::json!({
+            "schema_version": 2,
+            "name": "tahoe-base",
+            "version": "2026.07.02",
+            "os": { "product_version": "26.5" },
+            "hardware_model": REAL_HARDWARE_MODEL_B64,
+            "machine_id": REAL_MACHINE_ID_B64,
+            "minimum_cpu_count": 2,
+            "minimum_memory_mib": 4096,
+            "disk": {
+                "disk_format": "raw",
+                "uncompressed_size": 3 * BLOCK,
+                "uncompressed_sha256": "00",
+                "chunk_size": BLOCK,
+                "chunks": [{ "path": "disk.000.zst", "size": 1, "sha256": "00" }]
+            },
+            "aux": {
+                "path": "aux.img.zst",
+                "uncompressed_size": 1, "compressed_size": 1, "sha256": "00"
+            }
+        });
+        let manifest_path = publish.path().join("manifest.json");
+        std::fs::write(&manifest_path, manifest.to_string()).unwrap();
+
+        let mgr = MacImageManager::new(images.path());
+        let source = RemoteSource::Manifest(RemoteLocation::File(manifest_path));
+        let err = mgr.resolve_remote(&source).await.unwrap_err();
+        assert!(err.to_string().contains("disk chunks"), "{err}");
+    }
+
     /// Resolve answers "what would land / what's installed" without
     /// touching the registry: nothing is downloaded or registered, and
     /// `installed_version` flips from `None` to the landed version once a
@@ -833,13 +520,13 @@ mod tests {
         let images = tempdir().unwrap();
         let publish = tempdir().unwrap();
 
-        let disk = vec![0xABu8; SPARSE_BLOCK];
-        let (disk_csize, disk_sha) = write_zstd(&publish.path().join("disk.img.zst"), &disk);
+        let disk = vec![0xABu8; BLOCK];
+        let disk_json = publish_disk(publish.path(), &disk, BLOCK);
         let aux = vec![0x5Au8; 128];
         let (aux_csize, aux_sha) = write_zstd(&publish.path().join("aux.img.zst"), &aux);
 
         let manifest = serde_json::json!({
-            "schema_version": 1,
+            "schema_version": 2,
             "name": "tahoe-base",
             "version": "2026.07.02",
             "os": { "product_version": "26.5", "build": "25F71" },
@@ -848,13 +535,7 @@ mod tests {
             "machine_id": REAL_MACHINE_ID_B64,
             "minimum_cpu_count": 2,
             "minimum_memory_mib": 4096,
-            "disk": {
-                "path": "disk.img.zst",
-                "disk_format": "raw",
-                "uncompressed_size": disk.len(),
-                "compressed_size": disk_csize,
-                "sha256": disk_sha
-            },
+            "disk": disk_json,
             "aux": {
                 "path": "aux.img.zst",
                 "uncompressed_size": aux.len(),
@@ -890,13 +571,17 @@ mod tests {
         let images = tempdir().unwrap();
         let publish = tempdir().unwrap();
 
-        let disk = vec![0xABu8; SPARSE_BLOCK];
-        let (disk_csize, _) = write_zstd(&publish.path().join("disk.img.zst"), &disk);
+        let disk = vec![0xABu8; BLOCK];
+        let mut disk_json = publish_disk(publish.path(), &disk, BLOCK);
+        // Corrupt the first chunk's expected hash: the download succeeds but
+        // integrity verification must reject it.
+        disk_json["chunks"][0]["sha256"] =
+            serde_json::json!("0000000000000000000000000000000000000000000000000000000000000000");
         let aux = vec![0x5Au8; 128];
         let (aux_csize, aux_sha) = write_zstd(&publish.path().join("aux.img.zst"), &aux);
 
         let manifest = serde_json::json!({
-            "schema_version": 1,
+            "schema_version": 2,
             "name": "tahoe-base",
             "version": "2026.07.02",
             "os": { "product_version": "26.5" },
@@ -904,13 +589,7 @@ mod tests {
             "machine_id": REAL_MACHINE_ID_B64,
             "minimum_cpu_count": 2,
             "minimum_memory_mib": 4096,
-            "disk": {
-                "path": "disk.img.zst",
-                "disk_format": "raw",
-                "uncompressed_size": disk.len(),
-                "compressed_size": disk_csize,
-                "sha256": "0000000000000000000000000000000000000000000000000000000000000000"
-            },
+            "disk": disk_json,
             "aux": {
                 "path": "aux.img.zst",
                 "uncompressed_size": aux.len(),

--- a/app/arcbox-core/src/macos/pull.rs
+++ b/app/arcbox-core/src/macos/pull.rs
@@ -9,7 +9,7 @@
 //! registry entry.
 
 use std::io::Write;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use base64::Engine as _;
 use base64::engine::general_purpose::STANDARD as BASE64;
@@ -108,6 +108,34 @@ impl Write for SparseWriter {
     }
 }
 
+/// Removes the staging directory on drop unless disarmed.
+///
+/// This is what makes the pull future cancellation-safe: if the caller drops
+/// it at any await point (e.g. the gRPC client disconnected), the partial
+/// image is cleaned up by this guard's `Drop` rather than leaking.
+struct StagingGuard {
+    path: Option<PathBuf>,
+}
+
+impl StagingGuard {
+    fn new(path: PathBuf) -> Self {
+        Self { path: Some(path) }
+    }
+
+    /// Keeps the directory (it has been renamed into its final location).
+    fn disarm(&mut self) {
+        self.path = None;
+    }
+}
+
+impl Drop for StagingGuard {
+    fn drop(&mut self) {
+        if let Some(path) = &self.path {
+            let _ = std::fs::remove_dir_all(path);
+        }
+    }
+}
+
 /// Decodes a base64 manifest field.
 fn decode_field(field: &str, value: &str) -> Result<Vec<u8>> {
     BASE64
@@ -148,46 +176,136 @@ fn hex(bytes: &[u8]) -> String {
     })
 }
 
+/// Consecutive transient-failure budget for a streaming download; any received
+/// byte resets it, so a 20 GB pull tolerates many blips but not a dead link.
+const DOWNLOAD_RETRIES: u32 = 4;
+const DOWNLOAD_RETRY_DELAY: std::time::Duration = std::time::Duration::from_secs(2);
+
 /// Streams a compressed file from `location`, decompressing into a sparse,
 /// pre-sized `dst`. Verifies compressed size, SHA-256, and decompressed size
 /// against `spec`. `on_progress` receives the downloaded fraction.
+///
+/// HTTP downloads resume mid-stream on transient failures: the zstd decoder
+/// state lives in memory, so a dropped connection is re-requested with
+/// `Range: bytes=<received>-` and decoding continues where it left off. (A
+/// daemon restart still restarts the pull from zero — resume covers network
+/// blips within one attempt, which is the failure that matters at 20 GB.)
+/// Hash + decompress + sparse-write sink for a compressed download stream.
+///
+/// A struct rather than a closure so callers can read `received` between
+/// `consume` calls (the resume offset for `Range` re-requests).
+struct StreamSink<F: FnMut(f64)> {
+    decoder: zstd::stream::write::Decoder<'static, SparseWriter>,
+    hasher: Sha256,
+    received: u64,
+    compressed_size: u64,
+    path: String,
+    on_progress: F,
+}
+
+impl<F: FnMut(f64)> StreamSink<F> {
+    fn consume(&mut self, bytes: &[u8]) -> Result<()> {
+        self.hasher.update(bytes);
+        self.decoder
+            .write_all(bytes)
+            .map_err(|e| CoreError::macos(format!("decompress {}: {e}", self.path)))?;
+        self.received += bytes.len() as u64;
+        if self.compressed_size > 0 {
+            (self.on_progress)((self.received as f64 / self.compressed_size as f64).min(1.0));
+        }
+        Ok(())
+    }
+}
+
+/// Failure of a single download attempt: transient failures are retried from
+/// the current offset, fatal ones abort the pull.
+enum AttemptError {
+    Transient(CoreError),
+    Fatal(CoreError),
+}
+
+/// One HTTP request feeding the sink, resuming at `sink.received`.
+/// Returns the bytes this attempt contributed.
+async fn stream_http_once<F: FnMut(f64)>(
+    client: &reqwest::Client,
+    url: &reqwest::Url,
+    sink: &mut StreamSink<F>,
+) -> std::result::Result<u64, AttemptError> {
+    let mut request = client.get(url.clone());
+    if sink.received > 0 {
+        request = request.header(reqwest::header::RANGE, format!("bytes={}-", sink.received));
+    }
+    let mut resp = request
+        .send()
+        .await
+        .and_then(reqwest::Response::error_for_status)
+        .map_err(|e| AttemptError::Transient(CoreError::macos(format!("download {url}: {e}"))))?;
+    if sink.received > 0 && resp.status() != reqwest::StatusCode::PARTIAL_CONTENT {
+        // The server ignored the Range header; replaying the body from zero
+        // would corrupt the in-memory decoder state. Retrying cannot help.
+        return Err(AttemptError::Fatal(CoreError::macos(format!(
+            "download {url}: server does not honor Range requests; cannot resume"
+        ))));
+    }
+    let start = sink.received;
+    while let Some(chunk) = resp
+        .chunk()
+        .await
+        .map_err(|e| AttemptError::Transient(CoreError::macos(format!("download {url}: {e}"))))?
+    {
+        // A decode/write failure is local, not a network blip.
+        sink.consume(&chunk).map_err(AttemptError::Fatal)?;
+    }
+    Ok(sink.received - start)
+}
+
 async fn fetch_zstd_to_sparse(
     location: &RemoteLocation,
     spec: &RemoteFile,
     dst: &Path,
-    mut on_progress: impl FnMut(f64),
+    on_progress: impl FnMut(f64),
 ) -> Result<()> {
     let file = std::fs::File::create(dst)?;
     file.set_len(spec.uncompressed_size)?;
-    let mut decoder = zstd::stream::write::Decoder::new(SparseWriter::new(file))
-        .map_err(|e| CoreError::macos(format!("zstd init: {e}")))?;
-
-    let mut hasher = Sha256::new();
-    let mut received: u64 = 0;
-    let mut consume = |bytes: &[u8]| -> Result<()> {
-        hasher.update(bytes);
-        decoder
-            .write_all(bytes)
-            .map_err(|e| CoreError::macos(format!("decompress {}: {e}", spec.path)))?;
-        received += bytes.len() as u64;
-        if spec.compressed_size > 0 {
-            on_progress((received as f64 / spec.compressed_size as f64).min(1.0));
-        }
-        Ok(())
+    let mut sink = StreamSink {
+        decoder: zstd::stream::write::Decoder::new(SparseWriter::new(file))
+            .map_err(|e| CoreError::macos(format!("zstd init: {e}")))?,
+        hasher: Sha256::new(),
+        received: 0,
+        compressed_size: spec.compressed_size,
+        path: spec.path.clone(),
+        on_progress,
     };
 
     match location {
         RemoteLocation::Http(url) => {
-            let mut resp = reqwest::get(url.clone())
-                .await
-                .and_then(reqwest::Response::error_for_status)
-                .map_err(|e| CoreError::macos(format!("download {url}: {e}")))?;
-            while let Some(chunk) = resp
-                .chunk()
-                .await
-                .map_err(|e| CoreError::macos(format!("download {url}: {e}")))?
-            {
-                consume(&chunk)?;
+            let client = reqwest::Client::new();
+            let mut failures: u32 = 0;
+            while sink.received < spec.compressed_size {
+                match stream_http_once(&client, url, &mut sink).await {
+                    Ok(_) if sink.received >= spec.compressed_size => break,
+                    // Progress resets the failure budget; a clean-but-short
+                    // body counts as a failure too (otherwise it would spin).
+                    Ok(progressed) => {
+                        failures = if progressed > 0 { 1 } else { failures + 1 };
+                        tracing::warn!(
+                            "download {url}: connection ended early; resuming at byte {}",
+                            sink.received
+                        );
+                    }
+                    Err(AttemptError::Fatal(e)) => return Err(e),
+                    Err(AttemptError::Transient(e)) => {
+                        failures += 1;
+                        tracing::warn!("{e}; resuming at byte {}", sink.received);
+                    }
+                }
+                if failures > DOWNLOAD_RETRIES {
+                    return Err(CoreError::macos(format!(
+                        "download {url}: giving up after {DOWNLOAD_RETRIES} consecutive failures at byte {}",
+                        sink.received
+                    )));
+                }
+                tokio::time::sleep(DOWNLOAD_RETRY_DELAY).await;
             }
         }
         RemoteLocation::File(path) => {
@@ -199,11 +317,17 @@ async fn fetch_zstd_to_sparse(
                 if n == 0 {
                     break;
                 }
-                consume(&buf[..n])?;
+                sink.consume(&buf[..n])?;
             }
         }
     }
 
+    let StreamSink {
+        mut decoder,
+        hasher,
+        received,
+        ..
+    } = sink;
     decoder
         .flush()
         .map_err(|e| CoreError::macos(format!("decompress {}: {e}", spec.path)))?;
@@ -296,20 +420,18 @@ impl MacImageManager {
         }
         on_progress(PullStage::Validate, 1.0);
 
-        // Assemble in a staging directory; rename live only when complete.
+        // Assemble in a staging directory; rename live only when complete. The
+        // guard removes it on any early return — or if this future is dropped
+        // (client cancellation) at any await point.
         let staging = self.image_dir(&format!(".pull-{}", manifest.name));
         if staging.exists() {
             std::fs::remove_dir_all(&staging)?;
         }
         std::fs::create_dir_all(&staging)?;
+        let mut guard = StagingGuard::new(staging.clone());
 
-        let result = self
-            .pull_into(&staging, &manifest_location, &manifest, &mut on_progress)
-            .await;
-        if let Err(e) = result {
-            let _ = std::fs::remove_dir_all(&staging);
-            return Err(e);
-        }
+        self.pull_into(&staging, &manifest_location, &manifest, &mut on_progress)
+            .await?;
 
         std::fs::write(staging.join(HARDWARE_MODEL_FILE), &hardware_model)?;
         std::fs::write(staging.join(MACHINE_ID_FILE), &machine_id)?;
@@ -321,6 +443,7 @@ impl MacImageManager {
             std::fs::remove_dir_all(&final_dir)?;
         }
         std::fs::rename(&staging, &final_dir)?;
+        guard.disarm();
         on_progress(PullStage::Verify, 1.0);
         self.get(&manifest.name)
     }
@@ -397,6 +520,98 @@ fn meta_from_manifest(manifest: &ImageManifest, location: &RemoteLocation) -> Ma
 mod tests {
     use super::*;
     use tempfile::tempdir;
+
+    /// Minimal HTTP server for download tests. First plain GET: claims the
+    /// full length but sends only the first half, then hangs up (simulating a
+    /// dropped connection). `Range: bytes=N-` requests: served completely.
+    async fn serve_flaky_zst(listener: tokio::net::TcpListener, full: Vec<u8>) {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+        loop {
+            let Ok((mut sock, _)) = listener.accept().await else {
+                return;
+            };
+            let full = full.clone();
+            tokio::spawn(async move {
+                let mut req = Vec::new();
+                let mut buf = [0u8; 4096];
+                while !req.windows(4).any(|w| w == b"\r\n\r\n") {
+                    match sock.read(&mut buf).await {
+                        Ok(0) | Err(_) => return,
+                        Ok(n) => req.extend_from_slice(&buf[..n]),
+                    }
+                }
+                let req = String::from_utf8_lossy(&req).to_ascii_lowercase();
+                let range_start = req
+                    .lines()
+                    .find_map(|l| l.strip_prefix("range: bytes="))
+                    .and_then(|r| r.split('-').next())
+                    .and_then(|s| s.parse::<usize>().ok());
+                match range_start {
+                    None => {
+                        let head = format!(
+                            "HTTP/1.1 200 OK\r\ncontent-length: {}\r\nconnection: close\r\n\r\n",
+                            full.len()
+                        );
+                        let _ = sock.write_all(head.as_bytes()).await;
+                        let _ = sock.write_all(&full[..full.len() / 2]).await;
+                        // Drop mid-body: the client sees a broken connection.
+                    }
+                    Some(start) => {
+                        let rest = &full[start..];
+                        let head = format!(
+                            "HTTP/1.1 206 Partial Content\r\ncontent-length: {}\r\ncontent-range: bytes {start}-{}/{}\r\nconnection: close\r\n\r\n",
+                            rest.len(),
+                            full.len() - 1,
+                            full.len()
+                        );
+                        let _ = sock.write_all(head.as_bytes()).await;
+                        let _ = sock.write_all(rest).await;
+                    }
+                }
+            });
+        }
+    }
+
+    #[tokio::test]
+    async fn http_download_resumes_after_connection_drop() {
+        let mut raw = vec![0xABu8; SPARSE_BLOCK];
+        raw.extend_from_slice(&vec![0u8; SPARSE_BLOCK]);
+        raw.extend_from_slice(&vec![0xCDu8; SPARSE_BLOCK]);
+        let compressed = zstd::encode_all(&raw[..], 3).unwrap();
+        let spec = RemoteFile {
+            path: "disk.img.zst".into(),
+            uncompressed_size: raw.len() as u64,
+            compressed_size: compressed.len() as u64,
+            sha256: hex(&Sha256::digest(&compressed)),
+        };
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let url = format!("http://{}/disk.img.zst", listener.local_addr().unwrap());
+        tokio::spawn(serve_flaky_zst(listener, compressed));
+
+        let dir = tempdir().unwrap();
+        let dst = dir.path().join("disk.img");
+        fetch_zstd_to_sparse(&RemoteLocation::parse(&url), &spec, &dst, |_| {})
+            .await
+            .unwrap();
+        assert_eq!(std::fs::read(&dst).unwrap(), raw);
+    }
+
+    #[test]
+    fn staging_guard_removes_unless_disarmed() {
+        let dir = tempdir().unwrap();
+        let staging = dir.path().join("staging");
+
+        std::fs::create_dir_all(&staging).unwrap();
+        drop(StagingGuard::new(staging.clone()));
+        assert!(!staging.exists());
+
+        std::fs::create_dir_all(&staging).unwrap();
+        let mut guard = StagingGuard::new(staging.clone());
+        guard.disarm();
+        drop(guard);
+        assert!(staging.exists());
+    }
 
     /// Real hardware-model data representation captured from a Tahoe base
     /// image (`config.json .hardwareModel`); decodes on any host, and

--- a/app/arcbox-core/src/macos/pull.rs
+++ b/app/arcbox-core/src/macos/pull.rs
@@ -1,0 +1,572 @@
+//! Pulling published macOS base images into the local registry.
+//!
+//! [`MacImageManager::pull_remote`] resolves a reference against the published
+//! index (or consumes a manifest directly), validates host support *before*
+//! the multi-gigabyte download, then streams the zstd-compressed disk through
+//! decompression into a sparse `disk.img` — the compressed bytes never touch
+//! disk. The image is assembled in a staging directory and renamed live only
+//! after every integrity check passes, so a failed pull never leaves a broken
+//! registry entry.
+
+use std::io::Write;
+use std::path::Path;
+
+use base64::Engine as _;
+use base64::engine::general_purpose::STANDARD as BASE64;
+use chrono::Utc;
+use sha2::{Digest, Sha256};
+
+use super::image::{
+    AUX_FILE, DISK_FILE, HARDWARE_MODEL_FILE, MACHINE_ID_FILE, MacImage, MacImageManager,
+    MacImageMeta,
+};
+use super::remote::{ImageManifest, ImageReference, RemoteFile, RemoteIndex, RemoteLocation};
+use crate::error::{CoreError, Result};
+
+/// Where a [`MacImageManager::pull_remote`] finds its manifest.
+#[derive(Debug, Clone)]
+pub enum RemoteSource {
+    /// Resolve `stream[@version]` via the published index.
+    Reference(ImageReference),
+    /// Consume a manifest directly (URL or local path), bypassing the index.
+    Manifest(RemoteLocation),
+}
+
+/// The stage a [`MacImageManager::pull_remote`] is in, for progress reporting.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PullStage {
+    /// Resolving the reference and fetching the manifest.
+    Resolve,
+    /// Validating host support against the manifest.
+    Validate,
+    /// Downloading and decompressing the system disk (the long stage).
+    Disk,
+    /// Downloading and decompressing the auxiliary storage.
+    Aux,
+    /// Final integrity checks and registry landing.
+    Verify,
+}
+
+/// Zero-skipping block writer: keeps `disk.img` sparse by never writing
+/// all-zero blocks (the file is pre-sized, so skipped ranges become holes).
+///
+/// Alignment comes from buffering to fixed-size blocks; `flush` deliberately
+/// does not drain a partial block (the decompressor flushes mid-stream), the
+/// tail is written by [`SparseWriter::finish`].
+struct SparseWriter {
+    file: std::fs::File,
+    offset: u64,
+    buf: Vec<u8>,
+}
+
+/// Block granularity for zero detection; a multiple of the APFS block size.
+const SPARSE_BLOCK: usize = 64 * 1024;
+static ZERO_BLOCK: [u8; SPARSE_BLOCK] = [0u8; SPARSE_BLOCK];
+
+impl SparseWriter {
+    fn new(file: std::fs::File) -> Self {
+        Self {
+            file,
+            offset: 0,
+            buf: Vec::with_capacity(SPARSE_BLOCK),
+        }
+    }
+
+    fn flush_block(&mut self) -> std::io::Result<()> {
+        // Slice equality is a memcmp — much faster than a per-byte scan.
+        if self.buf.as_slice() != &ZERO_BLOCK[..self.buf.len()] {
+            use std::os::unix::fs::FileExt;
+            self.file.write_all_at(&self.buf, self.offset)?;
+        }
+        self.offset += self.buf.len() as u64;
+        self.buf.clear();
+        Ok(())
+    }
+
+    /// Drains the partial tail block and returns the total bytes written.
+    fn finish(mut self) -> std::io::Result<u64> {
+        if !self.buf.is_empty() {
+            self.flush_block()?;
+        }
+        self.file.flush()?;
+        Ok(self.offset)
+    }
+}
+
+impl Write for SparseWriter {
+    fn write(&mut self, data: &[u8]) -> std::io::Result<usize> {
+        let take = (SPARSE_BLOCK - self.buf.len()).min(data.len());
+        self.buf.extend_from_slice(&data[..take]);
+        if self.buf.len() == SPARSE_BLOCK {
+            self.flush_block()?;
+        }
+        Ok(take)
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
+/// Decodes a base64 manifest field.
+fn decode_field(field: &str, value: &str) -> Result<Vec<u8>> {
+    BASE64
+        .decode(value)
+        .map_err(|e| CoreError::macos(format!("manifest field '{field}' is not valid base64: {e}")))
+}
+
+/// Checks the manifest's hardware model against this host.
+///
+/// Kept synchronous and self-contained so the ObjC hardware-model object never
+/// lives across an await point (which would make the pull future `!Send`).
+fn validate_hardware_model(data: &[u8]) -> Result<()> {
+    let model = arcbox_vz::MacHardwareModel::from_data(data)?;
+    if !model.is_supported() {
+        return Err(CoreError::macos(
+            "this image's hardware model is not supported here (host macOS too old for the guest)",
+        ));
+    }
+    Ok(())
+}
+
+/// Verifies a hex SHA-256 against an expected manifest value.
+fn verify_sha256(what: &str, actual: &[u8], expected: &str) -> Result<()> {
+    let actual = hex(actual);
+    if !actual.eq_ignore_ascii_case(expected) {
+        return Err(CoreError::macos(format!(
+            "{what}: checksum mismatch (expected {expected}, got {actual})"
+        )));
+    }
+    Ok(())
+}
+
+fn hex(bytes: &[u8]) -> String {
+    use std::fmt::Write as _;
+    bytes.iter().fold(String::new(), |mut s, b| {
+        let _ = write!(s, "{b:02x}");
+        s
+    })
+}
+
+/// Streams a compressed file from `location`, decompressing into a sparse,
+/// pre-sized `dst`. Verifies compressed size, SHA-256, and decompressed size
+/// against `spec`. `on_progress` receives the downloaded fraction.
+async fn fetch_zstd_to_sparse(
+    location: &RemoteLocation,
+    spec: &RemoteFile,
+    dst: &Path,
+    mut on_progress: impl FnMut(f64),
+) -> Result<()> {
+    let file = std::fs::File::create(dst)?;
+    file.set_len(spec.uncompressed_size)?;
+    let mut decoder = zstd::stream::write::Decoder::new(SparseWriter::new(file))
+        .map_err(|e| CoreError::macos(format!("zstd init: {e}")))?;
+
+    let mut hasher = Sha256::new();
+    let mut received: u64 = 0;
+    let mut consume = |bytes: &[u8]| -> Result<()> {
+        hasher.update(bytes);
+        decoder
+            .write_all(bytes)
+            .map_err(|e| CoreError::macos(format!("decompress {}: {e}", spec.path)))?;
+        received += bytes.len() as u64;
+        if spec.compressed_size > 0 {
+            on_progress((received as f64 / spec.compressed_size as f64).min(1.0));
+        }
+        Ok(())
+    };
+
+    match location {
+        RemoteLocation::Http(url) => {
+            let mut resp = reqwest::get(url.clone())
+                .await
+                .and_then(reqwest::Response::error_for_status)
+                .map_err(|e| CoreError::macos(format!("download {url}: {e}")))?;
+            while let Some(chunk) = resp
+                .chunk()
+                .await
+                .map_err(|e| CoreError::macos(format!("download {url}: {e}")))?
+            {
+                consume(&chunk)?;
+            }
+        }
+        RemoteLocation::File(path) => {
+            use std::io::Read;
+            let mut src = std::fs::File::open(path)?;
+            let mut buf = vec![0u8; 1024 * 1024];
+            loop {
+                let n = src.read(&mut buf)?;
+                if n == 0 {
+                    break;
+                }
+                consume(&buf[..n])?;
+            }
+        }
+    }
+
+    decoder
+        .flush()
+        .map_err(|e| CoreError::macos(format!("decompress {}: {e}", spec.path)))?;
+    let written = decoder
+        .into_inner()
+        .finish()
+        .map_err(|e| CoreError::macos(format!("finalize {}: {e}", dst.display())))?;
+
+    if received != spec.compressed_size {
+        return Err(CoreError::macos(format!(
+            "{}: truncated download (expected {} compressed bytes, got {received})",
+            spec.path, spec.compressed_size
+        )));
+    }
+    verify_sha256(&spec.path, &hasher.finalize(), &spec.sha256)?;
+    if written != spec.uncompressed_size {
+        return Err(CoreError::macos(format!(
+            "{}: decompressed to {written} bytes, manifest says {}",
+            spec.path, spec.uncompressed_size
+        )));
+    }
+    Ok(())
+}
+
+impl MacImageManager {
+    /// Pulls a published base image into the local registry.
+    ///
+    /// Validates host support from the manifest before downloading anything
+    /// large, keeps the restored disk sparse, verifies every file against its
+    /// manifest hash, and lands the image atomically (staging dir + rename).
+    /// Re-pulling an already-present version is a no-op.
+    ///
+    /// # Errors
+    /// Returns an error if resolution, validation, download, integrity
+    /// verification, or the final registry landing fails.
+    pub async fn pull_remote(
+        &self,
+        source: RemoteSource,
+        mut on_progress: impl FnMut(PullStage, f64),
+    ) -> Result<MacImage> {
+        on_progress(PullStage::Resolve, 0.0);
+        let manifest_location = match &source {
+            RemoteSource::Manifest(location) => location.clone(),
+            RemoteSource::Reference(reference) => {
+                let base = super::remote::image_base().as_dir();
+                let index: RemoteIndex = base.join("index.json")?.fetch_json().await?;
+                if index.schema_version != 1 {
+                    return Err(CoreError::macos(format!(
+                        "unsupported image index schema_version {}",
+                        index.schema_version
+                    )));
+                }
+                let (_version, manifest_path) = index.resolve(reference)?;
+                base.join(&manifest_path)?
+            }
+        };
+        let manifest: ImageManifest = manifest_location.fetch_json().await?;
+        if manifest.schema_version != 1 {
+            return Err(CoreError::macos(format!(
+                "unsupported image manifest schema_version {}",
+                manifest.schema_version
+            )));
+        }
+        if manifest.disk.disk_format != "raw" {
+            return Err(CoreError::macos(format!(
+                "unsupported disk format '{}'",
+                manifest.disk.disk_format
+            )));
+        }
+        if let RemoteSource::Reference(reference) = &source {
+            if manifest.name != reference.stream {
+                return Err(CoreError::macos(format!(
+                    "manifest name '{}' does not match requested stream '{}'",
+                    manifest.name, reference.stream
+                )));
+            }
+        }
+        on_progress(PullStage::Resolve, 1.0);
+
+        on_progress(PullStage::Validate, 0.0);
+        let hardware_model = decode_field("hardware_model", &manifest.hardware_model)?;
+        let machine_id = decode_field("machine_id", &manifest.machine_id)?;
+        validate_hardware_model(&hardware_model)?;
+
+        if let Ok(existing) = self.get(&manifest.name) {
+            if existing.meta.version.as_deref() == Some(manifest.version.as_str()) {
+                on_progress(PullStage::Verify, 1.0);
+                return Ok(existing);
+            }
+        }
+        on_progress(PullStage::Validate, 1.0);
+
+        // Assemble in a staging directory; rename live only when complete.
+        let staging = self.image_dir(&format!(".pull-{}", manifest.name));
+        if staging.exists() {
+            std::fs::remove_dir_all(&staging)?;
+        }
+        std::fs::create_dir_all(&staging)?;
+
+        let result = self
+            .pull_into(&staging, &manifest_location, &manifest, &mut on_progress)
+            .await;
+        if let Err(e) = result {
+            let _ = std::fs::remove_dir_all(&staging);
+            return Err(e);
+        }
+
+        std::fs::write(staging.join(HARDWARE_MODEL_FILE), &hardware_model)?;
+        std::fs::write(staging.join(MACHINE_ID_FILE), &machine_id)?;
+        Self::write_meta_in(&staging, &meta_from_manifest(&manifest, &manifest_location))?;
+
+        on_progress(PullStage::Verify, 0.5);
+        let final_dir = self.image_dir(&manifest.name);
+        if final_dir.exists() {
+            std::fs::remove_dir_all(&final_dir)?;
+        }
+        std::fs::rename(&staging, &final_dir)?;
+        on_progress(PullStage::Verify, 1.0);
+        self.get(&manifest.name)
+    }
+
+    /// Downloads and verifies the disk and aux files into `staging`.
+    async fn pull_into(
+        &self,
+        staging: &Path,
+        manifest_location: &RemoteLocation,
+        manifest: &ImageManifest,
+        on_progress: &mut impl FnMut(PullStage, f64),
+    ) -> Result<()> {
+        on_progress(PullStage::Disk, 0.0);
+        fetch_zstd_to_sparse(
+            &manifest_location.join(&manifest.disk.file.path)?,
+            &manifest.disk.file,
+            &staging.join(DISK_FILE),
+            |frac| on_progress(PullStage::Disk, frac),
+        )
+        .await?;
+
+        on_progress(PullStage::Aux, 0.0);
+        let aux_compressed = manifest_location
+            .join(&manifest.aux.path)?
+            .fetch_bytes()
+            .await?;
+        if aux_compressed.len() as u64 != manifest.aux.compressed_size {
+            return Err(CoreError::macos(format!(
+                "{}: expected {} compressed bytes, got {}",
+                manifest.aux.path,
+                manifest.aux.compressed_size,
+                aux_compressed.len()
+            )));
+        }
+        verify_sha256(
+            &manifest.aux.path,
+            &Sha256::digest(&aux_compressed),
+            &manifest.aux.sha256,
+        )?;
+        let aux = zstd::decode_all(&aux_compressed[..])
+            .map_err(|e| CoreError::macos(format!("decompress {}: {e}", manifest.aux.path)))?;
+        if aux.len() as u64 != manifest.aux.uncompressed_size {
+            return Err(CoreError::macos(format!(
+                "{}: decompressed to {} bytes, manifest says {}",
+                manifest.aux.path,
+                aux.len(),
+                manifest.aux.uncompressed_size
+            )));
+        }
+        std::fs::write(staging.join(AUX_FILE), &aux)?;
+        on_progress(PullStage::Aux, 1.0);
+        Ok(())
+    }
+}
+
+/// Builds the local registry metadata for a pulled manifest.
+fn meta_from_manifest(manifest: &ImageManifest, location: &RemoteLocation) -> MacImageMeta {
+    MacImageMeta {
+        name: manifest.name.clone(),
+        source: Some(location.to_string()),
+        stream: Some(manifest.name.clone()),
+        version: Some(manifest.version.clone()),
+        os_version: Some(manifest.os.product_version.clone()),
+        os_build: (!manifest.os.build.is_empty()).then(|| manifest.os.build.clone()),
+        runner_version: manifest.runner_version.clone(),
+        minimum_cpu_count: manifest.minimum_cpu_count,
+        minimum_memory_mib: manifest.minimum_memory_mib,
+        disk_gb: manifest.disk.file.uncompressed_size / 1_000_000_000,
+        created_at: Utc::now(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write as _;
+    use tempfile::tempdir;
+
+    /// Real hardware-model data representation captured from a Tahoe base
+    /// image (`config.json .hardwareModel`); decodes on any host, and
+    /// `is_supported` is true on the Apple Silicon hosts tests run on.
+    const REAL_HARDWARE_MODEL_B64: &str = "YnBsaXN0MDDTAQIDBAQFXxAZRGF0YVJlcHJlc2VudGF0aW9uVmVyc2lvbl8QD1BsYXRmb3JtVmVyc2lvbl8QEk1pbmltdW1TdXBwb3J0ZWRPUxACowYHBxANEAAIDys9UlRYWgAAAAAAAAEBAAAAAAAAAAgAAAAAAAAAAAAAAAAAAABc";
+    const REAL_MACHINE_ID_B64: &str = "YnBsaXN0MDDRAQJURUNJRBQAAAAAAAAAAJzeRwpdz1o1CAsQAAAAAAAAAQEAAAAAAAAAAwAAAAAAAAAAAAAAAAAAACE=";
+
+    fn write_zstd(path: &Path, raw: &[u8]) -> (u64, String) {
+        let compressed = zstd::encode_all(raw, 3).unwrap();
+        std::fs::write(path, &compressed).unwrap();
+        (compressed.len() as u64, hex(&Sha256::digest(&compressed)))
+    }
+
+    #[test]
+    fn sparse_writer_skips_zero_blocks() {
+        // APFS only keeps holes in files above a size threshold (verified
+        // empirically: fully materialized at 16 MiB, sparse at 256 MiB), so
+        // this test must run at realistic scale. Data is streamed block-wise
+        // to keep the test memory-light.
+        const TOTAL: u64 = 256 * 1024 * 1024;
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("sparse.bin");
+
+        let file = std::fs::File::create(&path).unwrap();
+        file.set_len(TOTAL).unwrap();
+        let mut w = SparseWriter::new(file);
+        let data = vec![7u8; SPARSE_BLOCK];
+        let zeros = vec![0u8; SPARSE_BLOCK];
+        let blocks = TOTAL / SPARSE_BLOCK as u64;
+        for i in 0..blocks {
+            // Non-zero first and last blocks, zeros everywhere between.
+            if i == 0 || i == blocks - 1 {
+                w.write_all(&data).unwrap();
+            } else {
+                w.write_all(&zeros).unwrap();
+            }
+        }
+        assert_eq!(w.finish().unwrap(), TOTAL);
+
+        // Content: first/last blocks hold data, an interior block reads zero.
+        use std::os::unix::fs::FileExt;
+        let f = std::fs::File::open(&path).unwrap();
+        let mut buf = vec![0u8; SPARSE_BLOCK];
+        f.read_exact_at(&mut buf, 0).unwrap();
+        assert_eq!(buf, data);
+        f.read_exact_at(&mut buf, TOTAL - SPARSE_BLOCK as u64)
+            .unwrap();
+        assert_eq!(buf, data);
+        f.read_exact_at(&mut buf, TOTAL / 2).unwrap();
+        assert_eq!(buf, zeros);
+
+        // Allocation: the zero interior must be holes, not written blocks.
+        let allocated = std::fs::metadata(&path)
+            .map(|m| std::os::unix::fs::MetadataExt::blocks(&m) * 512)
+            .unwrap();
+        assert!(
+            allocated < 8 * 1024 * 1024,
+            "expected sparse file, got {allocated} bytes allocated for {TOTAL}"
+        );
+    }
+
+    #[tokio::test]
+    async fn pull_from_local_manifest_round_trips() {
+        let images = tempdir().unwrap();
+        let publish = tempdir().unwrap();
+
+        // Synthetic sparse disk: data, a zero gap, more data.
+        let mut disk = vec![0u8; 4 * SPARSE_BLOCK];
+        disk[0..SPARSE_BLOCK].fill(0xAB);
+        disk[3 * SPARSE_BLOCK..].fill(0xCD);
+        let (disk_csize, disk_sha) = write_zstd(&publish.path().join("disk.img.zst"), &disk);
+
+        let aux = vec![0x5Au8; 8192];
+        let (aux_csize, aux_sha) = write_zstd(&publish.path().join("aux.img.zst"), &aux);
+
+        let manifest = serde_json::json!({
+            "schema_version": 1,
+            "name": "tahoe-base",
+            "version": "2026.07.02",
+            "variant": "base",
+            "built_at": "2026-07-02T00:00:00Z",
+            "os": { "product_version": "26.5", "build": "25F71" },
+            "runner_version": "2.334.0",
+            "xcode": [],
+            "hardware_model": REAL_HARDWARE_MODEL_B64,
+            "machine_id": REAL_MACHINE_ID_B64,
+            "minimum_cpu_count": 2,
+            "minimum_memory_mib": 4096,
+            "disk": {
+                "path": "disk.img.zst",
+                "disk_format": "raw",
+                "uncompressed_size": disk.len(),
+                "compressed_size": disk_csize,
+                "sha256": disk_sha
+            },
+            "aux": {
+                "path": "aux.img.zst",
+                "uncompressed_size": aux.len(),
+                "compressed_size": aux_csize,
+                "sha256": aux_sha
+            }
+        });
+        let manifest_path = publish.path().join("manifest.json");
+        std::fs::write(&manifest_path, manifest.to_string()).unwrap();
+
+        let mgr = MacImageManager::new(images.path());
+        let source = RemoteSource::Manifest(RemoteLocation::File(manifest_path.clone()));
+        let image = mgr.pull_remote(source.clone(), |_, _| {}).await.unwrap();
+
+        assert_eq!(image.meta.name, "tahoe-base");
+        assert_eq!(image.meta.version.as_deref(), Some("2026.07.02"));
+        assert_eq!(image.meta.os_version.as_deref(), Some("26.5"));
+        assert_eq!(std::fs::read(image.disk_path()).unwrap(), disk);
+        assert_eq!(std::fs::read(image.aux_path()).unwrap(), aux);
+        assert!(image.hardware_model_path().exists());
+        assert!(image.machine_id_path().exists());
+
+        // Re-pull of the same version is a no-op (returns the existing image).
+        let again = mgr.pull_remote(source, |_, _| {}).await.unwrap();
+        assert_eq!(again.meta.created_at, image.meta.created_at);
+    }
+
+    #[tokio::test]
+    async fn pull_rejects_corrupted_disk() {
+        let images = tempdir().unwrap();
+        let publish = tempdir().unwrap();
+
+        let disk = vec![0xABu8; SPARSE_BLOCK];
+        let (disk_csize, _) = write_zstd(&publish.path().join("disk.img.zst"), &disk);
+        let aux = vec![0x5Au8; 128];
+        let (aux_csize, aux_sha) = write_zstd(&publish.path().join("aux.img.zst"), &aux);
+
+        let manifest = serde_json::json!({
+            "schema_version": 1,
+            "name": "tahoe-base",
+            "version": "2026.07.02",
+            "os": { "product_version": "26.5" },
+            "hardware_model": REAL_HARDWARE_MODEL_B64,
+            "machine_id": REAL_MACHINE_ID_B64,
+            "minimum_cpu_count": 2,
+            "minimum_memory_mib": 4096,
+            "disk": {
+                "path": "disk.img.zst",
+                "disk_format": "raw",
+                "uncompressed_size": disk.len(),
+                "compressed_size": disk_csize,
+                "sha256": "0000000000000000000000000000000000000000000000000000000000000000"
+            },
+            "aux": {
+                "path": "aux.img.zst",
+                "uncompressed_size": aux.len(),
+                "compressed_size": aux_csize,
+                "sha256": aux_sha
+            }
+        });
+        let manifest_path = publish.path().join("manifest.json");
+        std::fs::write(&manifest_path, manifest.to_string()).unwrap();
+
+        let mgr = MacImageManager::new(images.path());
+        let err = mgr
+            .pull_remote(
+                RemoteSource::Manifest(RemoteLocation::File(manifest_path)),
+                |_, _| {},
+            )
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("checksum mismatch"), "{err}");
+        // Nothing may be registered, and no staging debris may remain.
+        assert!(mgr.get("tahoe-base").is_err());
+        assert!(mgr.list().is_empty());
+    }
+}

--- a/app/arcbox-core/src/macos/pull.rs
+++ b/app/arcbox-core/src/macos/pull.rs
@@ -32,6 +32,35 @@ pub enum RemoteSource {
     Manifest(RemoteLocation),
 }
 
+/// What a [`MacImageManager::resolve_remote`] found, without downloading.
+///
+/// The concrete version a pull of the same source would land, its
+/// requirements, and what is currently installed under that stream name —
+/// everything a caller needs to answer "is an update pending" and "does
+/// this fit the host".
+#[derive(Debug, Clone)]
+pub struct ResolvedImage {
+    /// Stream name (`tahoe-base`).
+    pub name: String,
+    /// Concrete version a pull would land (`2026.07.02`), even when the
+    /// source reference floats.
+    pub version: String,
+    /// Guest macOS product version (e.g. `26.5`).
+    pub os_version: String,
+    /// Guest macOS build number, if published.
+    pub os_build: Option<String>,
+    /// Preinstalled GitHub Actions runner version, if published.
+    pub runner_version: Option<String>,
+    /// Minimum CPU count required by the guest.
+    pub minimum_cpu_count: u64,
+    /// Minimum guest memory in MiB required by the guest.
+    pub minimum_memory_mib: u64,
+    /// System disk size in GB (decimal, logical).
+    pub disk_gb: u64,
+    /// The version installed under this stream name locally, if any.
+    pub installed_version: Option<String>,
+}
+
 /// The stage a [`MacImageManager::pull_remote`] is in, for progress reporting.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PullStage {
@@ -356,7 +385,83 @@ async fn fetch_zstd_to_sparse(
     Ok(())
 }
 
+/// Resolves `source` to the manifest a pull would consume: index resolution
+/// (for a reference), then schema, disk-format, and name-match checks.
+/// Shared by [`MacImageManager::pull_remote`] and
+/// [`MacImageManager::resolve_remote`], so "what resolve reported" and
+/// "what pull lands" can never drift.
+async fn resolve_source(source: &RemoteSource) -> Result<(RemoteLocation, ImageManifest)> {
+    let manifest_location = match source {
+        RemoteSource::Manifest(location) => location.clone(),
+        RemoteSource::Reference(reference) => {
+            let base = super::remote::image_base().as_dir();
+            let index: RemoteIndex = base.join("index.json")?.fetch_json().await?;
+            if index.schema_version != 1 {
+                return Err(CoreError::macos(format!(
+                    "unsupported image index schema_version {}",
+                    index.schema_version
+                )));
+            }
+            let (_version, manifest_path) = index.resolve(reference)?;
+            base.join(&manifest_path)?
+        }
+    };
+    let manifest: ImageManifest = manifest_location.fetch_json().await?;
+    if manifest.schema_version != 1 {
+        return Err(CoreError::macos(format!(
+            "unsupported image manifest schema_version {}",
+            manifest.schema_version
+        )));
+    }
+    if manifest.disk.disk_format != "raw" {
+        return Err(CoreError::macos(format!(
+            "unsupported disk format '{}'",
+            manifest.disk.disk_format
+        )));
+    }
+    if let RemoteSource::Reference(reference) = source {
+        if manifest.name != reference.stream {
+            return Err(CoreError::macos(format!(
+                "manifest name '{}' does not match requested stream '{}'",
+                manifest.name, reference.stream
+            )));
+        }
+    }
+    Ok((manifest_location, manifest))
+}
+
 impl MacImageManager {
+    /// Resolves `source` against the published index without downloading
+    /// any artifact: the concrete version a pull would land, its
+    /// requirements, and the locally installed version of the same stream.
+    /// Also validates host support (hardware model), so a caller can reject
+    /// an image this host cannot boot before committing to a pull.
+    ///
+    /// # Errors
+    /// Returns an error if resolution fails (unknown stream/version,
+    /// unreachable index, malformed manifest) or the image's hardware model
+    /// is not supported on this host.
+    pub async fn resolve_remote(&self, source: &RemoteSource) -> Result<ResolvedImage> {
+        let (_, manifest) = resolve_source(source).await?;
+        let hardware_model = decode_field("hardware_model", &manifest.hardware_model)?;
+        validate_hardware_model(&hardware_model)?;
+        let installed_version = self
+            .get(&manifest.name)
+            .ok()
+            .and_then(|image| image.meta.version);
+        Ok(ResolvedImage {
+            name: manifest.name,
+            version: manifest.version,
+            os_version: manifest.os.product_version,
+            os_build: (!manifest.os.build.is_empty()).then_some(manifest.os.build),
+            runner_version: manifest.runner_version,
+            minimum_cpu_count: manifest.minimum_cpu_count,
+            minimum_memory_mib: manifest.minimum_memory_mib,
+            disk_gb: manifest.disk.file.uncompressed_size / 1_000_000_000,
+            installed_version,
+        })
+    }
+
     /// Pulls a published base image into the local registry.
     ///
     /// Validates host support from the manifest before downloading anything
@@ -373,42 +478,7 @@ impl MacImageManager {
         mut on_progress: impl FnMut(PullStage, f64),
     ) -> Result<MacImage> {
         on_progress(PullStage::Resolve, 0.0);
-        let manifest_location = match &source {
-            RemoteSource::Manifest(location) => location.clone(),
-            RemoteSource::Reference(reference) => {
-                let base = super::remote::image_base().as_dir();
-                let index: RemoteIndex = base.join("index.json")?.fetch_json().await?;
-                if index.schema_version != 1 {
-                    return Err(CoreError::macos(format!(
-                        "unsupported image index schema_version {}",
-                        index.schema_version
-                    )));
-                }
-                let (_version, manifest_path) = index.resolve(reference)?;
-                base.join(&manifest_path)?
-            }
-        };
-        let manifest: ImageManifest = manifest_location.fetch_json().await?;
-        if manifest.schema_version != 1 {
-            return Err(CoreError::macos(format!(
-                "unsupported image manifest schema_version {}",
-                manifest.schema_version
-            )));
-        }
-        if manifest.disk.disk_format != "raw" {
-            return Err(CoreError::macos(format!(
-                "unsupported disk format '{}'",
-                manifest.disk.disk_format
-            )));
-        }
-        if let RemoteSource::Reference(reference) = &source {
-            if manifest.name != reference.stream {
-                return Err(CoreError::macos(format!(
-                    "manifest name '{}' does not match requested stream '{}'",
-                    manifest.name, reference.stream
-                )));
-            }
-        }
+        let (manifest_location, manifest) = resolve_source(&source).await?;
         on_progress(PullStage::Resolve, 1.0);
 
         on_progress(PullStage::Validate, 0.0);
@@ -736,6 +806,67 @@ mod tests {
         // Re-pull of the same version is a no-op (returns the existing image).
         let again = mgr.pull_remote(source, |_, _| {}).await.unwrap();
         assert_eq!(again.meta.created_at, image.meta.created_at);
+    }
+
+    /// Resolve answers "what would land / what's installed" without
+    /// touching the registry: nothing is downloaded or registered, and
+    /// `installed_version` flips from `None` to the landed version once a
+    /// pull actually runs.
+    #[tokio::test]
+    async fn resolve_reports_metadata_without_pulling() {
+        let images = tempdir().unwrap();
+        let publish = tempdir().unwrap();
+
+        let disk = vec![0xABu8; SPARSE_BLOCK];
+        let (disk_csize, disk_sha) = write_zstd(&publish.path().join("disk.img.zst"), &disk);
+        let aux = vec![0x5Au8; 128];
+        let (aux_csize, aux_sha) = write_zstd(&publish.path().join("aux.img.zst"), &aux);
+
+        let manifest = serde_json::json!({
+            "schema_version": 1,
+            "name": "tahoe-base",
+            "version": "2026.07.02",
+            "os": { "product_version": "26.5", "build": "25F71" },
+            "runner_version": "2.334.0",
+            "hardware_model": REAL_HARDWARE_MODEL_B64,
+            "machine_id": REAL_MACHINE_ID_B64,
+            "minimum_cpu_count": 2,
+            "minimum_memory_mib": 4096,
+            "disk": {
+                "path": "disk.img.zst",
+                "disk_format": "raw",
+                "uncompressed_size": disk.len(),
+                "compressed_size": disk_csize,
+                "sha256": disk_sha
+            },
+            "aux": {
+                "path": "aux.img.zst",
+                "uncompressed_size": aux.len(),
+                "compressed_size": aux_csize,
+                "sha256": aux_sha
+            }
+        });
+        let manifest_path = publish.path().join("manifest.json");
+        std::fs::write(&manifest_path, manifest.to_string()).unwrap();
+
+        let mgr = MacImageManager::new(images.path());
+        let source = RemoteSource::Manifest(RemoteLocation::File(manifest_path));
+
+        let resolved = mgr.resolve_remote(&source).await.unwrap();
+        assert_eq!(resolved.name, "tahoe-base");
+        assert_eq!(resolved.version, "2026.07.02");
+        assert_eq!(resolved.os_version, "26.5");
+        assert_eq!(resolved.os_build.as_deref(), Some("25F71"));
+        assert_eq!(resolved.runner_version.as_deref(), Some("2.334.0"));
+        assert_eq!(resolved.minimum_cpu_count, 2);
+        assert_eq!(resolved.minimum_memory_mib, 4096);
+        assert_eq!(resolved.installed_version, None);
+        // Resolution must not have registered or staged anything.
+        assert!(mgr.list().is_empty());
+
+        mgr.pull_remote(source.clone(), |_, _| {}).await.unwrap();
+        let resolved = mgr.resolve_remote(&source).await.unwrap();
+        assert_eq!(resolved.installed_version.as_deref(), Some("2026.07.02"));
     }
 
     #[tokio::test]

--- a/app/arcbox-core/src/macos/pull.rs
+++ b/app/arcbox-core/src/macos/pull.rs
@@ -9,7 +9,7 @@
 //! registry entry.
 
 use std::io::Write;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 use base64::Engine as _;
 use base64::engine::general_purpose::STANDARD as BASE64;
@@ -21,6 +21,7 @@ use super::image::{
     MacImageMeta,
 };
 use super::remote::{ImageManifest, ImageReference, RemoteFile, RemoteIndex, RemoteLocation};
+use super::{StagingGuard, validate_name};
 use crate::error::{CoreError, Result};
 
 /// Where a [`MacImageManager::pull_remote`] finds its manifest.
@@ -134,34 +135,6 @@ impl Write for SparseWriter {
 
     fn flush(&mut self) -> std::io::Result<()> {
         Ok(())
-    }
-}
-
-/// Removes the staging directory on drop unless disarmed.
-///
-/// This is what makes the pull future cancellation-safe: if the caller drops
-/// it at any await point (e.g. the gRPC client disconnected), the partial
-/// image is cleaned up by this guard's `Drop` rather than leaking.
-struct StagingGuard {
-    path: Option<PathBuf>,
-}
-
-impl StagingGuard {
-    fn new(path: PathBuf) -> Self {
-        Self { path: Some(path) }
-    }
-
-    /// Keeps the directory (it has been renamed into its final location).
-    fn disarm(&mut self) {
-        self.path = None;
-    }
-}
-
-impl Drop for StagingGuard {
-    fn drop(&mut self) {
-        if let Some(path) = &self.path {
-            let _ = std::fs::remove_dir_all(path);
-        }
     }
 }
 
@@ -419,6 +392,9 @@ async fn resolve_source(source: &RemoteSource) -> Result<(RemoteLocation, ImageM
             manifest.disk.disk_format
         )));
     }
+    // The name becomes a registry directory; reject anything that could escape it
+    // (a `--manifest` source is not index-validated like a reference is).
+    validate_name(&manifest.name)?;
     if let RemoteSource::Reference(reference) = source {
         if manifest.name != reference.stream {
             return Err(CoreError::macos(format!(
@@ -481,6 +457,12 @@ impl MacImageManager {
         let (manifest_location, manifest) = resolve_source(&source).await?;
         on_progress(PullStage::Resolve, 1.0);
 
+        // Serialize pulls of the same image: concurrent pulls would otherwise
+        // share the `.pull-<name>` staging directory and corrupt each other's
+        // download. A second pull waits here, then no-ops via the check below.
+        let lock = self.pull_lock(&manifest.name).await;
+        let _pull_guard = lock.lock().await;
+
         on_progress(PullStage::Validate, 0.0);
         let hardware_model = decode_field("hardware_model", &manifest.hardware_model)?;
         let machine_id = decode_field("machine_id", &manifest.machine_id)?;
@@ -497,7 +479,7 @@ impl MacImageManager {
         // Assemble in a staging directory; rename live only when complete. The
         // guard removes it on any early return — or if this future is dropped
         // (client cancellation) at any await point.
-        let staging = self.image_dir(&format!(".pull-{}", manifest.name));
+        let staging = self.image_dir(&format!(".pull-{}", manifest.name))?;
         if staging.exists() {
             std::fs::remove_dir_all(&staging)?;
         }
@@ -512,7 +494,7 @@ impl MacImageManager {
         Self::write_meta_in(&staging, &meta_from_manifest(&manifest, &manifest_location))?;
 
         on_progress(PullStage::Verify, 0.5);
-        let final_dir = self.image_dir(&manifest.name);
+        let final_dir = self.image_dir(&manifest.name)?;
         if final_dir.exists() {
             std::fs::remove_dir_all(&final_dir)?;
         }
@@ -806,6 +788,40 @@ mod tests {
         // Re-pull of the same version is a no-op (returns the existing image).
         let again = mgr.pull_remote(source, |_, _| {}).await.unwrap();
         assert_eq!(again.meta.created_at, image.meta.created_at);
+    }
+
+    #[tokio::test]
+    async fn manifest_with_traversal_name_is_rejected() {
+        let images = tempdir().unwrap();
+        let publish = tempdir().unwrap();
+
+        // A `--manifest` source is not index-validated, so a hostile name must be
+        // rejected during resolution — before anything is downloaded or landed.
+        let manifest = serde_json::json!({
+            "schema_version": 1,
+            "name": "../evil",
+            "version": "2026.07.02",
+            "os": { "product_version": "26.5" },
+            "hardware_model": REAL_HARDWARE_MODEL_B64,
+            "machine_id": REAL_MACHINE_ID_B64,
+            "minimum_cpu_count": 2,
+            "minimum_memory_mib": 4096,
+            "disk": {
+                "path": "disk.img.zst", "disk_format": "raw",
+                "uncompressed_size": 1, "compressed_size": 1, "sha256": "00"
+            },
+            "aux": {
+                "path": "aux.img.zst",
+                "uncompressed_size": 1, "compressed_size": 1, "sha256": "00"
+            }
+        });
+        let manifest_path = publish.path().join("manifest.json");
+        std::fs::write(&manifest_path, manifest.to_string()).unwrap();
+
+        let mgr = MacImageManager::new(images.path());
+        let source = RemoteSource::Manifest(RemoteLocation::File(manifest_path));
+        assert!(mgr.pull_remote(source.clone(), |_, _| {}).await.is_err());
+        assert!(mgr.resolve_remote(&source).await.is_err());
     }
 
     /// Resolve answers "what would land / what's installed" without

--- a/app/arcbox-core/src/macos/pull.rs
+++ b/app/arcbox-core/src/macos/pull.rs
@@ -309,11 +309,15 @@ async fn fetch_zstd_to_sparse(
             }
         }
         RemoteLocation::File(path) => {
-            use std::io::Read;
-            let mut src = std::fs::File::open(path)?;
+            // tokio::fs (not std): every read is an await point, which is what
+            // keeps this future cancellable — a sync loop here would run to
+            // completion inside a single poll, immune to `select!`/drop, while
+            // pinning a runtime worker for the whole decompression.
+            use tokio::io::AsyncReadExt;
+            let mut src = tokio::fs::File::open(path).await?;
             let mut buf = vec![0u8; 1024 * 1024];
             loop {
-                let n = src.read(&mut buf)?;
+                let n = src.read(&mut buf).await?;
                 if n == 0 {
                     break;
                 }

--- a/app/arcbox-core/src/macos/remote.rs
+++ b/app/arcbox-core/src/macos/remote.rs
@@ -1,0 +1,377 @@
+//! Remote macOS image distribution: the published index and per-version
+//! manifests, image references, and fetching from HTTP or local paths.
+//!
+//! The wire format is owned by the `macos-runner-image-builder` repo (the
+//! producer); this module is the consuming side. All paths in the index and
+//! manifests are relative — the only absolute URL in the system is the base
+//! location this module is handed.
+
+use std::collections::HashMap;
+use std::fmt;
+use std::path::PathBuf;
+use std::str::FromStr;
+
+use serde::Deserialize;
+
+use crate::error::{CoreError, Result};
+
+/// Default base location of the published image index (the `darwin` bucket).
+///
+/// Overridable with the `ARCBOX_MACOS_IMAGE_BASE` environment variable.
+pub const DEFAULT_IMAGE_BASE: &str = "https://images.arcbox.dev";
+
+/// Environment variable overriding [`DEFAULT_IMAGE_BASE`].
+pub const IMAGE_BASE_ENV: &str = "ARCBOX_MACOS_IMAGE_BASE";
+
+/// Returns the effective image base location (env override or default).
+#[must_use]
+pub fn image_base() -> RemoteLocation {
+    let base = std::env::var(IMAGE_BASE_ENV).unwrap_or_else(|_| DEFAULT_IMAGE_BASE.to_string());
+    RemoteLocation::parse(&base)
+}
+
+/// A parsed image reference: `stream` or `stream@version`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ImageReference {
+    /// Stream name, e.g. `tahoe-base`.
+    pub stream: String,
+    /// Pinned version, e.g. `2026.07.02`; `None` follows the index's latest.
+    pub version: Option<String>,
+}
+
+impl FromStr for ImageReference {
+    type Err = CoreError;
+
+    fn from_str(s: &str) -> Result<Self> {
+        let (stream, version) = match s.split_once('@') {
+            Some((stream, version)) => (stream, Some(version.to_string())),
+            None => (s, None),
+        };
+        if stream.is_empty()
+            || !stream
+                .chars()
+                .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '.')
+        {
+            return Err(CoreError::macos(format!("invalid image reference '{s}'")));
+        }
+        if let Some(v) = &version {
+            if v.is_empty() {
+                return Err(CoreError::macos(format!("invalid image reference '{s}'")));
+            }
+        }
+        Ok(Self {
+            stream: stream.to_string(),
+            version,
+        })
+    }
+}
+
+impl fmt::Display for ImageReference {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match &self.version {
+            Some(v) => write!(f, "{}@{v}", self.stream),
+            None => write!(f, "{}", self.stream),
+        }
+    }
+}
+
+/// The published discovery index (`index.json` at the bucket root).
+#[derive(Debug, Deserialize)]
+pub struct RemoteIndex {
+    /// Index schema version.
+    pub schema_version: u32,
+    /// Streams by name.
+    pub images: HashMap<String, RemoteStream>,
+}
+
+/// One image stream in the index.
+#[derive(Debug, Deserialize)]
+pub struct RemoteStream {
+    /// The version `pull <stream>` resolves to.
+    pub latest: String,
+    /// All retained versions.
+    pub versions: HashMap<String, RemoteVersion>,
+}
+
+/// One published version of a stream.
+#[derive(Debug, Deserialize)]
+pub struct RemoteVersion {
+    /// Manifest path relative to the index location.
+    pub manifest: String,
+}
+
+impl RemoteIndex {
+    /// Resolves a reference to `(version, manifest path relative to the index)`.
+    ///
+    /// # Errors
+    /// Returns a not-found error for an unknown stream or version.
+    pub fn resolve(&self, reference: &ImageReference) -> Result<(String, String)> {
+        let stream = self
+            .images
+            .get(&reference.stream)
+            .ok_or_else(|| CoreError::not_found(format!("image stream '{}'", reference.stream)))?;
+        let version = reference
+            .version
+            .clone()
+            .unwrap_or_else(|| stream.latest.clone());
+        let entry = stream.versions.get(&version).ok_or_else(|| {
+            CoreError::not_found(format!("image '{}@{version}'", reference.stream))
+        })?;
+        Ok((version, entry.manifest.clone()))
+    }
+}
+
+/// A published image manifest (one immutable version of a stream).
+#[derive(Debug, Deserialize)]
+pub struct ImageManifest {
+    /// Manifest schema version.
+    pub schema_version: u32,
+    /// Stream name.
+    pub name: String,
+    /// Version label (`YYYY.MM.DD[.N]`).
+    pub version: String,
+    /// Variant (`base` / `full`).
+    #[serde(default)]
+    #[allow(dead_code, reason = "published schema field; not yet surfaced locally")]
+    pub variant: String,
+    /// Guest OS identity.
+    pub os: OsInfo,
+    /// Preinstalled GitHub Actions runner version, if any.
+    #[serde(default)]
+    pub runner_version: Option<String>,
+    /// Preinstalled Xcode versions (empty for base images).
+    #[serde(default)]
+    #[allow(dead_code, reason = "published schema field; not yet surfaced locally")]
+    pub xcode: Vec<String>,
+    /// VZ hardware-model `dataRepresentation`, base64.
+    pub hardware_model: String,
+    /// VZ machine-identifier `dataRepresentation`, base64.
+    pub machine_id: String,
+    /// Minimum CPU count required by the guest.
+    pub minimum_cpu_count: u64,
+    /// Minimum guest memory in MiB.
+    pub minimum_memory_mib: u64,
+    /// The compressed system disk.
+    pub disk: DiskFile,
+    /// The compressed auxiliary (NVRAM) storage.
+    pub aux: RemoteFile,
+}
+
+/// Guest OS identity in a manifest.
+#[derive(Debug, Deserialize)]
+pub struct OsInfo {
+    /// macOS product version, e.g. `26.5`.
+    pub product_version: String,
+    /// macOS build number, e.g. `25F71`.
+    #[serde(default)]
+    pub build: String,
+}
+
+/// A compressed file entry in a manifest.
+#[derive(Debug, Deserialize)]
+pub struct RemoteFile {
+    /// File name relative to the manifest's directory.
+    pub path: String,
+    /// Decompressed size in bytes.
+    pub uncompressed_size: u64,
+    /// Compressed (stored) size in bytes.
+    pub compressed_size: u64,
+    /// Hex SHA-256 of the compressed bytes.
+    pub sha256: String,
+}
+
+/// The disk entry: a [`RemoteFile`] plus its on-disk format.
+#[derive(Debug, Deserialize)]
+pub struct DiskFile {
+    /// Raw disk image format (currently always `raw`).
+    pub disk_format: String,
+    /// The file itself.
+    #[serde(flatten)]
+    pub file: RemoteFile,
+}
+
+/// A fetchable location: an HTTP(S) URL or a local filesystem path.
+///
+/// Locations are joined relatively (sibling files next to a manifest, the
+/// index at the base root), so published artifacts never contain absolute URLs.
+#[derive(Debug, Clone)]
+pub enum RemoteLocation {
+    /// An HTTP(S) URL.
+    Http(reqwest::Url),
+    /// A local file path (used by tests and `pull --manifest <path>`).
+    File(PathBuf),
+}
+
+impl RemoteLocation {
+    /// Parses a location: `http(s)://` becomes [`RemoteLocation::Http`],
+    /// anything else a local path.
+    #[must_use]
+    pub fn parse(s: &str) -> Self {
+        if s.starts_with("http://") || s.starts_with("https://") {
+            match reqwest::Url::parse(s) {
+                Ok(url) => return Self::Http(url),
+                Err(_) => return Self::File(PathBuf::from(s)),
+            }
+        }
+        Self::File(PathBuf::from(s))
+    }
+
+    /// Resolves `relative` against this location's directory.
+    ///
+    /// For a location pointing at a file (e.g. a manifest), the result is a
+    /// sibling; for a base location, a child.
+    ///
+    /// # Errors
+    /// Returns an error if URL joining fails.
+    pub fn join(&self, relative: &str) -> Result<Self> {
+        match self {
+            Self::Http(url) => {
+                let joined = url
+                    .join(relative)
+                    .map_err(|e| CoreError::macos(format!("join '{relative}' to {url}: {e}")))?;
+                Ok(Self::Http(joined))
+            }
+            Self::File(path) => {
+                let dir = path.parent().unwrap_or(path);
+                Ok(Self::File(dir.join(relative)))
+            }
+        }
+    }
+
+    /// Returns a location that treats the current one as a directory, so
+    /// [`RemoteLocation::join`] resolves children instead of siblings.
+    #[must_use]
+    pub fn as_dir(&self) -> Self {
+        match self {
+            Self::Http(url) => {
+                let mut s = url.to_string();
+                if !s.ends_with('/') {
+                    s.push('/');
+                }
+                Self::parse(&s)
+            }
+            Self::File(path) => Self::File(path.join("placeholder")),
+        }
+    }
+
+    /// Fetches the location's full contents into memory (small files only:
+    /// index, manifest, aux image).
+    ///
+    /// # Errors
+    /// Returns an error on network/IO failure or non-success HTTP status.
+    pub async fn fetch_bytes(&self) -> Result<Vec<u8>> {
+        match self {
+            Self::Http(url) => {
+                let resp = reqwest::get(url.clone())
+                    .await
+                    .and_then(reqwest::Response::error_for_status)
+                    .map_err(|e| CoreError::macos(format!("fetch {url}: {e}")))?;
+                let bytes = resp
+                    .bytes()
+                    .await
+                    .map_err(|e| CoreError::macos(format!("fetch {url}: {e}")))?;
+                Ok(bytes.to_vec())
+            }
+            Self::File(path) => Ok(std::fs::read(path)?),
+        }
+    }
+
+    /// Fetches and JSON-decodes the location's contents.
+    ///
+    /// # Errors
+    /// Returns an error on fetch failure or JSON that does not match `T`.
+    pub async fn fetch_json<T: serde::de::DeserializeOwned>(&self) -> Result<T> {
+        let bytes = self.fetch_bytes().await?;
+        serde_json::from_slice(&bytes).map_err(|e| CoreError::macos(format!("parse {self}: {e}")))
+    }
+}
+
+impl fmt::Display for RemoteLocation {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Http(url) => write!(f, "{url}"),
+            Self::File(path) => write!(f, "{}", path.display()),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn reference_parses_stream_and_version() {
+        let r: ImageReference = "tahoe-base".parse().unwrap();
+        assert_eq!(r.stream, "tahoe-base");
+        assert_eq!(r.version, None);
+
+        let r: ImageReference = "tahoe-base@2026.07.02".parse().unwrap();
+        assert_eq!(r.stream, "tahoe-base");
+        assert_eq!(r.version.as_deref(), Some("2026.07.02"));
+        assert_eq!(r.to_string(), "tahoe-base@2026.07.02");
+    }
+
+    #[test]
+    fn reference_rejects_garbage() {
+        assert!("".parse::<ImageReference>().is_err());
+        assert!("tahoe base".parse::<ImageReference>().is_err());
+        assert!("tahoe-base@".parse::<ImageReference>().is_err());
+        assert!("../evil".parse::<ImageReference>().is_err());
+    }
+
+    #[test]
+    fn index_resolves_latest_and_pinned() {
+        let index: RemoteIndex = serde_json::from_str(
+            r#"{
+                "schema_version": 1,
+                "images": {
+                    "tahoe-base": {
+                        "latest": "2026.07.02",
+                        "versions": {
+                            "2026.07.02": { "manifest": "tahoe-base/2026.07.02/manifest.json" },
+                            "2026.06.01": { "manifest": "tahoe-base/2026.06.01/manifest.json" }
+                        }
+                    }
+                }
+            }"#,
+        )
+        .unwrap();
+
+        let latest = index.resolve(&"tahoe-base".parse().unwrap()).unwrap();
+        assert_eq!(latest.0, "2026.07.02");
+        assert_eq!(latest.1, "tahoe-base/2026.07.02/manifest.json");
+
+        let pinned = index
+            .resolve(&"tahoe-base@2026.06.01".parse().unwrap())
+            .unwrap();
+        assert_eq!(pinned.0, "2026.06.01");
+
+        assert!(index.resolve(&"nope".parse().unwrap()).is_err());
+        assert!(
+            index
+                .resolve(&"tahoe-base@1999.01.01".parse().unwrap())
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn location_joins_relatively() {
+        let base = RemoteLocation::parse("https://images.arcbox.dev");
+        let index = base.as_dir().join("index.json").unwrap();
+        assert_eq!(index.to_string(), "https://images.arcbox.dev/index.json");
+
+        let manifest = base
+            .as_dir()
+            .join("tahoe-base/2026.07.02/manifest.json")
+            .unwrap();
+        let disk = manifest.join("disk.img.zst").unwrap();
+        assert_eq!(
+            disk.to_string(),
+            "https://images.arcbox.dev/tahoe-base/2026.07.02/disk.img.zst"
+        );
+
+        let manifest = RemoteLocation::parse("/tmp/out/manifest.json");
+        let disk = manifest.join("disk.img.zst").unwrap();
+        assert_eq!(disk.to_string(), "/tmp/out/disk.img.zst");
+    }
+}

--- a/app/arcbox-core/src/macos/remote.rs
+++ b/app/arcbox-core/src/macos/remote.rs
@@ -18,7 +18,7 @@ use crate::error::{CoreError, Result};
 /// Default base location of the published image index (the `darwin` bucket).
 ///
 /// Overridable with the `ARCBOX_MACOS_IMAGE_BASE` environment variable.
-pub const DEFAULT_IMAGE_BASE: &str = "https://images.arcbox.dev";
+pub const DEFAULT_IMAGE_BASE: &str = "https://darwin.arcboxcdn.com";
 
 /// Environment variable overriding [`DEFAULT_IMAGE_BASE`].
 pub const IMAGE_BASE_ENV: &str = "ARCBOX_MACOS_IMAGE_BASE";

--- a/app/arcbox-core/src/macos/remote.rs
+++ b/app/arcbox-core/src/macos/remote.rs
@@ -189,9 +189,16 @@ pub struct RemoteFile {
 /// bytes `[i * chunk_size, (i + 1) * chunk_size)`; the last chunk holds the
 /// remainder. Splitting keeps every stored object under the CDN's cacheable
 /// size limit and lets the client fetch, verify, and sparse-write chunks in
-/// parallel. The manifest also carries a whole-disk `uncompressed_sha256`; the
-/// client relies on per-chunk hashing plus deterministic placement instead of
-/// re-reading the assembled image, so that field is not consumed here.
+/// parallel.
+///
+/// Integrity model: each chunk is verified against its own compressed
+/// SHA-256 before it is decoded, and placed at the offset given by its array
+/// index — so the assembled disk is correct without re-reading the multi-GB
+/// result. This trusts the producer to emit chunks in offset order (they are:
+/// `disk.000.zst`, `disk.001.zst`, …). The manifest also carries a whole-disk
+/// `uncompressed_sha256` for out-of-band/publisher-side auditing; the client
+/// does not consume it (a client-side re-read would defeat the streaming
+/// design).
 #[derive(Debug, Deserialize)]
 pub struct DiskManifest {
     /// Raw disk image format (currently always `raw`).

--- a/app/arcbox-core/src/macos/remote.rs
+++ b/app/arcbox-core/src/macos/remote.rs
@@ -15,10 +15,14 @@ use serde::Deserialize;
 
 use crate::error::{CoreError, Result};
 
-/// Default base location of the published image index (the `darwin` bucket).
+/// Default base location of the published image index: the `darwin/` platform
+/// namespace at the CDN root (the `arcboxcdn-image` bucket fronted by
+/// `image.arcboxcdn.com`). `index.json` and every manifest resolve relative
+/// to this, so the namespace can move or gain a vanity domain without touching
+/// any published file.
 ///
 /// Overridable with the `ARCBOX_MACOS_IMAGE_BASE` environment variable.
-pub const DEFAULT_IMAGE_BASE: &str = "https://darwin.arcboxcdn.com";
+pub const DEFAULT_IMAGE_BASE: &str = "https://image.arcboxcdn.com/darwin";
 
 /// Environment variable overriding [`DEFAULT_IMAGE_BASE`].
 pub const IMAGE_BASE_ENV: &str = "ARCBOX_MACOS_IMAGE_BASE";
@@ -151,8 +155,8 @@ pub struct ImageManifest {
     pub minimum_cpu_count: u64,
     /// Minimum guest memory in MiB.
     pub minimum_memory_mib: u64,
-    /// The compressed system disk.
-    pub disk: DiskFile,
+    /// The compressed, chunked system disk.
+    pub disk: DiskManifest,
     /// The compressed auxiliary (NVRAM) storage.
     pub aux: RemoteFile,
 }
@@ -180,14 +184,35 @@ pub struct RemoteFile {
     pub sha256: String,
 }
 
-/// The disk entry: a [`RemoteFile`] plus its on-disk format.
+/// The system disk in a manifest: split at fixed `chunk_size` offsets into
+/// independently decompressible zstd frames. Chunk `i` covers uncompressed
+/// bytes `[i * chunk_size, (i + 1) * chunk_size)`; the last chunk holds the
+/// remainder. Splitting keeps every stored object under the CDN's cacheable
+/// size limit and lets the client fetch, verify, and sparse-write chunks in
+/// parallel. The manifest also carries a whole-disk `uncompressed_sha256`; the
+/// client relies on per-chunk hashing plus deterministic placement instead of
+/// re-reading the assembled image, so that field is not consumed here.
 #[derive(Debug, Deserialize)]
-pub struct DiskFile {
+pub struct DiskManifest {
     /// Raw disk image format (currently always `raw`).
     pub disk_format: String,
-    /// The file itself.
-    #[serde(flatten)]
-    pub file: RemoteFile,
+    /// Decompressed size of the assembled disk, in bytes.
+    pub uncompressed_size: u64,
+    /// Uncompressed run length each non-final chunk decompresses to.
+    pub chunk_size: u64,
+    /// Ordered chunks; each an independent zstd frame.
+    pub chunks: Vec<DiskChunk>,
+}
+
+/// One compressed disk chunk, stored as its own object next to the manifest.
+#[derive(Debug, Clone, Deserialize)]
+pub struct DiskChunk {
+    /// File name relative to the manifest's directory (`disk.NNN.zst`).
+    pub path: String,
+    /// Compressed (stored) size in bytes.
+    pub size: u64,
+    /// Hex SHA-256 of the compressed bytes.
+    pub sha256: String,
 }
 
 /// A fetchable location: an HTTP(S) URL or a local filesystem path.

--- a/app/arcbox-core/src/macos/vm.rs
+++ b/app/arcbox-core/src/macos/vm.rs
@@ -11,8 +11,9 @@ use std::time::Duration;
 
 use arcbox_vz::{
     MacAuxiliaryStorage, MacGraphicsDeviceConfiguration, MacHardwareModel, MacMachineIdentifier,
-    MacOSBootLoader, MacPlatform, StorageDeviceConfiguration, VirtualMachine,
-    VirtualMachineConfiguration, VirtualMachineState, min_cpu_count, min_memory_size,
+    MacOSBootLoader, MacPlatform, NetworkDeviceConfiguration, StorageDeviceConfiguration,
+    VirtualMachine, VirtualMachineConfiguration, VirtualMachineState, min_cpu_count,
+    min_memory_size,
 };
 
 use crate::error::{CoreError, Result};
@@ -63,6 +64,10 @@ impl MacVm {
             .set_platform(platform)
             .set_boot_loader(MacOSBootLoader::new()?)
             .add_storage_device(StorageDeviceConfiguration::disk_image(disk, false)?)
+            // NAT (vmnet shared) gives the guest a DHCP lease + outbound internet
+            // through the host with no host-side setup — all a CI runner needs to
+            // reach GitHub and pull dependencies.
+            .add_network_device(NetworkDeviceConfiguration::nat()?)
             .add_graphics_device(MacGraphicsDeviceConfiguration::new(1920, 1080, 80)?);
         config.validate()?;
         let vm = config.build()?;

--- a/app/arcbox-core/src/macos/vm.rs
+++ b/app/arcbox-core/src/macos/vm.rs
@@ -31,8 +31,10 @@ impl MacVm {
     /// Running state.
     ///
     /// `machine_id` is the persisted identifier the auxiliary storage was created with;
-    /// reusing it keeps the guest's identity stable across reboots. `cpus`/`memory_mib`
-    /// are floored to the framework minimums. Apple Silicon only.
+    /// reusing it keeps the guest's identity stable across reboots. `mac_address` is
+    /// pinned to the NAT interface so the guest's DHCP lease identifies it on the
+    /// host. `cpus`/`memory_mib` are floored to the framework minimums. Apple
+    /// Silicon only.
     ///
     /// # Errors
     /// Returns an error if the configuration is invalid, the VM cannot start, or it
@@ -46,6 +48,7 @@ impl MacVm {
         aux: &Path,
         hardware_model: &[u8],
         machine_id: &[u8],
+        mac_address: &str,
         cpus: u32,
         memory_mib: u64,
     ) -> Result<Self> {
@@ -66,8 +69,9 @@ impl MacVm {
             .add_storage_device(StorageDeviceConfiguration::disk_image(disk, false)?)
             // NAT (vmnet shared) gives the guest a DHCP lease + outbound internet
             // through the host with no host-side setup — all a CI runner needs to
-            // reach GitHub and pull dependencies.
-            .add_network_device(NetworkDeviceConfiguration::nat()?)
+            // reach GitHub and pull dependencies. The pinned MAC is what lets the
+            // host find that lease (see super::lease).
+            .add_network_device(NetworkDeviceConfiguration::nat_with_mac(mac_address)?)
             .add_graphics_device(MacGraphicsDeviceConfiguration::new(1920, 1080, 80)?);
         config.validate()?;
         let vm = config.build()?;

--- a/app/arcbox-core/src/macos/vm.rs
+++ b/app/arcbox-core/src/macos/vm.rs
@@ -1,7 +1,7 @@
 //! A running macOS guest VM, assembled from a cloned base image.
 //!
 //! [`MacVm::boot`] turns the disks produced by
-//! [`MacImageManager::clone_base`](super::image::MacImageManager::clone_base) into a
+//! [`MacImage::clone_into`](super::image::MacImage::clone_into) into a
 //! live `arcbox-vz` virtual machine. The machine identifier is the one persisted with
 //! the machine (the identifier its auxiliary storage was created with at install), so
 //! a machine keeps a stable identity across reboots.

--- a/app/arcbox-core/src/macos/vm.rs
+++ b/app/arcbox-core/src/macos/vm.rs
@@ -1,0 +1,123 @@
+//! A running macOS guest VM, assembled from a cloned base image.
+//!
+//! [`MacVm::boot`] turns the disks produced by
+//! [`MacImageManager::clone_base`](super::image::MacImageManager::clone_base) into a
+//! live `arcbox-vz` virtual machine. Each boot mints a fresh machine identifier
+//! (verified to start with the copied auxiliary storage), so concurrent clones of
+//! one base get distinct identities.
+
+use std::path::Path;
+use std::time::Duration;
+
+use arcbox_vz::{
+    MacAuxiliaryStorage, MacGraphicsDeviceConfiguration, MacHardwareModel, MacMachineIdentifier,
+    MacOSBootLoader, MacPlatform, StorageDeviceConfiguration, VZError, VirtualMachine,
+    VirtualMachineConfiguration, VirtualMachineState, min_cpu_count, min_memory_size,
+};
+
+use crate::error::{CoreError, Result};
+
+const READINESS_POLL_INTERVAL: Duration = Duration::from_millis(250);
+const READINESS_MAX_POLLS: u32 = 240; // ~60s
+
+fn vz_err(e: VZError) -> CoreError {
+    CoreError::macos(e.to_string())
+}
+
+/// A booted macOS guest VM built from a cloned base image.
+pub struct MacVm {
+    vm: VirtualMachine,
+}
+
+impl MacVm {
+    /// Boots a macOS guest from cloned instance disks and waits until it reaches the
+    /// Running state.
+    ///
+    /// A fresh machine identifier is generated so concurrent clones of the same base
+    /// have distinct identities. `cpus`/`memory_mib` are floored to the framework
+    /// minimums. Apple Silicon only.
+    ///
+    /// # Errors
+    /// Returns an error if the configuration is invalid, the VM cannot start, or it
+    /// does not reach Running within the readiness window.
+    #[allow(
+        clippy::future_not_send,
+        reason = "drives Virtualization.framework through ObjC pointers and the VM's dispatch queue, which are inherently !Send and held across await; the caller drives it on a single thread"
+    )]
+    pub async fn boot(
+        disk: &Path,
+        aux: &Path,
+        hardware_model: &[u8],
+        cpus: u32,
+        memory_mib: u64,
+    ) -> Result<Self> {
+        let hardware_model = MacHardwareModel::from_data(hardware_model).map_err(vz_err)?;
+        let machine_id = MacMachineIdentifier::new().map_err(vz_err)?;
+        let aux = MacAuxiliaryStorage::open(aux).map_err(vz_err)?;
+        let platform = MacPlatform::new(&hardware_model, &machine_id, &aux).map_err(vz_err)?;
+
+        let cpu_count = usize::try_from(u64::from(cpus).max(min_cpu_count())).unwrap_or(1);
+        let memory = (memory_mib * 1024 * 1024).max(min_memory_size());
+
+        let mut config = VirtualMachineConfiguration::new().map_err(vz_err)?;
+        config
+            .set_cpu_count(cpu_count)
+            .set_memory_size(memory)
+            .set_platform(platform)
+            .set_boot_loader(MacOSBootLoader::new().map_err(vz_err)?)
+            .add_storage_device(
+                StorageDeviceConfiguration::disk_image(disk, false).map_err(vz_err)?,
+            )
+            .add_graphics_device(
+                MacGraphicsDeviceConfiguration::new(1920, 1080, 80).map_err(vz_err)?,
+            );
+        config.validate().map_err(vz_err)?;
+        let vm = config.build().map_err(vz_err)?;
+
+        vm.start().await.map_err(vz_err)?;
+        let mut polls = 0;
+        while vm.state() != VirtualMachineState::Running && polls < READINESS_MAX_POLLS {
+            tokio::time::sleep(READINESS_POLL_INTERVAL).await;
+            polls += 1;
+        }
+        if vm.state() != VirtualMachineState::Running {
+            return Err(CoreError::macos(format!(
+                "macOS VM did not reach Running (state = {:?})",
+                vm.state()
+            )));
+        }
+        Ok(Self { vm })
+    }
+
+    /// Returns the current VM state.
+    #[must_use]
+    pub fn state(&self) -> VirtualMachineState {
+        self.vm.state()
+    }
+
+    /// Returns whether the VM is in the Running state.
+    #[must_use]
+    pub fn is_running(&self) -> bool {
+        self.vm.state() == VirtualMachineState::Running
+    }
+
+    /// Requests a graceful guest shutdown (the VM stops asynchronously).
+    ///
+    /// # Errors
+    /// Returns an error if the guest cannot be asked to stop.
+    pub fn request_stop(&self) -> Result<()> {
+        self.vm.request_stop().map_err(vz_err)
+    }
+
+    /// Forcibly stops the VM.
+    ///
+    /// # Errors
+    /// Returns an error if the VM cannot be stopped.
+    #[allow(
+        clippy::future_not_send,
+        reason = "Virtualization.framework VM handles are !Send; the caller drives stop on a single thread"
+    )]
+    pub async fn stop(&self) -> Result<()> {
+        self.vm.stop().await.map_err(vz_err)
+    }
+}

--- a/app/arcbox-core/src/macos/vm.rs
+++ b/app/arcbox-core/src/macos/vm.rs
@@ -2,16 +2,16 @@
 //!
 //! [`MacVm::boot`] turns the disks produced by
 //! [`MacImageManager::clone_base`](super::image::MacImageManager::clone_base) into a
-//! live `arcbox-vz` virtual machine. Each boot mints a fresh machine identifier
-//! (verified to start with the copied auxiliary storage), so concurrent clones of
-//! one base get distinct identities.
+//! live `arcbox-vz` virtual machine. The machine identifier is the one persisted with
+//! the machine (the identifier its auxiliary storage was created with at install), so
+//! a machine keeps a stable identity across reboots.
 
 use std::path::Path;
 use std::time::Duration;
 
 use arcbox_vz::{
     MacAuxiliaryStorage, MacGraphicsDeviceConfiguration, MacHardwareModel, MacMachineIdentifier,
-    MacOSBootLoader, MacPlatform, StorageDeviceConfiguration, VZError, VirtualMachine,
+    MacOSBootLoader, MacPlatform, StorageDeviceConfiguration, VirtualMachine,
     VirtualMachineConfiguration, VirtualMachineState, min_cpu_count, min_memory_size,
 };
 
@@ -19,10 +19,6 @@ use crate::error::{CoreError, Result};
 
 const READINESS_POLL_INTERVAL: Duration = Duration::from_millis(250);
 const READINESS_MAX_POLLS: u32 = 240; // ~60s
-
-fn vz_err(e: VZError) -> CoreError {
-    CoreError::macos(e.to_string())
-}
 
 /// A booted macOS guest VM built from a cloned base image.
 pub struct MacVm {
@@ -33,9 +29,9 @@ impl MacVm {
     /// Boots a macOS guest from cloned instance disks and waits until it reaches the
     /// Running state.
     ///
-    /// A fresh machine identifier is generated so concurrent clones of the same base
-    /// have distinct identities. `cpus`/`memory_mib` are floored to the framework
-    /// minimums. Apple Silicon only.
+    /// `machine_id` is the persisted identifier the auxiliary storage was created with;
+    /// reusing it keeps the guest's identity stable across reboots. `cpus`/`memory_mib`
+    /// are floored to the framework minimums. Apple Silicon only.
     ///
     /// # Errors
     /// Returns an error if the configuration is invalid, the VM cannot start, or it
@@ -48,33 +44,30 @@ impl MacVm {
         disk: &Path,
         aux: &Path,
         hardware_model: &[u8],
+        machine_id: &[u8],
         cpus: u32,
         memory_mib: u64,
     ) -> Result<Self> {
-        let hardware_model = MacHardwareModel::from_data(hardware_model).map_err(vz_err)?;
-        let machine_id = MacMachineIdentifier::new().map_err(vz_err)?;
-        let aux = MacAuxiliaryStorage::open(aux).map_err(vz_err)?;
-        let platform = MacPlatform::new(&hardware_model, &machine_id, &aux).map_err(vz_err)?;
+        let hardware_model = MacHardwareModel::from_data(hardware_model)?;
+        let machine_id = MacMachineIdentifier::from_data(machine_id)?;
+        let aux = MacAuxiliaryStorage::open(aux)?;
+        let platform = MacPlatform::new(&hardware_model, &machine_id, &aux)?;
 
         let cpu_count = usize::try_from(u64::from(cpus).max(min_cpu_count())).unwrap_or(1);
         let memory = (memory_mib * 1024 * 1024).max(min_memory_size());
 
-        let mut config = VirtualMachineConfiguration::new().map_err(vz_err)?;
+        let mut config = VirtualMachineConfiguration::new()?;
         config
             .set_cpu_count(cpu_count)
             .set_memory_size(memory)
             .set_platform(platform)
-            .set_boot_loader(MacOSBootLoader::new().map_err(vz_err)?)
-            .add_storage_device(
-                StorageDeviceConfiguration::disk_image(disk, false).map_err(vz_err)?,
-            )
-            .add_graphics_device(
-                MacGraphicsDeviceConfiguration::new(1920, 1080, 80).map_err(vz_err)?,
-            );
-        config.validate().map_err(vz_err)?;
-        let vm = config.build().map_err(vz_err)?;
+            .set_boot_loader(MacOSBootLoader::new()?)
+            .add_storage_device(StorageDeviceConfiguration::disk_image(disk, false)?)
+            .add_graphics_device(MacGraphicsDeviceConfiguration::new(1920, 1080, 80)?);
+        config.validate()?;
+        let vm = config.build()?;
 
-        vm.start().await.map_err(vz_err)?;
+        vm.start().await?;
         let mut polls = 0;
         while vm.state() != VirtualMachineState::Running && polls < READINESS_MAX_POLLS {
             tokio::time::sleep(READINESS_POLL_INTERVAL).await;
@@ -106,7 +99,7 @@ impl MacVm {
     /// # Errors
     /// Returns an error if the guest cannot be asked to stop.
     pub fn request_stop(&self) -> Result<()> {
-        self.vm.request_stop().map_err(vz_err)
+        Ok(self.vm.request_stop()?)
     }
 
     /// Forcibly stops the VM.
@@ -118,6 +111,6 @@ impl MacVm {
         reason = "Virtualization.framework VM handles are !Send; the caller drives stop on a single thread"
     )]
     pub async fn stop(&self) -> Result<()> {
-        self.vm.stop().await.map_err(vz_err)
+        Ok(self.vm.stop().await?)
     }
 }

--- a/app/arcbox-core/src/runtime.rs
+++ b/app/arcbox-core/src/runtime.rs
@@ -568,6 +568,18 @@ impl Runtime {
         tokio::fs::create_dir_all(self.config.data_dir.join("vms")).await?;
         tokio::fs::create_dir_all(self.config.data_dir.join("machines")).await?;
 
+        // VM-host-only mode: skip the entire Linux/Docker system-VM bootstrap.
+        // The Linux VM never boots (so no lifecycle actor and no idle balloon
+        // management), and no guest binaries are downloaded. The daemon layer
+        // likewise skips the Docker API, Docker CLI integration, and the
+        // Kubernetes proxy. macOS guest management is unaffected.
+        if !self.config.vm.autostart {
+            tracing::info!(
+                "Linux VM autostart disabled; running as a VM host only (Docker/Kubernetes unavailable)"
+            );
+            return Ok(());
+        }
+
         // Download every runtime binary in the boot manifest if not cached:
         // dockerd, containerd, containerd-shim-runc-v2, runc, docker-init, k3s,
         // and the optional FEX x86_64 interpreter for linux/amd64. ArcBox's

--- a/app/arcbox-core/src/runtime.rs
+++ b/app/arcbox-core/src/runtime.rs
@@ -591,6 +591,35 @@ impl Runtime {
         Ok(())
     }
 
+    /// Stops every running macOS guest, logging any per-machine failures.
+    ///
+    /// macOS VM operations are `!Send` (ObjC handles + the VM dispatch queue held
+    /// across await), so they are driven on a transient current-thread runtime inside
+    /// `spawn_blocking` — the same pattern the gRPC machine handlers use.
+    #[cfg(target_os = "macos")]
+    async fn shutdown_macos_guests(&self) {
+        let manager = Arc::clone(&self.mac_machine_manager);
+        let joined =
+            tokio::task::spawn_blocking(
+                move || match tokio::runtime::Builder::new_current_thread()
+                    .enable_all()
+                    .build()
+                {
+                    Ok(rt) => rt.block_on(manager.stop_all()),
+                    Err(e) => vec![(String::from("<all>"), CoreError::from(e))],
+                },
+            )
+            .await;
+        match joined {
+            Ok(errors) => {
+                for (name, e) in errors {
+                    tracing::warn!("Failed to stop macOS guest {}: {}", name, e);
+                }
+            }
+            Err(e) => tracing::warn!("macOS guest shutdown task failed to join: {}", e),
+        }
+    }
+
     /// Shuts down the runtime gracefully.
     ///
     /// # Errors
@@ -651,7 +680,11 @@ impl Runtime {
             }
         }
 
-        // 4. Stop network manager.
+        // 4. Stop any running macOS guests (separate manager from Linux machines).
+        #[cfg(target_os = "macos")]
+        self.shutdown_macos_guests().await;
+
+        // 5. Stop network manager.
         if let Err(e) = self.network_manager.stop() {
             tracing::warn!("Failed to stop network manager: {}", e);
         }
@@ -683,6 +716,10 @@ impl Runtime {
                 let _ = self.machine_manager.stop(&machine.name);
             }
         }
+
+        // Stop any running macOS guests (separate manager from Linux machines).
+        #[cfg(target_os = "macos")]
+        self.shutdown_macos_guests().await;
 
         // Stop network manager.
         let _ = self.network_manager.stop();

--- a/app/arcbox-core/src/runtime.rs
+++ b/app/arcbox-core/src/runtime.rs
@@ -11,6 +11,8 @@ use crate::container_backend::{DynContainerBackend, create_backend};
 use crate::error::{CoreError, Result};
 use crate::event::EventBus;
 use crate::machine::{MachineManager, MachineState};
+#[cfg(target_os = "macos")]
+use crate::macos::MacMachineManager;
 use crate::migration::MigrationManager;
 use crate::vm::VmManager;
 use crate::vm_lifecycle::{DEFAULT_MACHINE_NAME, VmLifecycleConfig, VmLifecycleManager};
@@ -84,6 +86,9 @@ pub struct Runtime {
     network_manager: Arc<NetworkManager>,
     /// Host-side runtime migration manager.
     migration_manager: Arc<MigrationManager>,
+    /// macOS guest machine manager (Apple Silicon only).
+    #[cfg(target_os = "macos")]
+    mac_machine_manager: Arc<MacMachineManager>,
     /// Inbound listener managers keyed by machine name, for port
     /// forwarding via L2 frame injection (macOS). Each utility VM owns its
     /// own bridge interface and therefore its own listener.
@@ -193,6 +198,9 @@ impl Runtime {
 
         let migration_manager = Arc::new(MigrationManager::new(config.docker.socket_path.clone()));
 
+        #[cfg(target_os = "macos")]
+        let mac_machine_manager = Arc::new(MacMachineManager::new(&config.data_dir));
+
         Ok(Self {
             config,
             event_bus,
@@ -202,6 +210,8 @@ impl Runtime {
             container_backend: system_backend,
             network_manager,
             migration_manager,
+            #[cfg(target_os = "macos")]
+            mac_machine_manager,
             #[cfg(target_os = "macos")]
             inbound_listeners: Arc::new(TokioRwLock::new(HashMap::new())),
             #[cfg(target_os = "macos")]
@@ -248,6 +258,13 @@ impl Runtime {
     #[must_use]
     pub const fn migration_manager(&self) -> &Arc<MigrationManager> {
         &self.migration_manager
+    }
+
+    /// Returns the macOS guest machine manager (Apple Silicon only).
+    #[cfg(target_os = "macos")]
+    #[must_use]
+    pub const fn mac_machine_manager(&self) -> &Arc<MacMachineManager> {
+        &self.mac_machine_manager
     }
 
     /// Returns the VM lifecycle manager.

--- a/app/arcbox-daemon/src/context.rs
+++ b/app/arcbox-daemon/src/context.rs
@@ -114,12 +114,15 @@ pub struct DaemonContext {
 pub struct VmArgs {
     pub guest_docker_vsock_port: Option<u32>,
     pub kernel: Option<PathBuf>,
+    /// `--no-linux-vm`: forces `config.vm.autostart = false` in `init_runtime`.
+    pub no_linux_vm: bool,
 }
 
 /// Handles to spawned services for drain-on-shutdown.
 pub struct ServiceHandles {
     pub dns: tokio::task::JoinHandle<()>,
-    pub docker: tokio::task::JoinHandle<()>,
+    /// Docker API server task; `None` in VM-host-only mode.
+    pub docker: Option<tokio::task::JoinHandle<()>>,
     pub grpc: tokio::task::JoinHandle<()>,
     pub kubernetes_proxy: Option<tokio::task::JoinHandle<()>>,
 }

--- a/app/arcbox-daemon/src/main.rs
+++ b/app/arcbox-daemon/src/main.rs
@@ -45,6 +45,12 @@ pub struct DaemonArgs {
     #[arg(long)]
     pub docker_integration: bool,
 
+    /// Run as a VM host only: do not boot the default Linux VM, and disable the
+    /// Docker API, Docker CLI integration, and Kubernetes proxy. macOS guest
+    /// management is unaffected. Overrides `[vm] autostart` in the config file.
+    #[arg(long)]
+    pub no_linux_vm: bool,
+
     /// Run in foreground (also log to stderr in human-readable format).
     #[arg(long)]
     pub foreground: bool,

--- a/app/arcbox-daemon/src/recovery.rs
+++ b/app/arcbox-daemon/src/recovery.rs
@@ -17,6 +17,12 @@ use crate::self_setup::SetupTask as _;
 /// - Re-installs the container subnet route (cold-start reconcile)
 /// - Installs DNS resolver and Docker socket via helper (best-effort)
 pub async fn run(ctx: &DaemonContext, runtime: &Arc<Runtime>) {
+    // Every recovery task here reconciles Linux-VM container networking or
+    // Docker integration; none apply in VM-host-only mode.
+    if !runtime.config().vm.autostart {
+        return;
+    }
+
     recover_container_networking(runtime, &ctx.setup_state).await;
 
     // Cold-start route reconcile (non-blocking). This is load-bearing after

--- a/app/arcbox-daemon/src/services.rs
+++ b/app/arcbox-daemon/src/services.rs
@@ -15,6 +15,8 @@ use arcbox_api::{
     SystemServiceServer, kubernetes_service_server::KubernetesServiceServer,
     machine_service_server::MachineServiceServer,
 };
+#[cfg(target_os = "macos")]
+use arcbox_api::{MacosServiceImpl, macos_service_server::MacosServiceServer};
 use arcbox_core::Runtime;
 use arcbox_docker::{DockerApiServer, DockerContextManager, ServerConfig};
 use tokio::net::UnixListener;
@@ -50,6 +52,8 @@ pub async fn start_grpc(
     info!(socket = %socket_path.display(), "gRPC server listening");
 
     let machine_service = MachineServiceImpl::new(Arc::clone(&shared_runtime));
+    #[cfg(target_os = "macos")]
+    let macos_service = MacosServiceImpl::new(Arc::clone(&shared_runtime));
     let kubernetes_service = KubernetesServiceImpl::new(Arc::clone(&shared_runtime));
     let migration_service = MigrationServiceImpl::new(Arc::clone(&shared_runtime));
     let sandbox_service = SandboxServiceImpl::new(Arc::clone(&shared_runtime));
@@ -75,14 +79,20 @@ pub async fn start_grpc(
 
     let shutdown = ctx.shutdown.clone();
     let handle = tokio::spawn(async move {
-        let result = Server::builder()
+        let router = Server::builder()
             .add_service(MachineServiceServer::new(machine_service))
             .add_service(KubernetesServiceServer::new(kubernetes_service))
             .add_service(MigrationServiceServer::new(migration_service))
             .add_service(SandboxServiceServer::new(sandbox_service))
             .add_service(SandboxSnapshotServiceServer::new(sandbox_snapshot_service))
             .add_service(SystemServiceServer::new(system_service))
-            .add_service(IconServiceServer::new(icon_service))
+            .add_service(IconServiceServer::new(icon_service));
+        // macOS guests are served only on Apple Silicon hosts; on other
+        // platforms the service is simply absent (the CLI `macos` noun is
+        // likewise macOS-only).
+        #[cfg(target_os = "macos")]
+        let router = router.add_service(MacosServiceServer::new(macos_service));
+        let result = router
             .add_service(reflection_v1)
             .add_service(reflection_v1alpha)
             .serve_with_incoming_shutdown(incoming, shutdown.cancelled())

--- a/app/arcbox-daemon/src/services.rs
+++ b/app/arcbox-daemon/src/services.rs
@@ -128,23 +128,29 @@ pub async fn start_services(
         }
     });
 
-    // Docker API server.
-    let docker_server = DockerApiServer::new(
-        ServerConfig {
-            socket_path: ctx.layout.docker_socket.clone(),
-        },
-        Arc::clone(runtime),
-    );
+    // VM-host-only mode: the Docker API, Docker CLI integration, and the
+    // Kubernetes proxy all depend on the Linux VM, so they are skipped when it
+    // is not booted.
+    let linux_vm = runtime.config().vm.autostart;
 
-    let docker_shutdown = ctx.shutdown.clone();
-    let docker = tokio::spawn(async move {
-        if let Err(e) = docker_server.run(docker_shutdown).await {
-            tracing::error!("Docker API server error: {}", e);
-        }
+    // Docker API server.
+    let docker = linux_vm.then(|| {
+        let docker_server = DockerApiServer::new(
+            ServerConfig {
+                socket_path: ctx.layout.docker_socket.clone(),
+            },
+            Arc::clone(runtime),
+        );
+        let docker_shutdown = ctx.shutdown.clone();
+        tokio::spawn(async move {
+            if let Err(e) = docker_server.run(docker_shutdown).await {
+                tracing::error!("Docker API server error: {}", e);
+            }
+        })
     });
 
     // Docker CLI integration (optional).
-    if ctx.docker_integration {
+    if linux_vm && ctx.docker_integration {
         match DockerContextManager::new_with_context_name(
             ctx.layout.docker_socket.clone(),
             ctx.profile.docker_context_name(),
@@ -163,7 +169,11 @@ pub async fn start_services(
     }
 
     // Kubernetes API proxy (TCP 127.0.0.1:16443 → guest vsock).
-    let kubernetes_proxy = crate::kubernetes_proxy::start(Arc::clone(runtime)).await;
+    let kubernetes_proxy = if linux_vm {
+        crate::kubernetes_proxy::start(Arc::clone(runtime)).await
+    } else {
+        None
+    };
 
     // Mirror route-install events into SetupStatus. VM (re)starts install
     // the container route from vm_lifecycle, outside the cold-start

--- a/app/arcbox-daemon/src/shutdown.rs
+++ b/app/arcbox-daemon/src/shutdown.rs
@@ -217,7 +217,10 @@ pub async fn wait_for_signal() {
 
 async fn drain(handles: &mut ServiceHandles) {
     if tokio::time::timeout(DRAIN_TIMEOUT, async {
-        let _ = tokio::join!(&mut handles.dns, &mut handles.docker, &mut handles.grpc);
+        let _ = tokio::join!(&mut handles.dns, &mut handles.grpc);
+        if let Some(h) = handles.docker.as_mut() {
+            let _ = h.await;
+        }
         if let Some(h) = handles.kubernetes_proxy.as_mut() {
             let _ = h.await;
         }
@@ -230,8 +233,10 @@ async fn drain(handles: &mut ServiceHandles) {
             DRAIN_TIMEOUT.as_secs()
         );
         handles.dns.abort();
-        handles.docker.abort();
         handles.grpc.abort();
+        if let Some(h) = handles.docker.as_mut() {
+            h.abort();
+        }
         if let Some(h) = handles.kubernetes_proxy.as_mut() {
             h.abort();
         }

--- a/app/arcbox-daemon/src/startup/mod.rs
+++ b/app/arcbox-daemon/src/startup/mod.rs
@@ -77,6 +77,7 @@ async fn init_early(args: DaemonArgs, handles: StartupHandles) -> Result<EarlyCo
         vm_args: VmArgs {
             guest_docker_vsock_port: args.guest_docker_vsock_port,
             kernel: args.kernel,
+            no_linux_vm: args.no_linux_vm,
         },
     })
 }
@@ -214,6 +215,11 @@ async fn init_runtime(ctx: &DaemonContext) -> Result<Arc<Runtime>> {
     // propagates config.vm.* into the VM lifecycle config.
     if let Some(ref kernel) = ctx.vm_args.kernel {
         config.vm.kernel_path = Some(kernel.clone());
+    }
+
+    // --no-linux-vm wins over the config file, forcing VM-host-only mode.
+    if ctx.vm_args.no_linux_vm {
+        config.vm.autostart = false;
     }
 
     let runtime = Arc::new(Runtime::new(config).context("Failed to create runtime")?);

--- a/app/arcbox-daemon/src/startup/pipeline.rs
+++ b/app/arcbox-daemon/src/startup/pipeline.rs
@@ -183,7 +183,9 @@ impl RuntimeServicesStarted {
             if self.linux_vm {
                 println!("Use 'arcbox docker enable' to configure Docker CLI integration.");
             } else {
-                println!("Running as a VM host only (--no-linux-vm): Docker and Kubernetes are disabled.");
+                println!(
+                    "Running as a VM host only (--no-linux-vm): Docker and Kubernetes are disabled."
+                );
             }
             println!("Press Ctrl+C to stop.");
 

--- a/app/arcbox-daemon/src/startup/pipeline.rs
+++ b/app/arcbox-daemon/src/startup/pipeline.rs
@@ -141,6 +141,7 @@ pub struct RuntimeBooted {
 impl RuntimeBooted {
     /// Starts services that require an initialized runtime.
     pub async fn start_runtime_services(self) -> Result<RuntimeServicesStarted> {
+        let linux_vm = self.runtime.config().vm.autostart;
         let handles = record_startup_phase("start_runtime_services", async {
             let handles = services::start_services(&self.ctx, &self.runtime, self.grpc).await?;
             recovery::run(&self.ctx, &self.runtime).await;
@@ -150,6 +151,7 @@ impl RuntimeBooted {
         Ok(RuntimeServicesStarted {
             ctx: self.ctx,
             handles,
+            linux_vm,
         })
     }
 }
@@ -157,6 +159,8 @@ impl RuntimeBooted {
 pub struct RuntimeServicesStarted {
     ctx: DaemonContext,
     handles: ServiceHandles,
+    /// Whether the Linux VM (and its Docker/K8s services) is running.
+    linux_vm: bool,
 }
 
 impl RuntimeServicesStarted {
@@ -169,12 +173,18 @@ impl RuntimeServicesStarted {
                 .set_phase(SetupPhase::Ready, "Daemon ready");
 
             println!("ArcBox daemon started");
-            println!("  Docker API: {}", self.ctx.layout.docker_socket.display());
+            if self.linux_vm {
+                println!("  Docker API: {}", self.ctx.layout.docker_socket.display());
+            }
             println!("  gRPC API:   {}", self.ctx.layout.grpc_socket.display());
             println!("  DNS:        127.0.0.1:{}", self.ctx.dns_port);
             println!("  Data:       {}", self.ctx.layout.data_dir.display());
             println!();
-            println!("Use 'arcbox docker enable' to configure Docker CLI integration.");
+            if self.linux_vm {
+                println!("Use 'arcbox docker enable' to configure Docker CLI integration.");
+            } else {
+                println!("Running as a VM host only (--no-linux-vm): Docker and Kubernetes are disabled.");
+            }
             println!("Press Ctrl+C to stop.");
 
             Ok(())

--- a/docs/macos-guest.md
+++ b/docs/macos-guest.md
@@ -75,8 +75,11 @@ VmManager::start                 macos::MacVm
 2. **Per-VM create (fast, CoW).**
 
    ```text
-   arcbox macos create <n> --image <base>
-     → MacImageManager.clone_base: clonefile(disk.img) CoW + copy aux.img  (APFS, seconds)
+   arcbox macos create <n> --image <base> [--cpus N --memory MiB]
+     → reject if --cpus / --memory are below the image's published minimums
+     → assemble in a staging dir, then rename it into place atomically
+       (concurrent creates of the same name cannot corrupt each other)
+     → MacImage.clone_into: clonefile(disk.img) CoW + copy aux.img  (APFS, seconds)
      → MacMachineManager persists a machine record + the base hardware model
        and machine identifier (clones share the base identifier — the one its
        NVRAM was created with; same practice as Tart, proven fine in CI fleets)
@@ -212,6 +215,10 @@ hard ceiling, verified against Apple/Arm primary sources:
   TDX/SEV-SNP equivalent; the Secure Enclave's memory encryption protects only the SEP;
   and Private Cloud Compute is Apple-internal and relies on attestation + statelessness,
   not in-use memory encryption. Integrity attestation ≠ confidentiality-from-host.
+- **(C) Registry path safety — ENFORCED.** Image and machine names are validated to a
+  single path component (no separators, `..`, or absolute paths), so a caller- or
+  manifest-supplied name can never escape the managed `macos/images` / `macos/machines`
+  roots when a directory is created, renamed, or removed.
 
 So macOS CI on Apple Silicon can offer (A) but never (B). Builds that genuinely require
 confidentiality from the host must run in a TEE on x86 (TDX/SEV-SNP) or Arm (CCA)

--- a/docs/macos-guest.md
+++ b/docs/macos-guest.md
@@ -4,10 +4,11 @@
 > VM stack (install → clone → boot) is verified on real Apple Silicon via the
 > `arcbox-vz` examples — see "Verification status" below.
 
-ArcBox can run **disposable macOS guests** on Apple Silicon: install macOS once from an
-IPSW into a reusable base image, then copy-on-write clone that image to boot clean,
-throwaway macOS VMs in seconds — the same "clone, use, discard" model ArcBox provides
-for Linux, extended to macOS.
+ArcBox can run **disposable macOS guests** on Apple Silicon: pull a pre-baked base
+image once from ArcBox's distribution bucket, then copy-on-write clone that image to
+boot clean, throwaway macOS VMs in seconds — the same "clone, use, discard" model
+ArcBox provides for Linux, extended to macOS. Images are baked and published by the
+`macos-runner-image-builder` repo (which also owns the artifact format spec).
 
 macOS guests run through `arcbox-vz` (Virtualization.framework) **only** — Apple permits
 booting macOS solely through Virtualization.framework, never through the custom HV VMM —
@@ -52,16 +53,24 @@ VmManager::start                 macos::MacVm
 
 ### macOS sub-paths
 
-1. **One-time install (slow, per base image).** Unlike Linux (direct kernel boot, no
-   install), macOS must be restored from an IPSW first:
+1. **One-time image pull (per base image).** The published artifact is a JSON
+   manifest + zstd-compressed disk/aux on ArcBox's `darwin` bucket (see the
+   `macos-runner-image-builder` repo for the format spec):
 
    ```text
-   arcbox macos image pull --ipsw <path|latest>
-     → arcbox-vz restore.rs: MacOSRestoreImage → most-featureful requirements
-     → temp VM + MacOSInstaller.install (~10-20 min, NSProgress percentage)
-     → base template: data_dir/macos/images/<name>/
+   arcbox macos image pull tahoe-base[@version]   (or --manifest <url|path>)
+     → resolve via index.json → fetch manifest
+     → validate hardware model support BEFORE the multi-GB download
+     → stream disk.img.zst: socket → zstd decode → zero-skipping sparse writes
+       (compressed bytes never touch disk; SHA-256 verified in flight)
+     → staging dir renamed live only after every check passes:
+       data_dir/macos/images/<name>/
           { disk.img, aux.img, hwmodel.bin, machine-id.bin, meta.json }
    ```
+
+   The legacy IPSW installer (`install_from_ipsw`, ~15 min `VZMacOSInstaller`
+   restore) is retained but unshipped behind the `macos-ipsw-install` feature of
+   `arcbox-core`; it is not reachable from the proto/CLI surface.
 
 2. **Per-VM create (fast, CoW).**
 
@@ -69,7 +78,8 @@ VmManager::start                 macos::MacVm
    arcbox macos create <n> --image <base>
      → MacImageManager.clone_base: clonefile(disk.img) CoW + copy aux.img  (APFS, seconds)
      → MacMachineManager persists a machine record + the base hardware model
-       (a fresh machine identifier is minted at boot, so concurrent clones differ)
+       and machine identifier (clones share the base identifier — the one its
+       NVRAM was created with; same practice as Tart, proven fine in CI fleets)
    ```
 
 3. **Per-VM start (hot path).**
@@ -114,7 +124,9 @@ Teardown for the disposable loop: `request_stop` (graceful) -> delete the per-VM
 | restore image + installer | `virt/arcbox-vz/src/restore.rs` |
 | VM lifecycle (stop/save/restore) | `virt/arcbox-vz/src/vm.rs` |
 | base-image registry + CoW clone | `app/arcbox-core/src/macos/image.rs` (`MacImageManager`) |
-| base-image install | `app/arcbox-core/src/macos/install.rs` (`install_from_ipsw`) |
+| published index/manifest schema | `app/arcbox-core/src/macos/remote.rs` |
+| base-image pull (streaming, sparse) | `app/arcbox-core/src/macos/pull.rs` (`pull_remote`) |
+| IPSW install (feature `macos-ipsw-install`, unshipped) | `app/arcbox-core/src/macos/install.rs` (`install_from_ipsw`) |
 | macOS machine lifecycle | `app/arcbox-core/src/macos/{vm.rs,machine.rs}` (`MacVm`, `MacMachineManager`) |
 | daemon wiring | `app/arcbox-core/src/runtime.rs` (`mac_machine_manager()`) |
 | daemon gRPC (macOS-only) | `app/arcbox-api/src/grpc/macos.rs` (`MacosServiceImpl`) |
@@ -131,19 +143,21 @@ current-thread runtime inside `spawn_blocking` (`grpc::run_macos_blocking`).
 ## Usage
 
 ```sh
-# 1. Install a base image once from a local IPSW (long-running, ~10–20 min):
-arcbox macos image pull sequoia --ipsw /path/to/UniversalMac_xx.ipsw
+# 1. Pull a published base image (multi-GB download; progress streams to the CLI):
+arcbox macos image pull tahoe-base            # latest per the published index
+arcbox macos image pull tahoe-base@2026.07.02 # pinned version
+arcbox macos image pull --manifest <url|path> # dev: bypass the index
 arcbox macos image ls
 
 # 2. Create a disposable guest by copy-on-write cloning the base (instant):
-arcbox macos create ci-1 --image sequoia --cpus 4 --memory 8192
+arcbox macos create ci-1 --image tahoe-base --cpus 4 --memory 8192
 
 # 3. Start / list / stop / remove:
 arcbox macos start ci-1
 arcbox macos ls
 arcbox macos stop ci-1
 arcbox macos rm ci-1
-arcbox macos image rm sequoia
+arcbox macos image rm tahoe-base
 ```
 
 ## Verification status

--- a/docs/macos-guest.md
+++ b/docs/macos-guest.md
@@ -90,14 +90,22 @@ VmManager::start                 macos::MacVm
           boot_loader = MacOSBootLoader
           platform    = MacPlatform{ hardware_model, machine_id, aux_storage }
           storage     = cloned disk.img        (StorageDeviceConfiguration)
-          network     = NAT (vmnet shared)     (DHCP + outbound internet, no host setup)
+          network     = NAT (vmnet shared)     (DHCP + outbound internet, no host setup;
+                                                MAC pinned from the machine record)
           graphics    = MacGraphicsDeviceConfiguration
      → vm.start().await  (serial dispatch queue + ObjC completion block -> Rust oneshot)
      → ready = VZ state == Running (+ optional SSH probe); no in-guest ArcBox agent
 
-   Not yet wired: a VirtioFS config share for per-VM provisioning (the channel a
-   CI-runner token would arrive through) and serial/entropy/balloon devices.
+   Not yet wired: serial/entropy/balloon devices.
    ```
+
+4. **Guest address discovery.** Each machine's MAC is generated at create,
+   persisted in its record, and pinned to the NAT interface at boot. vmnet's
+   DHCP server (`bootpd`) writes leases to `/var/db/dhcpd_leases`; the daemon
+   resolves the machine's lease by that MAC (`app/arcbox-core/src/macos/lease.rs`)
+   and reports the address via `Inspect`. `arcbox macos ip <n> [--wait <secs>]`
+   prints it — the handle callers (e.g. a CI driver) use to `ssh` into the
+   guest and run work directly, with no in-guest agent or provisioning channel.
 
 Teardown for the disposable loop: `request_stop` (graceful) -> delete the per-VM clone.
 `save_state`/`restore_state` (macOS 14+) enable Anka-style instant start later.
@@ -128,6 +136,7 @@ Teardown for the disposable loop: `request_stop` (graceful) -> delete the per-VM
 | base-image pull (streaming, sparse) | `app/arcbox-core/src/macos/pull.rs` (`pull_remote`) |
 | IPSW install (feature `macos-ipsw-install`, unshipped) | `app/arcbox-core/src/macos/install.rs` (`install_from_ipsw`) |
 | macOS machine lifecycle | `app/arcbox-core/src/macos/{vm.rs,machine.rs}` (`MacVm`, `MacMachineManager`) |
+| guest IP from DHCP lease | `app/arcbox-core/src/macos/lease.rs` |
 | daemon wiring | `app/arcbox-core/src/runtime.rs` (`mac_machine_manager()`) |
 | daemon gRPC (macOS-only) | `app/arcbox-api/src/grpc/macos.rs` (`MacosServiceImpl`) |
 | CLI | `app/arcbox-cli/src/commands/macos.rs` (`arcbox macos`) |

--- a/docs/macos-guest.md
+++ b/docs/macos-guest.md
@@ -25,30 +25,29 @@ and they are a **Machine-tier** capability (no Container or Sandbox tier).
 
 ## Startup Path Shape
 
-The CLI → gRPC → daemon "upper half" is shared with Linux machines. At the machine
-service it forks on `MachineKind`; the macOS lower half is an independent chain through
+macOS guests are a separate noun end to end: the `arcbox macos` CLI talks to a dedicated
+`MacosService`, distinct from the Linux `arcbox machine` / `MachineService`. The two share
+no request types and no routing — only the daemon process, the gRPC socket, and the reused
+`arcbox-vz` device configuration. The macOS lower half is an independent chain through
 `arcbox-vz` into Apple's framework, and never touches `arcbox-vmm` / HV / the vsock
 guest agent.
 
 ```text
-arcbox machine ...                         (CLI, shared)
-        │  gRPC
-        ▼
-app/arcbox-api/src/grpc/machine.rs         (machine service, shared)
-        ▼
-Runtime.machine_manager()                  (built in daemon init_runtime, shared)
-        ▼
-   ┌────────── route by guest_os / owning manager ───────────┐
-   │ Linux: machine_manager()               │ macOS: mac_machine_manager() │
-   ▼                                        ▼
-VmManager::start                          macos::MacVm
-  → Vmm::new (arcbox-vmm, VmBackend::Hv)     → arcbox-vz: VirtualMachineConfiguration
-  → custom HV VMM (darwin_hv/vcpu_loop)         .set_boot_loader(MacOSBootLoader)
-  → custom virtio + Linux kernel                .set_platform(MacPlatform{hw,id,aux})
-  → ready = vsock guest-agent ping              .add_storage/network/serial/... (reused)
-                                                .build() → VirtualMachine
-                                              → vm.start() → Virtualization.framework
-                                              → ready = VZ state==Running (+ opt. SSH)
+arcbox machine ...               arcbox macos ...            (CLI, separate nouns)
+        │  gRPC                          │  gRPC
+        ▼                               ▼
+MachineService (machine.rs)      MacosService (macos.rs, macOS-only)
+        ▼                               ▼
+Runtime.machine_manager()        Runtime.mac_machine_manager()
+        ▼                               ▼
+VmManager::start                 macos::MacVm
+  → Vmm::new (arcbox-vmm, Hv)       → arcbox-vz: VirtualMachineConfiguration
+  → custom HV VMM (vcpu_loop)          .set_boot_loader(MacOSBootLoader)
+  → custom virtio + Linux kernel       .set_platform(MacPlatform{hw,id,aux})
+  → ready = vsock guest-agent ping     .add_storage/network/serial/... (reused)
+                                       .build() → VirtualMachine
+                                     → vm.start() → Virtualization.framework
+                                     → ready = VZ state==Running (+ opt. SSH)
 ```
 
 ### macOS sub-paths
@@ -67,7 +66,7 @@ VmManager::start                          macos::MacVm
 2. **Per-VM create (fast, CoW).**
 
    ```text
-   arcbox machine create <n> --os macos --image <base>
+   arcbox macos create <n> --image <base>
      → MacImageManager.clone_base: clonefile(disk.img) CoW + copy aux.img  (APFS, seconds)
      → MacMachineManager persists a machine record + the base hardware model
        (a fresh machine identifier is minted at boot, so concurrent clones differ)
@@ -76,7 +75,7 @@ VmManager::start                          macos::MacVm
 3. **Per-VM start (hot path).**
 
    ```text
-   arcbox machine start <n>
+   arcbox macos start <n>
      → MacVm.build → arcbox-vz VirtualMachineConfiguration
           boot_loader = MacOSBootLoader
           platform    = MacPlatform{ hardware_model, machine_id, aux_storage }
@@ -115,14 +114,16 @@ Teardown for the disposable loop: `request_stop` (graceful) -> delete the per-VM
 | base-image install | `app/arcbox-core/src/macos/install.rs` (`install_from_ipsw`) |
 | macOS machine lifecycle | `app/arcbox-core/src/macos/{vm.rs,machine.rs}` (`MacVm`, `MacMachineManager`) |
 | daemon wiring | `app/arcbox-core/src/runtime.rs` (`mac_machine_manager()`) |
-| daemon gRPC + CLI | `app/arcbox-api/src/grpc/machine.rs`, `app/arcbox-cli/src/commands/{machine,macos}.rs` |
+| daemon gRPC (macOS-only) | `app/arcbox-api/src/grpc/macos.rs` (`MacosServiceImpl`) |
+| CLI | `app/arcbox-cli/src/commands/macos.rs` (`arcbox macos`) |
 
-The machine gRPC service routes by `guest_os` (on create) or by which manager owns the
-name (start/stop/remove) to `mac_machine_manager()`; there is no shared `MachineKind`
-enum — the Linux `MachineManager` and `MacMachineManager` are separate, unified only at
-the CLI/gRPC surface. macOS VM operations are `!Send` (ObjC handles + the VM dispatch
-queue across await) while tonic requires `Send` handler futures, so the daemon drives
-them on a transient current-thread runtime inside `spawn_blocking`.
+`MacosService` is a wholly separate gRPC service from the Linux `MachineService`: its own
+request types (macOS-shaped, in MiB/GiB, no Linux fields), its own `arcbox macos` CLI noun,
+and it delegates straight to `mac_machine_manager()` — no `guest_os` discriminator and no
+ownership-probe routing. The service is registered and the CLI noun exists only on Apple
+Silicon hosts. macOS VM operations are `!Send` (ObjC handles + the VM dispatch queue across
+await) while tonic requires `Send` handler futures, so the daemon drives them on a transient
+current-thread runtime inside `spawn_blocking` (`grpc::run_macos_blocking`).
 
 ## Usage
 
@@ -131,14 +132,14 @@ them on a transient current-thread runtime inside `spawn_blocking`.
 arcbox macos image pull sequoia --ipsw /path/to/UniversalMac_xx.ipsw
 arcbox macos image ls
 
-# 2. Create a disposable machine by copy-on-write cloning the base (instant):
-arcbox machine create ci-1 --os macos --image sequoia --cpus 4 --memory 8192
+# 2. Create a disposable guest by copy-on-write cloning the base (instant):
+arcbox macos create ci-1 --image sequoia --cpus 4 --memory 8192
 
 # 3. Start / list / stop / remove:
-arcbox machine start ci-1
-arcbox machine ls            # an OS column shows linux | macos
-arcbox machine stop ci-1
-arcbox machine rm ci-1
+arcbox macos start ci-1
+arcbox macos ls
+arcbox macos stop ci-1
+arcbox macos rm ci-1
 arcbox macos image rm sequoia
 ```
 
@@ -165,7 +166,7 @@ arcbox macos image rm sequoia
   binary does not link under the devenv/nix toolchain (its SDK lacks the macOS 15+
   `hv_gic_*` Hypervisor.framework symbols `arcbox-hv`'s GIC backend needs — a
   pre-existing limitation unrelated to this feature). A real `arcbox macos image pull`
-  → `arcbox machine create --os macos` → `arcbox machine start` run uses the project's
+  → `arcbox macos create` → `arcbox macos start` run uses the project's
   normal (system-SDK) build path, with the daemon Developer-ID-signed.
 
 ## Security model (zero-trust): what's achievable

--- a/docs/macos-guest.md
+++ b/docs/macos-guest.md
@@ -1,0 +1,118 @@
+# macOS Guest VMs
+
+> Status: in progress (see `PLAN.md`, branch `feat/macos-guest-vz`). This document is
+> the implementation navigation map; the end-user walkthrough is filled in by the
+> final slice.
+
+ArcBox can run **disposable macOS guests** on Apple Silicon: install macOS once from an
+IPSW into a reusable base image, then copy-on-write clone that image to boot clean,
+throwaway macOS VMs in seconds — the same "clone, use, discard" model ArcBox provides
+for Linux, extended to macOS.
+
+macOS guests run through `arcbox-vz` (Virtualization.framework) **only** — Apple permits
+booting macOS solely through Virtualization.framework, never through the custom HV VMM —
+and they are a **Machine-tier** capability (no Container or Sandbox tier).
+
+## Requirements
+
+- Apple Silicon (M1+). Intel/T2 is unsupported.
+- Host macOS 13+ (save/restore "instant start" needs 14+).
+- The guest macOS version is constrained by the host macOS version.
+- Data directory on an **APFS** volume (copy-on-write clone needs `clonefile`).
+- Developer ID signing for the daemon (`com.apple.security.virtualization`; see
+  `CLAUDE.md` → macOS Development). No additional entitlement is needed for install.
+- **At most 2 macOS guests per host** (Apple license cap) — enforced with a clear error.
+
+## Startup Path Shape
+
+The CLI → gRPC → daemon "upper half" is shared with Linux machines. At the machine
+service it forks on `MachineKind`; the macOS lower half is an independent chain through
+`arcbox-vz` into Apple's framework, and never touches `arcbox-vmm` / HV / the vsock
+guest agent.
+
+```text
+arcbox machine ...                         (CLI, shared)
+        │  gRPC
+        ▼
+app/arcbox-api/src/grpc/machine.rs         (machine service, shared)
+        ▼
+Runtime.machine_manager()                  (built in daemon init_runtime, shared)
+        ▼
+   ┌──────────────── fork: match MachineKind ────────────────┐
+   │ Linux (existing, untouched)            │ macOS (this work)         │
+   ▼                                        ▼
+VmManager::start                          macos::MacVm
+  → Vmm::new (arcbox-vmm, VmBackend::Hv)     → arcbox-vz: VirtualMachineConfiguration
+  → custom HV VMM (darwin_hv/vcpu_loop)         .set_boot_loader(MacOSBootLoader)
+  → custom virtio + Linux kernel                .set_platform(MacPlatform{hw,id,aux})
+  → ready = vsock guest-agent ping              .add_storage/network/serial/... (reused)
+                                                .build() → VirtualMachine
+                                              → vm.start() → Virtualization.framework
+                                              → ready = VZ state==Running (+ opt. SSH)
+```
+
+### macOS sub-paths
+
+1. **One-time install (slow, per base image).** Unlike Linux (direct kernel boot, no
+   install), macOS must be restored from an IPSW first:
+
+   ```text
+   arcbox macos image pull --ipsw <path|latest>
+     → arcbox-vz restore.rs: MacOSRestoreImage → most-featureful requirements
+     → temp VM + MacOSInstaller.install (~10-20 min, NSProgress percentage)
+     → base template: data_dir/macos/images/<name>/
+          { disk.img, aux.img, hwmodel.bin, machine-id.bin, meta.json }
+   ```
+
+2. **Per-VM create (fast, CoW).**
+
+   ```text
+   arcbox machine create <n> --os macos --image <base>
+     → MacImageManager.clone_base: libc::clonefile(disk.img)  (APFS CoW, seconds)
+     → fresh per-VM aux storage + machine-id (reuse base hwmodel)
+     → persist a kind=MacOs machine (Created)
+   ```
+
+3. **Per-VM start (hot path).**
+
+   ```text
+   arcbox machine start <n>
+     → MacVm.build → arcbox-vz VirtualMachineConfiguration
+          boot_loader = MacOSBootLoader
+          platform    = MacPlatform{ hardware_model, machine_id, aux_storage }
+          storage     = cloned disk.img        (reused StorageDeviceConfiguration)
+          + network / serial / entropy / balloon (reused)
+          + VirtioFS directory share for per-VM config injection (reused)
+     → vm.start().await  (serial dispatch queue + ObjC completion block -> Rust oneshot)
+     → ready = VZ state == Running (+ optional SSH probe); no in-guest ArcBox agent
+   ```
+
+Teardown for the disposable loop: `request_stop` (graceful) -> delete the per-VM clone.
+`save_state`/`restore_state` (macOS 14+) enable Anka-style instant start later.
+
+### How it differs from the Linux path
+
+- **Driver model.** Linux runs ArcBox's own vcpu loop; macOS hands the
+  `VZVirtualMachine` to Apple's framework and drives it via a serial dispatch queue +
+  completion blocks (`virt/arcbox-vz/src/vm.rs`).
+- **Readiness.** Linux waits on the vsock guest agent; macOS has no in-guest agent —
+  readiness is the VZ `Running` state, plus an optional SSH probe for interaction.
+- **Provisioning.** Linux boots a kernel directly; macOS adds the one-time IPSW install
+  step, after which per-VM provisioning is the fast CoW clone.
+- **Recovery.** On daemon restart, persisted macOS machines are reloaded and a stale
+  `Running` is corrected to `Stopped`, the same hook as Linux.
+
+## Module Map
+
+| Concern | Location |
+| --- | --- |
+| macOS boot loader | `virt/arcbox-vz/src/configuration/boot_loader.rs` (`MacOSBootLoader`) |
+| macOS platform | `virt/arcbox-vz/src/configuration/platform.rs` (`MacPlatform`) |
+| hardware model / machine id / aux storage | `virt/arcbox-vz/src/configuration/mac.rs` |
+| restore image + installer | `virt/arcbox-vz/src/restore.rs` |
+| VM lifecycle (stop/save/restore) | `virt/arcbox-vz/src/vm.rs` |
+| base-image install + CoW clone | `app/arcbox-core/src/macos/image.rs` |
+| macOS machine lifecycle | `app/arcbox-core/src/macos/vm.rs` + `MachineKind` |
+| daemon/CLI surface | `app/arcbox-api/src/grpc/machine.rs`, `app/arcbox-cli` |
+
+See `PLAN.md` for the full slice-by-slice plan, decision gates, and non-goals.

--- a/docs/macos-guest.md
+++ b/docs/macos-guest.md
@@ -147,6 +147,7 @@ current-thread runtime inside `spawn_blocking` (`grpc::run_macos_blocking`).
 arcbox macos image pull tahoe-base            # latest per the published index
 arcbox macos image pull tahoe-base@2026.07.02 # pinned version
 arcbox macos image pull --manifest <url|path> # dev: bypass the index
+arcbox macos image resolve tahoe-base        # what a pull would land, without downloading
 arcbox macos image ls
 
 # 2. Create a disposable guest by copy-on-write cloning the base (instant):

--- a/docs/macos-guest.md
+++ b/docs/macos-guest.md
@@ -1,8 +1,8 @@
 # macOS Guest VMs
 
-> Status: in progress (see `PLAN.md`, branch `feat/macos-guest-vz`). This document is
-> the implementation navigation map; the end-user walkthrough is filled in by the
-> final slice.
+> Status: implemented on branch `feat/macos-guest-vz` (PLAN.md slices 1–6). The macOS
+> VM stack (install → clone → boot) is verified on real Apple Silicon via the
+> `arcbox-vz` examples — see "Verification status" below.
 
 ArcBox can run **disposable macOS guests** on Apple Silicon: install macOS once from an
 IPSW into a reusable base image, then copy-on-write clone that image to boot clean,
@@ -38,8 +38,8 @@ app/arcbox-api/src/grpc/machine.rs         (machine service, shared)
         ▼
 Runtime.machine_manager()                  (built in daemon init_runtime, shared)
         ▼
-   ┌──────────────── fork: match MachineKind ────────────────┐
-   │ Linux (existing, untouched)            │ macOS (this work)         │
+   ┌────────── route by guest_os / owning manager ───────────┐
+   │ Linux: machine_manager()               │ macOS: mac_machine_manager() │
    ▼                                        ▼
 VmManager::start                          macos::MacVm
   → Vmm::new (arcbox-vmm, VmBackend::Hv)     → arcbox-vz: VirtualMachineConfiguration
@@ -68,9 +68,9 @@ VmManager::start                          macos::MacVm
 
    ```text
    arcbox machine create <n> --os macos --image <base>
-     → MacImageManager.clone_base: libc::clonefile(disk.img)  (APFS CoW, seconds)
-     → fresh per-VM aux storage + machine-id (reuse base hwmodel)
-     → persist a kind=MacOs machine (Created)
+     → MacImageManager.clone_base: clonefile(disk.img) CoW + copy aux.img  (APFS, seconds)
+     → MacMachineManager persists a machine record + the base hardware model
+       (a fresh machine identifier is minted at boot, so concurrent clones differ)
    ```
 
 3. **Per-VM start (hot path).**
@@ -111,8 +111,84 @@ Teardown for the disposable loop: `request_stop` (graceful) -> delete the per-VM
 | hardware model / machine id / aux storage | `virt/arcbox-vz/src/configuration/mac.rs` |
 | restore image + installer | `virt/arcbox-vz/src/restore.rs` |
 | VM lifecycle (stop/save/restore) | `virt/arcbox-vz/src/vm.rs` |
-| base-image install + CoW clone | `app/arcbox-core/src/macos/image.rs` |
-| macOS machine lifecycle | `app/arcbox-core/src/macos/vm.rs` + `MachineKind` |
-| daemon/CLI surface | `app/arcbox-api/src/grpc/machine.rs`, `app/arcbox-cli` |
+| base-image registry + CoW clone | `app/arcbox-core/src/macos/image.rs` (`MacImageManager`) |
+| base-image install | `app/arcbox-core/src/macos/install.rs` (`install_from_ipsw`) |
+| macOS machine lifecycle | `app/arcbox-core/src/macos/{vm.rs,machine.rs}` (`MacVm`, `MacMachineManager`) |
+| daemon wiring | `app/arcbox-core/src/runtime.rs` (`mac_machine_manager()`) |
+| daemon gRPC + CLI | `app/arcbox-api/src/grpc/machine.rs`, `app/arcbox-cli/src/commands/{machine,macos}.rs` |
+
+The machine gRPC service routes by `guest_os` (on create) or by which manager owns the
+name (start/stop/remove) to `mac_machine_manager()`; there is no shared `MachineKind`
+enum — the Linux `MachineManager` and `MacMachineManager` are separate, unified only at
+the CLI/gRPC surface. macOS VM operations are `!Send` (ObjC handles + the VM dispatch
+queue across await) while tonic requires `Send` handler futures, so the daemon drives
+them on a transient current-thread runtime inside `spawn_blocking`.
+
+## Usage
+
+```sh
+# 1. Install a base image once from a local IPSW (long-running, ~10–20 min):
+arcbox macos image pull sequoia --ipsw /path/to/UniversalMac_xx.ipsw
+arcbox macos image ls
+
+# 2. Create a disposable machine by copy-on-write cloning the base (instant):
+arcbox machine create ci-1 --os macos --image sequoia --cpus 4 --memory 8192
+
+# 3. Start / list / stop / remove:
+arcbox machine start ci-1
+arcbox machine ls            # an OS column shows linux | macos
+arcbox machine stop ci-1
+arcbox machine rm ci-1
+arcbox macos image rm sequoia
+```
+
+## Verification status
+
+- The macOS VM stack — restore-image load, install from IPSW, copy-on-write clone, and
+  boot — is verified end to end on real Apple Silicon via the `arcbox-vz` examples:
+  `macos_validate` (Gate A: config validates), `macos_install` (Gate B: install →
+  Running), and `macos_clone_boot` (CoW clone of a 64 GiB disk in ~90 µs → boot). Build
+  and Developer-ID-sign an example, then run the binary directly (not `cargo run`, which
+  re-strips the signature):
+
+  ```sh
+  direnv exec . cargo build -p arcbox-vz --example macos_install
+  codesign --force --entitlements bundle/arcbox.entitlements \
+    -s "Developer ID Application: …" target/debug/examples/macos_install
+  ./target/debug/examples/macos_install /path/to/UniversalMac_xx.ipsw
+  ```
+
+  Do **not** pass `--options runtime`: devenv/nix-built binaries link a nix-store
+  `libiconv` whose Team ID trips hardened-runtime library validation (exit 134).
+
+- The CLI → daemon → manager surface is implemented and clippy-clean, but the daemon
+  binary does not link under the devenv/nix toolchain (its SDK lacks the macOS 15+
+  `hv_gic_*` Hypervisor.framework symbols `arcbox-hv`'s GIC backend needs — a
+  pre-existing limitation unrelated to this feature). A real `arcbox macos image pull`
+  → `arcbox machine create --os macos` → `arcbox machine start` run uses the project's
+  normal (system-SDK) build path, with the daemon Developer-ID-signed.
+
+## Security model (zero-trust): what's achievable
+
+macOS guests are well suited to untrusted CI (e.g. GitHub Actions runners): the microVM
+gives VM-level isolation and the disposable clone is destroyed after each job. There is a
+hard ceiling, verified against Apple/Arm primary sources:
+
+- **(A) Don't trust the job / Runner — ACHIEVABLE.** A one-shot clone + a short-lived
+  scoped identity + destroy-after-use caps a compromised job's blast radius to one
+  throwaway VM. This is the target, and the clone → boot → teardown loop here delivers it.
+- **(B) Don't trust the host / platform (in-use confidentiality from the host) — NOT
+  ACHIEVABLE on Apple Silicon.** The host VMM owns guest RAM by design (`hv_vm_map`);
+  Virtualization.framework exposes no confidential-VM / encrypted-memory /
+  guest-attestation API; no Apple chip implements Arm CCA/RME, and there is no
+  TDX/SEV-SNP equivalent; the Secure Enclave's memory encryption protects only the SEP;
+  and Private Cloud Compute is Apple-internal and relies on attestation + statelessness,
+  not in-use memory encryption. Integrity attestation ≠ confidentiality-from-host.
+
+So macOS CI on Apple Silicon can offer (A) but never (B). Builds that genuinely require
+confidentiality from the host must run in a TEE on x86 (TDX/SEV-SNP) or Arm (CCA)
+hardware — not on a Mac — so **do not advertise "complete zero trust" for macOS CI**.
+The complementary building blocks to add at the runner layer are OIDC short-lived
+identity (replacing long-lived secrets) and Secure Enclave-held signing keys.
 
 See `PLAN.md` for the full slice-by-slice plan, decision gates, and non-goals.

--- a/docs/macos-guest.md
+++ b/docs/macos-guest.md
@@ -79,11 +79,14 @@ VmManager::start                 macos::MacVm
      → MacVm.build → arcbox-vz VirtualMachineConfiguration
           boot_loader = MacOSBootLoader
           platform    = MacPlatform{ hardware_model, machine_id, aux_storage }
-          storage     = cloned disk.img        (reused StorageDeviceConfiguration)
-          + network / serial / entropy / balloon (reused)
-          + VirtioFS directory share for per-VM config injection (reused)
+          storage     = cloned disk.img        (StorageDeviceConfiguration)
+          network     = NAT (vmnet shared)     (DHCP + outbound internet, no host setup)
+          graphics    = MacGraphicsDeviceConfiguration
      → vm.start().await  (serial dispatch queue + ObjC completion block -> Rust oneshot)
      → ready = VZ state == Running (+ optional SSH probe); no in-guest ArcBox agent
+
+   Not yet wired: a VirtioFS config share for per-VM provisioning (the channel a
+   CI-runner token would arrive through) and serial/entropy/balloon devices.
    ```
 
 Teardown for the disposable loop: `request_stop` (graceful) -> delete the per-VM clone.

--- a/rpc/arcbox-grpc/build.rs
+++ b/rpc/arcbox-grpc/build.rs
@@ -12,6 +12,7 @@ fn main() {
 
     let protos = [
         "../arcbox-protocol/proto/machine.proto",
+        "../arcbox-protocol/proto/macos.proto",
         "../arcbox-protocol/proto/container.proto",
         "../arcbox-protocol/proto/image.proto",
         "../arcbox-protocol/proto/agent.proto",

--- a/rpc/arcbox-grpc/src/lib.rs
+++ b/rpc/arcbox-grpc/src/lib.rs
@@ -5,7 +5,8 @@
 //!
 //! # Services
 //!
-//! - `MachineService` - Virtual machine management
+//! - `MachineService` - Linux virtual machine management
+//! - `MacosService` - macOS guest VM + base image management (Apple Silicon)
 //! - `AgentService` - Guest agent communication
 //! - `MigrationService` - Host-side runtime migration planning and execution
 //! - `VolumeService` - Volume management (from api.proto)
@@ -70,6 +71,7 @@ pub use sandbox_v1::sandbox_snapshot_service_client::SandboxSnapshotServiceClien
 pub use v1::agent_service_client::AgentServiceClient;
 pub use v1::icon_service_client::IconServiceClient;
 pub use v1::machine_service_client::MachineServiceClient;
+pub use v1::macos_service_client::MacosServiceClient;
 pub use v1::migration_service_client::MigrationServiceClient;
 pub use v1::system_service_client::SystemServiceClient;
 pub use v1::volume_service_client::VolumeServiceClient;
@@ -81,6 +83,7 @@ pub use sandbox_v1::sandbox_snapshot_service_server::{
 pub use v1::agent_service_server::{AgentService, AgentServiceServer};
 pub use v1::icon_service_server::{IconService, IconServiceServer};
 pub use v1::machine_service_server::{MachineService, MachineServiceServer};
+pub use v1::macos_service_server::{MacosService, MacosServiceServer};
 pub use v1::migration_service_server::{MigrationService, MigrationServiceServer};
 pub use v1::system_service_server::{SystemService, SystemServiceServer};
 pub use v1::volume_service_server::{VolumeService, VolumeServiceServer};

--- a/rpc/arcbox-protocol/build.rs
+++ b/rpc/arcbox-protocol/build.rs
@@ -22,6 +22,7 @@ fn main() {
     let protos = [
         "proto/common.proto",
         "proto/machine.proto",
+        "proto/macos.proto",
         "proto/container.proto",
         "proto/image.proto",
         "proto/agent.proto",

--- a/rpc/arcbox-protocol/proto/machine.proto
+++ b/rpc/arcbox-protocol/proto/machine.proto
@@ -13,7 +13,8 @@ package arcbox.v1;
 
 import "common.proto";
 
-// MachineService manages virtual machines.
+// MachineService manages Linux virtual machines. macOS guests are disposable,
+// single-purpose VMs with a separate lifecycle and live in MacosService.
 service MachineService {
     // Creates a new virtual machine.
     rpc Create(CreateMachineRequest) returns (CreateMachineResponse);
@@ -48,15 +49,6 @@ service MachineService {
 
     // Gets the SSH connection info.
     rpc SSHInfo(SSHInfoRequest) returns (SSHInfoResponse);
-
-    // Installs a macOS base image from a local IPSW (long-running). Apple Silicon only.
-    rpc MacImagePull(MacImagePullRequest) returns (Empty);
-
-    // Lists macOS base images.
-    rpc MacImageList(Empty) returns (MacImageListResponse);
-
-    // Removes a macOS base image.
-    rpc MacImageRemove(MacImageRemoveRequest) returns (Empty);
 }
 
 // Request to create a machine.
@@ -85,10 +77,6 @@ message CreateMachineRequest {
     reserved 11;
     // Kernel command line.
     string cmdline = 12;
-    // Guest OS: "linux" (default) or "macos".
-    string guest_os = 13;
-    // macOS base image name to clone (when guest_os is "macos").
-    string macos_image = 14;
 }
 
 // Request that targets a machine's guest agent.
@@ -201,8 +189,6 @@ message MachineSummary {
     string ip_address = 7;
     // Creation timestamp.
     int64 created = 8;
-    // Guest OS: "linux" or "macos".
-    string guest_os = 9;
 }
 
 // Request to inspect a machine.
@@ -325,46 +311,4 @@ message SSHInfoResponse {
     string identity_file = 4;
     // SSH command string.
     string command = 5;
-}
-
-// Request to install a macOS base image from a local IPSW.
-message MacImagePullRequest {
-    // Base image name.
-    string name = 1;
-    // Path to a local IPSW restore image.
-    string ipsw_path = 2;
-    // Number of CPUs for the install VM.
-    uint32 cpus = 3;
-    // Memory in bytes for the install VM.
-    uint64 memory = 4;
-    // System disk size in bytes.
-    uint64 disk_size = 5;
-}
-
-// Summary of a macOS base image.
-message MacImageSummary {
-    // Image name.
-    string name = 1;
-    // Minimum CPU count required by the restore image.
-    uint64 minimum_cpu_count = 2;
-    // Minimum memory in MiB required by the restore image.
-    uint64 minimum_memory_mib = 3;
-    // System disk size in GiB.
-    uint64 disk_gb = 4;
-    // Creation timestamp.
-    int64 created = 5;
-    // Source (IPSW path), if known.
-    string source = 6;
-}
-
-// Response listing macOS base images.
-message MacImageListResponse {
-    // Base images.
-    repeated MacImageSummary images = 1;
-}
-
-// Request to remove a macOS base image.
-message MacImageRemoveRequest {
-    // Image name.
-    string name = 1;
 }

--- a/rpc/arcbox-protocol/proto/machine.proto
+++ b/rpc/arcbox-protocol/proto/machine.proto
@@ -48,6 +48,15 @@ service MachineService {
 
     // Gets the SSH connection info.
     rpc SSHInfo(SSHInfoRequest) returns (SSHInfoResponse);
+
+    // Installs a macOS base image from a local IPSW (long-running). Apple Silicon only.
+    rpc MacImagePull(MacImagePullRequest) returns (Empty);
+
+    // Lists macOS base images.
+    rpc MacImageList(Empty) returns (MacImageListResponse);
+
+    // Removes a macOS base image.
+    rpc MacImageRemove(MacImageRemoveRequest) returns (Empty);
 }
 
 // Request to create a machine.
@@ -76,6 +85,10 @@ message CreateMachineRequest {
     reserved 11;
     // Kernel command line.
     string cmdline = 12;
+    // Guest OS: "linux" (default) or "macos".
+    string guest_os = 13;
+    // macOS base image name to clone (when guest_os is "macos").
+    string macos_image = 14;
 }
 
 // Request that targets a machine's guest agent.
@@ -188,6 +201,8 @@ message MachineSummary {
     string ip_address = 7;
     // Creation timestamp.
     int64 created = 8;
+    // Guest OS: "linux" or "macos".
+    string guest_os = 9;
 }
 
 // Request to inspect a machine.
@@ -310,4 +325,46 @@ message SSHInfoResponse {
     string identity_file = 4;
     // SSH command string.
     string command = 5;
+}
+
+// Request to install a macOS base image from a local IPSW.
+message MacImagePullRequest {
+    // Base image name.
+    string name = 1;
+    // Path to a local IPSW restore image.
+    string ipsw_path = 2;
+    // Number of CPUs for the install VM.
+    uint32 cpus = 3;
+    // Memory in bytes for the install VM.
+    uint64 memory = 4;
+    // System disk size in bytes.
+    uint64 disk_size = 5;
+}
+
+// Summary of a macOS base image.
+message MacImageSummary {
+    // Image name.
+    string name = 1;
+    // Minimum CPU count required by the restore image.
+    uint64 minimum_cpu_count = 2;
+    // Minimum memory in MiB required by the restore image.
+    uint64 minimum_memory_mib = 3;
+    // System disk size in GiB.
+    uint64 disk_gb = 4;
+    // Creation timestamp.
+    int64 created = 5;
+    // Source (IPSW path), if known.
+    string source = 6;
+}
+
+// Response listing macOS base images.
+message MacImageListResponse {
+    // Base images.
+    repeated MacImageSummary images = 1;
+}
+
+// Request to remove a macOS base image.
+message MacImageRemoveRequest {
+    // Image name.
+    string name = 1;
 }

--- a/rpc/arcbox-protocol/proto/macos.proto
+++ b/rpc/arcbox-protocol/proto/macos.proto
@@ -4,8 +4,9 @@
 // pre-baked base image once from ArcBox's distribution bucket, then
 // copy-on-write clone it to boot clean, throwaway VMs. They run only through
 // Virtualization.framework and share no lifecycle with Linux machines (no
-// guest agent, no kernel boot, no NAT IP), so they have their own service
-// rather than overloading MachineService.
+// guest agent, no kernel boot, no ArcBox NAT stack — networking is vmnet NAT,
+// with the guest address resolved from its DHCP lease), so they have their
+// own service rather than overloading MachineService.
 
 syntax = "proto3";
 
@@ -124,6 +125,12 @@ message MacosMachineInfo {
     string image = 5;
     // Creation timestamp.
     int64 created = 6;
+    // MAC address of the guest's NAT interface, pinned at creation.
+    string mac_address = 7;
+    // IPv4 address of the guest's DHCP lease. Empty until the running guest
+    // has acquired one (typically a few seconds after boot), and always
+    // empty for a stopped guest.
+    string ip_address = 8;
 }
 
 // Request to pull a published base image.

--- a/rpc/arcbox-protocol/proto/macos.proto
+++ b/rpc/arcbox-protocol/proto/macos.proto
@@ -37,6 +37,12 @@ service MacosService {
     // progress until the image is verified and registered (long-running).
     rpc ImagePull(MacosImagePullRequest) returns (stream MacosImagePullEvent);
 
+    // Resolves a published image reference against the distribution index
+    // without downloading anything: the concrete version a pull would land,
+    // its host requirements, and the locally installed version of the same
+    // stream. Fails if the image's hardware model cannot boot on this host.
+    rpc ImageResolve(MacosImageResolveRequest) returns (MacosImageResolveResponse);
+
     // Lists base images.
     rpc ImageList(Empty) returns (MacosImageListResponse);
 
@@ -135,10 +141,41 @@ message MacosImagePullRequest {
 
 // Progress event emitted while a base image pull runs.
 message MacosImagePullEvent {
-    // Stage: resolving | validating | disk | aux | verifying.
+    // Stage: resolving | validating | disk | aux | verifying | done.
     string stage = 1;
     // Completion fraction within the stage (0.0..=1.0).
     double fraction = 2;
+    // Set only on the final "done" event: the image that landed (or was
+    // already present) in the registry, so a caller learns the concrete
+    // version a floating reference resolved to.
+    MacosImageSummary image = 3;
+}
+
+// Request to resolve a published image reference. Same source semantics as
+// MacosImagePullRequest: exactly one of `reference` / `manifest_url`.
+message MacosImageResolveRequest {
+    // Image reference: a stream name with an optional pinned version.
+    string reference = 1;
+    // Manifest override (URL or daemon-local path); bypasses the index.
+    string manifest_url = 2;
+}
+
+// What a reference resolves to, without pulling.
+message MacosImageResolveResponse {
+    // Stream name (e.g. "tahoe-base").
+    string name = 1;
+    // Concrete version a pull would land, even for a floating reference.
+    string version = 2;
+    // Guest macOS product version (e.g. "26.5").
+    string os_version = 3;
+    // Minimum CPU count required by the guest.
+    uint64 minimum_cpu_count = 4;
+    // Minimum guest memory in MiB required by the guest.
+    uint64 minimum_memory_mib = 5;
+    // System disk size in GB (decimal, logical).
+    uint64 disk_gb = 6;
+    // Version currently installed under this stream name; empty if none.
+    string installed_version = 7;
 }
 
 // Summary of a macOS base image.

--- a/rpc/arcbox-protocol/proto/macos.proto
+++ b/rpc/arcbox-protocol/proto/macos.proto
@@ -1,0 +1,160 @@
+// macOS guest protocol definitions.
+//
+// macOS guests are disposable, single-purpose VMs on Apple Silicon: install a
+// base image once from an IPSW, then copy-on-write clone it to boot clean,
+// throwaway VMs. They run only through Virtualization.framework and share no
+// lifecycle with Linux machines (no guest agent, no kernel boot, no NAT IP),
+// so they have their own service rather than overloading MachineService.
+
+syntax = "proto3";
+
+package arcbox.v1;
+
+import "common.proto";
+
+// MacosService manages macOS guest VMs and their base images (Apple Silicon only).
+service MacosService {
+    // Creates a macOS guest by copy-on-write cloning a base image.
+    rpc Create(CreateMacosMachineRequest) returns (Empty);
+
+    // Starts a stopped macOS guest and waits until it is running.
+    rpc Start(StartMacosMachineRequest) returns (Empty);
+
+    // Stops a running macOS guest.
+    rpc Stop(StopMacosMachineRequest) returns (Empty);
+
+    // Removes a macOS guest and its cloned disks.
+    rpc Remove(RemoveMacosMachineRequest) returns (Empty);
+
+    // Lists macOS guests.
+    rpc List(Empty) returns (MacosMachineListResponse);
+
+    // Inspects a macOS guest.
+    rpc Inspect(InspectMacosMachineRequest) returns (MacosMachineInfo);
+
+    // Installs a base image from a local IPSW (long-running, ~10-20 min).
+    rpc ImagePull(MacosImagePullRequest) returns (Empty);
+
+    // Lists base images.
+    rpc ImageList(Empty) returns (MacosImageListResponse);
+
+    // Removes a base image.
+    rpc ImageRemove(MacosImageRemoveRequest) returns (Empty);
+}
+
+// Request to create a macOS guest from a base image.
+message CreateMacosMachineRequest {
+    // Guest name (unique).
+    string name = 1;
+    // Base image to copy-on-write clone.
+    string image = 2;
+    // Number of CPUs.
+    uint32 cpus = 3;
+    // Memory in MiB.
+    uint64 memory_mib = 4;
+}
+
+// Request to start a macOS guest.
+message StartMacosMachineRequest {
+    // Guest name.
+    string name = 1;
+}
+
+// Request to stop a macOS guest.
+message StopMacosMachineRequest {
+    // Guest name.
+    string name = 1;
+}
+
+// Request to remove a macOS guest.
+message RemoveMacosMachineRequest {
+    // Guest name.
+    string name = 1;
+    // Remove even if running (stops it first).
+    bool force = 2;
+}
+
+// Request to inspect a macOS guest.
+message InspectMacosMachineRequest {
+    // Guest name.
+    string name = 1;
+}
+
+// Summary of a macOS guest.
+message MacosMachineSummary {
+    // Guest name.
+    string name = 1;
+    // State (running, starting, stopped).
+    string state = 2;
+    // Number of CPUs.
+    uint32 cpus = 3;
+    // Memory in MiB.
+    uint64 memory_mib = 4;
+    // Base image it was cloned from.
+    string image = 5;
+    // Creation timestamp.
+    int64 created = 6;
+}
+
+// Response listing macOS guests.
+message MacosMachineListResponse {
+    // Guests.
+    repeated MacosMachineSummary machines = 1;
+}
+
+// Detailed information about a macOS guest.
+message MacosMachineInfo {
+    // Guest name.
+    string name = 1;
+    // State.
+    string state = 2;
+    // Number of CPUs.
+    uint32 cpus = 3;
+    // Memory in MiB.
+    uint64 memory_mib = 4;
+    // Base image it was cloned from.
+    string image = 5;
+    // Creation timestamp.
+    int64 created = 6;
+}
+
+// Request to install a base image from a local IPSW.
+//
+// The install VM's CPU/memory are derived from the restore image's own
+// requirements, so they are not part of the request.
+message MacosImagePullRequest {
+    // Base image name.
+    string name = 1;
+    // Path to a local IPSW restore image.
+    string ipsw_path = 2;
+    // System disk size in GiB.
+    uint64 disk_gb = 3;
+}
+
+// Summary of a macOS base image.
+message MacosImageSummary {
+    // Image name.
+    string name = 1;
+    // Minimum CPU count required by the restore image.
+    uint64 minimum_cpu_count = 2;
+    // Minimum memory in MiB required by the restore image.
+    uint64 minimum_memory_mib = 3;
+    // System disk size in GiB.
+    uint64 disk_gb = 4;
+    // Creation timestamp.
+    int64 created = 5;
+    // Source (IPSW path), if known.
+    string source = 6;
+}
+
+// Response listing macOS base images.
+message MacosImageListResponse {
+    // Base images.
+    repeated MacosImageSummary images = 1;
+}
+
+// Request to remove a macOS base image.
+message MacosImageRemoveRequest {
+    // Image name.
+    string name = 1;
+}

--- a/rpc/arcbox-protocol/proto/macos.proto
+++ b/rpc/arcbox-protocol/proto/macos.proto
@@ -1,10 +1,11 @@
 // macOS guest protocol definitions.
 //
-// macOS guests are disposable, single-purpose VMs on Apple Silicon: install a
-// base image once from an IPSW, then copy-on-write clone it to boot clean,
-// throwaway VMs. They run only through Virtualization.framework and share no
-// lifecycle with Linux machines (no guest agent, no kernel boot, no NAT IP),
-// so they have their own service rather than overloading MachineService.
+// macOS guests are disposable, single-purpose VMs on Apple Silicon: pull a
+// pre-baked base image once from ArcBox's distribution bucket, then
+// copy-on-write clone it to boot clean, throwaway VMs. They run only through
+// Virtualization.framework and share no lifecycle with Linux machines (no
+// guest agent, no kernel boot, no NAT IP), so they have their own service
+// rather than overloading MachineService.
 
 syntax = "proto3";
 
@@ -32,8 +33,9 @@ service MacosService {
     // Inspects a macOS guest.
     rpc Inspect(InspectMacosMachineRequest) returns (MacosMachineInfo);
 
-    // Installs a base image from a local IPSW (long-running, ~10-20 min).
-    rpc ImagePull(MacosImagePullRequest) returns (Empty);
+    // Pulls a published base image from the distribution bucket, streaming
+    // progress until the image is verified and registered (long-running).
+    rpc ImagePull(MacosImagePullRequest) returns (stream MacosImagePullEvent);
 
     // Lists base images.
     rpc ImageList(Empty) returns (MacosImageListResponse);
@@ -118,33 +120,45 @@ message MacosMachineInfo {
     int64 created = 6;
 }
 
-// Request to install a base image from a local IPSW.
+// Request to pull a published base image.
 //
-// The install VM's CPU/memory are derived from the restore image's own
-// requirements, so they are not part of the request.
+// Exactly one of `reference` / `manifest_url` must be set. CPU/memory/disk
+// characteristics come from the published manifest, not the request.
 message MacosImagePullRequest {
-    // Base image name.
-    string name = 1;
-    // Path to a local IPSW restore image.
-    string ipsw_path = 2;
-    // System disk size in GiB.
-    uint64 disk_gb = 3;
+    // Image reference: a stream name with an optional pinned version,
+    // e.g. "tahoe-base" or "tahoe-base@2026.07.02".
+    string reference = 1;
+    // Manifest override (URL or daemon-local path); bypasses the published
+    // index. Intended for development and pinning escapes.
+    string manifest_url = 2;
+}
+
+// Progress event emitted while a base image pull runs.
+message MacosImagePullEvent {
+    // Stage: resolving | validating | disk | aux | verifying.
+    string stage = 1;
+    // Completion fraction within the stage (0.0..=1.0).
+    double fraction = 2;
 }
 
 // Summary of a macOS base image.
 message MacosImageSummary {
     // Image name.
     string name = 1;
-    // Minimum CPU count required by the restore image.
+    // Minimum CPU count required by the guest.
     uint64 minimum_cpu_count = 2;
-    // Minimum memory in MiB required by the restore image.
+    // Minimum memory in MiB required by the guest.
     uint64 minimum_memory_mib = 3;
-    // System disk size in GiB.
+    // System disk size in GB (decimal, logical).
     uint64 disk_gb = 4;
     // Creation timestamp.
     int64 created = 5;
-    // Source (IPSW path), if known.
+    // Source (manifest location), if known.
     string source = 6;
+    // Published version label (e.g. "2026.07.02"), if pulled.
+    string version = 7;
+    // Guest macOS product version (e.g. "26.5"), if known.
+    string os_version = 8;
 }
 
 // Response listing macOS base images.

--- a/rpc/arcbox-protocol/src/generated/arcbox.v1.rs
+++ b/rpc/arcbox-protocol/src/generated/arcbox.v1.rs
@@ -613,12 +613,57 @@ pub struct MacosImagePullRequest {
 #[serde(rename_all = "camelCase")]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct MacosImagePullEvent {
-    /// Stage: resolving | validating | disk | aux | verifying.
+    /// Stage: resolving | validating | disk | aux | verifying | done.
     #[prost(string, tag = "1")]
     pub stage: ::prost::alloc::string::String,
     /// Completion fraction within the stage (0.0..=1.0).
     #[prost(double, tag = "2")]
     pub fraction: f64,
+    /// Set only on the final "done" event: the image that landed (or was
+    /// already present) in the registry, so a caller learns the concrete
+    /// version a floating reference resolved to.
+    #[prost(message, optional, tag = "3")]
+    pub image: ::core::option::Option<MacosImageSummary>,
+}
+/// Request to resolve a published image reference. Same source semantics as
+/// MacosImagePullRequest: exactly one of `reference` / `manifest_url`.
+#[derive(serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct MacosImageResolveRequest {
+    /// Image reference: a stream name with an optional pinned version.
+    #[prost(string, tag = "1")]
+    pub reference: ::prost::alloc::string::String,
+    /// Manifest override (URL or daemon-local path); bypasses the index.
+    #[prost(string, tag = "2")]
+    pub manifest_url: ::prost::alloc::string::String,
+}
+/// What a reference resolves to, without pulling.
+#[derive(serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct MacosImageResolveResponse {
+    /// Stream name (e.g. "tahoe-base").
+    #[prost(string, tag = "1")]
+    pub name: ::prost::alloc::string::String,
+    /// Concrete version a pull would land, even for a floating reference.
+    #[prost(string, tag = "2")]
+    pub version: ::prost::alloc::string::String,
+    /// Guest macOS product version (e.g. "26.5").
+    #[prost(string, tag = "3")]
+    pub os_version: ::prost::alloc::string::String,
+    /// Minimum CPU count required by the guest.
+    #[prost(uint64, tag = "4")]
+    pub minimum_cpu_count: u64,
+    /// Minimum guest memory in MiB required by the guest.
+    #[prost(uint64, tag = "5")]
+    pub minimum_memory_mib: u64,
+    /// System disk size in GB (decimal, logical).
+    #[prost(uint64, tag = "6")]
+    pub disk_gb: u64,
+    /// Version currently installed under this stream name; empty if none.
+    #[prost(string, tag = "7")]
+    pub installed_version: ::prost::alloc::string::String,
 }
 /// Summary of a macOS base image.
 #[derive(serde::Serialize, serde::Deserialize)]

--- a/rpc/arcbox-protocol/src/generated/arcbox.v1.rs
+++ b/rpc/arcbox-protocol/src/generated/arcbox.v1.rs
@@ -590,6 +590,14 @@ pub struct MacosMachineInfo {
     /// Creation timestamp.
     #[prost(int64, tag = "6")]
     pub created: i64,
+    /// MAC address of the guest's NAT interface, pinned at creation.
+    #[prost(string, tag = "7")]
+    pub mac_address: ::prost::alloc::string::String,
+    /// IPv4 address of the guest's DHCP lease. Empty until the running guest
+    /// has acquired one (typically a few seconds after boot), and always
+    /// empty for a stopped guest.
+    #[prost(string, tag = "8")]
+    pub ip_address: ::prost::alloc::string::String,
 }
 /// Request to pull a published base image.
 ///

--- a/rpc/arcbox-protocol/src/generated/arcbox.v1.rs
+++ b/rpc/arcbox-protocol/src/generated/arcbox.v1.rs
@@ -591,23 +591,34 @@ pub struct MacosMachineInfo {
     #[prost(int64, tag = "6")]
     pub created: i64,
 }
-/// Request to install a base image from a local IPSW.
+/// Request to pull a published base image.
 ///
-/// The install VM's CPU/memory are derived from the restore image's own
-/// requirements, so they are not part of the request.
+/// Exactly one of `reference` / `manifest_url` must be set. CPU/memory/disk
+/// characteristics come from the published manifest, not the request.
 #[derive(serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct MacosImagePullRequest {
-    /// Base image name.
+    /// Image reference: a stream name with an optional pinned version,
+    /// e.g. "tahoe-base" or "tahoe-base@2026.07.02".
     #[prost(string, tag = "1")]
-    pub name: ::prost::alloc::string::String,
-    /// Path to a local IPSW restore image.
+    pub reference: ::prost::alloc::string::String,
+    /// Manifest override (URL or daemon-local path); bypasses the published
+    /// index. Intended for development and pinning escapes.
     #[prost(string, tag = "2")]
-    pub ipsw_path: ::prost::alloc::string::String,
-    /// System disk size in GiB.
-    #[prost(uint64, tag = "3")]
-    pub disk_gb: u64,
+    pub manifest_url: ::prost::alloc::string::String,
+}
+/// Progress event emitted while a base image pull runs.
+#[derive(serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct MacosImagePullEvent {
+    /// Stage: resolving | validating | disk | aux | verifying.
+    #[prost(string, tag = "1")]
+    pub stage: ::prost::alloc::string::String,
+    /// Completion fraction within the stage (0.0..=1.0).
+    #[prost(double, tag = "2")]
+    pub fraction: f64,
 }
 /// Summary of a macOS base image.
 #[derive(serde::Serialize, serde::Deserialize)]
@@ -617,21 +628,27 @@ pub struct MacosImageSummary {
     /// Image name.
     #[prost(string, tag = "1")]
     pub name: ::prost::alloc::string::String,
-    /// Minimum CPU count required by the restore image.
+    /// Minimum CPU count required by the guest.
     #[prost(uint64, tag = "2")]
     pub minimum_cpu_count: u64,
-    /// Minimum memory in MiB required by the restore image.
+    /// Minimum memory in MiB required by the guest.
     #[prost(uint64, tag = "3")]
     pub minimum_memory_mib: u64,
-    /// System disk size in GiB.
+    /// System disk size in GB (decimal, logical).
     #[prost(uint64, tag = "4")]
     pub disk_gb: u64,
     /// Creation timestamp.
     #[prost(int64, tag = "5")]
     pub created: i64,
-    /// Source (IPSW path), if known.
+    /// Source (manifest location), if known.
     #[prost(string, tag = "6")]
     pub source: ::prost::alloc::string::String,
+    /// Published version label (e.g. "2026.07.02"), if pulled.
+    #[prost(string, tag = "7")]
+    pub version: ::prost::alloc::string::String,
+    /// Guest macOS product version (e.g. "26.5"), if known.
+    #[prost(string, tag = "8")]
+    pub os_version: ::prost::alloc::string::String,
 }
 /// Response listing macOS base images.
 #[derive(serde::Serialize, serde::Deserialize)]

--- a/rpc/arcbox-protocol/src/generated/arcbox.v1.rs
+++ b/rpc/arcbox-protocol/src/generated/arcbox.v1.rs
@@ -124,12 +124,6 @@ pub struct CreateMachineRequest {
     /// Kernel command line.
     #[prost(string, tag = "12")]
     pub cmdline: ::prost::alloc::string::String,
-    /// Guest OS: "linux" (default) or "macos".
-    #[prost(string, tag = "13")]
-    pub guest_os: ::prost::alloc::string::String,
-    /// macOS base image name to clone (when guest_os is "macos").
-    #[prost(string, tag = "14")]
-    pub macos_image: ::prost::alloc::string::String,
 }
 /// Request that targets a machine's guest agent.
 #[derive(serde::Serialize, serde::Deserialize)]
@@ -298,9 +292,6 @@ pub struct MachineSummary {
     /// Creation timestamp.
     #[prost(int64, tag = "8")]
     pub created: i64,
-    /// Guest OS: "linux" or "macos".
-    #[prost(string, tag = "9")]
-    pub guest_os: ::prost::alloc::string::String,
 }
 /// Request to inspect a machine.
 #[derive(serde::Serialize, serde::Deserialize)]
@@ -485,69 +476,6 @@ pub struct SshInfoResponse {
     /// SSH command string.
     #[prost(string, tag = "5")]
     pub command: ::prost::alloc::string::String,
-}
-/// Request to install a macOS base image from a local IPSW.
-#[derive(serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct MacImagePullRequest {
-    /// Base image name.
-    #[prost(string, tag = "1")]
-    pub name: ::prost::alloc::string::String,
-    /// Path to a local IPSW restore image.
-    #[prost(string, tag = "2")]
-    pub ipsw_path: ::prost::alloc::string::String,
-    /// Number of CPUs for the install VM.
-    #[prost(uint32, tag = "3")]
-    pub cpus: u32,
-    /// Memory in bytes for the install VM.
-    #[prost(uint64, tag = "4")]
-    pub memory: u64,
-    /// System disk size in bytes.
-    #[prost(uint64, tag = "5")]
-    pub disk_size: u64,
-}
-/// Summary of a macOS base image.
-#[derive(serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct MacImageSummary {
-    /// Image name.
-    #[prost(string, tag = "1")]
-    pub name: ::prost::alloc::string::String,
-    /// Minimum CPU count required by the restore image.
-    #[prost(uint64, tag = "2")]
-    pub minimum_cpu_count: u64,
-    /// Minimum memory in MiB required by the restore image.
-    #[prost(uint64, tag = "3")]
-    pub minimum_memory_mib: u64,
-    /// System disk size in GiB.
-    #[prost(uint64, tag = "4")]
-    pub disk_gb: u64,
-    /// Creation timestamp.
-    #[prost(int64, tag = "5")]
-    pub created: i64,
-    /// Source (IPSW path), if known.
-    #[prost(string, tag = "6")]
-    pub source: ::prost::alloc::string::String,
-}
-/// Response listing macOS base images.
-#[derive(serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct MacImageListResponse {
-    /// Base images.
-    #[prost(message, repeated, tag = "1")]
-    pub images: ::prost::alloc::vec::Vec<MacImageSummary>,
-}
-/// Request to remove a macOS base image.
-#[derive(serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct MacImageRemoveRequest {
-    /// Image name.
-    #[prost(string, tag = "1")]
-    pub name: ::prost::alloc::string::String,
 }
 /// Request to create a macOS guest from a base image.
 #[derive(serde::Serialize, serde::Deserialize)]

--- a/rpc/arcbox-protocol/src/generated/arcbox.v1.rs
+++ b/rpc/arcbox-protocol/src/generated/arcbox.v1.rs
@@ -549,6 +549,180 @@ pub struct MacImageRemoveRequest {
     #[prost(string, tag = "1")]
     pub name: ::prost::alloc::string::String,
 }
+/// Request to create a macOS guest from a base image.
+#[derive(serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct CreateMacosMachineRequest {
+    /// Guest name (unique).
+    #[prost(string, tag = "1")]
+    pub name: ::prost::alloc::string::String,
+    /// Base image to copy-on-write clone.
+    #[prost(string, tag = "2")]
+    pub image: ::prost::alloc::string::String,
+    /// Number of CPUs.
+    #[prost(uint32, tag = "3")]
+    pub cpus: u32,
+    /// Memory in MiB.
+    #[prost(uint64, tag = "4")]
+    pub memory_mib: u64,
+}
+/// Request to start a macOS guest.
+#[derive(serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct StartMacosMachineRequest {
+    /// Guest name.
+    #[prost(string, tag = "1")]
+    pub name: ::prost::alloc::string::String,
+}
+/// Request to stop a macOS guest.
+#[derive(serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct StopMacosMachineRequest {
+    /// Guest name.
+    #[prost(string, tag = "1")]
+    pub name: ::prost::alloc::string::String,
+}
+/// Request to remove a macOS guest.
+#[derive(serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct RemoveMacosMachineRequest {
+    /// Guest name.
+    #[prost(string, tag = "1")]
+    pub name: ::prost::alloc::string::String,
+    /// Remove even if running (stops it first).
+    #[prost(bool, tag = "2")]
+    pub force: bool,
+}
+/// Request to inspect a macOS guest.
+#[derive(serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct InspectMacosMachineRequest {
+    /// Guest name.
+    #[prost(string, tag = "1")]
+    pub name: ::prost::alloc::string::String,
+}
+/// Summary of a macOS guest.
+#[derive(serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct MacosMachineSummary {
+    /// Guest name.
+    #[prost(string, tag = "1")]
+    pub name: ::prost::alloc::string::String,
+    /// State (running, starting, stopped).
+    #[prost(string, tag = "2")]
+    pub state: ::prost::alloc::string::String,
+    /// Number of CPUs.
+    #[prost(uint32, tag = "3")]
+    pub cpus: u32,
+    /// Memory in MiB.
+    #[prost(uint64, tag = "4")]
+    pub memory_mib: u64,
+    /// Base image it was cloned from.
+    #[prost(string, tag = "5")]
+    pub image: ::prost::alloc::string::String,
+    /// Creation timestamp.
+    #[prost(int64, tag = "6")]
+    pub created: i64,
+}
+/// Response listing macOS guests.
+#[derive(serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct MacosMachineListResponse {
+    /// Guests.
+    #[prost(message, repeated, tag = "1")]
+    pub machines: ::prost::alloc::vec::Vec<MacosMachineSummary>,
+}
+/// Detailed information about a macOS guest.
+#[derive(serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct MacosMachineInfo {
+    /// Guest name.
+    #[prost(string, tag = "1")]
+    pub name: ::prost::alloc::string::String,
+    /// State.
+    #[prost(string, tag = "2")]
+    pub state: ::prost::alloc::string::String,
+    /// Number of CPUs.
+    #[prost(uint32, tag = "3")]
+    pub cpus: u32,
+    /// Memory in MiB.
+    #[prost(uint64, tag = "4")]
+    pub memory_mib: u64,
+    /// Base image it was cloned from.
+    #[prost(string, tag = "5")]
+    pub image: ::prost::alloc::string::String,
+    /// Creation timestamp.
+    #[prost(int64, tag = "6")]
+    pub created: i64,
+}
+/// Request to install a base image from a local IPSW.
+///
+/// The install VM's CPU/memory are derived from the restore image's own
+/// requirements, so they are not part of the request.
+#[derive(serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct MacosImagePullRequest {
+    /// Base image name.
+    #[prost(string, tag = "1")]
+    pub name: ::prost::alloc::string::String,
+    /// Path to a local IPSW restore image.
+    #[prost(string, tag = "2")]
+    pub ipsw_path: ::prost::alloc::string::String,
+    /// System disk size in GiB.
+    #[prost(uint64, tag = "3")]
+    pub disk_gb: u64,
+}
+/// Summary of a macOS base image.
+#[derive(serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct MacosImageSummary {
+    /// Image name.
+    #[prost(string, tag = "1")]
+    pub name: ::prost::alloc::string::String,
+    /// Minimum CPU count required by the restore image.
+    #[prost(uint64, tag = "2")]
+    pub minimum_cpu_count: u64,
+    /// Minimum memory in MiB required by the restore image.
+    #[prost(uint64, tag = "3")]
+    pub minimum_memory_mib: u64,
+    /// System disk size in GiB.
+    #[prost(uint64, tag = "4")]
+    pub disk_gb: u64,
+    /// Creation timestamp.
+    #[prost(int64, tag = "5")]
+    pub created: i64,
+    /// Source (IPSW path), if known.
+    #[prost(string, tag = "6")]
+    pub source: ::prost::alloc::string::String,
+}
+/// Response listing macOS base images.
+#[derive(serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct MacosImageListResponse {
+    /// Base images.
+    #[prost(message, repeated, tag = "1")]
+    pub images: ::prost::alloc::vec::Vec<MacosImageSummary>,
+}
+/// Request to remove a macOS base image.
+#[derive(serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct MacosImageRemoveRequest {
+    /// Image name.
+    #[prost(string, tag = "1")]
+    pub name: ::prost::alloc::string::String,
+}
 /// Request to create a container.
 #[derive(serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]

--- a/rpc/arcbox-protocol/src/generated/arcbox.v1.rs
+++ b/rpc/arcbox-protocol/src/generated/arcbox.v1.rs
@@ -124,6 +124,12 @@ pub struct CreateMachineRequest {
     /// Kernel command line.
     #[prost(string, tag = "12")]
     pub cmdline: ::prost::alloc::string::String,
+    /// Guest OS: "linux" (default) or "macos".
+    #[prost(string, tag = "13")]
+    pub guest_os: ::prost::alloc::string::String,
+    /// macOS base image name to clone (when guest_os is "macos").
+    #[prost(string, tag = "14")]
+    pub macos_image: ::prost::alloc::string::String,
 }
 /// Request that targets a machine's guest agent.
 #[derive(serde::Serialize, serde::Deserialize)]
@@ -292,6 +298,9 @@ pub struct MachineSummary {
     /// Creation timestamp.
     #[prost(int64, tag = "8")]
     pub created: i64,
+    /// Guest OS: "linux" or "macos".
+    #[prost(string, tag = "9")]
+    pub guest_os: ::prost::alloc::string::String,
 }
 /// Request to inspect a machine.
 #[derive(serde::Serialize, serde::Deserialize)]
@@ -476,6 +485,69 @@ pub struct SshInfoResponse {
     /// SSH command string.
     #[prost(string, tag = "5")]
     pub command: ::prost::alloc::string::String,
+}
+/// Request to install a macOS base image from a local IPSW.
+#[derive(serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct MacImagePullRequest {
+    /// Base image name.
+    #[prost(string, tag = "1")]
+    pub name: ::prost::alloc::string::String,
+    /// Path to a local IPSW restore image.
+    #[prost(string, tag = "2")]
+    pub ipsw_path: ::prost::alloc::string::String,
+    /// Number of CPUs for the install VM.
+    #[prost(uint32, tag = "3")]
+    pub cpus: u32,
+    /// Memory in bytes for the install VM.
+    #[prost(uint64, tag = "4")]
+    pub memory: u64,
+    /// System disk size in bytes.
+    #[prost(uint64, tag = "5")]
+    pub disk_size: u64,
+}
+/// Summary of a macOS base image.
+#[derive(serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct MacImageSummary {
+    /// Image name.
+    #[prost(string, tag = "1")]
+    pub name: ::prost::alloc::string::String,
+    /// Minimum CPU count required by the restore image.
+    #[prost(uint64, tag = "2")]
+    pub minimum_cpu_count: u64,
+    /// Minimum memory in MiB required by the restore image.
+    #[prost(uint64, tag = "3")]
+    pub minimum_memory_mib: u64,
+    /// System disk size in GiB.
+    #[prost(uint64, tag = "4")]
+    pub disk_gb: u64,
+    /// Creation timestamp.
+    #[prost(int64, tag = "5")]
+    pub created: i64,
+    /// Source (IPSW path), if known.
+    #[prost(string, tag = "6")]
+    pub source: ::prost::alloc::string::String,
+}
+/// Response listing macOS base images.
+#[derive(serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct MacImageListResponse {
+    /// Base images.
+    #[prost(message, repeated, tag = "1")]
+    pub images: ::prost::alloc::vec::Vec<MacImageSummary>,
+}
+/// Request to remove a macOS base image.
+#[derive(serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct MacImageRemoveRequest {
+    /// Image name.
+    #[prost(string, tag = "1")]
+    pub name: ::prost::alloc::string::String,
 }
 /// Request to create a container.
 #[derive(serde::Serialize, serde::Deserialize)]

--- a/virt/arcbox-vz/examples/macos_clone_boot.rs
+++ b/virt/arcbox-vz/examples/macos_clone_boot.rs
@@ -1,0 +1,90 @@
+//! Verify clone + boot: copy-on-write clone an installed base disk + aux storage and
+//! boot the clone. Confirms `clonefile(2)` is fast and space-shared, that a cloned
+//! installed disk is a valid bootable attachment, and whether a fresh machine
+//! identifier paired with the copied auxiliary storage still starts.
+//!
+//! ```sh
+//! cargo run -p arcbox-vz --example macos_clone_boot -- <base-dir>
+//! ```
+//! `base-dir` must hold an installed `disk.img` and `aux.img`.
+
+use std::error::Error;
+use std::ffi::CString;
+use std::os::unix::ffi::OsStrExt;
+use std::path::PathBuf;
+use std::time::Instant;
+
+use arcbox_vz::{
+    MacAuxiliaryStorage, MacGraphicsDeviceConfiguration, MacMachineIdentifier, MacOSBootLoader,
+    MacOSRestoreImage, MacPlatform, StorageDeviceConfiguration, VirtualMachineConfiguration,
+    VirtualMachineState, min_cpu_count, min_memory_size,
+};
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn Error>> {
+    if !arcbox_vz::is_supported() {
+        eprintln!("Virtualization is not supported on this host.");
+        return Ok(());
+    }
+    let base: PathBuf = std::env::args()
+        .nth(1)
+        .ok_or("usage: macos_clone_boot <base-dir>")?
+        .into();
+    let base_disk = base.join("disk.img");
+    let base_aux = base.join("aux.img");
+    let clone_dir = base.join("clone-test");
+    std::fs::create_dir_all(&clone_dir)?;
+    let clone_disk = clone_dir.join("disk.img");
+    let clone_aux = clone_dir.join("aux.img");
+
+    // Copy-on-write clone the installed system disk via clonefile(2).
+    let _ = std::fs::remove_file(&clone_disk);
+    let src = CString::new(base_disk.as_os_str().as_bytes())?;
+    let dst = CString::new(clone_disk.as_os_str().as_bytes())?;
+    let started = Instant::now();
+    // SAFETY: clonefile takes two valid NUL-terminated C paths and a flags word.
+    let rc = unsafe { libc::clonefile(src.as_ptr(), dst.as_ptr(), 0) };
+    if rc != 0 {
+        return Err(format!("clonefile failed: {}", std::io::Error::last_os_error()).into());
+    }
+    let logical = std::fs::metadata(&clone_disk)?.len();
+    println!(
+        "clonefile disk: {} GiB logical in {:?}",
+        logical / (1024 * 1024 * 1024),
+        started.elapsed()
+    );
+    std::fs::copy(&base_aux, &clone_aux)?;
+
+    // Re-derive the hardware model from the latest metadata; use a FRESH identifier.
+    let restore = MacOSRestoreImage::latest_supported().await?;
+    let reqs = restore.requirements()?;
+    let machine_id = MacMachineIdentifier::new()?;
+    let aux = MacAuxiliaryStorage::open(&clone_aux)?;
+    let platform = MacPlatform::new(&reqs.hardware_model, &machine_id, &aux)?;
+    let cpus = usize::try_from(reqs.minimum_cpu_count.max(min_cpu_count())).unwrap_or(1);
+    let memory = reqs.minimum_memory_size.max(min_memory_size());
+
+    let mut config = VirtualMachineConfiguration::new()?;
+    config
+        .set_cpu_count(cpus)
+        .set_memory_size(memory)
+        .set_platform(platform)
+        .set_boot_loader(MacOSBootLoader::new()?)
+        .add_storage_device(StorageDeviceConfiguration::disk_image(&clone_disk, false)?)
+        .add_graphics_device(MacGraphicsDeviceConfiguration::new(1920, 1080, 80)?);
+    config.validate()?;
+    let vm = config.build()?;
+
+    println!("booting clone (fresh machine-id, copied aux) ...");
+    vm.start().await?;
+    let mut waited = 0;
+    while vm.state() != VirtualMachineState::Running && waited < 40 {
+        tokio::time::sleep(std::time::Duration::from_millis(250)).await;
+        waited += 1;
+    }
+    println!("CLONE BOOT: state={:?}", vm.state());
+    tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+    println!("after 5s running: state={:?}", vm.state());
+    let _ = vm.stop().await;
+    Ok(())
+}

--- a/virt/arcbox-vz/examples/macos_install.rs
+++ b/virt/arcbox-vz/examples/macos_install.rs
@@ -16,9 +16,9 @@ use std::error::Error;
 use std::path::PathBuf;
 
 use arcbox_vz::{
-    MacAuxiliaryStorage, MacMachineIdentifier, MacOSBootLoader, MacOSInstaller, MacOSRestoreImage,
-    MacPlatform, StorageDeviceConfiguration, VirtualMachineConfiguration, VirtualMachineState,
-    min_cpu_count, min_memory_size,
+    MacAuxiliaryStorage, MacGraphicsDeviceConfiguration, MacMachineIdentifier, MacOSBootLoader,
+    MacOSInstaller, MacOSRestoreImage, MacPlatform, StorageDeviceConfiguration,
+    VirtualMachineConfiguration, VirtualMachineState, min_cpu_count, min_memory_size,
 };
 
 /// Size of the sparse macOS system disk image.
@@ -50,7 +50,11 @@ async fn main() -> Result<(), Box<dyn Error>> {
         return Err("restore image hardware model is not supported on this host".into());
     }
     let cpus = usize::try_from(reqs.minimum_cpu_count.max(min_cpu_count())).unwrap_or(1);
-    let memory = reqs.minimum_memory_size.max(min_memory_size());
+    // macOS installation/personalization is memory-hungry; use at least 8 GiB.
+    let memory = reqs
+        .minimum_memory_size
+        .max(8 * 1024 * 1024 * 1024)
+        .max(min_memory_size());
 
     // Create the system disk image (sparse) and fresh auxiliary storage.
     println!(
@@ -72,7 +76,8 @@ async fn main() -> Result<(), Box<dyn Error>> {
         .set_memory_size(memory)
         .set_platform(platform)
         .set_boot_loader(MacOSBootLoader::new()?)
-        .add_storage_device(StorageDeviceConfiguration::disk_image(&disk_path, false)?);
+        .add_storage_device(StorageDeviceConfiguration::disk_image(&disk_path, false)?)
+        .add_graphics_device(MacGraphicsDeviceConfiguration::new(1920, 1080, 80)?);
     config.validate()?;
     let vm = config.build()?;
 
@@ -88,9 +93,15 @@ async fn main() -> Result<(), Box<dyn Error>> {
             }
         })
         .await?;
-    println!("Install complete. Booting installed macOS ...");
+    println!("Install complete.");
 
-    vm.start().await?;
+    // VZMacOSInstaller leaves the VM running (booted into the installed OS); only
+    // issue a start if it came back stopped.
+    if vm.state() == VirtualMachineState::Stopped {
+        println!("Booting installed macOS ...");
+        vm.start().await?;
+    }
+
     let mut waited = 0;
     while vm.state() != VirtualMachineState::Running && waited < 60 {
         tokio::time::sleep(std::time::Duration::from_millis(500)).await;

--- a/virt/arcbox-vz/examples/macos_install.rs
+++ b/virt/arcbox-vz/examples/macos_install.rs
@@ -1,0 +1,110 @@
+//! Gate B for macOS guests: install macOS from a local IPSW and boot to Running.
+//!
+//! Builds a macOS VM configuration with a fresh system disk, runs `VZMacOSInstaller`
+//! against a local restore image, then starts the VM and waits for it to reach the
+//! Running state.
+//!
+//! Requires Apple Silicon, a binary signed with the
+//! `com.apple.security.virtualization` entitlement, and an APFS target directory.
+//! Installation takes roughly 10-20 minutes.
+//!
+//! ```sh
+//! cargo run -p arcbox-vz --example macos_install -- /path/to/UniversalMac.ipsw [target-dir]
+//! ```
+
+use std::error::Error;
+use std::path::PathBuf;
+
+use arcbox_vz::{
+    MacAuxiliaryStorage, MacMachineIdentifier, MacOSBootLoader, MacOSInstaller, MacOSRestoreImage,
+    MacPlatform, StorageDeviceConfiguration, VirtualMachineConfiguration, VirtualMachineState,
+    min_cpu_count, min_memory_size,
+};
+
+/// Size of the sparse macOS system disk image.
+const DISK_SIZE_BYTES: u64 = 64 * 1024 * 1024 * 1024;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn Error>> {
+    if !arcbox_vz::is_supported() {
+        eprintln!("Virtualization is not supported on this host (Apple Silicon required).");
+        return Ok(());
+    }
+
+    let mut args = std::env::args().skip(1);
+    let ipsw = args
+        .next()
+        .ok_or("usage: macos_install <ipsw-path> [target-dir]")?;
+    let target = args.next().map_or_else(
+        || std::env::temp_dir().join("arcbox-macos-install"),
+        PathBuf::from,
+    );
+    std::fs::create_dir_all(&target)?;
+    let disk_path = target.join("disk.img");
+    let aux_path = target.join("aux.img");
+
+    println!("Loading restore image {ipsw} ...");
+    let restore = MacOSRestoreImage::load_from_url(&ipsw).await?;
+    let reqs = restore.requirements()?;
+    if !reqs.hardware_model.is_supported() {
+        return Err("restore image hardware model is not supported on this host".into());
+    }
+    let cpus = usize::try_from(reqs.minimum_cpu_count.max(min_cpu_count())).unwrap_or(1);
+    let memory = reqs.minimum_memory_size.max(min_memory_size());
+
+    // Create the system disk image (sparse) and fresh auxiliary storage.
+    println!(
+        "Allocating {} GiB system disk at {} ...",
+        DISK_SIZE_BYTES / (1024 * 1024 * 1024),
+        disk_path.display()
+    );
+    let disk = std::fs::File::create(&disk_path)?;
+    disk.set_len(DISK_SIZE_BYTES)?;
+    drop(disk);
+    let _ = std::fs::remove_file(&aux_path);
+    let aux = MacAuxiliaryStorage::create(&aux_path, &reqs.hardware_model, true)?;
+    let machine_id = MacMachineIdentifier::new()?;
+    let platform = MacPlatform::new(&reqs.hardware_model, &machine_id, &aux)?;
+
+    let mut config = VirtualMachineConfiguration::new()?;
+    config
+        .set_cpu_count(cpus)
+        .set_memory_size(memory)
+        .set_platform(platform)
+        .set_boot_loader(MacOSBootLoader::new()?)
+        .add_storage_device(StorageDeviceConfiguration::disk_image(&disk_path, false)?);
+    config.validate()?;
+    let vm = config.build()?;
+
+    println!("Installing macOS (this can take 10-20 minutes) ...");
+    let installer = MacOSInstaller::new(&vm, &ipsw)?;
+    let mut last = String::new();
+    installer
+        .install(&vm, |fraction| {
+            let line = format!("{:.0}%", fraction * 100.0);
+            if line != last {
+                println!("  install progress: {line}");
+                last = line;
+            }
+        })
+        .await?;
+    println!("Install complete. Booting installed macOS ...");
+
+    vm.start().await?;
+    let mut waited = 0;
+    while vm.state() != VirtualMachineState::Running && waited < 60 {
+        tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+        waited += 1;
+    }
+
+    if vm.state() == VirtualMachineState::Running {
+        println!(
+            "Gate B PASS: macOS installed and VM reached Running ({cpus} cpus, {} MiB).",
+            memory / (1024 * 1024)
+        );
+        let _ = vm.stop().await;
+        Ok(())
+    } else {
+        Err(format!("VM did not reach Running (state = {:?})", vm.state()).into())
+    }
+}

--- a/virt/arcbox-vz/examples/macos_latest_url.rs
+++ b/virt/arcbox-vz/examples/macos_latest_url.rs
@@ -1,0 +1,23 @@
+//! Print the latest supported macOS restore image (IPSW) download URL.
+//!
+//! ```sh
+//! cargo run -p arcbox-vz --example macos_latest_url
+//! ```
+
+use std::error::Error;
+
+use arcbox_vz::MacOSRestoreImage;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn Error>> {
+    if !arcbox_vz::is_supported() {
+        eprintln!("Virtualization is not supported on this host (Apple Silicon required).");
+        return Ok(());
+    }
+    let restore = MacOSRestoreImage::latest_supported().await?;
+    match restore.url() {
+        Some(url) => println!("{url}"),
+        None => return Err("restore image exposes no URL".into()),
+    }
+    Ok(())
+}

--- a/virt/arcbox-vz/examples/macos_probe.rs
+++ b/virt/arcbox-vz/examples/macos_probe.rs
@@ -1,0 +1,87 @@
+//! Fast diagnostic: build a macOS VM config (platform + boot loader + disk +
+//! graphics) from the latest restore image METADATA (no multi-GB IPSW download)
+//! and try to START a bare VM. Isolates "is this config/storage attachment valid
+//! enough for the VM to start" from the full install flow.
+//!
+//! ```sh
+//! cargo run -p arcbox-vz --example macos_probe -- [target-dir]
+//! ```
+
+use std::error::Error;
+use std::path::PathBuf;
+
+use arcbox_vz::{
+    MacAuxiliaryStorage, MacGraphicsDeviceConfiguration, MacMachineIdentifier, MacOSBootLoader,
+    MacOSRestoreImage, MacPlatform, StorageDeviceConfiguration, VirtualMachineConfiguration,
+    VirtualMachineState, min_cpu_count, min_memory_size,
+};
+
+const DISK_SIZE_BYTES: u64 = 64 * 1024 * 1024 * 1024;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn Error>> {
+    if !arcbox_vz::is_supported() {
+        eprintln!("Virtualization is not supported on this host.");
+        return Ok(());
+    }
+    let dir = std::env::args().nth(1).map_or_else(
+        || std::env::temp_dir().join("arcbox-macos-probe"),
+        PathBuf::from,
+    );
+    std::fs::create_dir_all(&dir)?;
+    let disk_path = dir.join("disk.img");
+    let aux_path = dir.join("aux.img");
+
+    println!("Fetching latest restore image metadata ...");
+    let restore = MacOSRestoreImage::latest_supported().await?;
+    let reqs = restore.requirements()?;
+    let cpus = usize::try_from(reqs.minimum_cpu_count.max(min_cpu_count())).unwrap_or(1);
+    let memory = reqs.minimum_memory_size.max(min_memory_size());
+
+    let disk = std::fs::File::create(&disk_path)?;
+    disk.set_len(DISK_SIZE_BYTES)?;
+    disk.sync_all()?;
+    drop(disk);
+    let _ = std::fs::remove_file(&aux_path);
+    let aux = MacAuxiliaryStorage::create(&aux_path, &reqs.hardware_model, true)?;
+    let machine_id = MacMachineIdentifier::new()?;
+    let platform = MacPlatform::new(&reqs.hardware_model, &machine_id, &aux)?;
+
+    let mut config = VirtualMachineConfiguration::new()?;
+    config
+        .set_cpu_count(cpus)
+        .set_memory_size(memory)
+        .set_platform(platform)
+        .set_boot_loader(MacOSBootLoader::new()?)
+        .add_storage_device(StorageDeviceConfiguration::disk_image(&disk_path, false)?)
+        .add_graphics_device(MacGraphicsDeviceConfiguration::new(1920, 1080, 80)?);
+
+    print!("validate ... ");
+    match config.validate() {
+        Ok(()) => println!("OK"),
+        Err(e) => {
+            println!("ERR: {e}");
+            return Err(e.into());
+        }
+    }
+
+    let vm = config.build()?;
+    println!("starting bare VM (empty disk; will not boot an OS) ...");
+    match vm.start().await {
+        Ok(()) => {
+            for _ in 0..10 {
+                if vm.state() == VirtualMachineState::Running {
+                    break;
+                }
+                tokio::time::sleep(std::time::Duration::from_millis(300)).await;
+            }
+            println!(
+                "START OK — state={:?} (config + storage attachment are valid)",
+                vm.state()
+            );
+            let _ = vm.stop().await;
+        }
+        Err(e) => println!("START ERR: {e}"),
+    }
+    Ok(())
+}

--- a/virt/arcbox-vz/examples/macos_validate.rs
+++ b/virt/arcbox-vz/examples/macos_validate.rs
@@ -1,0 +1,78 @@
+//! Gate A for macOS guests: build and validate a macOS VM configuration.
+//!
+//! Obtains a hardware model from a restore image (the latest Apple publishes, or a
+//! local IPSW passed as the first argument), assembles a macOS
+//! `VirtualMachineConfiguration` (boot loader + platform + auxiliary storage), and
+//! validates it against Virtualization.framework.
+//!
+//! Requires Apple Silicon and a binary signed with the
+//! `com.apple.security.virtualization` entitlement.
+//!
+//! ```sh
+//! # Latest supported (fetches metadata only, no multi-GB download):
+//! cargo run -p arcbox-vz --example macos_validate
+//! # From a local restore image / IPSW:
+//! cargo run -p arcbox-vz --example macos_validate -- /path/to/UniversalMac.ipsw
+//! ```
+
+use std::error::Error;
+
+use arcbox_vz::{
+    MacAuxiliaryStorage, MacMachineIdentifier, MacOSBootLoader, MacOSRestoreImage, MacPlatform,
+    VirtualMachineConfiguration, min_cpu_count, min_memory_size,
+};
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn Error>> {
+    if !arcbox_vz::is_supported() {
+        eprintln!("Virtualization is not supported on this host (Apple Silicon required).");
+        return Ok(());
+    }
+
+    let restore = match std::env::args().nth(1) {
+        Some(path) => {
+            println!("Loading restore image from {path} ...");
+            MacOSRestoreImage::load_from_url(&path).await?
+        }
+        None => {
+            println!("Fetching latest supported restore image metadata ...");
+            MacOSRestoreImage::latest_supported().await?
+        }
+    };
+
+    let reqs = restore.requirements()?;
+    println!(
+        "Restore image: hardware model supported = {}, min cpus = {}, min memory = {} MiB",
+        reqs.hardware_model.is_supported(),
+        reqs.minimum_cpu_count,
+        reqs.minimum_memory_size / (1024 * 1024),
+    );
+
+    // Auxiliary storage (NVRAM) lives in a scratch directory for this check.
+    let dir = std::env::temp_dir().join("arcbox-macos-validate");
+    std::fs::create_dir_all(&dir)?;
+    let aux_path = dir.join("aux.img");
+    let _ = std::fs::remove_file(&aux_path);
+    let aux = MacAuxiliaryStorage::create(&aux_path, &reqs.hardware_model, true)?;
+    let machine_id = MacMachineIdentifier::new()?;
+    let platform = MacPlatform::new(&reqs.hardware_model, &machine_id, &aux)?;
+
+    let cpus = usize::try_from(reqs.minimum_cpu_count.max(min_cpu_count())).unwrap_or(1);
+    let memory = reqs.minimum_memory_size.max(min_memory_size());
+
+    let mut config = VirtualMachineConfiguration::new()?;
+    config
+        .set_cpu_count(cpus)
+        .set_memory_size(memory)
+        .set_platform(platform)
+        .set_boot_loader(MacOSBootLoader::new()?);
+
+    config.validate()?;
+    println!(
+        "Gate A PASS: macOS VM configuration validated ({cpus} cpus, {} MiB).",
+        memory / (1024 * 1024)
+    );
+
+    let _ = std::fs::remove_file(&aux_path);
+    Ok(())
+}

--- a/virt/arcbox-vz/src/configuration/boot_loader.rs
+++ b/virt/arcbox-vz/src/configuration/boot_loader.rs
@@ -108,3 +108,58 @@ impl Drop for LinuxBootLoader {
         }
     }
 }
+
+/// A boot loader for macOS guests.
+///
+/// The boot loader is parameterless; a macOS guest's identity lives in its
+/// [`MacPlatform`](crate::MacPlatform) (hardware model, machine identifier, and
+/// auxiliary storage). Pair this with a `MacPlatform` on the VM configuration.
+pub struct MacOSBootLoader {
+    inner: *mut AnyObject,
+}
+
+// SAFETY: Inner ObjC pointer is only used via msg_send! which dispatches to the ObjC runtime.
+unsafe impl Send for MacOSBootLoader {}
+
+impl MacOSBootLoader {
+    /// Creates a new macOS boot loader.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `VZMacOSBootLoader` is unavailable (non-Apple-Silicon hosts
+    /// or macOS versions without macOS-guest support) or cannot be created.
+    pub fn new() -> VZResult<Self> {
+        // SAFETY: ObjC alloc/init pattern on the VZMacOSBootLoader class. Result checked non-null.
+        unsafe {
+            let cls = get_class("VZMacOSBootLoader").ok_or_else(|| VZError::Internal {
+                code: -1,
+                message: "VZMacOSBootLoader class not found".into(),
+            })?;
+            let alloc = msg_send!(cls, alloc);
+            let obj = msg_send!(alloc, init);
+
+            if obj.is_null() {
+                return Err(VZError::Internal {
+                    code: -1,
+                    message: "Failed to create VZMacOSBootLoader".into(),
+                });
+            }
+
+            Ok(Self { inner: obj })
+        }
+    }
+}
+
+impl BootLoader for MacOSBootLoader {
+    fn as_ptr(&self) -> *mut AnyObject {
+        self.inner
+    }
+}
+
+impl Drop for MacOSBootLoader {
+    fn drop(&mut self) {
+        if !self.inner.is_null() {
+            release(self.inner);
+        }
+    }
+}

--- a/virt/arcbox-vz/src/configuration/mac.rs
+++ b/virt/arcbox-vz/src/configuration/mac.rs
@@ -208,6 +208,9 @@ impl MacAuxiliaryStorage {
             let url = nsurl_file_path(&path_str);
             let alloc = msg_send!(cls, alloc);
             let obj = msg_send!(alloc, initWithURL: url);
+            // initWithURL: retains the NSURL; release the +1 from nsurl_file_path
+            // (also covers the error path below).
+            release(url);
             if obj.is_null() {
                 return Err(VZError::InvalidConfiguration(format!(
                     "failed to open macOS auxiliary storage: {path_str}"
@@ -261,6 +264,9 @@ impl MacAuxiliaryStorage {
                 options,
                 &mut error,
             );
+            // The initializer retains the NSURL; release the +1 from nsurl_file_path
+            // (also covers the error path below).
+            release(url);
             if obj.is_null() {
                 return Err(extract_nserror(error));
             }

--- a/virt/arcbox-vz/src/configuration/mac.rs
+++ b/virt/arcbox-vz/src/configuration/mac.rs
@@ -14,7 +14,7 @@ use objc2::runtime::AnyObject;
 
 use crate::error::{VZError, VZResult};
 use crate::ffi::{
-    extract_nserror, get_class, nsdata_from_bytes, nsdata_to_vec, nsurl_file_path, release,
+    extract_nserror, get_class, nsdata_from_bytes, nsdata_to_vec, nsurl_file_path, release, retain,
 };
 use crate::{msg_send, msg_send_bool};
 
@@ -71,6 +71,16 @@ impl MacHardwareModel {
         // SAFETY: dataRepresentation returns an NSData owned by the model; nsdata_to_vec only reads it.
         let data = unsafe { msg_send!(self.inner, dataRepresentation) };
         nsdata_to_vec(data)
+    }
+
+    /// Wraps a hardware-model pointer borrowed from the framework (for example a
+    /// restore image's requirements), retaining it so it outlives its source.
+    pub(crate) fn from_retained_ptr(ptr: *mut AnyObject) -> Option<Self> {
+        if ptr.is_null() {
+            return None;
+        }
+        // SAFETY: ptr is a valid VZMacHardwareModel; retain balances the release in Drop.
+        Some(Self { inner: retain(ptr) })
     }
 
     pub(crate) fn as_ptr(&self) -> *mut AnyObject {

--- a/virt/arcbox-vz/src/configuration/mac.rs
+++ b/virt/arcbox-vz/src/configuration/mac.rs
@@ -1,0 +1,272 @@
+//! macOS guest platform sub-configurations: hardware model, machine identifier,
+//! and auxiliary storage.
+//!
+//! These are the macOS-specific pieces assembled into a
+//! [`MacPlatform`](crate::MacPlatform). A hardware model (and the minimum CPU/memory
+//! requirements) is obtained from a restore image during installation; both the
+//! hardware model and the machine identifier round-trip through an opaque data
+//! representation so a base image can be reconstructed for every clone.
+
+use std::ffi::c_void;
+use std::path::Path;
+
+use objc2::runtime::AnyObject;
+
+use crate::error::{VZError, VZResult};
+use crate::ffi::{
+    extract_nserror, get_class, nsdata_from_bytes, nsdata_to_vec, nsurl_file_path, release,
+};
+use crate::{msg_send, msg_send_bool};
+
+/// A macOS guest hardware model.
+///
+/// Obtained from a restore image during installation and persisted via
+/// [`data_representation`](Self::data_representation) so the same model can be
+/// reconstructed for every clone of a base image.
+pub struct MacHardwareModel {
+    inner: *mut AnyObject,
+}
+
+// SAFETY: Inner ObjC pointer is only used via msg_send! which dispatches to the ObjC runtime.
+unsafe impl Send for MacHardwareModel {}
+
+impl MacHardwareModel {
+    /// Reconstructs a hardware model from its opaque data representation.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `VZMacHardwareModel` is unavailable or the data is not a
+    /// valid representation.
+    pub fn from_data(data: &[u8]) -> VZResult<Self> {
+        // SAFETY: alloc/initWithDataRepresentation: on VZMacHardwareModel with an NSData
+        // built from a valid slice. The temporary NSData is released after init.
+        unsafe {
+            let cls = get_class("VZMacHardwareModel").ok_or_else(|| VZError::Internal {
+                code: -1,
+                message: "VZMacHardwareModel class not found".into(),
+            })?;
+            let nsdata = nsdata_from_bytes(data);
+            let alloc = msg_send!(cls, alloc);
+            let obj = msg_send!(alloc, initWithDataRepresentation: nsdata);
+            release(nsdata);
+            if obj.is_null() {
+                return Err(VZError::InvalidConfiguration(
+                    "invalid macOS hardware model data representation".into(),
+                ));
+            }
+            Ok(Self { inner: obj })
+        }
+    }
+
+    /// Returns whether this hardware model is supported by the current host.
+    #[must_use]
+    pub fn is_supported(&self) -> bool {
+        // SAFETY: Sending isSupported to a valid VZMacHardwareModel.
+        unsafe { msg_send_bool!(self.inner, isSupported).as_bool() }
+    }
+
+    /// Returns the opaque data representation for persistence.
+    #[must_use]
+    pub fn data_representation(&self) -> Vec<u8> {
+        // SAFETY: dataRepresentation returns an NSData owned by the model; nsdata_to_vec only reads it.
+        let data = unsafe { msg_send!(self.inner, dataRepresentation) };
+        nsdata_to_vec(data)
+    }
+
+    pub(crate) fn as_ptr(&self) -> *mut AnyObject {
+        self.inner
+    }
+}
+
+impl Drop for MacHardwareModel {
+    fn drop(&mut self) {
+        if !self.inner.is_null() {
+            release(self.inner);
+        }
+    }
+}
+
+/// A macOS guest machine identifier.
+///
+/// A freshly [`new`](Self::new) identifier gives a clone its own identity; persist it
+/// via [`data_representation`](Self::data_representation) and restore with
+/// [`from_data`](Self::from_data) to keep a machine's identity stable across restarts.
+pub struct MacMachineIdentifier {
+    inner: *mut AnyObject,
+}
+
+// SAFETY: Inner ObjC pointer is only used via msg_send! which dispatches to the ObjC runtime.
+unsafe impl Send for MacMachineIdentifier {}
+
+impl MacMachineIdentifier {
+    /// Creates a new random machine identifier.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `VZMacMachineIdentifier` is unavailable.
+    pub fn new() -> VZResult<Self> {
+        // SAFETY: ObjC alloc/init pattern on VZMacMachineIdentifier. Result checked non-null.
+        unsafe {
+            let cls = get_class("VZMacMachineIdentifier").ok_or_else(|| VZError::Internal {
+                code: -1,
+                message: "VZMacMachineIdentifier class not found".into(),
+            })?;
+            let alloc = msg_send!(cls, alloc);
+            let obj = msg_send!(alloc, init);
+            if obj.is_null() {
+                return Err(VZError::Internal {
+                    code: -1,
+                    message: "Failed to create VZMacMachineIdentifier".into(),
+                });
+            }
+            Ok(Self { inner: obj })
+        }
+    }
+
+    /// Reconstructs a machine identifier from its opaque data representation.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `VZMacMachineIdentifier` is unavailable or the data is not
+    /// a valid representation.
+    pub fn from_data(data: &[u8]) -> VZResult<Self> {
+        // SAFETY: alloc/initWithDataRepresentation: on VZMacMachineIdentifier with an
+        // NSData built from a valid slice. The temporary NSData is released after init.
+        unsafe {
+            let cls = get_class("VZMacMachineIdentifier").ok_or_else(|| VZError::Internal {
+                code: -1,
+                message: "VZMacMachineIdentifier class not found".into(),
+            })?;
+            let nsdata = nsdata_from_bytes(data);
+            let alloc = msg_send!(cls, alloc);
+            let obj = msg_send!(alloc, initWithDataRepresentation: nsdata);
+            release(nsdata);
+            if obj.is_null() {
+                return Err(VZError::InvalidConfiguration(
+                    "invalid macOS machine identifier data representation".into(),
+                ));
+            }
+            Ok(Self { inner: obj })
+        }
+    }
+
+    /// Returns the opaque data representation for persistence.
+    #[must_use]
+    pub fn data_representation(&self) -> Vec<u8> {
+        // SAFETY: dataRepresentation returns an NSData owned by the identifier; nsdata_to_vec only reads it.
+        let data = unsafe { msg_send!(self.inner, dataRepresentation) };
+        nsdata_to_vec(data)
+    }
+
+    pub(crate) fn as_ptr(&self) -> *mut AnyObject {
+        self.inner
+    }
+}
+
+impl Drop for MacMachineIdentifier {
+    fn drop(&mut self) {
+        if !self.inner.is_null() {
+            release(self.inner);
+        }
+    }
+}
+
+/// Auxiliary storage (the NVRAM-equivalent backing file) for a macOS guest.
+pub struct MacAuxiliaryStorage {
+    inner: *mut AnyObject,
+}
+
+// SAFETY: Inner ObjC pointer is only used via msg_send! which dispatches to the ObjC runtime.
+unsafe impl Send for MacAuxiliaryStorage {}
+
+impl MacAuxiliaryStorage {
+    /// Opens existing auxiliary storage at `path`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `VZMacAuxiliaryStorage` is unavailable or the storage
+    /// cannot be opened.
+    pub fn open(path: impl AsRef<Path>) -> VZResult<Self> {
+        let path_str = path.as_ref().to_string_lossy();
+        // SAFETY: ObjC alloc/initWithURL: pattern on VZMacAuxiliaryStorage with an NSURL
+        // built from a valid path. Result checked non-null.
+        unsafe {
+            let cls = get_class("VZMacAuxiliaryStorage").ok_or_else(|| VZError::Internal {
+                code: -1,
+                message: "VZMacAuxiliaryStorage class not found".into(),
+            })?;
+            let url = nsurl_file_path(&path_str);
+            let alloc = msg_send!(cls, alloc);
+            let obj = msg_send!(alloc, initWithURL: url);
+            if obj.is_null() {
+                return Err(VZError::InvalidConfiguration(format!(
+                    "failed to open macOS auxiliary storage: {path_str}"
+                )));
+            }
+            Ok(Self { inner: obj })
+        }
+    }
+
+    /// Creates new auxiliary storage at `path` for `hardware_model`.
+    ///
+    /// When `overwrite` is true an existing file at `path` is replaced.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `VZMacAuxiliaryStorage` is unavailable or the storage
+    /// cannot be created.
+    pub fn create(
+        path: impl AsRef<Path>,
+        hardware_model: &MacHardwareModel,
+        overwrite: bool,
+    ) -> VZResult<Self> {
+        let path_str = path.as_ref().to_string_lossy();
+        // SAFETY: alloc + initCreatingStorageAtURL:hardwareModel:options:error: on
+        // VZMacAuxiliaryStorage. The error out-parameter is written only on failure.
+        unsafe {
+            let cls = get_class("VZMacAuxiliaryStorage").ok_or_else(|| VZError::Internal {
+                code: -1,
+                message: "VZMacAuxiliaryStorage class not found".into(),
+            })?;
+            let url = nsurl_file_path(&path_str);
+            let alloc = msg_send!(cls, alloc);
+            // VZMacAuxiliaryStorageInitializationOptionAllowOverwrite = 1 << 0.
+            let options: u64 = u64::from(overwrite);
+            let mut error: *mut AnyObject = std::ptr::null_mut();
+            let sel = objc2::sel!(initCreatingStorageAtURL:hardwareModel:options:error:);
+            let func: unsafe extern "C" fn(
+                *mut AnyObject,
+                objc2::runtime::Sel,
+                *const AnyObject,
+                *const AnyObject,
+                u64,
+                *mut *mut AnyObject,
+            ) -> *mut AnyObject =
+                std::mem::transmute(crate::ffi::runtime::objc_msgSend as *const c_void);
+            let obj = func(
+                alloc,
+                sel,
+                url as *const AnyObject,
+                hardware_model.as_ptr() as *const AnyObject,
+                options,
+                &mut error,
+            );
+            if obj.is_null() {
+                return Err(extract_nserror(error));
+            }
+            Ok(Self { inner: obj })
+        }
+    }
+
+    pub(crate) fn as_ptr(&self) -> *mut AnyObject {
+        self.inner
+    }
+}
+
+impl Drop for MacAuxiliaryStorage {
+    fn drop(&mut self) {
+        if !self.inner.is_null() {
+            release(self.inner);
+        }
+    }
+}

--- a/virt/arcbox-vz/src/configuration/mod.rs
+++ b/virt/arcbox-vz/src/configuration/mod.rs
@@ -4,9 +4,11 @@
 //! including boot loaders, platform configurations, and device settings.
 
 mod boot_loader;
+mod mac;
 mod platform;
 mod vm_config;
 
-pub use boot_loader::{BootLoader, LinuxBootLoader};
-pub use platform::{GenericPlatform, Platform};
+pub use boot_loader::{BootLoader, LinuxBootLoader, MacOSBootLoader};
+pub use mac::{MacAuxiliaryStorage, MacHardwareModel, MacMachineIdentifier};
+pub use platform::{GenericPlatform, MacPlatform, Platform};
 pub use vm_config::VirtualMachineConfiguration;

--- a/virt/arcbox-vz/src/configuration/platform.rs
+++ b/virt/arcbox-vz/src/configuration/platform.rs
@@ -2,8 +2,10 @@
 
 use crate::error::{VZError, VZResult};
 use crate::ffi::{get_class, release};
-use crate::{msg_send, msg_send_bool, msg_send_void_bool};
+use crate::{msg_send, msg_send_bool, msg_send_void, msg_send_void_bool};
 use objc2::runtime::{AnyObject, Bool};
+
+use super::mac::{MacAuxiliaryStorage, MacHardwareModel, MacMachineIdentifier};
 
 /// Trait for platform configurations.
 pub trait Platform {
@@ -99,6 +101,74 @@ impl Platform for GenericPlatform {
 }
 
 impl Drop for GenericPlatform {
+    fn drop(&mut self) {
+        if !self.inner.is_null() {
+            release(self.inner);
+        }
+    }
+}
+
+/// A platform configuration for macOS guests.
+///
+/// Combines a hardware model, machine identifier, and auxiliary storage into the
+/// platform required to boot a macOS guest. Pair it with a
+/// [`MacOSBootLoader`](crate::MacOSBootLoader) on the VM configuration.
+pub struct MacPlatform {
+    inner: *mut AnyObject,
+}
+
+// SAFETY: Inner ObjC pointer is only used via msg_send! which dispatches to the ObjC runtime.
+unsafe impl Send for MacPlatform {}
+
+impl MacPlatform {
+    /// Creates a macOS platform from its hardware model, machine identifier, and
+    /// auxiliary storage.
+    ///
+    /// The platform retains its own references to each component (the properties are
+    /// strong), so the arguments may be dropped once this returns.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `VZMacPlatformConfiguration` is unavailable or cannot be
+    /// created.
+    pub fn new(
+        hardware_model: &MacHardwareModel,
+        machine_identifier: &MacMachineIdentifier,
+        auxiliary_storage: &MacAuxiliaryStorage,
+    ) -> VZResult<Self> {
+        // SAFETY: ObjC alloc/init on VZMacPlatformConfiguration, then strong-property
+        // setters that retain their arguments. Result checked non-null.
+        unsafe {
+            let cls = get_class("VZMacPlatformConfiguration").ok_or_else(|| VZError::Internal {
+                code: -1,
+                message: "VZMacPlatformConfiguration class not found".into(),
+            })?;
+            let alloc = msg_send!(cls, alloc);
+            let obj = msg_send!(alloc, init);
+
+            if obj.is_null() {
+                return Err(VZError::Internal {
+                    code: -1,
+                    message: "Failed to create VZMacPlatformConfiguration".into(),
+                });
+            }
+
+            msg_send_void!(obj, setHardwareModel: hardware_model.as_ptr());
+            msg_send_void!(obj, setMachineIdentifier: machine_identifier.as_ptr());
+            msg_send_void!(obj, setAuxiliaryStorage: auxiliary_storage.as_ptr());
+
+            Ok(Self { inner: obj })
+        }
+    }
+}
+
+impl Platform for MacPlatform {
+    fn as_ptr(&self) -> *mut AnyObject {
+        self.inner
+    }
+}
+
+impl Drop for MacPlatform {
     fn drop(&mut self) {
         if !self.inner.is_null() {
             release(self.inner);

--- a/virt/arcbox-vz/src/configuration/vm_config.rs
+++ b/virt/arcbox-vz/src/configuration/vm_config.rs
@@ -1,9 +1,9 @@
 //! Virtual machine configuration.
 
 use crate::device::{
-    EntropyDeviceConfiguration, MemoryBalloonDeviceConfiguration, NetworkDeviceConfiguration,
-    SerialPortConfiguration, SocketDeviceConfiguration, StorageDeviceConfiguration,
-    VirtioFileSystemDeviceConfiguration,
+    EntropyDeviceConfiguration, MacGraphicsDeviceConfiguration, MemoryBalloonDeviceConfiguration,
+    NetworkDeviceConfiguration, SerialPortConfiguration, SocketDeviceConfiguration,
+    StorageDeviceConfiguration, VirtioFileSystemDeviceConfiguration,
 };
 use crate::error::{VZError, VZResult};
 use crate::ffi::{DispatchQueue, get_class, nsarray, release};
@@ -27,6 +27,7 @@ pub struct VirtualMachineConfiguration {
     entropy_devices: Vec<*mut AnyObject>,
     directory_sharing_devices: Vec<*mut AnyObject>,
     memory_balloon_devices: Vec<*mut AnyObject>,
+    graphics_devices: Vec<*mut AnyObject>,
 }
 
 // SAFETY: Inner ObjC pointer is only used via msg_send! which dispatches to the ObjC runtime.
@@ -61,6 +62,7 @@ impl VirtualMachineConfiguration {
                 entropy_devices: Vec::new(),
                 directory_sharing_devices: Vec::new(),
                 memory_balloon_devices: Vec::new(),
+                graphics_devices: Vec::new(),
             })
         }
     }
@@ -128,6 +130,14 @@ impl VirtualMachineConfiguration {
     /// Adds a storage device to the VM.
     pub fn add_storage_device(&mut self, device: StorageDeviceConfiguration) -> &mut Self {
         self.storage_devices.push(device.into_ptr());
+        self
+    }
+
+    /// Adds a macOS graphics device to the VM.
+    ///
+    /// A macOS guest requires at least one graphics device to start.
+    pub fn add_graphics_device(&mut self, device: MacGraphicsDeviceConfiguration) -> &mut Self {
+        self.graphics_devices.push(device.into_ptr());
         self
     }
 
@@ -271,6 +281,11 @@ impl VirtualMachineConfiguration {
             if !self.memory_balloon_devices.is_empty() {
                 let array = nsarray(&self.memory_balloon_devices);
                 msg_send_void!(self.inner, setMemoryBalloonDevices: array);
+            }
+
+            if !self.graphics_devices.is_empty() {
+                let array = nsarray(&self.graphics_devices);
+                msg_send_void!(self.inner, setGraphicsDevices: array);
             }
         }
     }

--- a/virt/arcbox-vz/src/device/graphics.rs
+++ b/virt/arcbox-vz/src/device/graphics.rs
@@ -1,0 +1,109 @@
+//! macOS graphics device configuration.
+
+use crate::error::{VZError, VZResult};
+use crate::ffi::{get_class, nsarray, release};
+use crate::{msg_send, msg_send_void};
+use objc2::runtime::AnyObject;
+use std::ffi::c_void;
+
+/// Configuration for a macOS graphics device with a single display.
+///
+/// A macOS guest requires at least one graphics device to start. This creates a
+/// `VZMacGraphicsDeviceConfiguration` holding one `VZMacGraphicsDisplayConfiguration`.
+pub struct MacGraphicsDeviceConfiguration {
+    inner: *mut AnyObject,
+}
+
+// SAFETY: Inner ObjC pointer is only used via msg_send! which dispatches to the ObjC runtime.
+unsafe impl Send for MacGraphicsDeviceConfiguration {}
+
+impl MacGraphicsDeviceConfiguration {
+    /// Creates a graphics device with a single display of the given pixel
+    /// dimensions and pixel density.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the graphics/display class is unavailable or cannot be
+    /// created.
+    pub fn new(
+        width_in_pixels: isize,
+        height_in_pixels: isize,
+        pixels_per_inch: isize,
+    ) -> VZResult<Self> {
+        // SAFETY: alloc/init on VZMacGraphicsDisplayConfiguration (3 NSInteger args)
+        // and VZMacGraphicsDeviceConfiguration; setDisplays: takes an NSArray. The
+        // device's `displays` is a copy property, so the temporary display is
+        // released after it is set.
+        unsafe {
+            let display_cls = get_class("VZMacGraphicsDisplayConfiguration").ok_or_else(|| {
+                VZError::Internal {
+                    code: -1,
+                    message: "VZMacGraphicsDisplayConfiguration class not found".into(),
+                }
+            })?;
+            let display_alloc = msg_send!(display_cls, alloc);
+            let init_sel = objc2::sel!(initWithWidthInPixels:heightInPixels:pixelsPerInch:);
+            let init_fn: unsafe extern "C" fn(
+                *mut AnyObject,
+                objc2::runtime::Sel,
+                isize,
+                isize,
+                isize,
+            ) -> *mut AnyObject =
+                std::mem::transmute(crate::ffi::runtime::objc_msgSend as *const c_void);
+            let display = init_fn(
+                display_alloc,
+                init_sel,
+                width_in_pixels,
+                height_in_pixels,
+                pixels_per_inch,
+            );
+            if display.is_null() {
+                return Err(VZError::InvalidConfiguration(
+                    "failed to create macOS graphics display".into(),
+                ));
+            }
+
+            let device_cls = match get_class("VZMacGraphicsDeviceConfiguration") {
+                Some(cls) => cls,
+                None => {
+                    release(display);
+                    return Err(VZError::Internal {
+                        code: -1,
+                        message: "VZMacGraphicsDeviceConfiguration class not found".into(),
+                    });
+                }
+            };
+            let device = msg_send!(msg_send!(device_cls, alloc), init);
+            if device.is_null() {
+                release(display);
+                return Err(VZError::Internal {
+                    code: -1,
+                    message: "Failed to create macOS graphics device".into(),
+                });
+            }
+
+            let displays = nsarray(&[display]);
+            msg_send_void!(device, setDisplays: displays);
+            release(display);
+
+            Ok(Self { inner: device })
+        }
+    }
+
+    /// Consumes the configuration and returns the raw pointer.
+    #[must_use]
+    pub fn into_ptr(self) -> *mut AnyObject {
+        let ptr = self.inner;
+        std::mem::forget(self);
+        ptr
+    }
+}
+
+impl Drop for MacGraphicsDeviceConfiguration {
+    fn drop(&mut self) {
+        if !self.inner.is_null() {
+            release(self.inner);
+        }
+    }
+}

--- a/virt/arcbox-vz/src/device/mod.rs
+++ b/virt/arcbox-vz/src/device/mod.rs
@@ -6,6 +6,7 @@
 mod balloon;
 mod entropy;
 mod filesystem;
+mod graphics;
 mod network;
 mod serial;
 mod socket;
@@ -18,6 +19,7 @@ pub use filesystem::{
     DirectoryShare, LinuxRosettaDirectoryShare, MultipleDirectoryShare, RosettaAvailability,
     SharedDirectory, SingleDirectoryShare, VirtioFileSystemDeviceConfiguration,
 };
+pub use graphics::MacGraphicsDeviceConfiguration;
 pub use network::NetworkDeviceConfiguration;
 pub use serial::SerialPortConfiguration;
 pub use socket::SocketDeviceConfiguration;

--- a/virt/arcbox-vz/src/ffi/block.rs
+++ b/virt/arcbox-vz/src/ffi/block.rs
@@ -456,8 +456,7 @@ unsafe extern "C" fn state_block_invoke(block: *mut StateContextBlock, error: *m
         let result = if error.is_null() {
             Ok(())
         } else {
-            let desc: *mut AnyObject = crate::msg_send!(error, localizedDescription);
-            Err(crate::ffi::nsstring_to_string(desc))
+            Err(crate::ffi::describe_nserror(error))
         };
         let _ = sender.send(result);
     }

--- a/virt/arcbox-vz/src/ffi/block.rs
+++ b/virt/arcbox-vz/src/ffi/block.rs
@@ -496,6 +496,109 @@ pub fn create_state_completion_block(sender: oneshot::Sender<StateResult>) -> *c
     }
 }
 
+/// Result of an async call that yields a retained object pointer or an error.
+///
+/// On success the pointer bits (`usize`) of the result object are returned; the
+/// object is retained in the invoke handler so it outlives the callback, and the
+/// receiver owns that `+1` reference.
+pub type ObjectResult = Result<usize, String>;
+
+/// Block for completion handlers shaped `(id result, NSError *error)`.
+///
+/// Captures a oneshot sender; on invoke it retains a non-null result object and
+/// sends its pointer bits, or sends the error's localized description.
+#[repr(C)]
+pub struct ObjectContextBlock {
+    /// ISA pointer.
+    pub isa: *const c_void,
+    /// Block flags.
+    pub flags: i32,
+    /// Reserved.
+    pub reserved: i32,
+    /// Invoke function pointer — matches `(id, NSError *)` completion handlers.
+    pub invoke: unsafe extern "C" fn(*mut Self, *mut AnyObject, *mut AnyObject),
+    /// Block descriptor.
+    pub descriptor: *const BlockDescriptorWithHelpers,
+    /// Captured context: raw pointer to Box<`oneshot::Sender`<ObjectResult>>.
+    pub sender_ptr: *mut c_void,
+}
+
+unsafe extern "C" fn object_block_copy(_dst: *mut c_void, _src: *const c_void) {
+    // sender_ptr is a raw pointer; ownership transfers with the block copy.
+}
+
+unsafe extern "C" fn object_block_dispose(block: *mut c_void) {
+    // SAFETY: `block` is an `ObjectContextBlock` from the block runtime; `sender_ptr`
+    // is null (already consumed) or a valid Box pointer from create_object_completion_block.
+    unsafe {
+        let block = block as *mut ObjectContextBlock;
+        let sender_ptr = (*block).sender_ptr;
+        if !sender_ptr.is_null() {
+            let _ = Box::from_raw(sender_ptr as *mut oneshot::Sender<ObjectResult>);
+        }
+    }
+}
+
+unsafe extern "C" fn object_block_invoke(
+    block: *mut ObjectContextBlock,
+    object: *mut AnyObject,
+    error: *mut AnyObject,
+) {
+    // SAFETY: `block` is a valid `ObjectContextBlock` invoked by VZ. We take ownership
+    // of the boxed sender and null the pointer so dispose can't double-free. A non-null
+    // result object is retained so it outlives this callback.
+    unsafe {
+        let sender_ptr = (*block).sender_ptr;
+        if sender_ptr.is_null() {
+            return;
+        }
+        let sender = Box::from_raw(sender_ptr as *mut oneshot::Sender<ObjectResult>);
+        (*block).sender_ptr = ptr::null_mut();
+
+        let result = if !error.is_null() {
+            let desc: *mut AnyObject = crate::msg_send!(error, localizedDescription);
+            Err(crate::ffi::nsstring_to_string(desc))
+        } else if !object.is_null() {
+            let _: *mut AnyObject = crate::msg_send!(object, retain);
+            Ok(object as usize)
+        } else {
+            Err("completion handler received neither result nor error".to_string())
+        };
+        let _ = sender.send(result);
+    }
+}
+
+/// Descriptor for `ObjectContextBlock`.
+static OBJECT_CONTEXT_BLOCK_DESCRIPTOR: BlockDescriptorWithHelpers = BlockDescriptorWithHelpers {
+    reserved: 0,
+    size: std::mem::size_of::<ObjectContextBlock>() as u64,
+    copy_helper: object_block_copy,
+    dispose_helper: object_block_dispose,
+};
+
+/// Creates an `(id, NSError *)` completion block with a captured sender.
+///
+/// On invoke, a non-null result object is retained and its pointer bits are sent
+/// through `sender`; the receiver owns that `+1` reference.
+#[must_use]
+pub fn create_object_completion_block(sender: oneshot::Sender<ObjectResult>) -> *const c_void {
+    let sender_box = Box::new(sender);
+    let sender_ptr = Box::into_raw(sender_box) as *mut c_void;
+
+    // SAFETY: Stack block with the correct ABI layout; `_Block_copy` heap-copies it.
+    unsafe {
+        let stack_block = ObjectContextBlock {
+            isa: _NSConcreteStackBlock,
+            flags: BLOCK_HAS_COPY_DISPOSE,
+            reserved: 0,
+            invoke: object_block_invoke,
+            descriptor: &OBJECT_CONTEXT_BLOCK_DESCRIPTOR,
+            sender_ptr,
+        };
+        _Block_copy(&stack_block as *const ObjectContextBlock as *const c_void)
+    }
+}
+
 // ============================================================================
 // Block Runtime FFI
 // ============================================================================

--- a/virt/arcbox-vz/src/ffi/data.rs
+++ b/virt/arcbox-vz/src/ffi/data.rs
@@ -1,0 +1,60 @@
+//! `NSData` helpers.
+
+use objc2::runtime::AnyObject;
+use std::ffi::c_void;
+
+use super::runtime::get_class;
+use crate::msg_send;
+
+/// Creates an `NSData` that owns a copy of `bytes`.
+///
+/// Returns a `+1`-retained object (`alloc` + `initWithBytes:length:`); the caller is
+/// responsible for releasing it once any consumer has copied or retained the data.
+pub fn nsdata_from_bytes(bytes: &[u8]) -> *mut AnyObject {
+    // SAFETY: NSData is always available in the ObjC runtime. initWithBytes:length:
+    // copies `len` bytes from the valid slice pointer; an empty slice yields empty data.
+    unsafe {
+        let cls = get_class("NSData").expect("NSData class not found");
+        let alloc = msg_send!(cls, alloc);
+        let sel = objc2::sel!(initWithBytes:length:);
+        let func: unsafe extern "C" fn(
+            *mut AnyObject,
+            objc2::runtime::Sel,
+            *const c_void,
+            usize,
+        ) -> *mut AnyObject = std::mem::transmute(super::runtime::objc_msgSend as *const c_void);
+        func(alloc, sel, bytes.as_ptr() as *const c_void, bytes.len())
+    }
+}
+
+/// Copies the contents of an `NSData` into a `Vec<u8>`.
+///
+/// Returns an empty vector when `obj` is null or empty. The `NSData` is only read;
+/// its ownership is unchanged.
+#[must_use]
+pub fn nsdata_to_vec(obj: *mut AnyObject) -> Vec<u8> {
+    if obj.is_null() {
+        return Vec::new();
+    }
+    // SAFETY: obj is checked non-null. `length`/`bytes` return a buffer of `length`
+    // bytes owned by the NSData and valid for the duration of this read.
+    unsafe {
+        let len_sel = objc2::sel!(length);
+        let len_func: unsafe extern "C" fn(*const AnyObject, objc2::runtime::Sel) -> usize =
+            std::mem::transmute(super::runtime::objc_msgSend as *const c_void);
+        let len = len_func(obj as *const AnyObject, len_sel);
+        if len == 0 {
+            return Vec::new();
+        }
+        let bytes_sel = objc2::sel!(bytes);
+        let bytes_func: unsafe extern "C" fn(
+            *const AnyObject,
+            objc2::runtime::Sel,
+        ) -> *const c_void = std::mem::transmute(super::runtime::objc_msgSend as *const c_void);
+        let ptr = bytes_func(obj as *const AnyObject, bytes_sel).cast::<u8>();
+        if ptr.is_null() {
+            return Vec::new();
+        }
+        std::slice::from_raw_parts(ptr, len).to_vec()
+    }
+}

--- a/virt/arcbox-vz/src/ffi/mod.rs
+++ b/virt/arcbox-vz/src/ffi/mod.rs
@@ -138,6 +138,35 @@ pub fn extract_nserror(error: *mut AnyObject) -> VZError {
     }
 }
 
+/// Builds a detailed description of an `NSError`.
+///
+/// Includes the domain, code, and `userInfo` dictionary, which surfaces the
+/// underlying error and failure reason that `localizedDescription` alone hides.
+#[must_use]
+pub fn describe_nserror(error: *mut AnyObject) -> String {
+    if error.is_null() {
+        return "unknown error".to_string();
+    }
+    // SAFETY: error is non-null; localizedDescription/domain/userInfo and the userInfo
+    // dictionary's description return objects owned by the error or autoreleased; read-only.
+    unsafe {
+        let desc = nsstring_to_string(msg_send!(error, localizedDescription));
+        let code: i64 = msg_send_i64!(error, code);
+        let domain = nsstring_to_string(msg_send!(error, domain));
+        let info = msg_send!(error, userInfo);
+        let info_str = if info.is_null() {
+            String::new()
+        } else {
+            nsstring_to_string(msg_send!(info, description))
+        };
+        if info_str.is_empty() {
+            format!("{desc} (domain={domain}, code={code})")
+        } else {
+            format!("{desc} (domain={domain}, code={code}); userInfo={info_str}")
+        }
+    }
+}
+
 // ============================================================================
 // Tests
 // ============================================================================

--- a/virt/arcbox-vz/src/ffi/mod.rs
+++ b/virt/arcbox-vz/src/ffi/mod.rs
@@ -4,6 +4,7 @@
 //! safe API. Most users should not need to use this module directly.
 
 pub mod block;
+pub mod data;
 pub mod dispatch;
 pub mod foundation;
 pub mod memory;
@@ -11,6 +12,7 @@ pub mod runloop;
 pub mod runtime;
 
 pub use block::*;
+pub use data::*;
 pub use dispatch::*;
 pub use foundation::*;
 pub use memory::*;

--- a/virt/arcbox-vz/src/lib.rs
+++ b/virt/arcbox-vz/src/lib.rs
@@ -71,7 +71,10 @@ pub mod vm;
 // Re-exports for convenience
 pub use error::VZError;
 
-pub use configuration::{GenericPlatform, LinuxBootLoader, Platform, VirtualMachineConfiguration};
+pub use configuration::{
+    GenericPlatform, LinuxBootLoader, MacAuxiliaryStorage, MacHardwareModel, MacMachineIdentifier,
+    MacOSBootLoader, MacPlatform, Platform, VirtualMachineConfiguration,
+};
 
 pub use device::{
     DirectoryShare, EntropyDeviceConfiguration, LinuxRosettaDirectoryShare, MemoryBalloonDevice,

--- a/virt/arcbox-vz/src/lib.rs
+++ b/virt/arcbox-vz/src/lib.rs
@@ -65,6 +65,7 @@ pub mod ffi;
 pub mod configuration;
 pub(crate) mod delegate;
 pub mod device;
+pub mod restore;
 pub mod socket;
 pub mod vm;
 
@@ -84,6 +85,8 @@ pub use device::{
 };
 
 pub use socket::{VirtioSocketConnection, VirtioSocketDevice, VirtioSocketListener};
+
+pub use restore::{MacOSConfigurationRequirements, MacOSRestoreImage};
 
 pub use vm::{VirtualMachine, VirtualMachineState};
 

--- a/virt/arcbox-vz/src/lib.rs
+++ b/virt/arcbox-vz/src/lib.rs
@@ -86,7 +86,7 @@ pub use device::{
 
 pub use socket::{VirtioSocketConnection, VirtioSocketDevice, VirtioSocketListener};
 
-pub use restore::{MacOSConfigurationRequirements, MacOSRestoreImage};
+pub use restore::{MacOSConfigurationRequirements, MacOSInstaller, MacOSRestoreImage};
 
 pub use vm::{VirtualMachine, VirtualMachineState};
 

--- a/virt/arcbox-vz/src/lib.rs
+++ b/virt/arcbox-vz/src/lib.rs
@@ -78,10 +78,11 @@ pub use configuration::{
 };
 
 pub use device::{
-    DirectoryShare, EntropyDeviceConfiguration, LinuxRosettaDirectoryShare, MemoryBalloonDevice,
-    MemoryBalloonDeviceConfiguration, MultipleDirectoryShare, NetworkDeviceConfiguration,
-    RosettaAvailability, SerialPortConfiguration, SharedDirectory, SingleDirectoryShare,
-    SocketDeviceConfiguration, StorageDeviceConfiguration, VirtioFileSystemDeviceConfiguration,
+    DirectoryShare, EntropyDeviceConfiguration, LinuxRosettaDirectoryShare,
+    MacGraphicsDeviceConfiguration, MemoryBalloonDevice, MemoryBalloonDeviceConfiguration,
+    MultipleDirectoryShare, NetworkDeviceConfiguration, RosettaAvailability,
+    SerialPortConfiguration, SharedDirectory, SingleDirectoryShare, SocketDeviceConfiguration,
+    StorageDeviceConfiguration, VirtioFileSystemDeviceConfiguration,
 };
 
 pub use socket::{VirtioSocketConnection, VirtioSocketDevice, VirtioSocketListener};

--- a/virt/arcbox-vz/src/restore.rs
+++ b/virt/arcbox-vz/src/restore.rs
@@ -201,32 +201,35 @@ impl MacOSInstaller {
         virtual_machine: &VirtualMachine,
         restore_image_path: impl AsRef<Path>,
     ) -> VZResult<Self> {
-        let path_str = restore_image_path.as_ref().to_string_lossy();
-        // SAFETY: alloc/initWithVirtualMachine:restoreImageURL: on VZMacOSInstaller with a
-        // valid VM pointer and an NSURL from a local path. Result checked non-null.
-        unsafe {
-            let cls = get_class("VZMacOSInstaller").ok_or_else(|| VZError::Internal {
-                code: -1,
-                message: "VZMacOSInstaller class not found".into(),
-            })?;
-            let url = nsurl_file_path(&path_str);
-            let alloc = msg_send!(cls, alloc);
-            let obj = msg_send!(
-                alloc,
-                initWithVirtualMachine: virtual_machine.as_ptr(),
-                restoreImageURL: url
-            );
-            if obj.is_null() {
-                return Err(VZError::InvalidConfiguration(
-                    "failed to create VZMacOSInstaller".into(),
-                ));
+        let path_str = restore_image_path.as_ref().to_string_lossy().into_owned();
+        let vm_ptr = virtual_machine.as_ptr();
+        // VZMacOSInstaller's initializer asserts (dispatch_assert_queue) that it runs on
+        // the VM's dispatch queue, so construct it there.
+        let (inner, progress) = virtual_machine.dispatch_sync(|| {
+            // SAFETY: alloc/initWithVirtualMachine:restoreImageURL: on VZMacOSInstaller with
+            // a valid VM pointer and an NSURL from a local path. Result checked non-null.
+            unsafe {
+                let cls = get_class("VZMacOSInstaller").ok_or_else(|| VZError::Internal {
+                    code: -1,
+                    message: "VZMacOSInstaller class not found".into(),
+                })?;
+                let url = nsurl_file_path(&path_str);
+                let alloc = msg_send!(cls, alloc);
+                let obj = msg_send!(
+                    alloc,
+                    initWithVirtualMachine: vm_ptr,
+                    restoreImageURL: url
+                );
+                if obj.is_null() {
+                    return Err(VZError::InvalidConfiguration(
+                        "failed to create VZMacOSInstaller".into(),
+                    ));
+                }
+                let progress = msg_send!(obj, progress);
+                Ok((obj, progress))
             }
-            let progress = msg_send!(obj, progress);
-            Ok(Self {
-                inner: obj,
-                progress,
-            })
-        }
+        })?;
+        Ok(Self { inner, progress })
     }
 
     /// Returns installation progress as a fraction in `0.0..=1.0`.

--- a/virt/arcbox-vz/src/restore.rs
+++ b/virt/arcbox-vz/src/restore.rs
@@ -1,0 +1,153 @@
+//! macOS restore images.
+//!
+//! A restore image describes a macOS installation source — a local IPSW or the
+//! latest version Apple publishes. Its most-featureful supported configuration
+//! yields the hardware model and the minimum CPU/memory a guest needs, which are
+//! the inputs to a [`MacPlatform`](crate::MacPlatform) and a
+//! [`MacAuxiliaryStorage`](crate::MacAuxiliaryStorage).
+
+use std::ffi::c_void;
+use std::path::Path;
+
+use objc2::runtime::{AnyClass, AnyObject};
+use tokio::sync::oneshot;
+
+use crate::configuration::MacHardwareModel;
+use crate::error::{VZError, VZResult};
+use crate::ffi::{
+    _Block_release, ObjectResult, create_object_completion_block, get_class, nsurl_file_path,
+    release,
+};
+use crate::{msg_send, msg_send_u64};
+
+/// The most-featureful configuration a restore image supports.
+pub struct MacOSConfigurationRequirements {
+    /// The hardware model the guest must use.
+    pub hardware_model: MacHardwareModel,
+    /// Minimum number of CPUs the guest requires.
+    pub minimum_cpu_count: u64,
+    /// Minimum guest memory in bytes.
+    pub minimum_memory_size: u64,
+}
+
+/// A macOS restore image — a local IPSW or the latest version Apple publishes.
+pub struct MacOSRestoreImage {
+    inner: *mut AnyObject,
+}
+
+// SAFETY: Inner ObjC pointer is only used via msg_send! which dispatches to the ObjC runtime.
+unsafe impl Send for MacOSRestoreImage {}
+
+impl MacOSRestoreImage {
+    /// Fetches metadata for the latest supported restore image.
+    ///
+    /// This contacts Apple's servers for the metadata only; it does not download
+    /// the multi-gigabyte IPSW.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `VZMacOSRestoreImage` is unavailable or the fetch fails.
+    pub async fn latest_supported() -> VZResult<Self> {
+        let cls = get_class("VZMacOSRestoreImage").ok_or_else(|| VZError::Internal {
+            code: -1,
+            message: "VZMacOSRestoreImage class not found".into(),
+        })?;
+        let (tx, rx) = oneshot::channel::<ObjectResult>();
+        let block = create_object_completion_block(tx);
+        // SAFETY: +latestSupportedWithCompletionHandler: takes one block argument and
+        // returns void; `block` is a heap-copied block released after the await.
+        unsafe {
+            let sel = objc2::sel!(latestSupportedWithCompletionHandler:);
+            let func: unsafe extern "C" fn(*const AnyClass, objc2::runtime::Sel, *const c_void) =
+                std::mem::transmute(crate::ffi::runtime::objc_msgSend as *const c_void);
+            func(cls, sel, block);
+        }
+        let received = rx.await;
+        // SAFETY: `block` was returned by create_object_completion_block and not released elsewhere.
+        unsafe { _Block_release(block) };
+        Self::from_received(received)
+    }
+
+    /// Loads a restore image from a local file (an IPSW).
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `VZMacOSRestoreImage` is unavailable or the file cannot
+    /// be loaded as a restore image.
+    pub async fn load_from_url(path: impl AsRef<Path>) -> VZResult<Self> {
+        let path_str = path.as_ref().to_string_lossy();
+        let cls = get_class("VZMacOSRestoreImage").ok_or_else(|| VZError::Internal {
+            code: -1,
+            message: "VZMacOSRestoreImage class not found".into(),
+        })?;
+        let (tx, rx) = oneshot::channel::<ObjectResult>();
+        let block = create_object_completion_block(tx);
+        // SAFETY: +loadFromURL:completionHandler: takes an NSURL and a block and returns
+        // void; `block` is a heap-copied block released after the await.
+        unsafe {
+            let url = nsurl_file_path(&path_str);
+            let sel = objc2::sel!(loadFromURL:completionHandler:);
+            let func: unsafe extern "C" fn(
+                *const AnyClass,
+                objc2::runtime::Sel,
+                *const AnyObject,
+                *const c_void,
+            ) = std::mem::transmute(crate::ffi::runtime::objc_msgSend as *const c_void);
+            func(cls, sel, url as *const AnyObject, block);
+        }
+        let received = rx.await;
+        // SAFETY: `block` was returned by create_object_completion_block and not released elsewhere.
+        unsafe { _Block_release(block) };
+        Self::from_received(received)
+    }
+
+    /// Wraps the result delivered by the completion block into a restore image.
+    fn from_received(received: Result<ObjectResult, oneshot::error::RecvError>) -> VZResult<Self> {
+        let bits = received
+            .map_err(|_| VZError::Internal {
+                code: -1,
+                message: "restore image completion handler dropped".into(),
+            })?
+            .map_err(|message| VZError::Internal { code: -1, message })?;
+        Ok(Self {
+            inner: bits as *mut AnyObject,
+        })
+    }
+
+    /// Returns the most-featureful configuration this restore image supports.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the restore image exposes no supported configuration.
+    pub fn requirements(&self) -> VZResult<MacOSConfigurationRequirements> {
+        // SAFETY: mostFeaturefulSupportedConfiguration and its properties are read from
+        // a valid VZMacOSRestoreImage; the returned objects are owned by the framework.
+        unsafe {
+            let reqs = msg_send!(self.inner, mostFeaturefulSupportedConfiguration);
+            if reqs.is_null() {
+                return Err(VZError::InvalidConfiguration(
+                    "restore image has no supported configuration".into(),
+                ));
+            }
+            let hw_ptr = msg_send!(reqs, hardwareModel);
+            let hardware_model = MacHardwareModel::from_retained_ptr(hw_ptr).ok_or_else(|| {
+                VZError::InvalidConfiguration("restore image has no hardware model".into())
+            })?;
+            let minimum_cpu_count = msg_send_u64!(reqs, minimumSupportedCPUCount);
+            let minimum_memory_size = msg_send_u64!(reqs, minimumSupportedMemorySize);
+            Ok(MacOSConfigurationRequirements {
+                hardware_model,
+                minimum_cpu_count,
+                minimum_memory_size,
+            })
+        }
+    }
+}
+
+impl Drop for MacOSRestoreImage {
+    fn drop(&mut self) {
+        if !self.inner.is_null() {
+            release(self.inner);
+        }
+    }
+}

--- a/virt/arcbox-vz/src/restore.rs
+++ b/virt/arcbox-vz/src/restore.rs
@@ -54,10 +54,10 @@ impl MacOSRestoreImage {
         })?;
         let (tx, rx) = oneshot::channel::<ObjectResult>();
         let block = create_object_completion_block(tx);
-        // SAFETY: +latestSupportedWithCompletionHandler: takes one block argument and
-        // returns void; `block` is a heap-copied block released after the await.
+        // SAFETY: +fetchLatestSupportedWithCompletionHandler: takes one block argument
+        // and returns void; `block` is a heap-copied block released after the await.
         unsafe {
-            let sel = objc2::sel!(latestSupportedWithCompletionHandler:);
+            let sel = objc2::sel!(fetchLatestSupportedWithCompletionHandler:);
             let func: unsafe extern "C" fn(*const AnyClass, objc2::runtime::Sel, *const c_void) =
                 std::mem::transmute(crate::ffi::runtime::objc_msgSend as *const c_void);
             func(cls, sel, block);
@@ -82,11 +82,11 @@ impl MacOSRestoreImage {
         })?;
         let (tx, rx) = oneshot::channel::<ObjectResult>();
         let block = create_object_completion_block(tx);
-        // SAFETY: +loadFromURL:completionHandler: takes an NSURL and a block and returns
+        // SAFETY: +loadFileURL:completionHandler: takes an NSURL and a block and returns
         // void; `block` is a heap-copied block released after the await.
         unsafe {
             let url = nsurl_file_path(&path_str);
-            let sel = objc2::sel!(loadFromURL:completionHandler:);
+            let sel = objc2::sel!(loadFileURL:completionHandler:);
             let func: unsafe extern "C" fn(
                 *const AnyClass,
                 objc2::runtime::Sel,

--- a/virt/arcbox-vz/src/restore.rs
+++ b/virt/arcbox-vz/src/restore.rs
@@ -8,17 +8,20 @@
 
 use std::ffi::c_void;
 use std::path::Path;
+use std::time::Duration;
 
 use objc2::runtime::{AnyClass, AnyObject};
 use tokio::sync::oneshot;
+use tokio::time::sleep;
 
 use crate::configuration::MacHardwareModel;
 use crate::error::{VZError, VZResult};
 use crate::ffi::{
-    _Block_release, ObjectResult, create_object_completion_block, get_class, nsurl_file_path,
-    release,
+    _Block_release, ObjectResult, StateResult, create_object_completion_block,
+    create_state_completion_block, get_class, nsurl_file_path, release,
 };
-use crate::{msg_send, msg_send_u64};
+use crate::vm::VirtualMachine;
+use crate::{msg_send, msg_send_u64, msg_send_void};
 
 /// The most-featureful configuration a restore image supports.
 pub struct MacOSConfigurationRequirements {
@@ -145,6 +148,124 @@ impl MacOSRestoreImage {
 }
 
 impl Drop for MacOSRestoreImage {
+    fn drop(&mut self) {
+        if !self.inner.is_null() {
+            release(self.inner);
+        }
+    }
+}
+
+/// Installs macOS from a restore image onto a virtual machine's disk.
+///
+/// Wraps `VZMacOSInstaller`. Create it with the VM built for installation and a
+/// local restore image (IPSW), then drive [`install`](Self::install) — a long
+/// operation (tens of minutes) that reports progress as it runs.
+pub struct MacOSInstaller {
+    inner: *mut AnyObject,
+    progress: *mut AnyObject,
+}
+
+// SAFETY: Inner ObjC pointers are only used via msg_send! which dispatches to the ObjC runtime.
+unsafe impl Send for MacOSInstaller {}
+
+impl MacOSInstaller {
+    /// Creates an installer for `virtual_machine` from a local restore image.
+    ///
+    /// `restore_image_path` must be a local file (an IPSW); a restore image fetched
+    /// via [`MacOSRestoreImage::latest_supported`] must be downloaded first.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `VZMacOSInstaller` is unavailable or cannot be created.
+    pub fn new(
+        virtual_machine: &VirtualMachine,
+        restore_image_path: impl AsRef<Path>,
+    ) -> VZResult<Self> {
+        let path_str = restore_image_path.as_ref().to_string_lossy();
+        // SAFETY: alloc/initWithVirtualMachine:restoreImageURL: on VZMacOSInstaller with a
+        // valid VM pointer and an NSURL from a local path. Result checked non-null.
+        unsafe {
+            let cls = get_class("VZMacOSInstaller").ok_or_else(|| VZError::Internal {
+                code: -1,
+                message: "VZMacOSInstaller class not found".into(),
+            })?;
+            let url = nsurl_file_path(&path_str);
+            let alloc = msg_send!(cls, alloc);
+            let obj = msg_send!(
+                alloc,
+                initWithVirtualMachine: virtual_machine.as_ptr(),
+                restoreImageURL: url
+            );
+            if obj.is_null() {
+                return Err(VZError::InvalidConfiguration(
+                    "failed to create VZMacOSInstaller".into(),
+                ));
+            }
+            let progress = msg_send!(obj, progress);
+            Ok(Self {
+                inner: obj,
+                progress,
+            })
+        }
+    }
+
+    /// Returns installation progress as a fraction in `0.0..=1.0`.
+    #[must_use]
+    pub fn fraction_completed(&self) -> f64 {
+        if self.progress.is_null() {
+            return 0.0;
+        }
+        // SAFETY: fractionCompleted returns a double from a valid NSProgress.
+        unsafe {
+            let sel = objc2::sel!(fractionCompleted);
+            let func: unsafe extern "C" fn(*const AnyObject, objc2::runtime::Sel) -> f64 =
+                std::mem::transmute(crate::ffi::runtime::objc_msgSend as *const c_void);
+            func(self.progress as *const AnyObject, sel)
+        }
+    }
+
+    /// Installs macOS, invoking `on_progress` with the current fraction as it runs.
+    ///
+    /// `virtual_machine` must be the VM passed to [`new`](Self::new); the install is
+    /// dispatched on that VM's queue.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if installation fails.
+    pub async fn install(
+        &self,
+        virtual_machine: &VirtualMachine,
+        mut on_progress: impl FnMut(f64),
+    ) -> VZResult<()> {
+        let (tx, mut rx) = oneshot::channel::<StateResult>();
+        let block = create_state_completion_block(tx);
+        let installer = self.inner;
+        // Kick off the install on the VM's queue: the call returns immediately and the
+        // completion handler fires when installation finishes.
+        // SAFETY: installWithCompletionHandler: takes a heap-copied (NSError *) block.
+        virtual_machine.dispatch_sync(|| unsafe {
+            msg_send_void!(installer, installWithCompletionHandler: block);
+        });
+
+        let result = loop {
+            match rx.try_recv() {
+                Ok(result) => break result,
+                Err(oneshot::error::TryRecvError::Empty) => {
+                    on_progress(self.fraction_completed());
+                    sleep(Duration::from_secs(2)).await;
+                }
+                Err(oneshot::error::TryRecvError::Closed) => {
+                    break Err("install completion handler dropped".to_string());
+                }
+            }
+        };
+        // SAFETY: `block` was returned by create_state_completion_block and not released elsewhere.
+        unsafe { _Block_release(block) };
+        result.map_err(|message| VZError::Internal { code: -1, message })
+    }
+}
+
+impl Drop for MacOSInstaller {
     fn drop(&mut self) {
         if !self.inner.is_null() {
             release(self.inner);

--- a/virt/arcbox-vz/src/restore.rs
+++ b/virt/arcbox-vz/src/restore.rs
@@ -18,7 +18,7 @@ use crate::configuration::MacHardwareModel;
 use crate::error::{VZError, VZResult};
 use crate::ffi::{
     _Block_release, ObjectResult, StateResult, create_object_completion_block,
-    create_state_completion_block, get_class, nsurl_file_path, release,
+    create_state_completion_block, get_class, nsstring_to_string, nsurl_file_path, release,
 };
 use crate::vm::VirtualMachine;
 use crate::{msg_send, msg_send_u64, msg_send_void};
@@ -143,6 +143,26 @@ impl MacOSRestoreImage {
                 minimum_cpu_count,
                 minimum_memory_size,
             })
+        }
+    }
+
+    /// Returns the restore image URL.
+    ///
+    /// For an image fetched via [`latest_supported`](Self::latest_supported) this is
+    /// the remote IPSW download URL; for one loaded via
+    /// [`load_from_url`](Self::load_from_url) it is the local file URL.
+    #[must_use]
+    pub fn url(&self) -> Option<String> {
+        // SAFETY: URL is a readonly property returning an NSURL owned by the image;
+        // absoluteString returns an NSString that nsstring_to_string only reads.
+        unsafe {
+            let url = msg_send!(self.inner, URL);
+            if url.is_null() {
+                return None;
+            }
+            let s = msg_send!(url, absoluteString);
+            let out = nsstring_to_string(s);
+            if out.is_empty() { None } else { Some(out) }
         }
     }
 }

--- a/virt/arcbox-vz/src/restore.rs
+++ b/virt/arcbox-vz/src/restore.rs
@@ -86,7 +86,9 @@ impl MacOSRestoreImage {
         let (tx, rx) = oneshot::channel::<ObjectResult>();
         let block = create_object_completion_block(tx);
         // SAFETY: +loadFileURL:completionHandler: takes an NSURL and a block and returns
-        // void; `block` is a heap-copied block released after the await.
+        // void; `block` is a heap-copied block released after the await. The method
+        // retains the NSURL synchronously, so the +1 from nsurl_file_path is released
+        // immediately after the call.
         unsafe {
             let url = nsurl_file_path(&path_str);
             let sel = objc2::sel!(loadFileURL:completionHandler:);
@@ -97,6 +99,7 @@ impl MacOSRestoreImage {
                 *const c_void,
             ) = std::mem::transmute(crate::ffi::runtime::objc_msgSend as *const c_void);
             func(cls, sel, url as *const AnyObject, block);
+            release(url);
         }
         let received = rx.await;
         // SAFETY: `block` was returned by create_object_completion_block and not released elsewhere.
@@ -220,6 +223,9 @@ impl MacOSInstaller {
                     initWithVirtualMachine: vm_ptr,
                     restoreImageURL: url
                 );
+                // The initializer retains the NSURL; release the +1 from nsurl_file_path
+                // (also covers the error path below).
+                release(url);
                 if obj.is_null() {
                     return Err(VZError::InvalidConfiguration(
                         "failed to create VZMacOSInstaller".into(),
@@ -271,14 +277,16 @@ impl MacOSInstaller {
         });
 
         let result = loop {
-            match rx.try_recv() {
-                Ok(result) => break result,
-                Err(oneshot::error::TryRecvError::Empty) => {
-                    on_progress(self.fraction_completed());
-                    sleep(Duration::from_secs(2)).await;
+            tokio::select! {
+                // Prefer the completion signal so install() returns promptly when the
+                // installer finishes, rather than after the next progress tick.
+                biased;
+                received = &mut rx => {
+                    break received
+                        .unwrap_or_else(|_| Err("install completion handler dropped".to_string()));
                 }
-                Err(oneshot::error::TryRecvError::Closed) => {
-                    break Err("install completion handler dropped".to_string());
+                () = sleep(Duration::from_secs(2)) => {
+                    on_progress(self.fraction_completed());
                 }
             }
         };

--- a/virt/arcbox-vz/src/vm.rs
+++ b/virt/arcbox-vz/src/vm.rs
@@ -88,6 +88,23 @@ impl VirtualMachine {
         Self { inner: ptr, queue }
     }
 
+    /// Returns the underlying `VZVirtualMachine` pointer.
+    pub(crate) fn as_ptr(&self) -> *mut AnyObject {
+        self.inner
+    }
+
+    /// Runs `f` synchronously on the VM's dispatch queue.
+    ///
+    /// All operations on a `VZVirtualMachine` must be issued on the queue it was
+    /// created with; this lets associated objects (such as the macOS installer)
+    /// dispatch onto it.
+    pub(crate) fn dispatch_sync<F, R>(&self, f: F) -> R
+    where
+        F: FnOnce() -> R,
+    {
+        self.queue.sync(f)
+    }
+
     /// Returns the current state of the VM.
     pub fn state(&self) -> VirtualMachineState {
         // SAFETY: self.inner is a valid VZVirtualMachine pointer; dispatched

--- a/virt/arcbox-vz/src/vm.rs
+++ b/virt/arcbox-vz/src/vm.rs
@@ -5,7 +5,7 @@ use crate::error::{VZError, VZResult};
 use crate::ffi::{
     _Block_copy, _Block_release, _NSConcreteStackBlock, BlockPtr, DispatchQueue,
     SIMPLE_BLOCK_DESCRIPTOR, create_state_completion_block, extract_nserror, nsstring_to_string,
-    nsurl_file_path,
+    nsurl_file_path, release,
 };
 use crate::socket::VirtioSocketDevice;
 use crate::{msg_send, msg_send_bool, msg_send_i64};
@@ -519,6 +519,9 @@ impl VirtualMachine {
                     url as *const AnyObject,
                     block,
                 );
+                // The selector retains the NSURL synchronously; release the +1 from
+                // nsurl_file_path.
+                release(url);
             }
         });
         let result = rx.await.map_err(|_| VZError::Internal {

--- a/virt/arcbox-vz/src/vm.rs
+++ b/virt/arcbox-vz/src/vm.rs
@@ -4,12 +4,14 @@ use crate::device::{MemoryBalloonDevice, vm_memory_balloon_devices};
 use crate::error::{VZError, VZResult};
 use crate::ffi::{
     _Block_copy, _Block_release, _NSConcreteStackBlock, BlockPtr, DispatchQueue,
-    SIMPLE_BLOCK_DESCRIPTOR, create_state_completion_block, nsstring_to_string,
+    SIMPLE_BLOCK_DESCRIPTOR, create_state_completion_block, extract_nserror, nsstring_to_string,
+    nsurl_file_path,
 };
 use crate::socket::VirtioSocketDevice;
 use crate::{msg_send, msg_send_bool, msg_send_i64};
 use objc2::runtime::AnyObject;
 use std::ffi::c_void;
+use std::path::Path;
 use std::sync::OnceLock;
 use std::time::Duration;
 use tokio::sync::oneshot;
@@ -416,6 +418,116 @@ impl VirtualMachine {
         }
 
         Ok(())
+    }
+
+    /// Requests a graceful stop, asking the guest to shut down cleanly.
+    ///
+    /// Unlike [`stop`](Self::stop), this gives the guest a chance to shut down. The
+    /// request is issued on the VM's queue and returns once accepted; the VM
+    /// transitions to `Stopped` asynchronously (poll [`state`](Self::state)).
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the guest cannot be asked to stop (for example, the VM is
+    /// not running).
+    pub fn request_stop(&self) -> VZResult<()> {
+        let inner = self.inner;
+        self.queue.sync(|| {
+            // SAFETY: requestStopWithError: on a valid VZVirtualMachine; the error
+            // out-parameter is written only when the call returns NO.
+            unsafe {
+                let mut error: *mut AnyObject = std::ptr::null_mut();
+                if msg_send_bool!(inner, requestStopWithError: &mut error).as_bool() {
+                    Ok(())
+                } else {
+                    Err(extract_nserror(error))
+                }
+            }
+        })
+    }
+
+    /// Returns whether this host supports saving and restoring VM state (macOS 14+).
+    #[must_use]
+    pub fn supports_save_restore(&self) -> bool {
+        let sel = objc2::sel!(saveMachineStateToURL:completionHandler:);
+        // SAFETY: self.inner is a valid ObjC object; querying its class for a selector.
+        unsafe { &*(self.inner as *const AnyObject) }
+            .class()
+            .responds_to(sel)
+    }
+
+    /// Saves the state of a paused VM to a file for later restore (macOS 14+).
+    ///
+    /// The VM must be paused (see [`pause`](Self::pause)).
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if save/restore is unsupported on this host or the save fails.
+    pub async fn save_state(&self, path: impl AsRef<Path>) -> VZResult<()> {
+        if !self.supports_save_restore() {
+            return Err(VZError::Internal {
+                code: -1,
+                message: "saving VM state requires macOS 14+".into(),
+            });
+        }
+        let path_str = path.as_ref().to_string_lossy().into_owned();
+        self.state_to_file(&path_str, true).await
+    }
+
+    /// Restores a stopped VM from a file written by [`save_state`](Self::save_state) (macOS 14+).
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if save/restore is unsupported on this host or the restore
+    /// fails.
+    pub async fn restore_state(&self, path: impl AsRef<Path>) -> VZResult<()> {
+        if !self.supports_save_restore() {
+            return Err(VZError::Internal {
+                code: -1,
+                message: "restoring VM state requires macOS 14+".into(),
+            });
+        }
+        let path_str = path.as_ref().to_string_lossy().into_owned();
+        self.state_to_file(&path_str, false).await
+    }
+
+    /// Shared driver for save (`save = true`) and restore (`save = false`).
+    async fn state_to_file(&self, path: &str, save: bool) -> VZResult<()> {
+        let (tx, rx) = oneshot::channel::<crate::ffi::StateResult>();
+        let block = create_state_completion_block(tx);
+        let inner = self.inner;
+        let path = path.to_string();
+        self.queue.sync(|| {
+            // SAFETY: save/restoreMachineState…:completionHandler: take an NSURL and a
+            // heap-copied (NSError *) block; both selectors exist (checked by caller).
+            unsafe {
+                let url = nsurl_file_path(&path);
+                let sel = if save {
+                    objc2::sel!(saveMachineStateToURL:completionHandler:)
+                } else {
+                    objc2::sel!(restoreMachineStateFromURL:completionHandler:)
+                };
+                let func: unsafe extern "C" fn(
+                    *const AnyObject,
+                    objc2::runtime::Sel,
+                    *const AnyObject,
+                    *const c_void,
+                ) = std::mem::transmute(crate::ffi::runtime::objc_msgSend as *const c_void);
+                func(
+                    inner as *const AnyObject,
+                    sel,
+                    url as *const AnyObject,
+                    block,
+                );
+            }
+        });
+        let result = rx.await.map_err(|_| VZError::Internal {
+            code: -1,
+            message: "state operation cancelled".into(),
+        })?;
+        // SAFETY: `block` came from create_state_completion_block and is not released elsewhere.
+        unsafe { _Block_release(block) };
+        result.map_err(|message| VZError::Internal { code: -1, message })
     }
 
     /// Returns the socket devices configured on this VM.


### PR DESCRIPTION
## What

macOS guest VMs on Apple Silicon as a first-class ArcBox noun: pull a pre-baked base image from ArcBox's distribution bucket, copy-on-write clone it, and boot clean throwaway guests — the Linux "clone, use, discard" model extended to macOS. Foundation for the BYOC macOS Actions runner fleet (Linear RUN-36 tree).

## Surface

```sh
arcbox macos image pull tahoe-base[@2026.07.02]   # streamed progress; --manifest <url|path> for dev
arcbox macos image ls | rm
arcbox macos create ci-1 --image tahoe-base --cpus 4 --memory 8192
arcbox macos start | stop | rm | ls
```

Served by a dedicated `MacosService` (own proto, no `MachineService` coupling), registered only on Apple Silicon hosts. `ImagePull` is server-streaming (stage + fraction events).

## Design notes

- **Distribution format is ours** (JSON manifest + zstd, on the B2 `darwin` bucket behind darwin.arcboxcdn.com): no OCI client, no registry auth, no Tart traces in this codebase. Format spec + bake pipeline live in `macos-runner-image-builder` (the producer; this repo consumes).
- **Pull path** (`macos/remote.rs` + `macos/pull.rs`): index/manifest resolution → hardware-model validation *before* the multi-GB download → socket → zstd → zero-skipping sparse writes (compressed bytes never touch disk; SHA-256 hashed in flight) → staging dir renamed live only after every check passes.
- **Resume**: transient HTTP failures retry with `Range: bytes=N-` against the live decoder state (no temp file). A daemon restart restarts the pull; resume covers network blips, the failure that matters at 20 GB.
- **Cancellation**: client disconnect cancels the pull (`tx.closed()` + future drop); a `Drop`-based staging guard cleans partials at any await point.
- **Zero-skip writes are load-bearing**: `zstd --sparse` under-recovers holes on macOS (verified: 45 GB actual from a 31 GB original); our writer restores bit-identical sparseness.
- **IPSW installer retained, unshipped**: `install_from_ipsw` + Apple IPSW download compile under the off-by-default `macos-ipsw-install` feature (clippy-clean both configs) with zero product surface.
- Clones share the base machine identifier (same practice as Tart, proven in production CI fleets); `docs/macos-guest.md` corrected accordingly.

## Verification

- 12 unit tests incl. full pull round-trip against a synthetic artifact, corrupted-manifest rejection, sparse-writer allocation check (at 256 MiB — APFS materializes small files), and a flaky-HTTP-server resume test.
- On hardware (M-series, macOS 27): pulled a real 21 GiB baked artifact in 81 s with streamed CLI progress, disk landed 31 GB actual / 50 GB logical (bit-identical to bake source), `create`+`start` booted macOS 26.5 to SSH; stop/rm clean. Kill-mid-pull verified: staging removed within seconds.
- `cargo fmt --check`, `clippy --workspace --all-targets` and `clippy --features macos-ipsw-install` at zero warnings, full workspace test suite green.

## Known gaps (tracked)

- Reference-based pull against the live bucket awaits the first publish (RUN-38 In Review; `--manifest` path is fully E2E-verified).
- Runner bootstrap contract in the baked image is RUN-6.
