### PR TITLE
feat(fleet): macOS VM backend — darwin jobs in disposable guests via arcbox-daemon (RUN-31)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -568,6 +568,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sysinfo",
+ "thiserror",
  "tokio",
  "tokio-stream",
  "tokio-util",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -563,6 +563,8 @@ dependencies = [
  "hostname",
  "hyper-util",
  "keyring",
+ "libc",
+ "plist",
  "prost",
  "russh",
  "serde",
@@ -2129,9 +2131,6 @@ name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
-dependencies = [
- "powerfmt",
-]
 
 [[package]]
 name = "des"
@@ -3937,9 +3936,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.1.0"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-integer"
@@ -4577,9 +4576,9 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "plist"
-version = "1.8.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "740ebea15c5d1428f910cd1a5f52cebf8d25006245ed8ade92702f4943d91e07"
+checksum = "7da1d65da6dd5d1e44199ac0f58712d241c0f439f80adea8924d832384087f85"
 dependencies = [
  "base64",
  "indexmap 2.13.0",
@@ -4892,9 +4891,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.38.4"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
+checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
 dependencies = [
  "memchr",
 ]
@@ -6212,12 +6211,11 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.45"
+version = "0.3.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9e442fc33d7fdb45aa9bfeb312c095964abdf596f7567261062b2a7107aaabd"
+checksum = "18dfaaeddcb932337b5e7866ee7d0ce9b76d2fd092997146f187ec09b4558a50"
 dependencies = [
  "deranged",
- "itoa",
  "num-conv",
  "powerfmt",
  "serde_core",
@@ -6227,15 +6225,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.7"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b36ee98fd31ec7426d599183e8fe26932a8dc1fb76ddb6214d05493377d34ca"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.25"
+version = "0.2.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71e552d1249bf61ac2a52db88179fd0673def1e1ad8243a00d9ec9ed71fee3dd"
+checksum = "c431b87111666e491a90baa837f914fb45cd5dc3c268591b0220ff5057f2085f"
 dependencies = [
  "num-conv",
  "time-core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,14 +18,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aead"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1973cfbc1a2daf9cf550e74e1f088c28e7f7d8c1e1418fb6c9dc5184b7e84c99"
+dependencies = [
+ "crypto-common 0.2.2",
+ "inout 0.2.2",
+]
+
+[[package]]
 name = "aes"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
  "cfg-if",
- "cipher",
+ "cipher 0.4.4",
  "cpufeatures 0.2.17",
+]
+
+[[package]]
+name = "aes"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1fc76eaeac4c9164506c466d4ffdd8ec9d0c5bf57ee97177c4d8eceb3a0e138"
+dependencies = [
+ "cipher 0.5.2",
+ "cpubits",
+ "cpufeatures 0.3.0",
+ "zeroize",
+]
+
+[[package]]
+name = "aes-gcm"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdf011db2e21ce0d575593d749db5554b47fed37aff429e4dc50bc91ac93a028"
+dependencies = [
+ "aead",
+ "aes 0.9.1",
+ "cipher 0.5.2",
+ "ctr",
+ "ghash",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -217,7 +254,7 @@ version = "0.4.17"
 dependencies = [
  "futures-util",
  "reqwest",
- "sha2",
+ "sha2 0.10.9",
  "tempfile",
  "thiserror",
  "tokio",
@@ -234,7 +271,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "thiserror",
  "tokio",
  "toml 1.1.0+spec-1.1.0",
@@ -266,7 +303,7 @@ dependencies = [
  "sentry",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "tempfile",
  "tokio",
  "tokio-stream",
@@ -335,7 +372,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "statig",
  "tempfile",
  "thiserror",
@@ -428,7 +465,7 @@ dependencies = [
  "libc",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "tempfile",
  "thiserror",
  "tokio",
@@ -447,7 +484,7 @@ dependencies = [
  "arcbox-asset",
  "flate2",
  "serde",
- "sha2",
+ "sha2 0.10.9",
  "tar",
  "tempfile",
  "thiserror",
@@ -511,9 +548,12 @@ name = "arcbox-fleet-agent"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "arcbox-constants",
  "arcbox-fleet-control-proto",
  "arcbox-fleet-proto",
+ "arcbox-grpc",
  "arcbox-logging",
+ "arcbox-protocol",
  "async-stream",
  "bollard",
  "clap",
@@ -524,6 +564,7 @@ dependencies = [
  "hyper-util",
  "keyring",
  "prost",
+ "russh",
  "serde",
  "serde_json",
  "sysinfo",
@@ -978,6 +1019,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "argon2"
+version = "0.6.0-rc.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7af50940b73bf4e16c15c448a2b121c63f2d68e3e54b6a8731673cb4aa0cdff5"
+dependencies = [
+ "base64ct",
+ "blake2",
+ "cpufeatures 0.3.0",
+ "password-hash",
+]
+
+[[package]]
 name = "async-broadcast"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1278,10 +1331,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "base16ct"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd307490d624467aa6f74b0eabb77633d1f758a7b25f12bceb0b22e08d9726f6"
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "base64ct"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
+name = "bcrypt-pbkdf"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "144e573728da132683b9488acd528274c790e07fc06ff81ee29f9d8f8b1041e0"
+dependencies = [
+ "blowfish",
+ "pbkdf2",
+ "sha2 0.11.0",
+]
 
 [[package]]
 name = "bincode"
@@ -1323,12 +1399,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
+name = "blake2"
+version = "0.11.0-rc.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "061f1a09225e328e1ffbb378d2d49923c0ca5fee19fb5ac1cc9c1e9d52b93690"
+dependencies = [
+ "digest 0.11.3",
+]
+
+[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.7",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
+dependencies = [
+ "hybrid-array",
+ "zeroize",
 ]
 
 [[package]]
@@ -1337,7 +1432,16 @@ version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.7",
+]
+
+[[package]]
+name = "block-padding"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "710f1dd022ef4e93f8a438b4ba958de7f64308434fa6a87104481645cc30068b"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -1360,6 +1464,16 @@ dependencies = [
  "futures-io",
  "futures-lite",
  "piper",
+]
+
+[[package]]
+name = "blowfish"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62ce3946557b35e71d1bbe07ec385073ce9eda05043f95de134eb578fcf1a298"
+dependencies = [
+ "byteorder",
+ "cipher 0.5.2",
 ]
 
 [[package]]
@@ -1441,7 +1555,16 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
 dependencies = [
- "cipher",
+ "cipher 0.4.4",
+]
+
+[[package]]
+name = "cbc"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce2dc9ee5f88d11e0beb842c88b33c8a5cf0d1329c4b19494af42b07dbfe8896"
+dependencies = [
+ "cipher 0.5.2",
 ]
 
 [[package]]
@@ -1484,8 +1607,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
 dependencies = [
  "cfg-if",
+ "cipher 0.5.2",
  "cpufeatures 0.3.0",
  "rand_core 0.10.1",
+ "zeroize",
 ]
 
 [[package]]
@@ -1535,8 +1660,20 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
- "crypto-common",
- "inout",
+ "crypto-common 0.1.7",
+ "inout 0.1.4",
+]
+
+[[package]]
+name = "cipher"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8cf2a2c93cd704877c0858356ed03480ff301ee950b43f1cbe4573b088bfa6c"
+dependencies = [
+ "block-buffer 0.12.1",
+ "crypto-common 0.2.2",
+ "inout 0.2.2",
+ "zeroize",
 ]
 
 [[package]]
@@ -1600,6 +1737,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
+name = "cmov"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
+
+[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1637,6 +1780,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
 name = "containerregistry-image"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1645,7 +1794,7 @@ dependencies = [
  "hex",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "thiserror",
 ]
 
@@ -1686,6 +1835,12 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "cpubits"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15b85f9c39137c3a891689859392b1bd49812121d0d61c9caf00d46ed5ce06ae"
 
 [[package]]
 name = "cpufeatures"
@@ -1822,13 +1977,50 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
+name = "crypto-bigint"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a52aa3fcda4e6302a9f48734f234d35d4721b96f8fe07d073f07ce9df4f0271"
+dependencies = [
+ "cpubits",
+ "ctutils",
+ "getrandom 0.4.2",
+ "hybrid-array",
+ "num-traits",
+ "rand_core 0.10.1",
+ "serdect",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.7",
  "typenum",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "getrandom 0.4.2",
+ "hybrid-array",
+ "rand_core 0.10.1",
+]
+
+[[package]]
+name = "ctr"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baaca1c4b237092596f64d571e9db6ce4109c4ef9742e27590f1709594461f21"
+dependencies = [
+ "cipher 0.5.2",
 ]
 
 [[package]]
@@ -1840,6 +2032,43 @@ dependencies = [
  "dispatch2",
  "nix 0.31.2",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "ctutils"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
+ "subtle",
+]
+
+[[package]]
+name = "curve25519-dalek"
+version = "5.0.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c906a87e53a36ff795d72e06e8162a83c5436e3ea89e942a9cb9fc083f0a384f"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "curve25519-dalek-derive",
+ "digest 0.11.3",
+ "fiat-crypto",
+ "rustc_version",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1873,6 +2102,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "delegate"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "780eb241654bf097afb00fc5f054a09b687dad862e485fdcf8399bb056565370"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "der"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a69dedd701da44b0536442edf09c81a64b0ab97a7a4a5e3d1971f00027cbc63d"
+dependencies = [
+ "const-oid",
+ "pem-rfc7468",
+ "zeroize",
+]
+
+[[package]]
 name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1882,14 +2133,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "des"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "916a94e407b54f9034d71dd748234cd1e516ced6284009906ae246f177eafe5a"
+dependencies = [
+ "cipher 0.5.2",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "crypto-common 0.1.7",
  "subtle",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.1",
+ "const-oid",
+ "crypto-common 0.2.2",
+ "ctutils",
 ]
 
 [[package]]
@@ -1956,6 +2228,47 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
+name = "ecdsa"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0681a4fc24c767085329728d8dfba959af91228aa4610cca4f8ce317ba46ae0"
+dependencies = [
+ "der",
+ "digest 0.11.3",
+ "elliptic-curve",
+ "rfc6979",
+ "signature",
+ "spki",
+ "zeroize",
+]
+
+[[package]]
+name = "ed25519"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29fcf32e6c73d1079f83ab4d782de2d81620346a5f38c6237a86a22f8368980a"
+dependencies = [
+ "pkcs8",
+ "signature",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "3.0.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1685663e23882cd8517dcbcb1c23a6ebff4433c22dfb681d760219b62cd1b849"
+dependencies = [
+ "curve25519-dalek",
+ "ed25519",
+ "rand_core 0.10.1",
+ "serde",
+ "sha2 0.11.0",
+ "signature",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "educe"
 version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1972,6 +2285,28 @@ name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
+name = "elliptic-curve"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d65aa39b3a5c1c9c1b745c9a019234bb7a21b77abcb4f4d266d706e2d577d65"
+dependencies = [
+ "base16ct",
+ "crypto-bigint",
+ "crypto-common 0.2.2",
+ "digest 0.11.3",
+ "ff",
+ "group",
+ "hkdf 0.13.0",
+ "hybrid-array",
+ "pem-rfc7468",
+ "pkcs8",
+ "rand_core 0.10.1",
+ "sec1",
+ "subtle",
+ "zeroize",
+]
 
 [[package]]
 name = "encoding_rs"
@@ -2003,6 +2338,18 @@ version = "4.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ca9601fb2d62598ee17836250842873a413586e5d7ed88b356e38ddbb0ec631"
 dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "enum_dispatch"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa18ce2bc66555b3218614519ac839ddb759a7d6720732f979ef8d13be147ecd"
+dependencies = [
+ "once_cell",
  "proc-macro2",
  "quote",
  "syn",
@@ -2103,6 +2450,22 @@ dependencies = [
  "thiserror",
  "tokio",
 ]
+
+[[package]]
+name = "ff"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1f686ab92a9fb0eaf188f6c6c87b89490baa6fdb0db4544ba4dc47f7942489f"
+dependencies = [
+ "rand_core 0.10.1",
+ "subtle",
+]
+
+[[package]]
+name = "fiat-crypto"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64cd1e32ddd350061ae6edb1b082d7c54915b5c672c389143b9a63403a109f24"
 
 [[package]]
 name = "figment"
@@ -2315,6 +2678,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic-array"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2e55f16dcf0e9c00efbe2e655ffe45fc98e7066b52bc92f8a79e64060a79351"
+dependencies = [
+ "generic-array 0.14.7",
+ "rustversion",
+ "typenum",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2348,11 +2722,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 6.0.0",
  "rand_core 0.10.1",
  "wasip2",
  "wasip3",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "ghash"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2eecf2d5dc9b66b732b97707a0210906b1d30523eb773193ab777c0c84b3e8d5"
+dependencies = [
+ "polyval",
 ]
 
 [[package]]
@@ -2366,6 +2751,17 @@ name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
+name = "group"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fd1a1c7a5206c5b7a3f5a0d7ccd3ff85d0c8f5133d62a02680255b0004af5f4"
+dependencies = [
+ "ff",
+ "rand_core 0.10.1",
+ "subtle",
+]
 
 [[package]]
 name = "h2"
@@ -2452,6 +2848,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "hex-literal"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e712f64ec3850b98572bffac52e2c6f282b29fe6c5fa6d42334b30be438d95c1"
+
+[[package]]
 name = "hickory-proto"
 version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2476,7 +2878,16 @@ version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
 dependencies = [
- "hmac",
+ "hmac 0.12.1",
+]
+
+[[package]]
+name = "hkdf"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4aaa26c720c68b866f2c96ef5c1264b3e6f473fe5d4ce61cd44bbe913e553018"
+dependencies = [
+ "hmac 0.13.0",
 ]
 
 [[package]]
@@ -2485,7 +2896,16 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "hmac"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
+dependencies = [
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -2549,6 +2969,18 @@ name = "humantime"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
+dependencies = [
+ "ctutils",
+ "subtle",
+ "typenum",
+ "zeroize",
+]
 
 [[package]]
 name = "hyper"
@@ -2870,8 +3302,18 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
- "block-padding",
- "generic-array",
+ "block-padding 0.3.3",
+ "generic-array 0.14.7",
+]
+
+[[package]]
+name = "inout"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4250ce6452e92010fdf7268ccc5d14faa80bb12fc741938534c58f16804e03c7"
+dependencies = [
+ "block-padding 0.4.2",
+ "hybrid-array",
 ]
 
 [[package]]
@@ -2881,6 +3323,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "internal-russh-num-bigint"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae8e22120c32fb4d19ec55fba35015f57095cd95a2e3b732e44457f5915b2ee8"
+dependencies = [
+ "num-integer",
+ "num-traits",
+ "rand 0.10.1",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -3033,6 +3487,26 @@ dependencies = [
  "futures-util",
  "once_cell",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "keccak"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e24a010dd405bd7ed803e5253182815b41bf2e6a80cc3bfc066658e03a198aa"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+]
+
+[[package]]
+name = "kem"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01737161ba802849cfd486b5bd209d38ba4943494c249a8126005170c7621edd"
+dependencies = [
+ "crypto-common 0.2.2",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -3208,6 +3682,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
+name = "md5"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ebb8d8732c6a6df3d8f032a82911cfc747e00efb95cc46e8d0acd5b5b88570c"
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3266,6 +3746,31 @@ dependencies = [
  "log",
  "wasi",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "ml-kem"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e15f3e5b957493873e396a66914e83e616b6afe335cdef7efe5c6e1216aba66"
+dependencies = [
+ "hybrid-array",
+ "kem",
+ "module-lattice",
+ "pkcs8",
+ "rand_core 0.10.1",
+ "sha3",
+]
+
+[[package]]
+name = "module-lattice"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c61b87c9683ab7cb1c6871d261ad5479b6b10ceb52c4352aaca3b5d35a8febe"
+dependencies = [
+ "ctutils",
+ "hybrid-array",
+ "num-traits",
 ]
 
 [[package]]
@@ -3825,6 +4330,67 @@ dependencies = [
 ]
 
 [[package]]
+name = "p256"
+version = "0.14.0-rc.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6bb40a5099e2c38a09dd29321a7a7f045f165a54317679c7cdfb0cbaf8f6b1e"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primefield",
+ "primeorder",
+ "sha2 0.11.0",
+]
+
+[[package]]
+name = "p384"
+version = "0.14.0-rc.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "492f329d7eb11d22dadc988626b9ea1f503b4ab043a8b1e4e2cc4ae45dabdd70"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "fiat-crypto",
+ "primefield",
+ "primeorder",
+ "sha2 0.11.0",
+]
+
+[[package]]
+name = "p521"
+version = "0.14.0-rc.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff42e4ace5424e3b6d7cb82514be89866b85af87015f80341e37dcc21a66ce6e"
+dependencies = [
+ "base16ct",
+ "ecdsa",
+ "elliptic-curve",
+ "primefield",
+ "primeorder",
+ "sha2 0.11.0",
+]
+
+[[package]]
+name = "pageant"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f3a5ae18f65a85c67a77d18d42d3606c07948e3c17c1e5f74852b26589e88a5"
+dependencies = [
+ "base16ct",
+ "byteorder",
+ "bytes",
+ "delegate",
+ "futures",
+ "log",
+ "rand 0.10.1",
+ "sha2 0.11.0",
+ "thiserror",
+ "tokio",
+ "windows 0.62.2",
+ "windows-strings",
+]
+
+[[package]]
 name = "parking"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3854,6 +4420,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "password-hash"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aab41826031698d6ffcd9cff78ef56ef998e39dc7e5067cdfebe373842d4723b"
+dependencies = [
+ "phc",
+]
+
+[[package]]
+name = "pbkdf2"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112d82ceb8c5bf524d9af484d4e4970c9fd5a0cc15ba14ad93dccd28873b0629"
+dependencies = [
+ "digest 0.11.3",
+ "hmac 0.13.0",
+]
+
+[[package]]
 name = "pear"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3877,6 +4462,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "pem-rfc7468"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6305423e0e7738146434843d1694d621cce767262b2a86910beab705e4493d9"
+dependencies = [
+ "base64ct",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3890,6 +4484,16 @@ checksum = "3672b37090dbd86368a4145bc067582552b29c27377cad4e0a306c97f9bd7772"
 dependencies = [
  "fixedbitset",
  "indexmap 2.13.0",
+]
+
+[[package]]
+name = "phc"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44dc769b75f93afdddd8c7fa12d685292ddeff1e66f7f0f3a234cf1818afe892"
+dependencies = [
+ "base64ct",
+ "ctutils",
 ]
 
 [[package]]
@@ -3933,6 +4537,35 @@ dependencies = [
  "atomic-waker",
  "fastrand",
  "futures-io",
+]
+
+[[package]]
+name = "pkcs5"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63d440a804ec8d6fafbb6b84471e013286658d373248927692ab3366686220ca"
+dependencies = [
+ "aes 0.9.1",
+ "aes-gcm",
+ "cbc 0.2.1",
+ "der",
+ "pbkdf2",
+ "rand_core 0.10.1",
+ "scrypt",
+ "sha2 0.11.0",
+ "spki",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "451913da69c775a56034ea8d9003d27ee8948e12443eae7c038ba100a4f21cb7"
+dependencies = [
+ "der",
+ "pkcs5",
+ "rand_core 0.10.1",
+ "spki",
 ]
 
 [[package]]
@@ -3997,6 +4630,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "poly1305"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2d0073b297041425c7c3df6eb4792d598a15323fe63346852b092eca02904c"
+dependencies = [
+ "cpufeatures 0.3.0",
+ "universal-hash",
+ "zeroize",
+]
+
+[[package]]
+name = "polyval"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dfc63250416fea14f5749b90725916a6c903f599d51cb635aa7a52bfd03eede"
+dependencies = [
+ "cpubits",
+ "cpufeatures 0.3.0",
+ "universal-hash",
+]
+
+[[package]]
 name = "portable-atomic"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4034,6 +4689,33 @@ checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
  "syn",
+]
+
+[[package]]
+name = "primefield"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c555a6e4eb7d4e158fcb028c835c3b8642206ddc279b5c6b202ef9a8bdb592f4"
+dependencies = [
+ "crypto-bigint",
+ "crypto-common 0.2.2",
+ "ff",
+ "rand_core 0.10.1",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "primeorder"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c9f42978c78a00e3d68f69fc03e57a234debae69da4020a4fb588fcdcd07b06"
+dependencies = [
+ "elliptic-curve",
+ "once_cell",
+ "primefield",
+ "serdect",
+ "wnaf",
 ]
 
 [[package]]
@@ -4496,6 +5178,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rfc6979"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4a459cddafb3fe76b31fd8f1108007566c40301feb64dc7b54656eb7388172b"
+dependencies = [
+ "crypto-bigint",
+ "hmac 0.13.0",
+]
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4507,6 +5199,100 @@ dependencies = [
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "russh"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca6c3c1dd0a9ad3a9915a2f6e907d158f9a7e9ac32ddc772b003faafc027d9a8"
+dependencies = [
+ "aes 0.9.1",
+ "bitflags 2.11.0",
+ "block-padding 0.4.2",
+ "byteorder",
+ "bytes",
+ "cbc 0.2.1",
+ "cipher 0.5.2",
+ "crypto-bigint",
+ "ctr",
+ "curve25519-dalek",
+ "data-encoding",
+ "delegate",
+ "der",
+ "digest 0.11.3",
+ "ecdsa",
+ "ed25519-dalek",
+ "elliptic-curve",
+ "enum_dispatch",
+ "flate2",
+ "futures",
+ "generic-array 1.4.3",
+ "getrandom 0.4.2",
+ "ghash",
+ "hex-literal",
+ "hmac 0.13.0",
+ "inout 0.2.2",
+ "internal-russh-num-bigint",
+ "keccak",
+ "log",
+ "md5",
+ "ml-kem",
+ "module-lattice",
+ "num-bigint",
+ "p256",
+ "p384",
+ "p521",
+ "pageant",
+ "pbkdf2",
+ "pkcs5",
+ "pkcs8",
+ "polyval",
+ "rand 0.10.1",
+ "rand_core 0.10.1",
+ "ring",
+ "russh-cryptovec",
+ "russh-util",
+ "salsa20",
+ "scrypt",
+ "sec1",
+ "sha1",
+ "sha2 0.11.0",
+ "sha3",
+ "signature",
+ "spki",
+ "ssh-encoding",
+ "ssh-key",
+ "subtle",
+ "thiserror",
+ "tokio",
+ "typenum",
+ "universal-hash",
+ "zeroize",
+]
+
+[[package]]
+name = "russh-cryptovec"
+version = "0.62.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3aec6cb630dbe85d72ffd7bcd95f07e1bd69f9f270ee8adfa1afe443a6331438"
+dependencies = [
+ "log",
+ "nix 0.31.2",
+ "ssh-encoding",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "russh-util"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "668424a5dde0bcb45b55ba7de8476b93831b4aa2fa6947e145f3b053e22c60b6"
+dependencies = [
+ "chrono",
+ "tokio",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
 ]
 
 [[package]]
@@ -4601,6 +5387,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
+name = "salsa20"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f874456e72520ff1375a06c588eaf074b0f01f9e9e1aada45bd9b7954a6e42c"
+dependencies = [
+ "cfg-if",
+ "cipher 0.5.2",
+]
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4651,21 +5447,47 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
+name = "scrypt"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d87af57419b594aa23fa95f09f0e06d80d84ba01c26148c43844cad6ff4485f0"
+dependencies = [
+ "cfg-if",
+ "pbkdf2",
+ "salsa20",
+ "sha2 0.11.0",
+]
+
+[[package]]
+name = "sec1"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d56d437c2f19203ce5f7122e507831de96f3d2d4d3be5af44a0b0a09d8a80e4d"
+dependencies = [
+ "base16ct",
+ "ctutils",
+ "der",
+ "hybrid-array",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "secret-service"
 version = "5.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a62d7f86047af0077255a29494136b9aaaf697c76ff70b8e49cded4e2623c14"
 dependencies = [
- "aes",
- "cbc",
+ "aes 0.8.4",
+ "cbc 0.1.2",
  "futures-util",
- "generic-array",
+ "generic-array 0.14.7",
  "getrandom 0.2.17",
- "hkdf",
+ "hkdf 0.12.4",
  "num",
  "once_cell",
  "serde",
- "sha2",
+ "sha2 0.10.9",
  "zbus",
 ]
 
@@ -4944,6 +5766,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "serdect"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66cf8fedced2fcf12406bcb34223dffb92eaf34908ede12fed414c82b7f00b3e"
+dependencies = [
+ "base16ct",
+ "serde",
+]
+
+[[package]]
+name = "sha1"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4951,7 +5794,28 @@ checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
+]
+
+[[package]]
+name = "sha3"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be176f1a57ce4e3d31c1a166222d9768de5954f811601fb7ca06fc8203905ce1"
+dependencies = [
+ "digest 0.11.3",
+ "keccak",
 ]
 
 [[package]]
@@ -4998,6 +5862,16 @@ checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
 dependencies = [
  "errno",
  "libc",
+]
+
+[[package]]
+name = "signature"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28d567dcbaf0049cb8ac2608a76cd95ff9e4412e1899d389ee400918ca7537f5"
+dependencies = [
+ "digest 0.11.3",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -5055,6 +5929,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "spki"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d9efca8738c78ee9484207732f728b1ef517bbb1833d6fc0879ca898a522f6f"
+dependencies = [
+ "base64ct",
+ "der",
+]
+
+[[package]]
 name = "splicetcp"
 version = "0.4.17"
 dependencies = [
@@ -5066,6 +5950,63 @@ dependencies = [
  "libc",
  "tokio",
  "tracing",
+]
+
+[[package]]
+name = "ssh-cipher"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d801accda99469cde6d73da741422610fdf6508a72d9a69d1b55cb241c720597"
+dependencies = [
+ "aead",
+ "aes 0.9.1",
+ "aes-gcm",
+ "chacha20",
+ "cipher 0.5.2",
+ "ctutils",
+ "des",
+ "poly1305",
+ "ssh-encoding",
+ "zeroize",
+]
+
+[[package]]
+name = "ssh-encoding"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b54d0ed0498daf3f78d82e00e28c8eec9d75a067c4cfbcc7a0f7d0f4077749e"
+dependencies = [
+ "base64ct",
+ "bytes",
+ "ctutils",
+ "digest 0.11.3",
+ "pem-rfc7468",
+ "zeroize",
+]
+
+[[package]]
+name = "ssh-key"
+version = "0.7.0-rc.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9a32fae177b74a22aa9c5b01bf7e68b33545be32d9e381e248058d2adc15ce3"
+dependencies = [
+ "argon2",
+ "bcrypt-pbkdf",
+ "ctutils",
+ "ed25519-dalek",
+ "hex",
+ "hmac 0.13.0",
+ "p256",
+ "p384",
+ "p521",
+ "rand_core 0.10.1",
+ "sec1",
+ "sha1",
+ "sha2 0.11.0",
+ "signature",
+ "ssh-cipher",
+ "ssh-encoding",
+ "zeroize",
 ]
 
 [[package]]
@@ -5155,7 +6096,7 @@ dependencies = [
  "memchr",
  "ntapi",
  "rayon",
- "windows",
+ "windows 0.57.0",
 ]
 
 [[package]]
@@ -5773,9 +6714,9 @@ checksum = "9ea3136b675547379c4bd395ca6b938e5ad3c3d20fad76e7fe85f9e0d011419c"
 
 [[package]]
 name = "typenum"
-version = "1.19.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "typify"
@@ -5864,6 +6805,16 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "universal-hash"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4987bdc12753382e0bec4a65c50738ffaabc998b9cdd1f952fb5f39b0048a96"
+dependencies = [
+ "crypto-common 0.2.2",
+ "ctutils",
+]
 
 [[package]]
 name = "unsafe-libyaml"
@@ -6245,6 +7196,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
+dependencies = [
+ "windows-collections",
+ "windows-core 0.62.2",
+ "windows-future",
+ "windows-numerics",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
+dependencies = [
+ "windows-core 0.62.2",
+]
+
+[[package]]
 name = "windows-core"
 version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6267,6 +7239,17 @@ dependencies = [
  "windows-link",
  "windows-result 0.4.1",
  "windows-strings",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
+dependencies = [
+ "windows-core 0.62.2",
+ "windows-link",
+ "windows-threading",
 ]
 
 [[package]]
@@ -6330,6 +7313,16 @@ dependencies = [
  "regex",
  "windows-sys 0.61.2",
  "zeroize",
+]
+
+[[package]]
+name = "windows-numerics"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
+dependencies = [
+ "windows-core 0.62.2",
+ "windows-link",
 ]
 
 [[package]]
@@ -6452,6 +7445,15 @@ dependencies = [
  "windows_x86_64_gnu 0.53.1",
  "windows_x86_64_gnullvm 0.53.1",
  "windows_x86_64_msvc 0.53.1",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]
@@ -6705,6 +7707,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "wnaf"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab12e7090f27e2ffd9322651492942d50c2926094af30601e1964337db39daf1"
+dependencies = [
+ "ff",
+ "group",
+ "hybrid-array",
+]
+
+[[package]]
 name = "writeable"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6747,7 +7760,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "tar",
  "tempfile",
  "toml_edit 0.25.12+spec-1.1.0",
@@ -6763,7 +7776,7 @@ checksum = "43f625fca4bd17471d87a0b7f94142d314281e8c5347c5fe6e9d475f4d421e42"
 dependencies = [
  "anyhow",
  "plist",
- "sha2",
+ "sha2 0.10.9",
  "xshell",
 ]
 
@@ -6911,9 +7924,9 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.8.2"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 
 [[package]]
 name = "zerotrie"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -253,7 +253,7 @@ name = "arcbox-asset"
 version = "0.4.17"
 dependencies = [
  "futures-util",
- "reqwest",
+ "reqwest 0.12.28",
  "sha2 0.10.9",
  "tempfile",
  "thiserror",
@@ -268,7 +268,7 @@ checksum = "73e728afead5d82392eb81911a43ef556e32a3df2a0d4e6bc3e74c5def33f8ce"
 dependencies = [
  "dirs",
  "futures-util",
- "reqwest",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "sha2 0.10.9",
@@ -369,7 +369,7 @@ dependencies = [
  "ifbridge",
  "libc",
  "prost",
- "reqwest",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "sha2 0.10.9",
@@ -566,10 +566,13 @@ dependencies = [
  "libc",
  "plist",
  "prost",
+ "reqwest 0.13.4",
  "russh",
  "serde",
  "serde_json",
+ "sha2 0.10.9",
  "sysinfo",
+ "tempfile",
  "thiserror",
  "tokio",
  "tokio-stream",
@@ -1208,6 +1211,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "aws-lc-rs"
+version = "1.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4342d8937fc7e5dd9b1c60292261c0670c882a2cd1719cfc11b1af41731e32ad"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d9ceb1da931507a12f4fccea479dccd00da1943e1b4ae72d8e502d707361444"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+ "pkg-config",
+]
+
+[[package]]
 name = "axum"
 version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1740,6 +1766,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "cmov"
 version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2170,7 +2205,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "daa6bd72b26b8c8f81ddea345f66059dd052ca4f85902af7733986f81bfca61e"
 dependencies = [
- "reqwest",
+ "reqwest 0.12.28",
  "serde",
  "thiserror",
  "tracing",
@@ -2220,6 +2255,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "dyn-clone"
@@ -2430,7 +2471,7 @@ dependencies = [
  "prettyplease",
  "progenitor",
  "progenitor-client",
- "reqwest",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "syn",
@@ -2444,7 +2485,7 @@ checksum = "8f527f191f67fbc2e056e1fb4e891256faf9c6d2c2b54e6e585da6e365b04058"
 dependencies = [
  "fc-api",
  "libc",
- "reqwest",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "thiserror",
@@ -2556,6 +2597,12 @@ checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "fsevent-sys"
@@ -4791,7 +4838,7 @@ dependencies = [
  "bytes",
  "futures-core",
  "percent-encoding",
- "reqwest",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -4924,6 +4971,7 @@ version = "0.11.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
 dependencies = [
+ "aws-lc-rs",
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
@@ -5178,6 +5226,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "reqwest"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower 0.5.3",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "rfc6979"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5335,6 +5418,7 @@ version = "0.23.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
 dependencies = [
+ "aws-lc-rs",
  "log",
  "once_cell",
  "ring",
@@ -5342,6 +5426,18 @@ dependencies = [
  "rustls-webpki",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
 ]
 
 [[package]]
@@ -5364,11 +5460,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-platform-verifier"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
+dependencies = [
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
+
+[[package]]
 name = "rustls-webpki"
 version = "0.103.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -5532,7 +5656,7 @@ checksum = "d92d893ba7469d361a6958522fa440e4e2bc8bf4c5803cd1bf40b9af63f8f9a8"
 dependencies = [
  "cfg_aliases",
  "httpdate",
- "reqwest",
+ "reqwest 0.12.28",
  "rustls",
  "sentry-anyhow",
  "sentry-backtrace",
@@ -7137,6 +7261,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-root-certs"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d46a5a140e6f7afeccd8eae97eff335163939eac8b929834875168b29b3d267"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "webpki-roots"
 version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7757,7 +7890,7 @@ dependencies = [
  "clap",
  "dirs",
  "flate2",
- "reqwest",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "sha2 0.10.9",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6359,6 +6359,7 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
+ "futures-util",
  "pin-project-lite",
  "slab",
  "tokio",

--- a/docs/macos-guest.md
+++ b/docs/macos-guest.md
@@ -110,6 +110,16 @@ VmManager::start                 macos::MacVm
    prints it — the handle callers (e.g. a CI driver) use to `ssh` into the
    guest and run work directly, with no in-guest agent or provisioning channel.
 
+5. **Fleet consumption (`fleet/arcbox-fleet-agent/src/vm.rs`).** The fleet
+   agent's VM backend is a plain client of this surface: per darwin job it
+   `Create`s a `fleet-<job>` clone, `Start`s it (the daemon's two-guest cap is
+   the admission signal), waits for the `Inspect`-reported address, runs the
+   image-baked Actions runner over SSH (`admin`/`admin` — the runner-image
+   contract; guests are host-only reachable via vmnet NAT), and treats the ssh
+   session's exit as job completion. `Remove(force)` is teardown *and*
+   cancellation. `ImagePull`/`ImageList` back the agent's `macos_runner_image`
+   prepare flow.
+
 Teardown for the disposable loop: `request_stop` (graceful) -> delete the per-VM clone.
 `save_state`/`restore_state` (macOS 14+) enable Anka-style instant start later.
 

--- a/fleet/arcbox-fleet-agent/Cargo.toml
+++ b/fleet/arcbox-fleet-agent/Cargo.toml
@@ -38,6 +38,10 @@ command-group = { version = "5.0.1", features = ["with-tokio"] }
 tokio-util = "0.7.18"
 bollard = "0.21.0"
 hyper-util = "0.1"
+arcbox-grpc.workspace = true
+arcbox-protocol.workspace = true
+arcbox-constants.workspace = true
+russh = { version = "0.62.1", default-features = false, features = ["ring", "flate2"] }
 
 [lints]
 workspace = true

--- a/fleet/arcbox-fleet-agent/Cargo.toml
+++ b/fleet/arcbox-fleet-agent/Cargo.toml
@@ -43,6 +43,8 @@ arcbox-protocol.workspace = true
 arcbox-constants.workspace = true
 russh = { version = "0.62.1", default-features = false, features = ["ring", "flate2"] }
 thiserror.workspace = true
+plist = "1.10.0"
+libc.workspace = true
 
 [lints]
 workspace = true

--- a/fleet/arcbox-fleet-agent/Cargo.toml
+++ b/fleet/arcbox-fleet-agent/Cargo.toml
@@ -35,7 +35,7 @@ dirs = { workspace = true }
 hostname = { workspace = true }
 sysinfo = { workspace = true }
 command-group = { version = "5.0.1", features = ["with-tokio"] }
-tokio-util = "0.7.18"
+tokio-util = { version = "0.7.18", features = ["rt"] }
 bollard = "0.21.0"
 hyper-util = "0.1"
 arcbox-grpc.workspace = true

--- a/fleet/arcbox-fleet-agent/Cargo.toml
+++ b/fleet/arcbox-fleet-agent/Cargo.toml
@@ -42,6 +42,7 @@ arcbox-grpc.workspace = true
 arcbox-protocol.workspace = true
 arcbox-constants.workspace = true
 russh = { version = "0.62.1", default-features = false, features = ["ring", "flate2"] }
+thiserror.workspace = true
 
 [lints]
 workspace = true

--- a/fleet/arcbox-fleet-agent/Cargo.toml
+++ b/fleet/arcbox-fleet-agent/Cargo.toml
@@ -45,9 +45,14 @@ russh = { version = "0.62.1", default-features = false, features = ["ring", "fla
 thiserror.workspace = true
 plist = "1.10.0"
 libc.workspace = true
+sha2.workspace = true
+reqwest = { version = "0.13.4", default-features = false, features = ["rustls"] }
 
 [lints]
 workspace = true
 
 [target.'cfg(target_os = "macos")'.dependencies]
 keyring = "4"
+
+[dev-dependencies]
+tempfile.workspace = true

--- a/fleet/arcbox-fleet-agent/src/attach.rs
+++ b/fleet/arcbox-fleet-agent/src/attach.rs
@@ -412,6 +412,8 @@ mod tests {
             docker_mode: DockerMode::Disabled,
             runner_script: None,
             participate: true,
+            vm_mode: crate::config::VmMode::Auto,
+            macos_runner_image: "tahoe-base".to_owned(),
         }
     }
 
@@ -479,6 +481,10 @@ mod tests {
             docker: crate::config::DockerConfig {
                 mode: DockerMode::Disabled,
                 linux_runner_image: "img".to_owned(),
+            },
+            vm: crate::config::VmConfig {
+                mode: crate::config::VmMode::Disabled,
+                macos_runner_image: "tahoe-base".to_owned(),
             },
             credential_store: crate::config::CredentialMode::File,
         };
@@ -552,6 +558,10 @@ mod tests {
             docker: crate::config::DockerConfig {
                 mode: DockerMode::Disabled,
                 linux_runner_image: "img".to_owned(),
+            },
+            vm: crate::config::VmConfig {
+                mode: crate::config::VmMode::Disabled,
+                macos_runner_image: "tahoe-base".to_owned(),
             },
             credential_store: crate::config::CredentialMode::File,
         }

--- a/fleet/arcbox-fleet-agent/src/attach.rs
+++ b/fleet/arcbox-fleet-agent/src/attach.rs
@@ -12,7 +12,7 @@ use anyhow::{Context, Result};
 use arcbox_fleet_control_proto::v1 as control_proto;
 use arcbox_fleet_proto::v1::fleet_gateway_service_client::FleetGatewayServiceClient;
 use arcbox_fleet_proto::v1::{
-    AttachRequest, Capability, Heartbeat, HostTelemetry, attach_request, attach_response,
+    Attach, AttachRequest, Capability, Heartbeat, HostTelemetry, attach_request, attach_response,
 };
 use tokio::sync::mpsc;
 use tokio_stream::wrappers::ReceiverStream;
@@ -22,7 +22,7 @@ use tonic::Request;
 use tonic::metadata::MetadataValue;
 use tracing::{info, warn};
 
-use crate::config::{AgentConfig, PROTOCOL_VERSION};
+use crate::config::AgentConfig;
 use crate::credentials::Credential;
 use crate::docker;
 use crate::host;
@@ -38,30 +38,38 @@ const INITIAL_BACKOFF: Duration = Duration::from_secs(1);
 const MAX_BACKOFF: Duration = Duration::from_secs(60);
 const OUTBOUND_CAPACITY: usize = 64;
 const MACHINE_TOKEN_HEADER: &str = "x-arcbox-machine-token";
-const PROTOCOL_VERSION_HEADER: &str = "x-arcbox-protocol-version";
 /// How long to wait for runners to be torn down and reaped on shutdown before
 /// giving up. Killing a process group or container is near-instant, so this is a
 /// generous ceiling rather than an expected wait.
 const SHUTDOWN_GRACE: Duration = Duration::from_secs(15);
 
-/// Wrap `message` with the machine-credential and protocol-version metadata
-/// every authenticated gateway RPC carries (`Attach` here,
-/// `enroll::unenroll`'s `Unenroll`).
+/// Wrap `message` with the machine-credential metadata every authenticated
+/// gateway RPC carries (`Attach` here, `enroll::unenroll`'s `Unenroll`). The
+/// agent build identity travels as the first in-band `Attach` message rather
+/// than as a metadata header; see [`connect_and_serve`].
 pub fn authenticated_request<T>(message: T, machine_token: &str) -> Result<Request<T>> {
     let mut request = Request::new(message);
     let token: MetadataValue<_> = machine_token
         .parse()
         .context("machine token is not a valid metadata value")?;
     request.metadata_mut().insert(MACHINE_TOKEN_HEADER, token);
-    // Protocol-version handshake: the gateway rejects an unsupported version.
-    let version: MetadataValue<_> = PROTOCOL_VERSION
-        .to_string()
-        .parse()
-        .expect("protocol version is a valid metadata value");
-    request
-        .metadata_mut()
-        .insert(PROTOCOL_VERSION_HEADER, version);
     Ok(request)
+}
+
+/// Terminal error returned by the attach loop when the gateway refuses the
+/// build. The reconnect loop matches on this to park visibly (analogous to
+/// [`is_unauthenticated`]) instead of retrying — a different binary is what's
+/// required, not another connection attempt.
+#[derive(Debug, thiserror::Error)]
+#[error("gateway refused agent build; expected version {expected_version}")]
+struct AgentUpdateRequired {
+    expected_version: String,
+}
+
+fn as_agent_update_required(error: &anyhow::Error) -> Option<&AgentUpdateRequired> {
+    error
+        .chain()
+        .find_map(|cause| cause.downcast_ref::<AgentUpdateRequired>())
 }
 
 /// Whether the error chain contains an `UNAUTHENTICATED` gRPC status — the
@@ -190,6 +198,29 @@ pub async fn run(
                 shutdown.cancelled().await;
                 break;
             }
+            Err(e) if as_agent_update_required(&e).is_some() => {
+                // The gateway pins a specific agent build and this binary
+                // isn't it. Retrying will keep hitting the same rejection;
+                // park until the operator installs the expected binary.
+                // Reuses `CredentialRejected` for the parked-state signal
+                // because it's the closest existing variant — a proper
+                // "update required" state can land alongside push-update.
+                let expected = as_agent_update_required(&e)
+                    .expect("just matched above")
+                    .expected_version
+                    .clone();
+                warn!(
+                    expected = %expected,
+                    current = env!("CARGO_PKG_VERSION"),
+                    "gateway refused the agent build; parked until the expected binary is installed"
+                );
+                state.set_enrollment(
+                    control_proto::Enrollment::CredentialRejected,
+                    &credential.machine_id,
+                );
+                shutdown.cancelled().await;
+                break;
+            }
             Err(e) => {
                 warn!(error = %e, backoff_secs = backoff.as_secs(), "attach failed; retrying");
             }
@@ -248,18 +279,27 @@ async fn connect_and_serve(
     let gateway = state.gateway_target();
     let (req_tx, req_rx) = mpsc::channel::<AttachRequest>(OUTBOUND_CAPACITY);
 
-    // Start heartbeating before the request is even sent, not after the
-    // response arrives. The gateway acks each heartbeat on the response
-    // stream (its only keepalive signal for a proxy/load balancer sitting in
-    // front), so if the client waits for a response before saying anything,
-    // neither side ever sends a byte: the connection sits fully idle until
-    // an intermediary's own idle-connection timeout (AWS ALB defaults to
-    // 60s) resets it, and the response headers the origin sent immediately
-    // are only ever delivered bundled with that reset. Speaking first breaks
-    // the standoff.
-    // Held only for its abort-on-drop side effect: it must outlive every exit
-    // path of this function, not be read.
-    let _heartbeat = spawn_heartbeat(req_tx.clone(), capabilities.to_vec(), state.clone());
+    // Send `Attach` as the very first outbound message, buffered on `req_tx`
+    // before the gRPC call runs. Three reasons: it's the handshake message
+    // the gateway checks agent_version against; it declares the capabilities
+    // and host facts that are constant for this process's lifetime (so
+    // Heartbeat can carry only what actually changes); and it satisfies the
+    // PLAT-34 "speak first" property — the gateway (or a proxy in front)
+    // will not release its response headers until it sees the client say
+    // something, and if the client waits for the response before sending
+    // anything the whole stream idle-times-out. The mpsc buffer holds the
+    // message until tonic drains it once the stream opens.
+    let attach_msg = AttachRequest {
+        msg: Some(attach_request::Msg::Attach(Attach {
+            agent_version: env!("CARGO_PKG_VERSION").to_owned(),
+            capabilities: capabilities.to_vec(),
+            host_info_json: host::host_info_json(),
+        })),
+    };
+    req_tx
+        .send(attach_msg)
+        .await
+        .context("outbound stream closed before Attach could be buffered")?;
 
     // The connect + Attach-RPC handshake can block indefinitely — no connect
     // timeout is configured on the tonic `Endpoint` — and, unlike the
@@ -287,13 +327,36 @@ async fn connect_and_serve(
             .context("Attach RPC failed")
             .map(|response| response.into_inner())
     };
-    // `_heartbeat` (an `AbortOnDropHandle`) is aborted automatically on every
-    // exit from this function, including `?` above and the early return here.
     let mut inbound = tokio::select! {
         biased;
         () = shutdown.cancelled() => return Ok(()),
         result = connect => result?,
     };
+
+    // First inbound message is the handshake result: `AttachAccepted` and we
+    // proceed, or `AttachRejected(AgentUpdate)` and we park the reconnect
+    // loop by returning [`AgentUpdateRequired`].
+    let handshake = inbound
+        .message()
+        .await
+        .context("Attach handshake response failed")?
+        .ok_or_else(|| anyhow::anyhow!("attach stream closed before handshake response"))?;
+    match handshake.msg {
+        Some(attach_response::Msg::AttachAccepted(_)) => {}
+        Some(attach_response::Msg::AttachRejected(update)) => {
+            return Err(anyhow::Error::new(AgentUpdateRequired {
+                expected_version: update.expected_version,
+            }));
+        }
+        other => anyhow::bail!("unexpected first response from gateway: {other:?}"),
+    }
+
+    // Only start heartbeating once the handshake succeeded; a rejected
+    // machine has no business pushing telemetry, and the mpsc would fill
+    // with heartbeats a closing stream can never deliver. Held only for its
+    // abort-on-drop side effect: it must outlive every exit path below.
+    let _heartbeat = spawn_heartbeat(req_tx.clone(), state.clone());
+
     *backoff = INITIAL_BACKOFF;
     state.set_enrollment(control_proto::Enrollment::Attached, &credential.machine_id);
     state.set_gateway_current(&gateway);
@@ -336,7 +399,9 @@ async fn connect_and_serve(
 
 /// Route one inbound `AttachResponse` to the supervisor. Synchronous: every
 /// handler only mutates supervisor state and spawns work, so dispatch can never
-/// stall the stream loop.
+/// stall the stream loop. The handshake variants (`AttachAccepted`/
+/// `AttachRejected`) are consumed by [`connect_and_serve`] before this runs;
+/// seeing either mid-stream is a gateway bug, logged and ignored.
 fn dispatch(supervisor: &RunnerSupervisor, msg: Option<attach_response::Msg>) {
     match msg {
         Some(attach_response::Msg::ProvisionRunner(order)) => {
@@ -347,11 +412,17 @@ fn dispatch(supervisor: &RunnerSupervisor, msg: Option<attach_response::Msg>) {
         Some(attach_response::Msg::OfferVerdictAck(ack)) => {
             supervisor.handle_ack(&ack.offer_token);
         }
-        // No-op the gateway acks each heartbeat with, purely so a proxy in
-        // front of the gateway (e.g. Cloudflare) sees server->client traffic
-        // and never idle-times-out the stream.
-        Some(attach_response::Msg::Keepalive(_)) => {
-            tracing::debug!("received keepalive from gateway");
+        // Each heartbeat gets an ack, whose sole purpose is to keep
+        // server->client traffic flowing so a proxy in front of the gateway
+        // (e.g. Cloudflare) doesn't idle-cut the stream (PLAT-34).
+        Some(attach_response::Msg::HeartbeatAck(_)) => {
+            tracing::debug!("received heartbeat ack from gateway");
+        }
+        Some(attach_response::Msg::AttachAccepted(_)) => {
+            warn!("unexpected AttachAccepted after handshake; ignoring");
+        }
+        Some(attach_response::Msg::AttachRejected(_)) => {
+            warn!("unexpected AttachRejected after handshake; ignoring");
         }
         None => {}
     }
@@ -382,15 +453,15 @@ fn spawn_verdict_resend(
     })
 }
 
-/// Periodically push a declarative capability + telemetry heartbeat until the
-/// channel closes.
+/// Periodically push a live telemetry pulse until the channel closes.
 ///
 /// Heartbeats are connection-scoped: the task is spawned per connection and
 /// aborted when it drops, so a momentary disconnect does not leave stale
-/// heartbeats queued for the next stream.
+/// heartbeats queued for the next stream. Capability set and host facts are
+/// declared once per stream in the `Attach` handshake (they're constant for
+/// the process lifetime), so this loop carries only what actually changes.
 fn spawn_heartbeat(
     outbound: mpsc::Sender<AttachRequest>,
-    capabilities: Vec<Capability>,
     state: AgentState,
 ) -> AbortOnDropHandle<()> {
     AbortOnDropHandle::new(tokio::spawn(async move {
@@ -400,8 +471,6 @@ fn spawn_heartbeat(
             let telemetry = host::telemetry();
             state.set_telemetry(telemetry_to_control(&telemetry));
             let msg = attach_request::Msg::Heartbeat(Heartbeat {
-                capabilities: capabilities.clone(),
-                host_info_json: host::host_info_json(),
                 telemetry: Some(telemetry),
             });
             if outbound
@@ -582,9 +651,19 @@ mod tests {
                 .await
                 .map_err(|e| tonic::Status::internal(e.to_string()))?
                 .ok_or_else(|| tonic::Status::internal("closed before any message arrived"))?;
-            // Empty, immediately-closed response: this test only cares that
-            // headers were unblocked, not about dispatch.
-            let (_tx, rx) = mpsc::channel(1);
+            // Send AttachAccepted then immediately close — under the redesigned
+            // handshake, the client waits for this before proceeding. Without
+            // it the client would treat the empty stream as a handshake
+            // failure. This test only cares that response headers were
+            // unblocked once the client spoke first, not about dispatch.
+            let (tx, rx) = mpsc::channel(1);
+            let _ = tx
+                .send(Ok(arcbox_fleet_proto::v1::AttachResponse {
+                    msg: Some(attach_response::Msg::AttachAccepted(
+                        arcbox_fleet_proto::v1::AttachAccepted {},
+                    )),
+                }))
+                .await;
             Ok(tonic::Response::new(
                 tokio_stream::wrappers::ReceiverStream::new(rx),
             ))

--- a/fleet/arcbox-fleet-agent/src/attach.rs
+++ b/fleet/arcbox-fleet-agent/src/attach.rs
@@ -17,6 +17,7 @@ use arcbox_fleet_proto::v1::{
 use tokio::sync::mpsc;
 use tokio_stream::wrappers::ReceiverStream;
 use tokio_util::sync::CancellationToken;
+use tokio_util::task::AbortOnDropHandle;
 use tonic::Request;
 use tonic::metadata::MetadataValue;
 use tracing::{info, warn};
@@ -247,6 +248,19 @@ async fn connect_and_serve(
     let gateway = state.gateway_target();
     let (req_tx, req_rx) = mpsc::channel::<AttachRequest>(OUTBOUND_CAPACITY);
 
+    // Start heartbeating before the request is even sent, not after the
+    // response arrives. The gateway acks each heartbeat on the response
+    // stream (its only keepalive signal for a proxy/load balancer sitting in
+    // front), so if the client waits for a response before saying anything,
+    // neither side ever sends a byte: the connection sits fully idle until
+    // an intermediary's own idle-connection timeout (AWS ALB defaults to
+    // 60s) resets it, and the response headers the origin sent immediately
+    // are only ever delivered bundled with that reset. Speaking first breaks
+    // the standoff.
+    // Held only for its abort-on-drop side effect: it must outlive every exit
+    // path of this function, not be read.
+    let _heartbeat = spawn_heartbeat(req_tx.clone(), capabilities.to_vec(), state.clone());
+
     // The connect + Attach-RPC handshake can block indefinitely — no connect
     // timeout is configured on the tonic `Endpoint` — and, unlike the
     // message loop below, has no cancellation awareness of its own. Without
@@ -273,6 +287,8 @@ async fn connect_and_serve(
             .context("Attach RPC failed")
             .map(|response| response.into_inner())
     };
+    // `_heartbeat` (an `AbortOnDropHandle`) is aborted automatically on every
+    // exit from this function, including `?` above and the early return here.
     let mut inbound = tokio::select! {
         biased;
         () = shutdown.cancelled() => return Ok(()),
@@ -291,9 +307,7 @@ async fn connect_and_serve(
         }
     }
 
-    let heartbeat = spawn_heartbeat(req_tx.clone(), capabilities.to_vec(), state.clone());
-
-    let outcome = loop {
+    loop {
         tokio::select! {
             () = shutdown.cancelled() => break Ok(()),
             event = egress_rx.recv() => match event {
@@ -309,15 +323,15 @@ async fn connect_and_serve(
                 None => break Ok(()),
             },
             message = inbound.message() => match message {
-                Ok(Some(message)) => dispatch(supervisor, message.msg),
+                Ok(Some(message)) => {
+                    tracing::debug!(msg = ?message.msg, "inbound attach message");
+                    dispatch(supervisor, message.msg);
+                }
                 Ok(None) => break Ok(()),
                 Err(status) => break Err(anyhow::Error::from(status)),
             },
         }
-    };
-
-    heartbeat.abort();
-    outcome
+    }
 }
 
 /// Route one inbound `AttachResponse` to the supervisor. Synchronous: every
@@ -336,7 +350,9 @@ fn dispatch(supervisor: &RunnerSupervisor, msg: Option<attach_response::Msg>) {
         // No-op the gateway acks each heartbeat with, purely so a proxy in
         // front of the gateway (e.g. Cloudflare) sees server->client traffic
         // and never idle-times-out the stream.
-        Some(attach_response::Msg::Keepalive(_)) => {}
+        Some(attach_response::Msg::Keepalive(_)) => {
+            tracing::debug!("received keepalive from gateway");
+        }
         None => {}
     }
 }
@@ -376,8 +392,8 @@ fn spawn_heartbeat(
     outbound: mpsc::Sender<AttachRequest>,
     capabilities: Vec<Capability>,
     state: AgentState,
-) -> tokio::task::JoinHandle<()> {
-    tokio::spawn(async move {
+) -> AbortOnDropHandle<()> {
+    AbortOnDropHandle::new(tokio::spawn(async move {
         let mut ticker = tokio::time::interval(HEARTBEAT_INTERVAL);
         loop {
             ticker.tick().await;
@@ -396,7 +412,7 @@ fn spawn_heartbeat(
                 break;
             }
         }
-    })
+    }))
 }
 
 #[cfg(test)]
@@ -531,6 +547,130 @@ mod tests {
             .expect("parked loop exits on shutdown")
             .expect("attach task must not panic")
             .expect("clean exit");
+    }
+
+    /// A gateway that never sends a response until it has read the agent's
+    /// first request message — replicating a load balancer that won't relay
+    /// a quiet response and instead idle-times it out (PLAT-34: the real
+    /// deployment held the response for a full 60s, then reset the stream,
+    /// because neither side ever sent anything first).
+    struct SilentUntilFirstMessageGateway;
+
+    #[tonic::async_trait]
+    impl arcbox_fleet_proto::v1::fleet_gateway_service_server::FleetGatewayService
+        for SilentUntilFirstMessageGateway
+    {
+        async fn enroll(
+            &self,
+            _: Request<arcbox_fleet_proto::v1::EnrollRequest>,
+        ) -> Result<tonic::Response<arcbox_fleet_proto::v1::EnrollResponse>, tonic::Status>
+        {
+            Err(tonic::Status::unimplemented("not used by this test"))
+        }
+
+        type AttachStream = tokio_stream::wrappers::ReceiverStream<
+            Result<arcbox_fleet_proto::v1::AttachResponse, tonic::Status>,
+        >;
+
+        async fn attach(
+            &self,
+            request: Request<tonic::Streaming<AttachRequest>>,
+        ) -> Result<tonic::Response<Self::AttachStream>, tonic::Status> {
+            request
+                .into_inner()
+                .message()
+                .await
+                .map_err(|e| tonic::Status::internal(e.to_string()))?
+                .ok_or_else(|| tonic::Status::internal("closed before any message arrived"))?;
+            // Empty, immediately-closed response: this test only cares that
+            // headers were unblocked, not about dispatch.
+            let (_tx, rx) = mpsc::channel(1);
+            Ok(tonic::Response::new(
+                tokio_stream::wrappers::ReceiverStream::new(rx),
+            ))
+        }
+
+        async fn unenroll(
+            &self,
+            _: Request<arcbox_fleet_proto::v1::UnenrollRequest>,
+        ) -> Result<tonic::Response<arcbox_fleet_proto::v1::UnenrollResponse>, tonic::Status>
+        {
+            Err(tonic::Status::unimplemented("not used by this test"))
+        }
+    }
+
+    /// Regression test for PLAT-34: if the agent waits for the gateway's
+    /// response before sending anything, and the gateway (or a proxy in
+    /// front of it) withholds its response until it sees the agent send
+    /// something, both sides deadlock — silently, until whatever's fronting
+    /// the connection eventually resets it on its own idle timeout. The
+    /// agent must speak first.
+    #[tokio::test]
+    async fn connect_and_serve_sends_a_message_before_the_gateway_ever_responds() {
+        use arcbox_fleet_proto::v1::fleet_gateway_service_server::FleetGatewayServiceServer;
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let gateway = format!("http://{}", listener.local_addr().unwrap());
+        tokio::spawn(
+            tonic::transport::Server::builder()
+                .add_service(FleetGatewayServiceServer::new(
+                    SilentUntilFirstMessageGateway,
+                ))
+                .serve_with_incoming(tokio_stream::wrappers::TcpListenerStream::new(listener)),
+        );
+
+        // `connect_and_serve` dials `state.gateway_target()`, not
+        // `config.gateway` (see that fn's own doc) — the state must be
+        // seeded with the mock's address, matching how enrollment does it.
+        let state = AgentState::new(&PersistedSettings {
+            gateway: gateway.clone(),
+            ..seed()
+        });
+        let (events, _rx) = mpsc::channel(1);
+        let supervisor = RunnerSupervisor::new(
+            events,
+            None,
+            None,
+            None,
+            Vec::new(),
+            AgentState::new(&seed()),
+        );
+        let (_egress_tx, mut egress_rx) = mpsc::channel::<AttachRequest>(1);
+        let mut pending = None;
+        let mut backoff = INITIAL_BACKOFF;
+        let shutdown = CancellationToken::new();
+
+        let config = AgentConfig {
+            gateway,
+            ..config()
+        };
+        let credential = credential();
+
+        // A generous-but-bounded deadline distinguishes "worked" from
+        // "deadlocked with the mock" without depending on any real network
+        // timeout.
+        tokio::time::timeout(
+            Duration::from_secs(3),
+            connect_and_serve(
+                &config,
+                &credential,
+                &supervisor,
+                &mut egress_rx,
+                &mut pending,
+                &mut backoff,
+                &[],
+                &shutdown,
+                &state,
+            ),
+        )
+        .await
+        .expect("must send a message before waiting on the response, not deadlock with the gateway")
+        .expect("clean exit once the mock's response stream closes");
+
+        assert_eq!(
+            state.current().enrollment,
+            control_proto::Enrollment::Attached as i32,
+        );
     }
 
     /// The verdict-resend loop is attachment-scoped: cancelling the shutdown

--- a/fleet/arcbox-fleet-agent/src/attach.rs
+++ b/fleet/arcbox-fleet-agent/src/attach.rs
@@ -28,6 +28,7 @@ use crate::docker;
 use crate::host;
 use crate::runner::RunnerSupervisor;
 use crate::state::AgentState;
+use crate::update;
 
 const HEARTBEAT_INTERVAL: Duration = Duration::from_secs(15);
 /// How often to resend verdicts still awaiting an `OfferVerdictAck`. Comfortably
@@ -56,14 +57,27 @@ pub fn authenticated_request<T>(message: T, machine_token: &str) -> Result<Reque
     Ok(request)
 }
 
-/// Terminal error returned by the attach loop when the gateway refuses the
-/// build. The reconnect loop matches on this to park visibly (analogous to
-/// [`is_unauthenticated`]) instead of retrying — a different binary is what's
+/// Error returned by the attach loop when the gateway requires a different
+/// build — at the handshake (`AttachRejected`) or pushed mid-stream on a
+/// `HeartbeatAck` after draining. The reconnect loop matches on this: with a
+/// `payload` it self-updates and re-execs; without one it parks visibly
+/// (analogous to [`is_unauthenticated`]) — a different binary is what's
 /// required, not another connection attempt.
 #[derive(Debug, thiserror::Error)]
 #[error("gateway refused agent build; expected version {expected_version}")]
 struct AgentUpdateRequired {
     expected_version: String,
+    /// The pushed download, when the gateway carried one.
+    payload: Option<update::UpdatePayload>,
+}
+
+impl From<arcbox_fleet_proto::v1::AgentUpdate> for AgentUpdateRequired {
+    fn from(update: arcbox_fleet_proto::v1::AgentUpdate) -> Self {
+        Self {
+            payload: update::UpdatePayload::from_wire(&update),
+            expected_version: update.expected_version,
+        }
+    }
 }
 
 fn as_agent_update_required(error: &anyhow::Error) -> Option<&AgentUpdateRequired> {
@@ -153,6 +167,10 @@ pub async fn run(
     // connection dropped; re-sent first on the next connection so a terminal
     // event is never lost to a closed stream.
     let mut pending: Option<AttachRequest> = None;
+    // Whether the supervisor is draining for a self-update. Spans reconnects
+    // so a successful re-attach (the pin moved back to this build) can undo
+    // exactly the update drain and nothing else.
+    let mut drained_for_update = false;
 
     // Attachment-scoped: resend unacked verdicts across reconnects within this
     // attachment, exiting when `shutdown` fires. Tied to the attachment rather
@@ -173,6 +191,7 @@ pub async fn run(
             &capabilities,
             &shutdown,
             &state,
+            &mut drained_for_update,
         )
         .await;
         // A shutdown during the connection is a clean exit, not a failure to log
@@ -199,27 +218,64 @@ pub async fn run(
                 break;
             }
             Err(e) if as_agent_update_required(&e).is_some() => {
-                // The gateway pins a specific agent build and this binary
-                // isn't it. Retrying will keep hitting the same rejection;
-                // park until the operator installs the expected binary.
-                // Reuses `CredentialRejected` for the parked-state signal
-                // because it's the closest existing variant — a proper
-                // "update required" state can land alongside push-update.
-                let expected = as_agent_update_required(&e)
-                    .expect("just matched above")
-                    .expected_version
-                    .clone();
-                warn!(
-                    expected = %expected,
+                let required = as_agent_update_required(&e).expect("just matched above");
+                let Some(payload) = required.payload.clone() else {
+                    // The gateway pins a different build but carried no
+                    // download (pre-registry gateway, or no asset for this
+                    // platform). Retrying will keep hitting the same
+                    // rejection; park until the operator installs the
+                    // expected binary. Reuses `CredentialRejected` for the
+                    // parked-state signal — `Updating` is the in-progress
+                    // state, not this dead end.
+                    warn!(
+                        expected = %required.expected_version,
+                        current = env!("CARGO_PKG_VERSION"),
+                        "gateway refused the agent build; parked until the expected binary is installed"
+                    );
+                    state.set_enrollment(
+                        control_proto::Enrollment::CredentialRejected,
+                        &credential.machine_id,
+                    );
+                    shutdown.cancelled().await;
+                    break;
+                };
+                info!(
+                    expected = %payload.expected_version,
                     current = env!("CARGO_PKG_VERSION"),
-                    "gateway refused the agent build; parked until the expected binary is installed"
+                    "gateway requires a different build; self-updating"
                 );
-                state.set_enrollment(
-                    control_proto::Enrollment::CredentialRejected,
-                    &credential.machine_id,
-                );
-                shutdown.cancelled().await;
-                break;
+                state.set_enrollment(control_proto::Enrollment::Updating, &credential.machine_id);
+                // Off-stream no new offers can arrive, but jobs may still be
+                // running (a mid-stream drain that lost its connection, or a
+                // reconnect that got version-rejected). Never kill them for
+                // an update.
+                supervisor.drain_for_update();
+                drained_for_update = true;
+                tokio::select! {
+                    biased;
+                    () = shutdown.cancelled() => break,
+                    () = supervisor.drained_of_jobs() => {}
+                }
+                // Returns only on failure; success replaces this process.
+                let error = update::apply_and_exec(&config, &payload).await;
+                if error
+                    .chain()
+                    .any(|c| c.downcast_ref::<update::UnmanagedBinary>().is_some())
+                {
+                    // Not our binary to manage — same dead end as an update
+                    // without a download: park for the operator.
+                    warn!(
+                        error = %error,
+                        "self-update declined; parked until the expected binary is installed"
+                    );
+                    state.set_enrollment(
+                        control_proto::Enrollment::CredentialRejected,
+                        &credential.machine_id,
+                    );
+                    shutdown.cancelled().await;
+                    break;
+                }
+                warn!(error = %error, backoff_secs = backoff.as_secs(), "self-update failed; retrying");
             }
             Err(e) => {
                 warn!(error = %e, backoff_secs = backoff.as_secs(), "attach failed; retrying");
@@ -256,7 +312,8 @@ pub async fn run(
     reason = "one connection's lifecycle genuinely needs all of: endpoint config, \
               credential, the persistent supervisor, the cross-reconnect egress queue \
               and its pending slot, the mutable backoff, advertised capabilities, the \
-              shutdown token, and the observable state handle"
+              shutdown token, the observable state handle, and the cross-reconnect \
+              update-drain flag"
 )]
 async fn connect_and_serve(
     config: &AgentConfig,
@@ -268,6 +325,7 @@ async fn connect_and_serve(
     capabilities: &[Capability],
     shutdown: &CancellationToken,
     state: &AgentState,
+    drained_for_update: &mut bool,
 ) -> Result<()> {
     // The desired (`target`) gateway, not `config.gateway` directly —
     // `AgentSupervisor` seeds it from config, and an `Enroll` gateway
@@ -344,11 +402,17 @@ async fn connect_and_serve(
         .context("Attach handshake response failed")?
         .ok_or_else(|| anyhow::anyhow!("attach stream closed before handshake response"))?;
     match handshake.msg {
-        Some(attach_response::Msg::AttachAccepted(_)) => {}
+        Some(attach_response::Msg::AttachAccepted(_)) => {
+            // A drain begun for an update that never happened (the pin moved
+            // back to this build before the swap) is moot once the gateway
+            // accepts this build again.
+            if *drained_for_update {
+                supervisor.resume_after_moot_update();
+                *drained_for_update = false;
+            }
+        }
         Some(attach_response::Msg::AttachRejected(update)) => {
-            return Err(anyhow::Error::new(AgentUpdateRequired {
-                expected_version: update.expected_version,
-            }));
+            return Err(anyhow::Error::new(AgentUpdateRequired::from(update)));
         }
         other => anyhow::bail!("unexpected first response from gateway: {other:?}"),
     }
@@ -372,9 +436,20 @@ async fn connect_and_serve(
         }
     }
 
+    // A mid-stream update pushed on a HeartbeatAck. The stream stays live
+    // while the supervisor drains — cancels keep arriving and verdicts keep
+    // delivering — and only once everything is settled does the loop leave
+    // with `AgentUpdateRequired`, handing the swap to the reconnect loop.
+    let mut pending_update: Option<AgentUpdateRequired> = None;
+
     loop {
         tokio::select! {
             () = shutdown.cancelled() => break Ok(()),
+            () = supervisor.settled(), if pending_update.is_some() => {
+                break Err(anyhow::Error::new(
+                    pending_update.take().expect("guarded by is_some"),
+                ));
+            }
             event = egress_rx.recv() => match event {
                 Some(msg) => {
                     if let Err(err) = req_tx.send(msg).await {
@@ -390,12 +465,39 @@ async fn connect_and_serve(
             message = inbound.message() => match message {
                 Ok(Some(message)) => {
                     tracing::debug!(msg = ?message.msg, "inbound attach message");
+                    if let Some(update) = pushed_update(&message) {
+                        if pending_update.is_none()
+                            && update.expected_version != env!("CARGO_PKG_VERSION")
+                        {
+                            info!(
+                                expected = %update.expected_version,
+                                current = env!("CARGO_PKG_VERSION"),
+                                "gateway pushed an update; draining before the swap"
+                            );
+                            supervisor.drain_for_update();
+                            *drained_for_update = true;
+                            pending_update = Some(AgentUpdateRequired::from(update.clone()));
+                        }
+                        continue;
+                    }
                     dispatch(supervisor, message.msg);
                 }
                 Ok(None) => break Ok(()),
                 Err(status) => break Err(anyhow::Error::from(status)),
             },
         }
+    }
+}
+
+/// The update payload riding on a `HeartbeatAck`, if any. Extracted before
+/// [`dispatch`] because acting on it (drain, then leave the stream) belongs
+/// to the connection loop, not the synchronous dispatcher.
+fn pushed_update(
+    message: &arcbox_fleet_proto::v1::AttachResponse,
+) -> Option<&arcbox_fleet_proto::v1::AgentUpdate> {
+    match &message.msg {
+        Some(attach_response::Msg::HeartbeatAck(ack)) => ack.update.as_ref(),
+        _ => None,
     }
 }
 
@@ -730,6 +832,7 @@ mod tests {
         // A generous-but-bounded deadline distinguishes "worked" from
         // "deadlocked with the mock" without depending on any real network
         // timeout.
+        let mut drained_for_update = false;
         tokio::time::timeout(
             Duration::from_secs(3),
             connect_and_serve(
@@ -742,6 +845,7 @@ mod tests {
                 &[],
                 &shutdown,
                 &state,
+                &mut drained_for_update,
             ),
         )
         .await
@@ -833,6 +937,7 @@ mod tests {
         let config = config();
         let credential = credential();
 
+        let mut drained_for_update = false;
         let result = tokio::time::timeout(
             Duration::from_secs(1),
             connect_and_serve(
@@ -845,6 +950,7 @@ mod tests {
                 &[],
                 &shutdown,
                 &state,
+                &mut drained_for_update,
             ),
         )
         .await

--- a/fleet/arcbox-fleet-agent/src/attach.rs
+++ b/fleet/arcbox-fleet-agent/src/attach.rs
@@ -100,6 +100,7 @@ fn telemetry_to_control(t: &HostTelemetry) -> control_proto::HostTelemetry {
 pub fn spawn_supervisor(
     config: &AgentConfig,
     docker: Option<docker::DockerRunner>,
+    vm: Option<crate::vm::VmRunner>,
     capabilities: Vec<Capability>,
     state: AgentState,
 ) -> (RunnerSupervisor, mpsc::Receiver<AttachRequest>) {
@@ -108,6 +109,7 @@ pub fn spawn_supervisor(
         egress_tx,
         config.runner_script.clone(),
         docker,
+        vm,
         capabilities,
         state,
     );
@@ -493,7 +495,8 @@ mod tests {
             machine_id: "fltm_parked".to_owned(),
             machine_token: "flt_revoked".to_owned(),
         };
-        let (supervisor, egress_rx) = spawn_supervisor(&config, None, Vec::new(), state.clone());
+        let (supervisor, egress_rx) =
+            spawn_supervisor(&config, None, None, Vec::new(), state.clone());
         let shutdown = CancellationToken::new();
         let run = tokio::spawn(run(
             config,
@@ -537,8 +540,14 @@ mod tests {
     #[tokio::test]
     async fn verdict_resend_task_exits_when_shutdown_fires() {
         let (events, _rx) = mpsc::channel(1);
-        let supervisor =
-            RunnerSupervisor::new(events, None, None, Vec::new(), AgentState::new(&seed()));
+        let supervisor = RunnerSupervisor::new(
+            events,
+            None,
+            None,
+            None,
+            Vec::new(),
+            AgentState::new(&seed()),
+        );
         let shutdown = CancellationToken::new();
         let handle = spawn_verdict_resend(supervisor, shutdown.clone());
 
@@ -586,8 +595,14 @@ mod tests {
     async fn connect_and_serve_bails_out_immediately_when_already_cancelled() {
         let state = AgentState::new(&seed());
         let (events, _rx) = mpsc::channel(1);
-        let supervisor =
-            RunnerSupervisor::new(events, None, None, Vec::new(), AgentState::new(&seed()));
+        let supervisor = RunnerSupervisor::new(
+            events,
+            None,
+            None,
+            None,
+            Vec::new(),
+            AgentState::new(&seed()),
+        );
         let (_egress_tx, mut egress_rx) = mpsc::channel::<AttachRequest>(1);
         let mut pending = None;
         let mut backoff = INITIAL_BACKOFF;

--- a/fleet/arcbox-fleet-agent/src/attach.rs
+++ b/fleet/arcbox-fleet-agent/src/attach.rs
@@ -294,6 +294,8 @@ async fn connect_and_serve(
             agent_version: env!("CARGO_PKG_VERSION").to_owned(),
             capabilities: capabilities.to_vec(),
             host_info_json: host::host_info_json(),
+            host_os: host::host_os(),
+            host_arch: host::host_arch(),
         })),
     };
     req_tx

--- a/fleet/arcbox-fleet-agent/src/attach.rs
+++ b/fleet/arcbox-fleet-agent/src/attach.rs
@@ -485,6 +485,7 @@ mod tests {
             vm: crate::config::VmConfig {
                 mode: crate::config::VmMode::Disabled,
                 macos_runner_image: "tahoe-base".to_owned(),
+                daemon_socket: std::path::PathBuf::from("/nonexistent/arcbox.sock"),
             },
             credential_store: crate::config::CredentialMode::File,
         };
@@ -562,6 +563,7 @@ mod tests {
             vm: crate::config::VmConfig {
                 mode: crate::config::VmMode::Disabled,
                 macos_runner_image: "tahoe-base".to_owned(),
+                daemon_socket: std::path::PathBuf::from("/nonexistent/arcbox.sock"),
             },
             credential_store: crate::config::CredentialMode::File,
         }

--- a/fleet/arcbox-fleet-agent/src/config.rs
+++ b/fleet/arcbox-fleet-agent/src/config.rs
@@ -92,11 +92,6 @@ pub struct VmConfig {
     pub macos_runner_image: String,
     /// arcbox-daemon gRPC socket — the daemon↔CLI socket contract
     /// (`~/.arcbox/run/arcbox.sock` by default, via `arcbox-constants`).
-    #[expect(
-        dead_code,
-        reason = "read by the VM backend's startup probe, which lands in the next commit \
-                  of this change set; the #[expect] forces removal then"
-    )]
     pub daemon_socket: PathBuf,
 }
 

--- a/fleet/arcbox-fleet-agent/src/config.rs
+++ b/fleet/arcbox-fleet-agent/src/config.rs
@@ -13,7 +13,7 @@ use crate::credentials::CredentialStore;
 
 /// Production gateway endpoint. Overridable via `ARCBOX_FLEET_GATEWAY` for
 /// local/e2e testing (e.g. `http://127.0.0.1:50061`).
-pub const DEFAULT_GATEWAY: &str = "https://fleet.arcbox.dev";
+pub const DEFAULT_GATEWAY: &str = "https://gateway.fleet.arcbox.dev";
 
 const ENV_GATEWAY: &str = "ARCBOX_FLEET_GATEWAY";
 const ENV_RUNNER_SCRIPT: &str = "ARCBOX_FLEET_RUNNER_SCRIPT";

--- a/fleet/arcbox-fleet-agent/src/config.rs
+++ b/fleet/arcbox-fleet-agent/src/config.rs
@@ -24,6 +24,7 @@ const ENV_DOCKER: &str = "ARCBOX_FLEET_DOCKER";
 const ENV_LINUX_RUNNER_IMAGE: &str = "ARCBOX_FLEET_LINUX_RUNNER_IMAGE";
 const ENV_VM: &str = "ARCBOX_FLEET_VM";
 const ENV_MACOS_RUNNER_IMAGE: &str = "ARCBOX_FLEET_MACOS_RUNNER_IMAGE";
+const ENV_DAEMON_SOCKET: &str = "ARCBOX_FLEET_DAEMON_SOCKET";
 const ENV_CREDENTIAL_STORE: &str = "ARCBOX_FLEET_CREDENTIAL_STORE";
 
 /// Reject an offer when 1-minute load average per core exceeds this.
@@ -89,6 +90,14 @@ pub struct VmConfig {
     pub mode: VmMode,
     /// macOS base-image stream darwin VM jobs boot from.
     pub macos_runner_image: String,
+    /// arcbox-daemon gRPC socket — the daemon↔CLI socket contract
+    /// (`~/.arcbox/run/arcbox.sock` by default, via `arcbox-constants`).
+    #[expect(
+        dead_code,
+        reason = "read by the VM backend's startup probe, which lands in the next commit \
+                  of this change set; the #[expect] forces removal then"
+    )]
+    pub daemon_socket: PathBuf,
 }
 
 /// Resolved agent configuration.
@@ -158,6 +167,10 @@ impl AgentConfig {
         };
         let macos_runner_image = std::env::var(ENV_MACOS_RUNNER_IMAGE)
             .unwrap_or_else(|_| DEFAULT_MACOS_RUNNER_IMAGE.to_string());
+        let daemon_socket = match std::env::var_os(ENV_DAEMON_SOCKET) {
+            Some(path) => PathBuf::from(path),
+            None => arcbox_constants::paths::HostLayout::from_env_or_default().grpc_socket,
+        };
 
         let credential_store = match std::env::var(ENV_CREDENTIAL_STORE).as_deref() {
             Ok("keyring") => CredentialMode::Keyring,
@@ -190,6 +203,7 @@ impl AgentConfig {
             vm: VmConfig {
                 mode: vm_mode,
                 macos_runner_image,
+                daemon_socket,
             },
             credential_store,
         })

--- a/fleet/arcbox-fleet-agent/src/config.rs
+++ b/fleet/arcbox-fleet-agent/src/config.rs
@@ -35,9 +35,6 @@ const DEFAULT_LINUX_RUNNER_IMAGE: &str = "ghcr.io/actions/actions-runner:latest"
 /// Published macOS base-image stream with the Actions runner baked in.
 pub const DEFAULT_MACOS_RUNNER_IMAGE: &str = "tahoe-base";
 
-/// Wire-protocol version this agent speaks; the gateway rejects a mismatch.
-pub const PROTOCOL_VERSION: u32 = 1;
-
 /// Whether Docker-based Linux job execution is enabled.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum DockerMode {

--- a/fleet/arcbox-fleet-agent/src/config.rs
+++ b/fleet/arcbox-fleet-agent/src/config.rs
@@ -22,6 +22,8 @@ const ENV_MEM_FLOOR_MIB: &str = "ARCBOX_FLEET_MEM_FLOOR_MIB";
 const ENV_DATA_DIR: &str = "ARCBOX_FLEET_DATA_DIR";
 const ENV_DOCKER: &str = "ARCBOX_FLEET_DOCKER";
 const ENV_LINUX_RUNNER_IMAGE: &str = "ARCBOX_FLEET_LINUX_RUNNER_IMAGE";
+const ENV_VM: &str = "ARCBOX_FLEET_VM";
+const ENV_MACOS_RUNNER_IMAGE: &str = "ARCBOX_FLEET_MACOS_RUNNER_IMAGE";
 const ENV_CREDENTIAL_STORE: &str = "ARCBOX_FLEET_CREDENTIAL_STORE";
 
 /// Reject an offer when 1-minute load average per core exceeds this.
@@ -29,6 +31,8 @@ const DEFAULT_LOAD_CEILING: f64 = 0.9;
 /// Reject an offer when available memory is below this many MiB.
 const DEFAULT_MEM_FLOOR_MIB: u64 = 2048;
 const DEFAULT_LINUX_RUNNER_IMAGE: &str = "ghcr.io/actions/actions-runner:latest";
+/// Published macOS base-image stream with the Actions runner baked in.
+pub const DEFAULT_MACOS_RUNNER_IMAGE: &str = "tahoe-base";
 
 /// Wire-protocol version this agent speaks; the gateway rejects a mismatch.
 pub const PROTOCOL_VERSION: u32 = 1;
@@ -41,6 +45,19 @@ pub enum DockerMode {
     /// Require Docker; fail startup if the socket is unreachable.
     Enabled,
     /// Never use Docker, even if available.
+    Disabled,
+}
+
+/// Whether darwin jobs run in disposable macOS VMs provisioned through the
+/// local arcbox-daemon (isolation), instead of the pre-installed host runner.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum VmMode {
+    /// Probe the daemon at startup; fall back to the host runner if it cannot
+    /// serve VMs (unreachable, or the macOS runner image is not installed).
+    Auto,
+    /// Require the daemon; fail startup if it cannot serve VMs.
+    Enabled,
+    /// Never run darwin jobs in VMs, even if the daemon could.
     Disabled,
 }
 
@@ -65,6 +82,15 @@ pub struct DockerConfig {
     pub linux_runner_image: String,
 }
 
+/// VM-backend configuration for running darwin jobs in disposable macOS
+/// guests via the local arcbox-daemon.
+#[derive(Debug, Clone)]
+pub struct VmConfig {
+    pub mode: VmMode,
+    /// macOS base-image stream darwin VM jobs boot from.
+    pub macos_runner_image: String,
+}
+
 /// Resolved agent configuration.
 #[derive(Debug, Clone)]
 pub struct AgentConfig {
@@ -82,6 +108,8 @@ pub struct AgentConfig {
     pub data_dir: PathBuf,
     /// Docker runtime configuration for Linux jobs.
     pub docker: DockerConfig,
+    /// VM-backend configuration for darwin jobs.
+    pub vm: VmConfig,
     /// Where the machine credential is persisted (OS keychain vs file).
     pub credential_store: CredentialMode,
 }
@@ -120,6 +148,17 @@ impl AgentConfig {
         let linux_runner_image = std::env::var(ENV_LINUX_RUNNER_IMAGE)
             .unwrap_or_else(|_| DEFAULT_LINUX_RUNNER_IMAGE.to_string());
 
+        let vm_mode = match std::env::var(ENV_VM).as_deref() {
+            Ok("true") => VmMode::Enabled,
+            Ok("false") => VmMode::Disabled,
+            Ok("auto") | Err(_) => VmMode::Auto,
+            Ok(other) => {
+                anyhow::bail!("{ENV_VM} must be 'auto', 'true', or 'false', got '{other}'")
+            }
+        };
+        let macos_runner_image = std::env::var(ENV_MACOS_RUNNER_IMAGE)
+            .unwrap_or_else(|_| DEFAULT_MACOS_RUNNER_IMAGE.to_string());
+
         let credential_store = match std::env::var(ENV_CREDENTIAL_STORE).as_deref() {
             Ok("keyring") => CredentialMode::Keyring,
             Ok("file") => CredentialMode::File,
@@ -147,6 +186,10 @@ impl AgentConfig {
             docker: DockerConfig {
                 mode: docker_mode,
                 linux_runner_image,
+            },
+            vm: VmConfig {
+                mode: vm_mode,
+                macos_runner_image,
             },
             credential_store,
         })

--- a/fleet/arcbox-fleet-agent/src/control/image.rs
+++ b/fleet/arcbox-fleet-agent/src/control/image.rs
@@ -63,7 +63,11 @@ fn resolve_kinds(raw: &[i32]) -> Result<Vec<ImageKind>, String> {
         .iter()
         .map(|&v| match ImageKind::try_from(v) {
             Ok(ImageKind::LinuxRunnerImage) => Ok(ImageKind::LinuxRunnerImage),
-            Ok(ImageKind::Unspecified) | Err(_) => Err(format!("unsupported image kind {v}")),
+            // Wired up with the VM backend's Prepare path (see the module
+            // doc); until then an explicit request for it is rejected.
+            Ok(ImageKind::MacosRunnerImage | ImageKind::Unspecified) | Err(_) => {
+                Err(format!("unsupported image kind {v}"))
+            }
         })
         .collect::<Result<Vec<_>, _>>()?;
     kinds.sort_unstable();
@@ -147,6 +151,8 @@ mod tests {
             docker_mode: DockerMode::Disabled,
             runner_script: None,
             participate: true,
+            vm_mode: crate::config::VmMode::Auto,
+            macos_runner_image: "tahoe-base".to_owned(),
         }
     }
 

--- a/fleet/arcbox-fleet-agent/src/control/image.rs
+++ b/fleet/arcbox-fleet-agent/src/control/image.rs
@@ -1,9 +1,9 @@
 //! `FleetImageService` — converges each image setting's `current` onto its
 //! `target` by fetching and verifying the target artifact through the
-//! runtime that owns it (the Docker socket today; the arcbox-daemon socket
-//! once the macOS VM backend lands), streaming progress. Split from
-//! `FleetSettingsService` so quick state reads/writes never share a service
-//! with RPCs that stream a multi-gigabyte transfer.
+//! runtime that owns it (the Docker socket for `linux_runner_image`; the
+//! arcbox-daemon socket for `macos_runner_image`), streaming progress.
+//! Split from `FleetSettingsService` so quick state reads/writes never
+//! share a service with RPCs that stream a multi-gigabyte transfer.
 
 use std::pin::Pin;
 use std::sync::Arc;
@@ -15,6 +15,7 @@ use tonic::{Request, Response, Status};
 
 use crate::docker::DockerRunner;
 use crate::state::AgentState;
+use crate::vm::VmRunner;
 
 pub struct ImageService {
     state: AgentState,
@@ -22,6 +23,9 @@ pub struct ImageService {
     /// `docker_mode` changes are restart-scoped (see
     /// `AgentSupervisor::docker`'s doc).
     docker: Option<DockerRunner>,
+    /// The process-lifetime macOS VM backend handle, if active. Never
+    /// stale for the same reason (`vm_mode` is restart-scoped).
+    vm: Option<VmRunner>,
     /// Serializes preparations. Two racing Prepares would pull concurrently
     /// and promote in arbitrary order, so the loser gets `ABORTED` instead
     /// of queueing behind a transfer of unknown length.
@@ -29,10 +33,11 @@ pub struct ImageService {
 }
 
 impl ImageService {
-    pub fn new(state: AgentState, docker: Option<DockerRunner>) -> Self {
+    pub fn new(state: AgentState, docker: Option<DockerRunner>, vm: Option<VmRunner>) -> Self {
         Self {
             state,
             docker,
+            vm,
             busy: Arc::new(tokio::sync::Mutex::new(())),
         }
     }
@@ -48,26 +53,32 @@ fn event(kind: ImageKind, detail: &str, stage: &str, fraction: f64) -> PrepareRe
 }
 
 /// Expand the requested kinds: empty prepares every kind this agent
-/// supports. An unrecognized kind (a newer client) is rejected rather than
-/// silently skipped, so "prepare everything I asked for" never quietly
-/// under-delivers. Duplicates collapse to one preparation.
+/// supports — the Linux image always, the macOS image on macOS hosts
+/// (`macos_supported`). An unrecognized or host-unsupported kind is
+/// rejected rather than silently skipped, so "prepare everything I asked
+/// for" never quietly under-delivers. Duplicates collapse to one
+/// preparation.
 ///
 /// Returns a plain message rather than `Status` — every failure here maps
 /// to the same `INVALID_ARGUMENT` code, so the caller does that one
 /// conversion (the same convention as `control::settings::validate`).
-fn resolve_kinds(raw: &[i32]) -> Result<Vec<ImageKind>, String> {
+fn resolve_kinds(raw: &[i32], macos_supported: bool) -> Result<Vec<ImageKind>, String> {
     if raw.is_empty() {
-        return Ok(vec![ImageKind::LinuxRunnerImage]);
+        let mut kinds = vec![ImageKind::LinuxRunnerImage];
+        if macos_supported {
+            kinds.push(ImageKind::MacosRunnerImage);
+        }
+        return Ok(kinds);
     }
     let mut kinds = raw
         .iter()
         .map(|&v| match ImageKind::try_from(v) {
             Ok(ImageKind::LinuxRunnerImage) => Ok(ImageKind::LinuxRunnerImage),
-            // Wired up with the VM backend's Prepare path (see the module
-            // doc); until then an explicit request for it is rejected.
-            Ok(ImageKind::MacosRunnerImage | ImageKind::Unspecified) | Err(_) => {
-                Err(format!("unsupported image kind {v}"))
+            Ok(ImageKind::MacosRunnerImage) if macos_supported => Ok(ImageKind::MacosRunnerImage),
+            Ok(ImageKind::MacosRunnerImage) => {
+                Err("macos-runner-image requires a macOS host".to_owned())
             }
+            Ok(ImageKind::Unspecified) | Err(_) => Err(format!("unsupported image kind {v}")),
         })
         .collect::<Result<Vec<_>, _>>()?;
     kinds.sort_unstable();
@@ -83,12 +94,14 @@ impl FleetImageServiceTrait for ImageService {
         &self,
         request: Request<PrepareRequest>,
     ) -> Result<Response<Self::PrepareStream>, Status> {
-        let kinds = resolve_kinds(&request.into_inner().kinds).map_err(Status::invalid_argument)?;
+        let kinds = resolve_kinds(&request.into_inner().kinds, std::env::consts::OS == "macos")
+            .map_err(Status::invalid_argument)?;
         let busy = Arc::clone(&self.busy)
             .try_lock_owned()
             .map_err(|_| Status::aborted("another prepare is already in progress"))?;
         let state = self.state.clone();
         let docker = self.docker.clone();
+        let vm = self.vm.clone();
 
         // The work runs inside the stream itself, not a detached task, so a
         // client disconnect drops it mid-pull: no promotion happens, and a
@@ -96,37 +109,73 @@ impl FleetImageServiceTrait for ImageService {
         let stream = async_stream::try_stream! {
             let _busy = busy;
             for kind in kinds {
-                // `resolve_kinds` admits no other variant.
-                debug_assert_eq!(kind, ImageKind::LinuxRunnerImage);
-                let target = state.linux_runner_image_target();
-                match &docker {
-                    Some(docker) => {
-                        // All-or-nothing: every advertised arch must pull
-                        // before promotion, so a partial-arch image can
-                        // never become current while the full capability
-                        // set is still advertised. Fail-fast on the first
-                        // arch that can't — `current` is left untouched.
-                        for arch in docker.linux_arches() {
-                            let platform = format!("linux/{arch}");
-                            yield event(kind, &platform, "pulling", 0.0);
-                            docker.pull(&target, &arch).await.map_err(|e| {
-                                Status::failed_precondition(format!(
-                                    "linux_runner_image {target} is not pullable for \
-                                     {platform}; current image left unchanged: {e:#}"
-                                ))
-                            })?;
-                            yield event(kind, &platform, "pulling", 1.0);
+                match kind {
+                    ImageKind::LinuxRunnerImage => {
+                        let target = state.linux_runner_image_target();
+                        match &docker {
+                            Some(docker) => {
+                                // All-or-nothing: every advertised arch must pull
+                                // before promotion, so a partial-arch image can
+                                // never become current while the full capability
+                                // set is still advertised. Fail-fast on the first
+                                // arch that can't — `current` is left untouched.
+                                for arch in docker.linux_arches() {
+                                    let platform = format!("linux/{arch}");
+                                    yield event(kind, &platform, "pulling", 0.0);
+                                    docker.pull(&target, &arch).await.map_err(|e| {
+                                        Status::failed_precondition(format!(
+                                            "linux_runner_image {target} is not pullable for \
+                                             {platform}; current image left unchanged: {e:#}"
+                                        ))
+                                    })?;
+                                    yield event(kind, &platform, "pulling", 1.0);
+                                }
+                            }
+                            // Without Docker no Linux job can dispatch, so there is
+                            // nothing to verify the image against — promote rather
+                            // than leave the setting pending forever on a
+                            // host-runner-only box. (Startup behaves the same way:
+                            // `AgentState::new` seeds current == target, and it is
+                            // `init_docker` that verifies the seed when Docker is on.)
+                            None => yield event(kind, "docker not configured", "skipped", 1.0),
                         }
+                        state.set_linux_runner_image_current(&target);
                     }
-                    // Without Docker no Linux job can dispatch, so there is
-                    // nothing to verify the image against — promote rather
-                    // than leave the setting pending forever on a
-                    // host-runner-only box. (Startup behaves the same way:
-                    // `AgentState::new` seeds current == target, and it is
-                    // `init_docker` that verifies the seed when Docker is on.)
-                    None => yield event(kind, "docker not configured", "skipped", 1.0),
+                    ImageKind::MacosRunnerImage => {
+                        let target = state.macos_runner_image_target();
+                        match &vm {
+                            Some(vm) => {
+                                // The daemon streams pull progress (its terminal
+                                // stage is "done"); relay each event. Any failure
+                                // leaves `current` untouched.
+                                let mut pull = vm.pull(&target).await.map_err(|e| {
+                                    Status::failed_precondition(format!(
+                                        "macos_runner_image {target} pull could not start; \
+                                         current image left unchanged: {e:#}"
+                                    ))
+                                })?;
+                                loop {
+                                    let progress = pull.message().await.map_err(|e| {
+                                        Status::failed_precondition(format!(
+                                            "macos_runner_image {target} is not pullable; \
+                                             current image left unchanged: {e}"
+                                        ))
+                                    })?;
+                                    let Some(progress) = progress else { break };
+                                    yield event(kind, &progress.stage, "pulling", progress.fraction);
+                                }
+                            }
+                            // Same rationale as the Docker-absent branch: with the
+                            // VM backend inactive no darwin VM job can dispatch, so
+                            // there is nothing to verify against — promote rather
+                            // than leave the setting pending forever.
+                            None => yield event(kind, "vm backend not active", "skipped", 1.0),
+                        }
+                        state.set_macos_runner_image_current(&target);
+                    }
+                    // `resolve_kinds` admits no other variant.
+                    ImageKind::Unspecified => unreachable!("resolve_kinds admits no other variant"),
                 }
-                state.set_linux_runner_image_current(&target);
                 yield event(kind, "", "promoted", 1.0);
             }
         };
@@ -159,8 +208,12 @@ mod tests {
     #[test]
     fn empty_kinds_resolve_to_every_supported_kind() {
         assert_eq!(
-            resolve_kinds(&[]).unwrap(),
+            resolve_kinds(&[], false).unwrap(),
             vec![ImageKind::LinuxRunnerImage]
+        );
+        assert_eq!(
+            resolve_kinds(&[], true).unwrap(),
+            vec![ImageKind::LinuxRunnerImage, ImageKind::MacosRunnerImage]
         );
     }
 
@@ -171,7 +224,7 @@ mod tests {
             ImageKind::LinuxRunnerImage as i32,
         ];
         assert_eq!(
-            resolve_kinds(&raw).unwrap(),
+            resolve_kinds(&raw, false).unwrap(),
             vec![ImageKind::LinuxRunnerImage]
         );
     }
@@ -179,8 +232,18 @@ mod tests {
     #[test]
     fn unknown_and_unspecified_kinds_are_rejected() {
         for bad in [0, 999] {
-            assert!(resolve_kinds(&[bad]).is_err(), "accepted kind {bad}");
+            assert!(resolve_kinds(&[bad], true).is_err(), "accepted kind {bad}");
         }
+    }
+
+    #[test]
+    fn macos_kind_requires_a_macos_host() {
+        let raw = [ImageKind::MacosRunnerImage as i32];
+        assert_eq!(
+            resolve_kinds(&raw, true).unwrap(),
+            vec![ImageKind::MacosRunnerImage]
+        );
+        assert!(resolve_kinds(&raw, false).is_err());
     }
 
     /// The real pull path needs a live Docker daemon (see `docker.rs`, which
@@ -191,10 +254,12 @@ mod tests {
     async fn prepare_without_docker_promotes_target() {
         let state = AgentState::new(&seed());
         state.set_linux_runner_image_target("ghcr.io/acme/runner:v2");
-        let service = ImageService::new(state.clone(), None);
+        let service = ImageService::new(state.clone(), None, None);
 
         let mut stream = service
-            .prepare(Request::new(PrepareRequest { kinds: Vec::new() }))
+            .prepare(Request::new(PrepareRequest {
+                kinds: vec![ImageKind::LinuxRunnerImage as i32],
+            }))
             .await
             .expect("Prepare")
             .into_inner();
@@ -211,11 +276,41 @@ mod tests {
         );
     }
 
+    /// The macOS kind's promotion contract mirrors the Docker one: with the
+    /// VM backend inactive nothing dispatches to it, so the target promotes
+    /// rather than pending forever. macOS-only because the kind is rejected
+    /// outright on other hosts (see `macos_kind_requires_a_macos_host`).
+    #[cfg(target_os = "macos")]
+    #[tokio::test]
+    async fn prepare_without_vm_backend_promotes_macos_target() {
+        let state = AgentState::new(&seed());
+        state.set_macos_runner_image_target("tahoe-base@2026.07.02");
+        let service = ImageService::new(state.clone(), None, None);
+
+        let mut stream = service
+            .prepare(Request::new(PrepareRequest {
+                kinds: vec![ImageKind::MacosRunnerImage as i32],
+            }))
+            .await
+            .expect("Prepare")
+            .into_inner();
+        let mut stages = Vec::new();
+        while let Some(item) = stream.next().await {
+            stages.push(item.expect("event").stage);
+        }
+
+        assert_eq!(stages, ["skipped", "promoted"]);
+        assert_eq!(
+            state.macos_runner_image_current(),
+            state.macos_runner_image_target()
+        );
+    }
+
     /// A second Prepare while one is live must be refused, not queued — and
     /// dropping the live stream (client disconnect) must release the slot.
     #[tokio::test]
     async fn concurrent_prepare_is_refused_until_the_first_stream_drops() {
-        let service = ImageService::new(AgentState::new(&seed()), None);
+        let service = ImageService::new(AgentState::new(&seed()), None, None);
 
         let held = service
             .prepare(Request::new(PrepareRequest { kinds: Vec::new() }))

--- a/fleet/arcbox-fleet-agent/src/control/lifecycle.rs
+++ b/fleet/arcbox-fleet-agent/src/control/lifecycle.rs
@@ -34,10 +34,16 @@ impl FleetLifecycleService for LifecycleService {
         &self,
         _request: Request<GetAgentInfoRequest>,
     ) -> Result<Response<GetAgentInfoResponse>, Status> {
+        let mut features = Vec::new();
+        if self.supervisor.vm_active() {
+            // The local daemon serves disposable macOS guests for darwin
+            // jobs (see crate::vm).
+            features.push("vm-backend".to_owned());
+        }
         Ok(Response::new(GetAgentInfoResponse {
             agent_version: env!("CARGO_PKG_VERSION").to_owned(),
             api_version: API_VERSION,
-            features: Vec::new(),
+            features,
         }))
     }
 

--- a/fleet/arcbox-fleet-agent/src/control/mod.rs
+++ b/fleet/arcbox-fleet-agent/src/control/mod.rs
@@ -91,6 +91,7 @@ pub async fn serve(
     info!(socket = %socket_path.display(), "control-plane server listening");
 
     let docker = supervisor.docker();
+    let vm = supervisor.vm();
     Server::builder()
         .add_service(FleetLifecycleServiceServer::new(LifecycleService::new(
             supervisor,
@@ -103,7 +104,7 @@ pub async fn serve(
             settings_store,
         )))
         .add_service(FleetImageServiceServer::new(ImageService::new(
-            state, docker,
+            state, docker, vm,
         )))
         .serve_with_incoming_shutdown(incoming, shutdown.cancelled())
         .await
@@ -301,6 +302,14 @@ impl AgentSupervisor {
     /// `vm_mode` changes are restart-scoped.
     pub fn vm_active(&self) -> bool {
         self.vm.is_some()
+    }
+
+    /// A handle to the macOS VM backend, if active — read by [`serve`] and
+    /// passed to `FleetImageService` to prepare a candidate
+    /// `macos_runner_image` through the daemon. Fixed at construction, same
+    /// rationale as [`Self::docker`].
+    fn vm(&self) -> Option<crate::vm::VmRunner> {
+        self.vm.clone()
     }
 
     /// Spawn the attach task for `credential` and build its [`Attachment`].

--- a/fleet/arcbox-fleet-agent/src/control/mod.rs
+++ b/fleet/arcbox-fleet-agent/src/control/mod.rs
@@ -705,6 +705,8 @@ mod tests {
             docker_mode: DockerMode::Disabled,
             runner_script: None,
             participate: true,
+            vm_mode: crate::config::VmMode::Auto,
+            macos_runner_image: "tahoe-base".to_owned(),
         }
     }
 
@@ -718,6 +720,10 @@ mod tests {
             docker: DockerConfig {
                 mode: DockerMode::Disabled,
                 linux_runner_image: "ghcr.io/actions/actions-runner:latest".to_owned(),
+            },
+            vm: crate::config::VmConfig {
+                mode: crate::config::VmMode::Disabled,
+                macos_runner_image: "tahoe-base".to_owned(),
             },
             credential_store: CredentialMode::File,
         }

--- a/fleet/arcbox-fleet-agent/src/control/mod.rs
+++ b/fleet/arcbox-fleet-agent/src/control/mod.rs
@@ -228,6 +228,7 @@ enum State {
 pub struct AgentSupervisor {
     config: AgentConfig,
     docker: Option<DockerRunner>,
+    vm: Option<crate::vm::VmRunner>,
     capabilities: Vec<Capability>,
     /// Cancelled on process shutdown (SIGTERM/Ctrl-C); every attachment's
     /// `shutdown` is a child of this token.
@@ -248,6 +249,7 @@ impl AgentSupervisor {
     pub async fn new(
         config: AgentConfig,
         docker: Option<DockerRunner>,
+        vm: Option<crate::vm::VmRunner>,
         capabilities: Vec<Capability>,
         process_shutdown: CancellationToken,
         agent_state: AgentState,
@@ -256,6 +258,7 @@ impl AgentSupervisor {
         let this = Self {
             config,
             docker,
+            vm,
             capabilities,
             process_shutdown,
             state: Mutex::new(State::Unenrolled),
@@ -292,6 +295,14 @@ impl AgentSupervisor {
         self.docker.clone()
     }
 
+    /// Whether the macOS VM backend is active — the daemon probe succeeded
+    /// at startup. Reported as a `GetAgentInfo` feature so clients can
+    /// discover it. Fixed at construction like [`Self::docker`]:
+    /// `vm_mode` changes are restart-scoped.
+    pub fn vm_active(&self) -> bool {
+        self.vm.is_some()
+    }
+
     /// Spawn the attach task for `credential` and build its [`Attachment`].
     /// `credential_gateway` is the store key the credential is persisted
     /// under (see [`Attachment::credential_gateway`]).
@@ -308,6 +319,7 @@ impl AgentSupervisor {
         let (supervisor, egress_rx) = attach::spawn_supervisor(
             &self.config,
             self.docker.clone(),
+            self.vm.clone(),
             self.capabilities.clone(),
             self.agent_state.clone(),
         );
@@ -739,6 +751,7 @@ mod tests {
             AgentSupervisor::new(
                 test_config(dir.to_path_buf()),
                 None,
+                None,
                 Vec::new(),
                 CancellationToken::new(),
                 agent_state,
@@ -811,6 +824,7 @@ mod tests {
         let (events, _events_rx) = tokio::sync::mpsc::channel(1);
         let runner = crate::runner::RunnerSupervisor::new(
             events,
+            None,
             None,
             None,
             Vec::new(),
@@ -906,6 +920,7 @@ mod tests {
         let supervisor = AgentSupervisor::new(
             config,
             None,
+            None,
             Vec::new(),
             CancellationToken::new(),
             agent_state.clone(),
@@ -939,6 +954,7 @@ mod tests {
             AgentSupervisor::new(
                 test_config(dir.clone()),
                 None,
+                None,
                 Vec::new(),
                 CancellationToken::new(),
                 agent_state.clone(),
@@ -959,7 +975,7 @@ mod tests {
         });
         let (events, _events_rx) = tokio::sync::mpsc::channel(1);
         let runner =
-            crate::runner::RunnerSupervisor::new(events, None, None, Vec::new(), agent_state);
+            crate::runner::RunnerSupervisor::new(events, None, None, None, Vec::new(), agent_state);
         // A persisted credential, so the completed unenroll can prove the
         // local clear happens even though this gateway is unreachable (the
         // server-side call is best-effort).

--- a/fleet/arcbox-fleet-agent/src/control/mod.rs
+++ b/fleet/arcbox-fleet-agent/src/control/mod.rs
@@ -724,6 +724,7 @@ mod tests {
             vm: crate::config::VmConfig {
                 mode: crate::config::VmMode::Disabled,
                 macos_runner_image: "tahoe-base".to_owned(),
+                daemon_socket: std::path::PathBuf::from("/nonexistent/arcbox.sock"),
             },
             credential_store: CredentialMode::File,
         }

--- a/fleet/arcbox-fleet-agent/src/control/mod.rs
+++ b/fleet/arcbox-fleet-agent/src/control/mod.rs
@@ -674,6 +674,10 @@ impl AgentSupervisor {
             Enrollment::Unspecified | Enrollment::Unenrolled => ConnectionState::Unenrolled,
             Enrollment::Detached => ConnectionState::Detached,
             Enrollment::CredentialRejected => ConnectionState::CredentialRejected,
+            // A self-update drains before it swaps, so "not accepting new
+            // offers" is exactly what a status consumer should see; the
+            // swap itself replaces the process within seconds.
+            Enrollment::Updating => ConnectionState::Draining,
             Enrollment::Attaching | Enrollment::Attached if snapshot.draining => {
                 ConnectionState::Draining
             }

--- a/fleet/arcbox-fleet-agent/src/control/settings.rs
+++ b/fleet/arcbox-fleet-agent/src/control/settings.rs
@@ -17,9 +17,9 @@ use tonic::transport::Endpoint;
 use tonic::{Request, Response, Status};
 
 use super::Internal;
-use crate::config::DockerMode;
+use crate::config::{DockerMode, VmMode};
 use crate::settings::SettingsStore;
-use crate::state::{AgentState, docker_mode_from_wire};
+use crate::state::{AgentState, docker_mode_from_wire, vm_mode_from_wire};
 
 pub struct SettingsService {
     state: AgentState,
@@ -89,6 +89,14 @@ impl FleetSettingsServiceTrait for SettingsService {
         if let Some(v) = req.participate {
             self.state.set_participate_target(v);
         }
+        // Target only — `FleetImageService.Prepare` pulls it through the
+        // daemon and promotes it to `current`.
+        if let Some(v) = &req.macos_runner_image {
+            self.state.set_macos_runner_image_target(v);
+        }
+        if let Some(v) = req.vm_mode {
+            self.state.set_vm_mode_target(vm_mode_from_wire(v));
+        }
 
         self.store
             .store(&self.state.persisted_settings())
@@ -144,13 +152,28 @@ fn validate(req: &UpdateSettingsRequest, state: &AgentState) -> Result<(), Strin
             return Err(format!("runner_script {runner_script} does not exist"));
         }
     }
+    if let Some(macos_runner_image) = &req.macos_runner_image {
+        if macos_runner_image.trim().is_empty() {
+            return Err("macos_runner_image must not be empty".to_owned());
+        }
+    }
+    if let Some(vm_mode) = req.vm_mode
+        && vm_mode_from_wire(vm_mode) == VmMode::Enabled
+        && std::env::consts::OS != "macos"
+    {
+        return Err(
+            "vm_mode=enabled requires a macOS host (the VM backend runs macOS guests via \
+                    the local arcbox-daemon)"
+                .to_owned(),
+        );
+    }
 
-    // Only gate this request if it actually touches docker_mode or
-    // runner_script — a host that already has this combination from its
-    // env-derived seed (a legitimate, existing deployment shape; see this
-    // module's doc) must not have every *unrelated* UpdateSettings call
-    // (e.g. just load_ceiling) rejected because of it.
-    if req.docker_mode.is_some() || req.runner_script.is_some() {
+    // Only gate this request if it actually touches docker_mode,
+    // runner_script, or vm_mode — a host that already has this combination
+    // from its env-derived seed (a legitimate, existing deployment shape;
+    // see this module's doc) must not have every *unrelated* UpdateSettings
+    // call (e.g. just load_ceiling) rejected because of it.
+    if req.docker_mode.is_some() || req.runner_script.is_some() || req.vm_mode.is_some() {
         let persisted = state.persisted_settings();
         let effective_docker_mode = req
             .docker_mode
@@ -162,15 +185,19 @@ fn validate(req: &UpdateSettingsRequest, state: &AgentState) -> Result<(), Strin
                 .map(|p| p.to_string_lossy().into_owned())
                 .unwrap_or_default()
         });
+        let effective_vm_mode = req.vm_mode.map_or(persisted.vm_mode, vm_mode_from_wire);
+        // Only Enabled modes are guarantees; Auto may resolve to nothing.
         let leaves_nothing_servable = matches!(
             effective_docker_mode,
             DockerMode::Auto | DockerMode::Disabled
-        ) && effective_runner_script.is_empty();
+        ) && effective_runner_script.is_empty()
+            && effective_vm_mode != VmMode::Enabled;
         if leaves_nothing_servable {
             return Err(
-                "cannot leave docker_mode as auto/disabled with no runner_script configured — \
-                 this would leave the host advertising no capabilities at all; supply \
-                 runner_script in the same request or set docker_mode to enabled"
+                "cannot leave docker_mode as auto/disabled with no runner_script configured and \
+                 vm_mode not enabled — this would leave the host advertising no capabilities at \
+                 all; supply runner_script in the same request, or set docker_mode or vm_mode to \
+                 enabled"
                     .to_owned(),
             );
         }
@@ -195,6 +222,8 @@ mod tests {
             docker_mode: DockerMode::Auto,
             runner_script: None,
             participate: true,
+            vm_mode: crate::config::VmMode::Auto,
+            macos_runner_image: "tahoe-base".to_owned(),
         }
     }
 
@@ -207,6 +236,8 @@ mod tests {
             docker_mode: None,
             runner_script: None,
             participate: None,
+            macos_runner_image: None,
+            vm_mode: None,
         }
     }
 
@@ -276,6 +307,45 @@ mod tests {
             ..request()
         };
         assert!(validate(&req, &state).is_ok());
+    }
+
+    #[test]
+    fn rejects_empty_macos_runner_image() {
+        let state = AgentState::new(&seed());
+        let req = UpdateSettingsRequest {
+            macos_runner_image: Some("  ".to_owned()),
+            ..request()
+        };
+        assert!(validate(&req, &state).is_err());
+    }
+
+    /// vm_mode=enabled is a servability guarantee, so it rescues the
+    /// docker-disabled/no-runner-script combination the cross-field check
+    /// otherwise rejects. macOS-only: on other hosts vm_mode=enabled is
+    /// itself rejected first.
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn vm_enabled_satisfies_the_servability_check() {
+        let state = AgentState::new(&seed());
+        let req = UpdateSettingsRequest {
+            docker_mode: Some(control_proto::DockerMode::Disabled as i32),
+            vm_mode: Some(control_proto::VmMode::Enabled as i32),
+            ..request()
+        };
+        assert!(validate(&req, &state).is_ok());
+
+        // Downgrading vm_mode while nothing else serves is rejected.
+        let state = AgentState::new(&crate::settings::PersistedSettings {
+            docker_mode: DockerMode::Disabled,
+            runner_script: None,
+            vm_mode: VmMode::Enabled,
+            ..seed()
+        });
+        let req = UpdateSettingsRequest {
+            vm_mode: Some(control_proto::VmMode::Disabled as i32),
+            ..request()
+        };
+        assert!(validate(&req, &state).is_err());
     }
 
     #[test]

--- a/fleet/arcbox-fleet-agent/src/enroll.rs
+++ b/fleet/arcbox-fleet-agent/src/enroll.rs
@@ -6,11 +6,11 @@ use std::time::Duration;
 
 use anyhow::{Context, Result};
 use arcbox_fleet_proto::v1::fleet_gateway_service_client::FleetGatewayServiceClient;
-use arcbox_fleet_proto::v1::{Capability, EnrollRequest, UnenrollRequest};
+use arcbox_fleet_proto::v1::{Capability, EnrollRequest, UnenrollRequest, enroll_response};
 use tracing::{info, warn};
 
 use crate::attach::authenticated_request;
-use crate::config::{AgentConfig, PROTOCOL_VERSION};
+use crate::config::AgentConfig;
 use crate::credentials::Credential;
 use crate::host;
 
@@ -28,6 +28,10 @@ const GATEWAY_UNENROLL_TIMEOUT: Duration = Duration::from_secs(10);
 /// `gateway`: `quick enroll` uses the persisted-settings (or configured
 /// default) gateway; the RPC uses its `control_plane` override if given, else
 /// the current settings target.
+///
+/// A gateway that expects a different agent build refuses enrollment with
+/// `EnrollResponse::update_required`; surface the expected version so the
+/// operator installs the right binary instead of a stringly-typed error.
 pub async fn enroll(
     config: &AgentConfig,
     token: String,
@@ -49,7 +53,7 @@ pub async fn enroll(
         mem_mib: host::mem_mib(),
         capabilities,
         host_info_json: host::host_info_json(),
-        protocol_version: PROTOCOL_VERSION,
+        agent_version: env!("CARGO_PKG_VERSION").to_owned(),
     };
 
     let response = client
@@ -58,12 +62,24 @@ pub async fn enroll(
         .context("Enroll RPC failed")?
         .into_inner();
 
-    let credential = Credential {
-        machine_id: response.machine_id,
-        machine_token: response.machine_token,
-    };
-    info!(machine_id = %credential.machine_id, "enrolled");
-    Ok(credential)
+    match response.result {
+        Some(enroll_response::Result::Enrolled(enrolled)) => {
+            let credential = Credential {
+                machine_id: enrolled.machine_id,
+                machine_token: enrolled.machine_token,
+            };
+            info!(machine_id = %credential.machine_id, "enrolled");
+            Ok(credential)
+        }
+        Some(enroll_response::Result::UpdateRequired(update)) => {
+            anyhow::bail!(
+                "enrollment refused: gateway expects agent version {}, this binary is {}",
+                update.expected_version,
+                env!("CARGO_PKG_VERSION"),
+            );
+        }
+        None => anyhow::bail!("gateway returned an empty EnrollResponse"),
+    }
 }
 
 /// Decommission the machine at `gateway` on a best-effort, time-bounded basis,

--- a/fleet/arcbox-fleet-agent/src/enroll.rs
+++ b/fleet/arcbox-fleet-agent/src/enroll.rs
@@ -13,6 +13,29 @@ use crate::attach::authenticated_request;
 use crate::config::AgentConfig;
 use crate::credentials::Credential;
 use crate::host;
+use crate::update::UpdatePayload;
+
+/// Enrollment refused because the gateway pins a different build. Carries
+/// the pushed download (when the gateway had one for this platform) so the
+/// CLI enroll path can self-update and re-exec into a retry.
+#[derive(Debug, thiserror::Error)]
+#[error(
+    "enrollment refused: gateway expects agent version {expected_version}, \
+     this binary is {current}",
+    current = env!("CARGO_PKG_VERSION")
+)]
+pub struct EnrollUpdateRequired {
+    pub expected_version: String,
+    pub payload: Option<UpdatePayload>,
+}
+
+/// The downloadable update carried by an [`enroll`] refusal, if any.
+pub fn update_payload(error: &anyhow::Error) -> Option<UpdatePayload> {
+    error
+        .chain()
+        .find_map(|cause| cause.downcast_ref::<EnrollUpdateRequired>())
+        .and_then(|refused| refused.payload.clone())
+}
 
 /// Bound on the best-effort gateway `Unenroll` call. Generous for a healthy
 /// round-trip, but a blackholed gateway must not prevent the terminal local
@@ -30,8 +53,9 @@ const GATEWAY_UNENROLL_TIMEOUT: Duration = Duration::from_secs(10);
 /// the current settings target.
 ///
 /// A gateway that expects a different agent build refuses enrollment with
-/// `EnrollResponse::update_required`; surface the expected version so the
-/// operator installs the right binary instead of a stringly-typed error.
+/// `EnrollResponse::update_required`, surfaced as [`EnrollUpdateRequired`]:
+/// the CLI enroll path self-updates and retries when the refusal carries a
+/// download, and otherwise shows the operator the expected version.
 pub async fn enroll(
     config: &AgentConfig,
     token: String,
@@ -73,11 +97,10 @@ pub async fn enroll(
             Ok(credential)
         }
         Some(enroll_response::Result::UpdateRequired(update)) => {
-            anyhow::bail!(
-                "enrollment refused: gateway expects agent version {}, this binary is {}",
-                update.expected_version,
-                env!("CARGO_PKG_VERSION"),
-            );
+            Err(anyhow::Error::new(EnrollUpdateRequired {
+                payload: UpdatePayload::from_wire(&update),
+                expected_version: update.expected_version,
+            }))
         }
         None => anyhow::bail!("gateway returned an empty EnrollResponse"),
     }

--- a/fleet/arcbox-fleet-agent/src/enroll.rs
+++ b/fleet/arcbox-fleet-agent/src/enroll.rs
@@ -54,6 +54,7 @@ pub async fn enroll(
         capabilities,
         host_info_json: host::host_info_json(),
         agent_version: env!("CARGO_PKG_VERSION").to_owned(),
+        host_os: host::host_os(),
     };
 
     let response = client

--- a/fleet/arcbox-fleet-agent/src/host.rs
+++ b/fleet/arcbox-fleet-agent/src/host.rs
@@ -82,17 +82,25 @@ pub fn telemetry() -> HostTelemetry {
 /// - **Docker-served Linux capabilities.** `docker_arches` is the set of Linux
 ///   arches Docker can run (empty when Docker is absent), each backed by
 ///   `docker`. On Apple Silicon that is arm64 (native) plus amd64 (Rosetta).
+/// - **VM capability.** `vm_active` means the local arcbox-daemon can boot
+///   disposable macOS guests (see `crate::vm`); the native `(os, arch)` is
+///   then served by `vm`, which wins over the host runner — isolation is the
+///   point of the backend.
 /// - **Host-runner capability.** The native `(os, arch)` served by the
 ///   pre-installed runner, backed by `host_runner`. Omitted when no runner
-///   script is configured, or when Linux jobs are already Docker-served on
-///   this host (a Linux host with Docker). macOS is `host_runner` today; the
-///   `vm` backend arrives with VM isolation.
-pub fn capabilities(runner_script_present: bool, docker_arches: &[String]) -> Vec<Capability> {
+///   script is configured, or when the native pair is already served by
+///   Docker (a Linux host) or by the VM backend (above).
+pub fn capabilities(
+    runner_script_present: bool,
+    docker_arches: &[String],
+    vm_active: bool,
+) -> Vec<Capability> {
     build_capabilities(
         &host_os(),
         &host_arch(),
         runner_script_present,
         docker_arches,
+        vm_active,
     )
 }
 
@@ -103,6 +111,7 @@ fn build_capabilities(
     native_arch: &str,
     runner_script_present: bool,
     docker_arches: &[String],
+    vm_active: bool,
 ) -> Vec<Capability> {
     let mut caps = Vec::new();
 
@@ -112,6 +121,15 @@ fn build_capabilities(
             arch: arch.clone(),
             backed_by: Backend::Docker as i32,
         });
+    }
+
+    if vm_active {
+        caps.push(Capability {
+            os: native_os.to_owned(),
+            arch: native_arch.to_owned(),
+            backed_by: Backend::Vm as i32,
+        });
+        return caps;
     }
 
     let host_served_by_docker = native_os == "linux" && !docker_arches.is_empty();
@@ -144,7 +162,7 @@ mod tests {
 
     #[test]
     fn host_only_without_docker() {
-        let caps = build_capabilities("darwin", "arm64", true, &[]);
+        let caps = build_capabilities("darwin", "arm64", true, &[], false);
         assert_eq!(caps.len(), 1);
         assert_eq!(
             triple(&caps[0]),
@@ -155,7 +173,7 @@ mod tests {
     #[test]
     fn macos_adds_docker_linux_capabilities() {
         let arches = vec!["arm64".to_owned(), "amd64".to_owned()];
-        let caps = build_capabilities("darwin", "arm64", true, &arches);
+        let caps = build_capabilities("darwin", "arm64", true, &arches, false);
         // Two docker linux capabilities plus the darwin host-runner one.
         assert_eq!(caps.len(), 3);
         assert_eq!(triple(&caps[0]), ("linux", "arm64", Backend::Docker as i32));
@@ -170,7 +188,7 @@ mod tests {
     fn linux_host_capability_is_docker_served() {
         // On a Linux host with Docker the native capability IS the docker linux
         // one — no separate host-runner capability is added.
-        let caps = build_capabilities("linux", "amd64", true, &["amd64".to_owned()]);
+        let caps = build_capabilities("linux", "amd64", true, &["amd64".to_owned()], false);
         assert_eq!(caps.len(), 1);
         assert_eq!(triple(&caps[0]), ("linux", "amd64", Backend::Docker as i32));
     }
@@ -178,8 +196,25 @@ mod tests {
     #[test]
     fn omits_host_capability_without_runner_script() {
         // Docker-only macOS: no runner script means no darwin capability.
-        let caps = build_capabilities("darwin", "arm64", false, &["arm64".to_owned()]);
+        let caps = build_capabilities("darwin", "arm64", false, &["arm64".to_owned()], false);
         assert_eq!(caps.len(), 1);
         assert_eq!(triple(&caps[0]), ("linux", "arm64", Backend::Docker as i32));
+    }
+
+    #[test]
+    fn vm_backend_serves_the_native_pair_and_wins_over_host_runner() {
+        // With the VM backend active, darwin/arm64 is VM-served even though a
+        // runner script is configured — isolation wins.
+        let caps = build_capabilities("darwin", "arm64", true, &["arm64".to_owned()], true);
+        assert_eq!(caps.len(), 2);
+        assert_eq!(triple(&caps[0]), ("linux", "arm64", Backend::Docker as i32));
+        assert_eq!(triple(&caps[1]), ("darwin", "arm64", Backend::Vm as i32));
+    }
+
+    #[test]
+    fn vm_backend_without_runner_script_still_serves_darwin() {
+        let caps = build_capabilities("darwin", "arm64", false, &[], true);
+        assert_eq!(caps.len(), 1);
+        assert_eq!(triple(&caps[0]), ("darwin", "arm64", Backend::Vm as i32));
     }
 }

--- a/fleet/arcbox-fleet-agent/src/main.rs
+++ b/fleet/arcbox-fleet-agent/src/main.rs
@@ -37,9 +37,6 @@ mod host;
 mod runner;
 mod settings;
 mod state;
-// The VM backend's job routing lands in the next commit of this change
-// set; the #[expect] forces this attribute's removal then.
-#[expect(dead_code)]
 mod vm;
 
 use std::path::PathBuf;
@@ -56,10 +53,11 @@ use clap::{Args, Parser, Subcommand};
 use tokio_util::sync::CancellationToken;
 use tracing::{info, warn};
 
-use crate::config::{AgentConfig, DockerMode};
+use crate::config::{AgentConfig, DockerMode, VmMode};
 use crate::docker::DockerRunner;
 use crate::settings::{PersistedSettings, SettingsStore};
 use crate::state::AgentState;
+use crate::vm::VmRunner;
 
 #[derive(Debug, Parser)]
 #[command(name = "arcbox-fleet-agent", author, version, about)]
@@ -220,12 +218,12 @@ async fn run(command: Command, config: AgentConfig) -> Result<()> {
             let token = resolve_enrollment_token(token_file, token)?;
             let settings_store = SettingsStore::new(config.settings_path());
             let seed = load_or_seed_settings(&settings_store, &config)?;
-            // Enrollment is pure credential exchange — it never needs Docker, so
-            // an operator can enroll before the runtime is up. The capabilities
-            // sent here are an initial hint, replaced wholesale by the first
-            // heartbeat once the agent attaches, so we advertise what we know
-            // without probing the runtime.
-            let capabilities = capabilities(seed.runner_script.is_some(), None);
+            // Enrollment is pure credential exchange — it never needs Docker or
+            // the daemon, so an operator can enroll before either runtime is up.
+            // The capabilities sent here are an initial hint, replaced wholesale
+            // by the first heartbeat once the agent attaches, so we advertise
+            // what we know without probing the runtimes.
+            let capabilities = capabilities(seed.runner_script.is_some(), None, None);
             let credential = enroll::enroll(&config, token, capabilities, &seed.gateway).await?;
             config
                 .credential_store_for(&seed.gateway)
@@ -236,7 +234,14 @@ async fn run(command: Command, config: AgentConfig) -> Result<()> {
             let settings_store = SettingsStore::new(config.settings_path());
             let seed = load_or_seed_settings(&settings_store, &config)?;
             let docker = init_docker(seed.docker_mode, &seed.linux_runner_image).await?;
-            let capabilities = capabilities(seed.runner_script.is_some(), docker.as_ref());
+            let vm = init_vm(
+                seed.vm_mode,
+                &seed.macos_runner_image,
+                &config.vm.daemon_socket,
+            )
+            .await?;
+            let capabilities =
+                capabilities(seed.runner_script.is_some(), docker.as_ref(), vm.as_ref());
             let credential = config.credential_store_for(&seed.gateway).load()?.context(
                 "no credential found — run `arcbox-fleet-agent quick enroll --token-file …` first",
             )?;
@@ -253,6 +258,7 @@ async fn run(command: Command, config: AgentConfig) -> Result<()> {
             let (supervisor, egress_rx) = attach::spawn_supervisor(
                 &config,
                 docker,
+                vm,
                 capabilities.clone(),
                 agent_state.clone(),
             );
@@ -282,7 +288,14 @@ async fn run(command: Command, config: AgentConfig) -> Result<()> {
             let settings_store = SettingsStore::new(config.settings_path());
             let seed = load_or_seed_settings(&settings_store, &config)?;
             let docker = init_docker(seed.docker_mode, &seed.linux_runner_image).await?;
-            let capabilities = capabilities(seed.runner_script.is_some(), docker.as_ref());
+            let vm = init_vm(
+                seed.vm_mode,
+                &seed.macos_runner_image,
+                &config.vm.daemon_socket,
+            )
+            .await?;
+            let capabilities =
+                capabilities(seed.runner_script.is_some(), docker.as_ref(), vm.as_ref());
             let socket_path = config.control_socket_path();
 
             // Cascades to every attach task's child token, so runners still
@@ -295,6 +308,7 @@ async fn run(command: Command, config: AgentConfig) -> Result<()> {
                 control::AgentSupervisor::new(
                     config,
                     docker,
+                    vm,
                     capabilities,
                     shutdown.clone(),
                     agent_state.clone(),
@@ -533,13 +547,17 @@ fn resolve_enrollment_token(token_file: Option<PathBuf>, token: Option<String>) 
     Ok(token)
 }
 
-/// Build the capabilities this agent advertises: the native host-runner
-/// capability (if a runner script is configured) plus any Docker-served
-/// Linux capabilities. Capacity is decided per offer from live telemetry,
-/// not here.
-fn capabilities(runner_script_present: bool, docker: Option<&DockerRunner>) -> Vec<Capability> {
+/// Build the capabilities this agent advertises: any Docker-served Linux
+/// capabilities, plus the native pair — VM-served when the daemon backend
+/// is active, else the host runner (if a runner script is configured).
+/// Capacity is decided per offer from live telemetry, not here.
+fn capabilities(
+    runner_script_present: bool,
+    docker: Option<&DockerRunner>,
+    vm: Option<&VmRunner>,
+) -> Vec<Capability> {
     let docker_arches = docker.map(DockerRunner::linux_arches).unwrap_or_default();
-    host::capabilities(runner_script_present, &docker_arches)
+    host::capabilities(runner_script_present, &docker_arches, vm.is_some())
 }
 
 /// Probe Docker availability according to `mode`.
@@ -554,6 +572,41 @@ async fn init_docker(mode: DockerMode, linux_runner_image: &str) -> Result<Optio
             Ok(runner) => Ok(Some(runner)),
             Err(e) => {
                 warn!(error = %e, "docker not available; linux capabilities will not be advertised");
+                Ok(None)
+            }
+        },
+    }
+}
+
+/// Probe the local arcbox-daemon's macOS VM backend according to `mode`
+/// (mirrors [`init_docker`]). The backend is macOS-only: on other hosts
+/// `Auto` resolves to none and `Enabled` fails startup.
+async fn init_vm(
+    mode: VmMode,
+    macos_runner_image: &str,
+    daemon_socket: &std::path::Path,
+) -> Result<Option<VmRunner>> {
+    if std::env::consts::OS != "macos" {
+        anyhow::ensure!(
+            mode != VmMode::Enabled,
+            "vm_mode=enabled requires a macOS host (the VM backend runs macOS guests via the \
+             local arcbox-daemon)"
+        );
+        return Ok(None);
+    }
+    match mode {
+        VmMode::Disabled => Ok(None),
+        VmMode::Enabled => {
+            let runner = VmRunner::new(daemon_socket, macos_runner_image).await?;
+            Ok(Some(runner))
+        }
+        VmMode::Auto => match VmRunner::new(daemon_socket, macos_runner_image).await {
+            Ok(runner) => Ok(Some(runner)),
+            Err(e) => {
+                warn!(
+                    error = format!("{e:#}"),
+                    "macOS VM backend not available; darwin jobs fall back to the host runner"
+                );
                 Ok(None)
             }
         },

--- a/fleet/arcbox-fleet-agent/src/main.rs
+++ b/fleet/arcbox-fleet-agent/src/main.rs
@@ -165,6 +165,13 @@ enum SettingsCommand {
         /// reattaches with the same identity.
         #[arg(long)]
         participate: Option<bool>,
+        /// macOS base-image stream darwin VM jobs boot from (e.g.
+        /// "tahoe-base" or "tahoe-base@2026.07.02").
+        #[arg(long)]
+        macos_runner_image: Option<String>,
+        /// "auto" | "enabled" | "disabled".
+        #[arg(long)]
+        vm_mode: Option<String>,
     },
 }
 
@@ -394,10 +401,17 @@ async fn run(command: Command, config: AgentConfig) -> Result<()> {
             docker_mode,
             runner_script,
             participate,
+            macos_runner_image,
+            vm_mode,
         }) => {
             let docker_mode = docker_mode
                 .as_deref()
                 .map(parse_docker_mode)
+                .transpose()?
+                .map(|m| m as i32);
+            let vm_mode = vm_mode
+                .as_deref()
+                .map(parse_vm_mode)
                 .transpose()?
                 .map(|m| m as i32);
             let channel = control::client::connect_default(&config).await?;
@@ -411,6 +425,8 @@ async fn run(command: Command, config: AgentConfig) -> Result<()> {
                     docker_mode,
                     runner_script: runner_script.map(|p| p.to_string_lossy().into_owned()),
                     participate,
+                    macos_runner_image,
+                    vm_mode,
                 })
                 .await
                 .context("UpdateSettings RPC failed")?
@@ -558,6 +574,7 @@ fn parse_image_kind(s: &str) -> Result<control_proto::ImageKind> {
 fn image_kind_label(raw: i32) -> &'static str {
     match control_proto::ImageKind::try_from(raw).unwrap_or(control_proto::ImageKind::Unspecified) {
         control_proto::ImageKind::LinuxRunnerImage => "linux_runner_image",
+        control_proto::ImageKind::MacosRunnerImage => "macos_runner_image",
         control_proto::ImageKind::Unspecified => "unknown",
     }
 }
@@ -581,6 +598,26 @@ fn parse_docker_mode(s: &str) -> Result<control_proto::DockerMode> {
         other => {
             anyhow::bail!("docker_mode must be 'auto', 'enabled', or 'disabled', got '{other}'")
         }
+    }
+}
+
+fn parse_vm_mode(s: &str) -> Result<control_proto::VmMode> {
+    match s.to_lowercase().as_str() {
+        "auto" => Ok(control_proto::VmMode::Auto),
+        "enabled" => Ok(control_proto::VmMode::Enabled),
+        "disabled" => Ok(control_proto::VmMode::Disabled),
+        other => {
+            anyhow::bail!("vm_mode must be 'auto', 'enabled', or 'disabled', got '{other}'")
+        }
+    }
+}
+
+fn vm_mode_label(raw: i32) -> &'static str {
+    match control_proto::VmMode::try_from(raw).unwrap_or(control_proto::VmMode::Unspecified) {
+        control_proto::VmMode::Auto => "auto",
+        control_proto::VmMode::Enabled => "enabled",
+        control_proto::VmMode::Disabled => "disabled",
+        control_proto::VmMode::Unspecified => "unspecified",
     }
 }
 
@@ -649,6 +686,12 @@ fn print_settings(s: control_proto::AgentSettings) {
             &v.target
         };
         print_setting("runner_script", current, target);
+    }
+    if let Some(v) = s.macos_runner_image {
+        print_setting("macos_runner_image", &v.current, &v.target);
+    }
+    if let Some(v) = s.vm_mode {
+        print_setting("vm_mode", vm_mode_label(v.current), vm_mode_label(v.target));
     }
 }
 

--- a/fleet/arcbox-fleet-agent/src/main.rs
+++ b/fleet/arcbox-fleet-agent/src/main.rs
@@ -109,17 +109,6 @@ enum Command {
         /// supports.
         kinds: Vec<String>,
     },
-    /// Install a per-user LaunchAgent so `serve` starts on login (macOS).
-    ///
-    /// Installs the invoking binary into the managed path
-    /// (`<data_dir>/bin/arcbox-fleet-agent`) that self-update owns, renders
-    /// the plist against it and the agent's data-dir log path, writes it to
-    /// `~/Library/LaunchAgents/`, and `launchctl bootstrap`s it into the
-    /// current GUI session.
-    InstallService,
-    /// Remove the LaunchAgent installed by `install-service` (macOS).
-    /// Idempotent — safe to run when nothing is installed.
-    UninstallService,
 }
 
 #[derive(Debug, Subcommand)]
@@ -138,6 +127,17 @@ enum QuickCommand {
     ///
     /// Does not stop a concurrently running `quick run` process.
     Unenroll,
+    /// Install a per-user LaunchAgent so `serve` starts on login (macOS).
+    ///
+    /// Installs the invoking binary into the managed path
+    /// (`<data_dir>/bin/arcbox-fleet-agent`) that self-update owns, renders
+    /// the plist against it and the agent's data-dir log path, writes it to
+    /// `~/Library/LaunchAgents/`, and `launchctl bootstrap`s it into the
+    /// current GUI session.
+    InstallService,
+    /// Remove the LaunchAgent installed by `quick install-service` (macOS).
+    /// Idempotent — safe to run when nothing is installed.
+    UninstallService,
 }
 
 #[derive(Debug, Args)]
@@ -507,8 +507,8 @@ async fn run(command: Command, config: AgentConfig) -> Result<()> {
             }
             Ok(())
         }
-        Command::InstallService => install_service(&config),
-        Command::UninstallService => uninstall_service(),
+        Command::Quick(QuickCommand::InstallService) => install_service(&config),
+        Command::Quick(QuickCommand::UninstallService) => uninstall_service(),
     }
 }
 
@@ -524,8 +524,8 @@ fn install_service(config: &AgentConfig) -> Result<()> {
 #[cfg(not(target_os = "macos"))]
 fn install_service(_config: &AgentConfig) -> Result<()> {
     anyhow::bail!(
-        "install-service is only implemented for macOS; Linux systemd (user unit) support \
-         is planned as a follow-up"
+        "quick install-service is only implemented for macOS; Linux systemd (user unit) \
+         support is planned as a follow-up"
     )
 }
 
@@ -537,8 +537,8 @@ fn uninstall_service() -> Result<()> {
 #[cfg(not(target_os = "macos"))]
 fn uninstall_service() -> Result<()> {
     anyhow::bail!(
-        "uninstall-service is only implemented for macOS; Linux systemd (user unit) support \
-         is planned as a follow-up"
+        "quick uninstall-service is only implemented for macOS; Linux systemd (user unit) \
+         support is planned as a follow-up"
     )
 }
 

--- a/fleet/arcbox-fleet-agent/src/main.rs
+++ b/fleet/arcbox-fleet-agent/src/main.rs
@@ -101,8 +101,9 @@ enum Command {
     /// then promote it to current. Also the "update to latest" verb — a
     /// floating target (a moving tag) is re-fetched and re-promoted.
     Prepare {
-        /// Image kinds to prepare ("linux-runner-image"). Empty prepares
-        /// every kind the agent supports.
+        /// Image kinds to prepare ("linux-runner-image",
+        /// "macos-runner-image"). Empty prepares every kind the agent
+        /// supports.
         kinds: Vec<String>,
     },
 }
@@ -624,7 +625,10 @@ fn load_or_seed_settings(store: &SettingsStore, config: &AgentConfig) -> Result<
 fn parse_image_kind(s: &str) -> Result<control_proto::ImageKind> {
     match s.to_lowercase().as_str() {
         "linux-runner-image" => Ok(control_proto::ImageKind::LinuxRunnerImage),
-        other => anyhow::bail!("image kind must be 'linux-runner-image', got '{other}'"),
+        "macos-runner-image" => Ok(control_proto::ImageKind::MacosRunnerImage),
+        other => anyhow::bail!(
+            "image kind must be 'linux-runner-image' or 'macos-runner-image', got '{other}'"
+        ),
     }
 }
 

--- a/fleet/arcbox-fleet-agent/src/main.rs
+++ b/fleet/arcbox-fleet-agent/src/main.rs
@@ -37,6 +37,10 @@ mod host;
 mod runner;
 mod settings;
 mod state;
+// The VM backend's job routing lands in the next commit of this change
+// set; the #[expect] forces this attribute's removal then.
+#[expect(dead_code)]
+mod vm;
 
 use std::path::PathBuf;
 use std::sync::Arc;

--- a/fleet/arcbox-fleet-agent/src/main.rs
+++ b/fleet/arcbox-fleet-agent/src/main.rs
@@ -138,6 +138,15 @@ enum QuickCommand {
     /// Remove the LaunchAgent installed by `quick install-service` (macOS).
     /// Idempotent — safe to run when nothing is installed.
     UninstallService,
+    /// Self-update to the latest published fleet-agent build.
+    ///
+    /// Recovery/bootstrap path: resolves the current version from the
+    /// release CDN's `latest.json`, downloads the platform binary, verifies
+    /// its pinned sha256, and re-execs on the new build. Gateway pushes
+    /// remain the authoritative routine-rollout mechanism; run this only
+    /// when the gateway is unreachable, before enrollment, or to escape a
+    /// bad pinned version.
+    SelfUpdate,
 }
 
 #[derive(Debug, Args)]
@@ -509,7 +518,26 @@ async fn run(command: Command, config: AgentConfig) -> Result<()> {
         }
         Command::Quick(QuickCommand::InstallService) => install_service(&config),
         Command::Quick(QuickCommand::UninstallService) => uninstall_service(),
+        Command::Quick(QuickCommand::SelfUpdate) => self_update(&config).await,
     }
+}
+
+/// Manual self-update: resolve `latest.json` on the CDN, compare against
+/// `CARGO_PKG_VERSION`, and hand off to [`update::apply_and_exec`] when
+/// a newer build exists. Returns `Ok(())` on the already-latest no-op;
+/// the update path only returns on failure (success re-execs).
+async fn self_update(config: &AgentConfig) -> Result<()> {
+    let payload = update::resolve_latest(&host::host_os(), &host::host_arch()).await?;
+    if payload.expected_version == env!("CARGO_PKG_VERSION") {
+        println!("already at latest ({})", payload.expected_version);
+        return Ok(());
+    }
+    info!(
+        current = env!("CARGO_PKG_VERSION"),
+        expected = %payload.expected_version,
+        "self-updating from CDN's latest"
+    );
+    Err(update::apply_and_exec(config, &payload).await)
 }
 
 /// macOS: install the LaunchAgent via [`service::install`]. Other Unix

--- a/fleet/arcbox-fleet-agent/src/main.rs
+++ b/fleet/arcbox-fleet-agent/src/main.rs
@@ -35,6 +35,8 @@ mod enroll;
 mod fsutil;
 mod host;
 mod runner;
+#[cfg(target_os = "macos")]
+mod service;
 mod settings;
 mod state;
 mod vm;
@@ -106,6 +108,16 @@ enum Command {
         /// supports.
         kinds: Vec<String>,
     },
+    /// Install a per-user LaunchAgent so `serve` starts on login (macOS).
+    ///
+    /// Renders the plist against the invoking binary (`env::current_exe()`)
+    /// and the agent's data-dir log path, writes it to
+    /// `~/Library/LaunchAgents/`, and `launchctl bootstrap`s it into the
+    /// current GUI session. Re-run after moving the binary.
+    InstallService,
+    /// Remove the LaunchAgent installed by `install-service` (macOS).
+    /// Idempotent — safe to run when nothing is installed.
+    UninstallService,
 }
 
 #[derive(Debug, Subcommand)]
@@ -474,7 +486,39 @@ async fn run(command: Command, config: AgentConfig) -> Result<()> {
             }
             Ok(())
         }
+        Command::InstallService => install_service(&config),
+        Command::UninstallService => uninstall_service(),
     }
+}
+
+/// macOS: install the LaunchAgent via [`service::install`]. Other Unix
+/// targets (Linux) bail with a pointer to the planned systemd support;
+/// keeping the subcommand in the CLI shape lets docs and tab-completion
+/// stay uniform across hosts.
+#[cfg(target_os = "macos")]
+fn install_service(config: &AgentConfig) -> Result<()> {
+    service::install(config)
+}
+
+#[cfg(not(target_os = "macos"))]
+fn install_service(_config: &AgentConfig) -> Result<()> {
+    anyhow::bail!(
+        "install-service is only implemented for macOS; Linux systemd (user unit) support \
+         is planned as a follow-up"
+    )
+}
+
+#[cfg(target_os = "macos")]
+fn uninstall_service() -> Result<()> {
+    service::uninstall()
+}
+
+#[cfg(not(target_os = "macos"))]
+fn uninstall_service() -> Result<()> {
+    anyhow::bail!(
+        "uninstall-service is only implemented for macOS; Linux systemd (user unit) support \
+         is planned as a follow-up"
+    )
 }
 
 /// Build a `CancellationToken` cancelled on the first termination signal

--- a/fleet/arcbox-fleet-agent/src/main.rs
+++ b/fleet/arcbox-fleet-agent/src/main.rs
@@ -39,6 +39,7 @@ mod runner;
 mod service;
 mod settings;
 mod state;
+mod update;
 mod vm;
 
 use std::path::PathBuf;
@@ -237,7 +238,26 @@ async fn run(command: Command, config: AgentConfig) -> Result<()> {
             // by the first heartbeat once the agent attaches, so we advertise
             // what we know without probing the runtimes.
             let capabilities = capabilities(seed.runner_script.is_some(), None, None);
-            let credential = enroll::enroll(&config, token, capabilities, &seed.gateway).await?;
+            let credential = match enroll::enroll(&config, token, capabilities, &seed.gateway).await
+            {
+                Ok(credential) => credential,
+                Err(error) => {
+                    // A version-refused enrollment that carries a download
+                    // self-updates and re-execs this same `enroll`
+                    // invocation on the new build (the join token is
+                    // multi-use). Managed-path and probe failures fall
+                    // through to the original refusal.
+                    if let Some(payload) = enroll::update_payload(&error) {
+                        info!(
+                            expected = %payload.expected_version,
+                            "gateway requires a different build; self-updating before enrolling"
+                        );
+                        let update_error = update::apply_and_exec(&config, &payload).await;
+                        warn!(error = %update_error, "self-update failed");
+                    }
+                    return Err(error);
+                }
+            };
             config
                 .credential_store_for(&seed.gateway)
                 .store(&credential)?;

--- a/fleet/arcbox-fleet-agent/src/main.rs
+++ b/fleet/arcbox-fleet-agent/src/main.rs
@@ -111,10 +111,11 @@ enum Command {
     },
     /// Install a per-user LaunchAgent so `serve` starts on login (macOS).
     ///
-    /// Renders the plist against the invoking binary (`env::current_exe()`)
-    /// and the agent's data-dir log path, writes it to
+    /// Installs the invoking binary into the managed path
+    /// (`<data_dir>/bin/arcbox-fleet-agent`) that self-update owns, renders
+    /// the plist against it and the agent's data-dir log path, writes it to
     /// `~/Library/LaunchAgents/`, and `launchctl bootstrap`s it into the
-    /// current GUI session. Re-run after moving the binary.
+    /// current GUI session.
     InstallService,
     /// Remove the LaunchAgent installed by `install-service` (macOS).
     /// Idempotent — safe to run when nothing is installed.

--- a/fleet/arcbox-fleet-agent/src/runner.rs
+++ b/fleet/arcbox-fleet-agent/src/runner.rs
@@ -587,6 +587,8 @@ mod tests {
             docker_mode: crate::config::DockerMode::Auto,
             runner_script: None,
             participate: true,
+            vm_mode: crate::config::VmMode::Auto,
+            macos_runner_image: "tahoe-base".to_owned(),
         }
     }
 

--- a/fleet/arcbox-fleet-agent/src/runner.rs
+++ b/fleet/arcbox-fleet-agent/src/runner.rs
@@ -103,6 +103,10 @@ struct Inner {
     backends: HashMap<(String, String), Backend>,
     /// Set once `Drain` is received; no new jobs are accepted.
     draining: std::sync::atomic::AtomicBool,
+    /// Set while a self-update is pending; no new jobs are accepted. Kept
+    /// separate from `draining` so a moot update (the pin moved back to this
+    /// build before the swap) can resume without clearing an operator drain.
+    draining_for_update: std::sync::atomic::AtomicBool,
     /// Observable state mirrored to `FleetStateService.Watch` subscribers.
     state: AgentState,
 }
@@ -162,6 +166,7 @@ impl RunnerSupervisor {
                 vm,
                 backends,
                 draining: std::sync::atomic::AtomicBool::new(false),
+                draining_for_update: std::sync::atomic::AtomicBool::new(false),
                 state,
             }),
         }
@@ -235,6 +240,10 @@ impl RunnerSupervisor {
             .inner
             .draining
             .load(std::sync::atomic::Ordering::Relaxed)
+            || self
+                .inner
+                .draining_for_update
+                .load(std::sync::atomic::Ordering::Relaxed)
         {
             return Admission::Reject("host is draining".to_owned());
         }
@@ -310,8 +319,67 @@ impl RunnerSupervisor {
         self.inner
             .draining
             .store(false, std::sync::atomic::Ordering::Relaxed);
-        self.inner.state.set_draining(false);
+        self.inner.state.set_draining(self.draining_for_update());
         info!("resumed: accepting new offers");
+    }
+
+    fn draining_for_update(&self) -> bool {
+        self.inner
+            .draining_for_update
+            .load(std::sync::atomic::Ordering::Relaxed)
+    }
+
+    /// Stop accepting new offers because a self-update is pending. The
+    /// operator's own drain flag is untouched, so
+    /// [`Self::resume_after_moot_update`] can undo exactly this without
+    /// cancelling a deliberate local drain.
+    pub fn drain_for_update(&self) {
+        self.inner
+            .draining_for_update
+            .store(true, std::sync::atomic::Ordering::Relaxed);
+        self.inner.state.set_draining(true);
+        info!("draining for self-update: no new offers will be accepted");
+    }
+
+    /// Clear the update drain after the update became moot — the pin moved
+    /// back to this build before the swap happened (a rollback racing the
+    /// drain). An operator drain, if any, stays in force.
+    pub fn resume_after_moot_update(&self) {
+        self.inner
+            .draining_for_update
+            .store(false, std::sync::atomic::Ordering::Relaxed);
+        let operator_drain = self
+            .inner
+            .draining
+            .load(std::sync::atomic::Ordering::Relaxed);
+        self.inner.state.set_draining(operator_drain);
+        info!("self-update became moot; resuming");
+    }
+
+    /// True when nothing runs here and no verdict awaits its ack — the
+    /// point at which the process can be replaced without losing work.
+    pub fn is_settled(&self) -> bool {
+        self.inner.in_flight.is_empty() && self.inner.outstanding.is_empty()
+    }
+
+    /// Wait until every in-flight job releases its slot. Unbounded — a
+    /// self-update must never kill a customer's running job — and polled,
+    /// like [`Self::shutdown`]'s drain. Used off-stream, where `outstanding`
+    /// verdicts cannot drain (delivering them needs a live attach), so only
+    /// `in_flight` gates.
+    pub async fn drained_of_jobs(&self) {
+        while !self.inner.in_flight.is_empty() {
+            tokio::time::sleep(Duration::from_millis(200)).await;
+        }
+    }
+
+    /// Wait for [`Self::is_settled`]. Only meaningful while attached (acks
+    /// must be able to arrive); polled for the same reason as
+    /// [`Self::drained_of_jobs`].
+    pub async fn settled(&self) {
+        while !self.is_settled() {
+            tokio::time::sleep(Duration::from_millis(200)).await;
+        }
     }
 
     /// Begin graceful shutdown: stop accepting offers, cancel every in-flight

--- a/fleet/arcbox-fleet-agent/src/runner.rs
+++ b/fleet/arcbox-fleet-agent/src/runner.rs
@@ -5,10 +5,11 @@
 //! webhook is the authoritative outcome.
 //!
 //! Backend is chosen from the agent's own advertised capabilities: Linux jobs a
-//! Docker capability serves run in a container (isolation); a `host_runner`
-//! capability runs via the pre-installed runner. Capacity is never a number —
-//! admission gates on live load and free memory, so a busy host simply rejects
-//! and the platform re-offers elsewhere.
+//! Docker capability serves run in a container (isolation); darwin jobs a `vm`
+//! capability serves run in a disposable macOS guest via the local daemon
+//! (isolation); a `host_runner` capability runs via the pre-installed runner.
+//! Capacity is never a number — admission gates on live load and free memory,
+//! so a busy host simply rejects and the platform re-offers elsewhere.
 
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
@@ -29,6 +30,12 @@ use tracing::{info, warn};
 use crate::docker::{DockerRunner, RunSpec};
 use crate::host;
 use crate::state::AgentState;
+use crate::vm::VmRunner;
+
+/// Watchdog on a VM job's runtime: GitHub concludes jobs at 6 h, so a
+/// session still open past that (plus slack) means the guest wedged — treat
+/// it as a cancellation and destroy the guest.
+const MAX_VM_JOB_RUNTIME: Duration = Duration::from_secs(6 * 3600 + 1800);
 
 /// Convert a gateway-advertised capability into its control-plane
 /// counterpart. A plain function, not `From`: both `Capability` types are
@@ -90,6 +97,8 @@ struct Inner {
     runner_script: Option<PathBuf>,
     /// Docker runtime for Linux jobs, if available.
     docker: Option<DockerRunner>,
+    /// macOS VM backend for darwin jobs, if the local daemon serves it.
+    vm: Option<VmRunner>,
     /// The backend serving each advertised `(os, arch)` — the routing table.
     backends: HashMap<(String, String), Backend>,
     /// Set once `Drain` is received; no new jobs are accepted.
@@ -128,6 +137,7 @@ impl RunnerSupervisor {
         events: mpsc::Sender<AttachRequest>,
         runner_script: Option<PathBuf>,
         docker: Option<DockerRunner>,
+        vm: Option<VmRunner>,
         capabilities: Vec<Capability>,
         state: AgentState,
     ) -> Self {
@@ -149,6 +159,7 @@ impl RunnerSupervisor {
                 in_flight: DashMap::new(),
                 runner_script,
                 docker,
+                vm,
                 backends,
                 draining: std::sync::atomic::AtomicBool::new(false),
                 state,
@@ -348,10 +359,98 @@ impl RunnerSupervisor {
         match backend {
             Backend::Docker => self.run_docker_job(&job_id, &order, &token, cancel).await,
             Backend::HostRunner => self.run_host_job(&job_id, &order, &token, cancel).await,
-            // We never advertise these, so admit() never routes to them; reject
-            // defensively rather than panic if one ever slips through.
-            Backend::Vm | Backend::Unspecified => {
+            Backend::Vm => self.run_vm_job(&job_id, &order, &token, cancel).await,
+            // Never advertised, so admit() never routes here; reject
+            // defensively rather than panic if it ever slips through.
+            Backend::Unspecified => {
                 self.reject(&job_id, &token, "backend not supported by this agent");
+            }
+        }
+    }
+
+    /// Run a job in a disposable macOS guest via the local daemon. Same
+    /// cancellation discipline as [`Self::run_docker_job`]: observed during
+    /// startup and while running, teardown awaited — destroying the guest
+    /// kills the runner, so no in-guest process management exists or is
+    /// needed. A runtime watchdog backstops a wedged guest whose ssh
+    /// session would otherwise stay open forever.
+    async fn run_vm_job(
+        &self,
+        job_id: &str,
+        order: &ProvisionRunner,
+        token: &str,
+        cancel: CancellationToken,
+    ) {
+        // Invariant: the vm capability is only advertised when the daemon
+        // probe succeeded, so admit() routes here only with `vm` set.
+        let vm = self
+            .inner
+            .vm
+            .as_ref()
+            .expect("vm backend implies a vm runner");
+
+        // Startup (clone, boot, DHCP wait, ssh) takes minutes and must not
+        // make the agent deaf to CancelRunner.
+        let runner_image = self.inner.state.macos_runner_image_current();
+        let started = {
+            let start = std::pin::pin!(vm.start(crate::vm::RunSpec {
+                job_id,
+                encoded_jit_config: &order.encoded_jit_config,
+                runner_image: &runner_image,
+            }));
+            tokio::select! {
+                result = start => Some(result),
+                () = cancel.cancelled() => None,
+            }
+        };
+        let mut running = match started {
+            Some(Ok(running)) => running,
+            Some(Err(e)) => {
+                // Includes the daemon's two-guest license-cap refusal: reject
+                // and the platform re-offers elsewhere.
+                self.reject(
+                    job_id,
+                    token,
+                    &format!("failed to start macOS guest: {e:#}"),
+                );
+                return;
+            }
+            None => {
+                // Canceled mid-startup: no verdict is owed (the platform
+                // already concluded the job). Dropping `start` stopped the
+                // provisioning; the awaited remove reaches whatever it had
+                // created by then (the name is deterministic).
+                vm.remove_job_vm(job_id).await;
+                info!(job_id, "runner canceled during startup");
+                return;
+            }
+        };
+
+        // The runner command has been issued in the guest: accept the offer.
+        self.accept(job_id, token);
+        info!(job_id, "runner started (vm)");
+
+        let exited = {
+            let wait = std::pin::pin!(running.wait());
+            tokio::select! {
+                exit = wait => Some(exit),
+                () = cancel.cancelled() => None,
+                () = tokio::time::sleep(MAX_VM_JOB_RUNTIME) => {
+                    warn!(job_id, "vm job exceeded the runtime watchdog; destroying guest");
+                    None
+                }
+            }
+        };
+        match exited {
+            Some(exit_status) => {
+                info!(job_id, ?exit_status, "runner exited");
+                running.destroy().await;
+            }
+            // CancelRunner or the watchdog: destroy the guest, awaited, so
+            // the in-flight slot outlives the guest — never the reverse.
+            None => {
+                running.destroy().await;
+                info!(job_id, "runner canceled");
             }
         }
     }
@@ -598,6 +697,7 @@ mod tests {
             events,
             Some(PathBuf::from("/nonexistent")),
             None,
+            None,
             capabilities,
             AgentState::new(&seed()),
         )
@@ -624,6 +724,15 @@ mod tests {
         assert_eq!(
             sup.admit("rjob_a", "darwin", "arm64", &idle()),
             Admission::Accept(Backend::HostRunner)
+        );
+    }
+
+    #[test]
+    fn vm_backed_capability_routes_to_the_vm_backend() {
+        let sup = supervisor(vec![capability("darwin", "arm64", Backend::Vm)]);
+        assert_eq!(
+            sup.admit("rjob_a", "darwin", "arm64", &idle()),
+            Admission::Accept(Backend::Vm)
         );
     }
 
@@ -702,6 +811,7 @@ mod tests {
             events,
             Some(PathBuf::from("/nonexistent")),
             None,
+            None,
             vec![capability("darwin", "arm64", Backend::HostRunner)],
             AgentState::new(&seed()),
         );
@@ -719,6 +829,7 @@ mod tests {
         let sup = RunnerSupervisor::new(
             events,
             Some(PathBuf::from("/nonexistent")),
+            None,
             None,
             vec![capability("darwin", "arm64", Backend::HostRunner)],
             AgentState::new(&crate::settings::PersistedSettings {
@@ -938,7 +1049,7 @@ mod tests {
     async fn shutdown_does_not_flip_observable_draining_but_drain_does() {
         let drained = AgentState::new(&seed());
         let (events, _rx) = mpsc::channel(1);
-        RunnerSupervisor::new(events, None, None, Vec::new(), drained.clone()).handle_drain();
+        RunnerSupervisor::new(events, None, None, None, Vec::new(), drained.clone()).handle_drain();
         assert!(
             drained.current().draining,
             "Drain flips the observable flag"
@@ -946,7 +1057,7 @@ mod tests {
 
         let torn_down = AgentState::new(&seed());
         let (events, _rx) = mpsc::channel(1);
-        RunnerSupervisor::new(events, None, None, Vec::new(), torn_down.clone())
+        RunnerSupervisor::new(events, None, None, None, Vec::new(), torn_down.clone())
             .shutdown(Duration::from_secs(1))
             .await;
         assert!(

--- a/fleet/arcbox-fleet-agent/src/service.rs
+++ b/fleet/arcbox-fleet-agent/src/service.rs
@@ -20,15 +20,17 @@ use crate::config::AgentConfig;
 const LABEL: &str = "com.arcboxlabs.fleet.agent";
 
 /// Install the LaunchAgent so `arcbox-fleet-agent serve` starts on the next
-/// user login (and immediately if the user is already logged in). Renders
-/// the plist against the binary that invoked this command
-/// (`env::current_exe()`) and the agent's configured data directory, writes
-/// it to `~/Library/LaunchAgents/`, and bootstraps it into the current GUI
-/// session. Idempotent-refusal on second run: if the job is already loaded,
-/// prints an actionable message asking the operator to `uninstall-service`
-/// first instead of silently overwriting a live install.
+/// user login (and immediately if the user is already logged in). The
+/// invoking binary is first installed into the managed path
+/// (`<data_dir>/bin/arcbox-fleet-agent`) — the location the self-updater
+/// owns and the plist points at, so binary swaps never invalidate the
+/// service definition. Writes the plist to `~/Library/LaunchAgents/` and
+/// bootstraps it into the current GUI session. Idempotent-refusal on second
+/// run: if the job is already loaded, prints an actionable message asking
+/// the operator to `uninstall-service` first instead of silently
+/// overwriting a live install.
 pub fn install(config: &AgentConfig) -> Result<()> {
-    let binary = std::env::current_exe().context("resolving the current binary path")?;
+    let binary = install_managed_binary(config)?;
 
     let plist_path = plist_path()?;
     let plist_dir = plist_path
@@ -117,8 +119,36 @@ pub fn uninstall() -> Result<()> {
     Ok(())
 }
 
-/// Compose the LaunchAgent plist. `binary` is the absolute path to the
-/// current agent binary (so a rename or move requires re-installing);
+/// Copy the invoking binary into the managed path the self-updater owns.
+/// A no-op when already running from there (a re-exec'd updated binary, or
+/// an operator invoking the managed install directly). The copy goes
+/// through a sibling temp file + rename so a crash mid-copy can never leave
+/// a truncated binary at the path launchd starts.
+fn install_managed_binary(config: &AgentConfig) -> Result<PathBuf> {
+    let current = std::env::current_exe().context("resolving the current binary path")?;
+    let managed = crate::update::managed_binary(config);
+    if current
+        .canonicalize()
+        .ok()
+        .is_some_and(|c| managed.canonicalize().is_ok_and(|m| c == m))
+    {
+        return Ok(managed);
+    }
+    let bin_dir = managed
+        .parent()
+        .ok_or_else(|| anyhow!("managed binary path has no parent"))?;
+    std::fs::create_dir_all(bin_dir).with_context(|| format!("creating {}", bin_dir.display()))?;
+    let staging = bin_dir.join("arcbox-fleet-agent.installing");
+    std::fs::copy(&current, &staging)
+        .with_context(|| format!("copying {} to {}", current.display(), staging.display()))?;
+    std::fs::rename(&staging, &managed)
+        .with_context(|| format!("installing {}", managed.display()))?;
+    println!("installed binary at {}", managed.display());
+    Ok(managed)
+}
+
+/// Compose the LaunchAgent plist. `binary` is the managed binary path (the
+/// self-updater swaps it in place, so the plist survives every update);
 /// `log_dir` is where launchd tees stdout/stderr — ideally the same
 /// directory the agent's own logger uses, so early-startup output before
 /// [`arcbox_logging::init`] has a chance to land in the same place.

--- a/fleet/arcbox-fleet-agent/src/service.rs
+++ b/fleet/arcbox-fleet-agent/src/service.rs
@@ -1,0 +1,253 @@
+//! `install-service` / `uninstall-service` — user LaunchAgent installer for
+//! macOS. Renders the plist with runtime-resolved paths
+//! (`env::current_exe()`, `$HOME`) and drives `launchctl`, so a plain
+//! `arcbox-fleet-agent install-service` sets up start-on-login without
+//! sudo, static plist files, or manual `launchctl` incantations.
+//!
+//! macOS-only for now. Linux systemd (user unit) is planned as a follow-up.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use anyhow::{Context, Result, anyhow, bail};
+use plist::{Dictionary, Value};
+
+use crate::config::AgentConfig;
+
+/// Reverse-DNS Label for the LaunchAgent job. Mirrors the pattern used by
+/// `com.arcboxlabs.desktop.helper` so operators can eyeball ArcBox jobs
+/// in a single `launchctl print` output.
+const LABEL: &str = "com.arcboxlabs.fleet.agent";
+
+/// Install the LaunchAgent so `arcbox-fleet-agent serve` starts on the next
+/// user login (and immediately if the user is already logged in). Renders
+/// the plist against the binary that invoked this command
+/// (`env::current_exe()`) and the agent's configured data directory, writes
+/// it to `~/Library/LaunchAgents/`, and bootstraps it into the current GUI
+/// session. Idempotent-refusal on second run: if the job is already loaded,
+/// prints an actionable message asking the operator to `uninstall-service`
+/// first instead of silently overwriting a live install.
+pub fn install(config: &AgentConfig) -> Result<()> {
+    let binary = std::env::current_exe().context("resolving the current binary path")?;
+
+    let plist_path = plist_path()?;
+    let plist_dir = plist_path
+        .parent()
+        .ok_or_else(|| anyhow!("LaunchAgents plist path has no parent"))?;
+    std::fs::create_dir_all(plist_dir)
+        .with_context(|| format!("creating {}", plist_dir.display()))?;
+
+    if plist_path.exists() {
+        bail!(
+            "{LABEL} is already installed at {}; run `arcbox-fleet-agent uninstall-service` \
+             first (or delete the plist by hand) before reinstalling",
+            plist_path.display()
+        );
+    }
+
+    let log_dir = config.data_dir.join("log");
+    std::fs::create_dir_all(&log_dir)
+        .with_context(|| format!("creating log dir {}", log_dir.display()))?;
+
+    let plist = launch_agent_plist(&binary, &log_dir);
+    plist::to_file_xml(&plist_path, &plist)
+        .with_context(|| format!("writing {}", plist_path.display()))?;
+
+    let uid = current_uid();
+    let target = format!("gui/{uid}");
+    let output = Command::new("launchctl")
+        .args(["bootstrap", &target])
+        .arg(&plist_path)
+        .output()
+        .context("invoking `launchctl bootstrap`")?;
+    if !output.status.success() {
+        // Leave the plist on disk — the operator can inspect it and either
+        // fix the environment or `uninstall-service` to clean up.
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        bail!(
+            "`launchctl bootstrap {target} {}` failed ({}): {}",
+            plist_path.display(),
+            output.status,
+            stderr.trim()
+        );
+    }
+
+    println!("installed LaunchAgent {LABEL}");
+    println!("  plist:  {}", plist_path.display());
+    println!("  binary: {}", binary.display());
+    println!("  status: launchctl print {target}/{LABEL}");
+    Ok(())
+}
+
+/// Remove the LaunchAgent installed by [`install`]. Idempotent: a `bootout`
+/// error when the job isn't loaded is treated as success, and a missing
+/// plist file is treated as success — the desired end state is "not
+/// installed," regardless of which piece was already gone.
+pub fn uninstall() -> Result<()> {
+    let plist_path = plist_path()?;
+    let uid = current_uid();
+    let target = format!("gui/{uid}/{LABEL}");
+
+    let output = Command::new("launchctl")
+        .args(["bootout", &target])
+        .output()
+        .context("invoking `launchctl bootout`")?;
+    // `bootout` exits non-zero when the job isn't loaded; we want the same
+    // outcome as when it *was* loaded and we successfully removed it, so
+    // ignore the exit code and just log the stderr for visibility. A real
+    // failure (e.g., malformed target) still surfaces via the printed
+    // stderr, without preventing plist cleanup below.
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        let stderr = stderr.trim();
+        if !stderr.is_empty() {
+            eprintln!("launchctl bootout: {stderr}");
+        }
+    }
+
+    match std::fs::remove_file(&plist_path) {
+        Ok(()) => {}
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+        Err(e) => {
+            return Err(anyhow!(e).context(format!("removing {}", plist_path.display())));
+        }
+    }
+
+    println!("uninstalled LaunchAgent {LABEL}");
+    Ok(())
+}
+
+/// Compose the LaunchAgent plist. `binary` is the absolute path to the
+/// current agent binary (so a rename or move requires re-installing);
+/// `log_dir` is where launchd tees stdout/stderr — ideally the same
+/// directory the agent's own logger uses, so early-startup output before
+/// [`arcbox_logging::init`] has a chance to land in the same place.
+fn launch_agent_plist(binary: &Path, log_dir: &Path) -> Value {
+    let stdout = log_dir.join("fleet-agent.stdout.log");
+    let stderr = log_dir.join("fleet-agent.stderr.log");
+
+    let mut dict = Dictionary::new();
+    dict.insert("Label".into(), Value::String(LABEL.into()));
+    dict.insert(
+        "ProgramArguments".into(),
+        Value::Array(vec![
+            Value::String(binary.to_string_lossy().into_owned()),
+            Value::String("serve".into()),
+        ]),
+    );
+    dict.insert("RunAtLoad".into(), Value::Boolean(true));
+
+    // SuccessfulExit=false: launchd respawns non-zero exits only, so a
+    // SIGTERM shutdown from `launchctl bootout` doesn't get resurrected.
+    let mut keep_alive = Dictionary::new();
+    keep_alive.insert("SuccessfulExit".into(), Value::Boolean(false));
+    dict.insert("KeepAlive".into(), Value::Dictionary(keep_alive));
+
+    // Ceiling between SIGTERM and SIGKILL. Comfortably above the agent's
+    // own SHUTDOWN_GRACE for runner drain, with headroom for zombie reap.
+    dict.insert("ExitTimeOut".into(), Value::Integer(60.into()));
+
+    // launchd's tee of stdout/stderr, so anything the agent writes before
+    // it opens its own log file still lands next to the real logs.
+    dict.insert(
+        "StandardOutPath".into(),
+        Value::String(stdout.to_string_lossy().into_owned()),
+    );
+    dict.insert(
+        "StandardErrorPath".into(),
+        Value::String(stderr.to_string_lossy().into_owned()),
+    );
+
+    Value::Dictionary(dict)
+}
+
+/// Path where the plist is installed. LaunchAgents in `~/Library/LaunchAgents`
+/// load per-user on GUI login; a system-wide install would need
+/// `/Library/LaunchAgents` (all users) or `/Library/LaunchDaemons` (root,
+/// no session) — deliberately out of scope for the per-user install.
+fn plist_path() -> Result<PathBuf> {
+    let home = dirs::home_dir().ok_or_else(|| anyhow!("could not resolve home directory"))?;
+    Ok(home
+        .join("Library")
+        .join("LaunchAgents")
+        .join(format!("{LABEL}.plist")))
+}
+
+/// Read the effective UID via `libc::getuid`. LaunchAgents live under
+/// `gui/{uid}`; we need the numeric id, not the login name.
+fn current_uid() -> u32 {
+    // SAFETY: getuid is a POSIX system call with no preconditions and no
+    // failure mode — always returns the caller's real UID.
+    unsafe { libc::getuid() }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn expect_string<'a>(dict: &'a Dictionary, key: &str) -> &'a str {
+        dict.get(key)
+            .and_then(Value::as_string)
+            .unwrap_or_else(|| panic!("plist missing string key {key}"))
+    }
+
+    #[test]
+    fn plist_carries_label_binary_serve_and_log_paths() {
+        let plist = launch_agent_plist(
+            Path::new("/usr/local/bin/arcbox-fleet-agent"),
+            Path::new("/home/user/.arcbox/fleet/log"),
+        );
+        let dict = plist.as_dictionary().expect("root is a dict");
+
+        assert_eq!(expect_string(dict, "Label"), LABEL);
+        assert_eq!(
+            expect_string(dict, "StandardOutPath"),
+            "/home/user/.arcbox/fleet/log/fleet-agent.stdout.log"
+        );
+        assert_eq!(
+            expect_string(dict, "StandardErrorPath"),
+            "/home/user/.arcbox/fleet/log/fleet-agent.stderr.log"
+        );
+
+        let args = dict
+            .get("ProgramArguments")
+            .and_then(Value::as_array)
+            .expect("ProgramArguments is an array");
+        let args: Vec<&str> = args.iter().filter_map(Value::as_string).collect();
+        assert_eq!(args, ["/usr/local/bin/arcbox-fleet-agent", "serve"]);
+    }
+
+    #[test]
+    fn plist_respawns_only_on_crash_not_clean_exit() {
+        let plist = launch_agent_plist(Path::new("/x"), Path::new("/y"));
+        let dict = plist.as_dictionary().expect("root is a dict");
+        assert_eq!(
+            dict.get("RunAtLoad").and_then(Value::as_boolean),
+            Some(true)
+        );
+
+        // SuccessfulExit=false: SIGTERM shutdowns don't get resurrected;
+        // only genuine crashes trigger a respawn.
+        let keep_alive = dict
+            .get("KeepAlive")
+            .and_then(Value::as_dictionary)
+            .expect("KeepAlive is a dict");
+        assert_eq!(
+            keep_alive.get("SuccessfulExit").and_then(Value::as_boolean),
+            Some(false)
+        );
+    }
+
+    #[test]
+    fn plist_serializes_to_valid_xml_with_correct_doctype() {
+        let plist = launch_agent_plist(
+            Path::new("/usr/local/bin/arcbox-fleet-agent"),
+            Path::new("/log"),
+        );
+        let mut buf: Vec<u8> = Vec::new();
+        plist::to_writer_xml(&mut buf, &plist).expect("plist serializes");
+        let xml = String::from_utf8(buf).expect("plist crate emits UTF-8");
+        assert!(xml.contains("<!DOCTYPE plist PUBLIC"));
+        assert!(xml.contains("<key>Label</key>"));
+    }
+}

--- a/fleet/arcbox-fleet-agent/src/service.rs
+++ b/fleet/arcbox-fleet-agent/src/service.rs
@@ -1,7 +1,7 @@
-//! `install-service` / `uninstall-service` — user LaunchAgent installer for
-//! macOS. Renders the plist with runtime-resolved paths
+//! `quick install-service` / `quick uninstall-service` — user LaunchAgent
+//! installer for macOS. Renders the plist with runtime-resolved paths
 //! (`env::current_exe()`, `$HOME`) and drives `launchctl`, so a plain
-//! `arcbox-fleet-agent install-service` sets up start-on-login without
+//! `arcbox-fleet-agent quick install-service` sets up start-on-login without
 //! sudo, static plist files, or manual `launchctl` incantations.
 //!
 //! macOS-only for now. Linux systemd (user unit) is planned as a follow-up.
@@ -27,7 +27,7 @@ const LABEL: &str = "com.arcboxlabs.fleet.agent";
 /// service definition. Writes the plist to `~/Library/LaunchAgents/` and
 /// bootstraps it into the current GUI session. Idempotent-refusal on second
 /// run: if the job is already loaded, prints an actionable message asking
-/// the operator to `uninstall-service` first instead of silently
+/// the operator to `quick uninstall-service` first instead of silently
 /// overwriting a live install.
 pub fn install(config: &AgentConfig) -> Result<()> {
     let binary = install_managed_binary(config)?;
@@ -41,7 +41,7 @@ pub fn install(config: &AgentConfig) -> Result<()> {
 
     if plist_path.exists() {
         bail!(
-            "{LABEL} is already installed at {}; run `arcbox-fleet-agent uninstall-service` \
+            "{LABEL} is already installed at {}; run `arcbox-fleet-agent quick uninstall-service` \
              first (or delete the plist by hand) before reinstalling",
             plist_path.display()
         );
@@ -64,7 +64,7 @@ pub fn install(config: &AgentConfig) -> Result<()> {
         .context("invoking `launchctl bootstrap`")?;
     if !output.status.success() {
         // Leave the plist on disk — the operator can inspect it and either
-        // fix the environment or `uninstall-service` to clean up.
+        // fix the environment or `quick uninstall-service` to clean up.
         let stderr = String::from_utf8_lossy(&output.stderr);
         bail!(
             "`launchctl bootstrap {target} {}` failed ({}): {}",

--- a/fleet/arcbox-fleet-agent/src/settings.rs
+++ b/fleet/arcbox-fleet-agent/src/settings.rs
@@ -164,6 +164,7 @@ mod tests {
             vm: crate::config::VmConfig {
                 mode: crate::config::VmMode::Disabled,
                 macos_runner_image: "tahoe-base".to_owned(),
+                daemon_socket: std::path::PathBuf::from("/nonexistent/arcbox.sock"),
             },
             credential_store: crate::config::CredentialMode::File,
         };

--- a/fleet/arcbox-fleet-agent/src/settings.rs
+++ b/fleet/arcbox-fleet-agent/src/settings.rs
@@ -11,8 +11,17 @@ use std::path::PathBuf;
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
 
-use crate::config::{AgentConfig, DockerMode};
+use crate::config::{AgentConfig, DEFAULT_MACOS_RUNNER_IMAGE, DockerMode, VmMode};
 use crate::fsutil::write_json_atomic;
+
+/// Serde defaults for fields added after settings files already existed in
+/// the wild — a pre-field settings.json must load as if seeded fresh.
+fn default_vm_mode() -> VmMode {
+    VmMode::Auto
+}
+fn default_macos_runner_image() -> String {
+    DEFAULT_MACOS_RUNNER_IMAGE.to_owned()
+}
 
 /// Live-settable agent configuration, as last requested (`target`) — see
 /// [`crate::state::AgentState`] for the paired `current` values the engine
@@ -31,6 +40,12 @@ pub struct PersistedSettings {
     /// credential but stays detached. Persisted so a launchd restart honors
     /// an operator's detach instead of silently reattaching.
     pub participate: bool,
+    /// Whether darwin jobs run in daemon-provisioned macOS VMs.
+    #[serde(default = "default_vm_mode")]
+    pub vm_mode: VmMode,
+    /// macOS base-image stream darwin VM jobs boot from.
+    #[serde(default = "default_macos_runner_image")]
+    pub macos_runner_image: String,
 }
 
 impl From<&AgentConfig> for PersistedSettings {
@@ -46,6 +61,8 @@ impl From<&AgentConfig> for PersistedSettings {
             // No env seed: a fresh install participates; only an explicit
             // UpdateSettings opts a machine out.
             participate: true,
+            vm_mode: config.vm.mode,
+            macos_runner_image: config.vm.macos_runner_image.clone(),
         }
     }
 }
@@ -105,6 +122,8 @@ mod tests {
             docker_mode: DockerMode::Auto,
             runner_script: Some(PathBuf::from("/opt/actions-runner/run.sh")),
             participate: true,
+            vm_mode: crate::config::VmMode::Auto,
+            macos_runner_image: "tahoe-base".to_owned(),
         }
     }
 
@@ -142,6 +161,10 @@ mod tests {
                 mode: DockerMode::Enabled,
                 linux_runner_image: "example/image:latest".to_owned(),
             },
+            vm: crate::config::VmConfig {
+                mode: crate::config::VmMode::Disabled,
+                macos_runner_image: "tahoe-base".to_owned(),
+            },
             credential_store: crate::config::CredentialMode::File,
         };
 
@@ -152,5 +175,25 @@ mod tests {
         assert_eq!(seeded.mem_floor_mib, config.mem_floor_mib);
         assert_eq!(seeded.docker_mode, config.docker.mode);
         assert_eq!(seeded.linux_runner_image, config.docker.linux_runner_image);
+        assert_eq!(seeded.vm_mode, config.vm.mode);
+        assert_eq!(seeded.macos_runner_image, config.vm.macos_runner_image);
+    }
+
+    /// A settings.json written before the VM-backend fields existed must
+    /// load as if those fields were seeded fresh.
+    #[test]
+    fn pre_vm_fields_settings_file_loads_with_defaults() {
+        let json = r#"{
+            "load_ceiling": 0.9,
+            "mem_floor_mib": 2048,
+            "linux_runner_image": "ghcr.io/actions/actions-runner:latest",
+            "gateway": "https://fleet.arcbox.dev",
+            "docker_mode": "Auto",
+            "runner_script": null,
+            "participate": true
+        }"#;
+        let settings: PersistedSettings = serde_json::from_str(json).unwrap();
+        assert_eq!(settings.vm_mode, crate::config::VmMode::Auto);
+        assert_eq!(settings.macos_runner_image, DEFAULT_MACOS_RUNNER_IMAGE);
     }
 }

--- a/fleet/arcbox-fleet-agent/src/state.rs
+++ b/fleet/arcbox-fleet-agent/src/state.rs
@@ -10,10 +10,11 @@ use std::sync::Arc;
 use arcbox_fleet_control_proto::v1::{
     AgentSettings, AgentStateSnapshot, BoolSetting, Capability, DockerModeSetting, DoubleSetting,
     Enrollment, HostTelemetry, InFlightJob, OfferVerdict, StringSetting, Uint64Setting,
+    VmModeSetting,
 };
 use tokio::sync::watch;
 
-use crate::config::DockerMode;
+use crate::config::{DockerMode, VmMode};
 use crate::settings::PersistedSettings;
 
 /// Bound on `recent_verdicts` so a long-lived agent's snapshot doesn't grow
@@ -62,6 +63,35 @@ pub fn docker_mode_from_wire(raw: i32) -> DockerMode {
         .into()
 }
 
+/// `VmMode` mirrors `DockerMode`'s conversion trio above, for the same
+/// orphan-rule reasons.
+fn vm_mode_to_control(mode: VmMode) -> arcbox_fleet_control_proto::v1::VmMode {
+    match mode {
+        VmMode::Auto => arcbox_fleet_control_proto::v1::VmMode::Auto,
+        VmMode::Enabled => arcbox_fleet_control_proto::v1::VmMode::Enabled,
+        VmMode::Disabled => arcbox_fleet_control_proto::v1::VmMode::Disabled,
+    }
+}
+
+impl From<arcbox_fleet_control_proto::v1::VmMode> for VmMode {
+    fn from(mode: arcbox_fleet_control_proto::v1::VmMode) -> Self {
+        match mode {
+            arcbox_fleet_control_proto::v1::VmMode::Enabled => Self::Enabled,
+            arcbox_fleet_control_proto::v1::VmMode::Disabled => Self::Disabled,
+            arcbox_fleet_control_proto::v1::VmMode::Auto
+            | arcbox_fleet_control_proto::v1::VmMode::Unspecified => Self::Auto,
+        }
+    }
+}
+
+/// Parse a wire `VmMode` i32, falling back to `Auto` like
+/// [`docker_mode_from_wire`].
+pub fn vm_mode_from_wire(raw: i32) -> VmMode {
+    arcbox_fleet_control_proto::v1::VmMode::try_from(raw)
+        .unwrap_or(arcbox_fleet_control_proto::v1::VmMode::Unspecified)
+        .into()
+}
+
 fn path_to_setting_value(path: Option<&Path>) -> String {
     path.map(|p| p.to_string_lossy().into_owned())
         .unwrap_or_default()
@@ -100,6 +130,7 @@ impl AgentState {
     pub fn new(seed: &PersistedSettings) -> Self {
         let runner_script = path_to_setting_value(seed.runner_script.as_deref());
         let docker_mode = docker_mode_to_control(seed.docker_mode) as i32;
+        let vm_mode = vm_mode_to_control(seed.vm_mode);
         let settings = AgentSettings {
             load_ceiling: Some(DoubleSetting {
                 current: seed.load_ceiling,
@@ -128,6 +159,14 @@ impl AgentState {
             participate: Some(BoolSetting {
                 current: seed.participate,
                 target: seed.participate,
+            }),
+            macos_runner_image: Some(StringSetting {
+                current: seed.macos_runner_image.clone(),
+                target: seed.macos_runner_image.clone(),
+            }),
+            vm_mode: Some(VmModeSetting {
+                current: vm_mode as i32,
+                target: vm_mode as i32,
             }),
         };
         let (tx, _) = watch::channel(AgentStateSnapshot {
@@ -184,6 +223,13 @@ impl AgentState {
                 &s.runner_script.as_ref().expect(SETTINGS_INVARIANT).target,
             ),
             participate: s.participate.as_ref().expect(SETTINGS_INVARIANT).target,
+            vm_mode: vm_mode_from_wire(s.vm_mode.as_ref().expect(SETTINGS_INVARIANT).target),
+            macos_runner_image: s
+                .macos_runner_image
+                .as_ref()
+                .expect(SETTINGS_INVARIANT)
+                .target
+                .clone(),
         }
     }
 
@@ -261,6 +307,42 @@ impl AgentState {
     pub fn linux_runner_image_target(&self) -> String {
         settings_of(&self.tx.borrow())
             .linux_runner_image
+            .as_ref()
+            .expect(SETTINGS_INVARIANT)
+            .target
+            .clone()
+    }
+
+    #[cfg_attr(
+        not(test),
+        expect(
+            dead_code,
+            reason = "consumed by the VM backend's job routing, which lands in the next commit \
+                  of this change set; the #[expect] forces removal then"
+        )
+    )]
+    pub fn macos_runner_image_current(&self) -> String {
+        settings_of(&self.tx.borrow())
+            .macos_runner_image
+            .as_ref()
+            .expect(SETTINGS_INVARIANT)
+            .current
+            .clone()
+    }
+
+    /// The desired macOS image — what `FleetImageService.Prepare` pulls
+    /// through the daemon and then promotes to `current`.
+    #[cfg_attr(
+        not(test),
+        expect(
+            dead_code,
+            reason = "consumed by the macOS image Prepare path, which lands later in this \
+                  change set; the #[expect] forces removal then"
+        )
+    )]
+    pub fn macos_runner_image_target(&self) -> String {
+        settings_of(&self.tx.borrow())
+            .macos_runner_image
             .as_ref()
             .expect(SETTINGS_INVARIANT)
             .target
@@ -424,6 +506,49 @@ impl AgentState {
         });
     }
 
+    pub fn set_vm_mode_target(&self, mode: VmMode) {
+        let mode = vm_mode_to_control(mode) as i32;
+        self.tx.send_modify(|s| {
+            settings_mut(s)
+                .vm_mode
+                .as_mut()
+                .expect(SETTINGS_INVARIANT)
+                .target = mode;
+        });
+    }
+
+    pub fn set_macos_runner_image_target(&self, value: &str) {
+        self.tx.send_modify(|s| {
+            value.clone_into(
+                &mut settings_mut(s)
+                    .macos_runner_image
+                    .as_mut()
+                    .expect(SETTINGS_INVARIANT)
+                    .target,
+            );
+        });
+    }
+
+    #[cfg_attr(
+        not(test),
+        expect(
+            dead_code,
+            reason = "consumed by the macOS image Prepare path, which lands later in this \
+                  change set; the #[expect] forces removal then"
+        )
+    )]
+    pub fn set_macos_runner_image_current(&self, value: &str) {
+        self.tx.send_modify(|s| {
+            value.clone_into(
+                &mut settings_mut(s)
+                    .macos_runner_image
+                    .as_mut()
+                    .expect(SETTINGS_INVARIANT)
+                    .current,
+            );
+        });
+    }
+
     pub fn set_runner_script_target(&self, script: Option<&Path>) {
         let value = path_to_setting_value(script);
         self.tx.send_modify(|s| {
@@ -474,6 +599,8 @@ mod tests {
             docker_mode: DockerMode::Auto,
             runner_script: None,
             participate: true,
+            vm_mode: crate::config::VmMode::Auto,
+            macos_runner_image: "tahoe-base".to_owned(),
         }
     }
 
@@ -602,6 +729,20 @@ mod tests {
         assert_eq!(
             state.linux_runner_image_current(),
             state.linux_runner_image_target()
+        );
+    }
+
+    #[test]
+    fn macos_runner_image_current_and_target_are_independent() {
+        let state = AgentState::new(&seed());
+        state.set_macos_runner_image_target("tahoe-base@2026.07.02");
+        assert_eq!(state.macos_runner_image_current(), "tahoe-base");
+        assert_eq!(state.macos_runner_image_target(), "tahoe-base@2026.07.02");
+
+        state.set_macos_runner_image_current("tahoe-base@2026.07.02");
+        assert_eq!(
+            state.macos_runner_image_current(),
+            state.macos_runner_image_target()
         );
     }
 

--- a/fleet/arcbox-fleet-agent/src/state.rs
+++ b/fleet/arcbox-fleet-agent/src/state.rs
@@ -313,14 +313,6 @@ impl AgentState {
             .clone()
     }
 
-    #[cfg_attr(
-        not(test),
-        expect(
-            dead_code,
-            reason = "consumed by the VM backend's job routing, which lands in the next commit \
-                  of this change set; the #[expect] forces removal then"
-        )
-    )]
     pub fn macos_runner_image_current(&self) -> String {
         settings_of(&self.tx.borrow())
             .macos_runner_image

--- a/fleet/arcbox-fleet-agent/src/state.rs
+++ b/fleet/arcbox-fleet-agent/src/state.rs
@@ -324,14 +324,6 @@ impl AgentState {
 
     /// The desired macOS image — what `FleetImageService.Prepare` pulls
     /// through the daemon and then promotes to `current`.
-    #[cfg_attr(
-        not(test),
-        expect(
-            dead_code,
-            reason = "consumed by the macOS image Prepare path, which lands later in this \
-                  change set; the #[expect] forces removal then"
-        )
-    )]
     pub fn macos_runner_image_target(&self) -> String {
         settings_of(&self.tx.borrow())
             .macos_runner_image
@@ -521,14 +513,6 @@ impl AgentState {
         });
     }
 
-    #[cfg_attr(
-        not(test),
-        expect(
-            dead_code,
-            reason = "consumed by the macOS image Prepare path, which lands later in this \
-                  change set; the #[expect] forces removal then"
-        )
-    )]
     pub fn set_macos_runner_image_current(&self, value: &str) {
         self.tx.send_modify(|s| {
             value.clone_into(

--- a/fleet/arcbox-fleet-agent/src/update.rs
+++ b/fleet/arcbox-fleet-agent/src/update.rs
@@ -1,0 +1,358 @@
+//! Self-update executor: download → verify → probe → swap → re-exec.
+//!
+//! Runs when the gateway pushes an [`AgentUpdate`] carrying a download
+//! (`binary_url` + `binary_sha256`). The checksum from the gateway — not the
+//! download host — is the integrity root; the `--version` probe of the
+//! downloaded binary is the loop-breaker (a mis-registered release whose
+//! binary reports the wrong version can never be installed, so the agent can
+//! never exec itself into an update cycle).
+//!
+//! Self-update only manages binaries it owns: the running executable must be
+//! the managed path (`<data_dir>/bin/arcbox-fleet-agent`, where
+//! `install-service` and the install script place it). A dev build or a
+//! hand-installed binary elsewhere parks on the expected version exactly as
+//! before self-update existed.
+
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result, bail};
+use arcbox_fleet_proto::v1::AgentUpdate;
+use sha2::{Digest, Sha256};
+use tracing::info;
+
+use crate::config::AgentConfig;
+
+/// Name of the previous binary, kept beside the managed one after a swap —
+/// forensics only; recovery from a bad release is re-promoting the previous
+/// version server-side, not a local rollback.
+const PREVIOUS_SUFFIX: &str = "arcbox-fleet-agent.prev";
+
+/// A pushed update that actually carries a download. Wire payloads without a
+/// URL (pre-registry gateways, releases missing this platform's asset) stay
+/// on the park path and never construct one of these.
+#[derive(Debug, Clone)]
+pub struct UpdatePayload {
+    pub expected_version: String,
+    pub binary_url: String,
+    pub binary_sha256: String,
+}
+
+impl UpdatePayload {
+    /// Extract the downloadable payload from a wire `AgentUpdate`; `None`
+    /// when the gateway sent only an expected version (the park path).
+    pub fn from_wire(update: &AgentUpdate) -> Option<Self> {
+        if update.binary_url.is_empty() {
+            return None;
+        }
+        Some(Self {
+            expected_version: update.expected_version.clone(),
+            binary_url: update.binary_url.clone(),
+            binary_sha256: update.binary_sha256.clone(),
+        })
+    }
+}
+
+/// The running executable is not the managed binary, so self-update declines
+/// to touch it. Typed so callers park (operator manages this binary) instead
+/// of retrying.
+#[derive(Debug, thiserror::Error)]
+#[error("running binary {current} is not the managed {managed}; self-update declined")]
+pub struct UnmanagedBinary {
+    current: String,
+    managed: String,
+}
+
+/// The path `install-service` and the self-updater own.
+pub fn managed_binary(config: &AgentConfig) -> PathBuf {
+    config.data_dir.join("bin").join("arcbox-fleet-agent")
+}
+
+/// Download, verify, probe, and swap `payload` into the managed path, then
+/// re-exec it with this process's arguments. Returns only on failure; on
+/// success the process image is replaced (same PID, so launchd's job
+/// bookkeeping is undisturbed).
+pub async fn apply_and_exec(config: &AgentConfig, payload: &UpdatePayload) -> anyhow::Error {
+    let managed = match apply(config, payload).await {
+        Ok(managed) => managed,
+        Err(error) => return error,
+    };
+    exec_replacement(&managed)
+}
+
+/// Everything up to (not including) the exec: leaves the verified new binary
+/// at the managed path and the old one beside it as `.prev`. Split from
+/// [`apply_and_exec`] so tests can exercise the full pipeline — exec is
+/// untestable in-process.
+async fn apply(config: &AgentConfig, payload: &UpdatePayload) -> Result<PathBuf> {
+    let managed = managed_binary(config);
+    let current = std::env::current_exe().context("resolving the current binary path")?;
+    ensure_managed(&current, &managed)?;
+
+    info!(
+        version = %payload.expected_version,
+        url = %payload.binary_url,
+        "self-update: downloading"
+    );
+    let staged = download_verified(config, payload).await?;
+    probe_version(&staged, &payload.expected_version).await?;
+
+    // Two renames, not a copy: the running image keeps its (now unlinked
+    // via .prev) inode, and the managed path atomically becomes the new
+    // binary — there is no instant where the path is missing or truncated.
+    let previous = managed.with_file_name(PREVIOUS_SUFFIX);
+    tokio::fs::rename(&managed, &previous)
+        .await
+        .with_context(|| format!("parking previous binary at {}", previous.display()))?;
+    tokio::fs::rename(&staged, &managed)
+        .await
+        .with_context(|| format!("installing new binary at {}", managed.display()))?;
+    info!(version = %payload.expected_version, "self-update: binary swapped; re-executing");
+    Ok(managed)
+}
+
+/// Replace this process image with `binary`, preserving argv. Returns only
+/// the exec error.
+fn exec_replacement(binary: &Path) -> anyhow::Error {
+    use std::os::unix::process::CommandExt;
+    let error = std::process::Command::new(binary)
+        .args(std::env::args_os().skip(1))
+        .exec();
+    anyhow::Error::new(error).context(format!("exec {}", binary.display()))
+}
+
+/// Self-update owns exactly the managed path; refuse anything else.
+/// Canonicalized on both sides so a symlinked data dir still matches.
+fn ensure_managed(current: &Path, managed: &Path) -> Result<()> {
+    let canonical_current = current
+        .canonicalize()
+        .with_context(|| format!("canonicalizing {}", current.display()))?;
+    let canonical_managed = managed
+        .canonicalize()
+        .unwrap_or_else(|_| managed.to_path_buf());
+    if canonical_current != canonical_managed {
+        bail!(UnmanagedBinary {
+            current: canonical_current.display().to_string(),
+            managed: managed.display().to_string(),
+        });
+    }
+    Ok(())
+}
+
+/// Fetch the binary into `<data_dir>/updates/` and require its SHA-256 to
+/// match the gateway-pinned digest before anything executes or moves it.
+async fn download_verified(config: &AgentConfig, payload: &UpdatePayload) -> Result<PathBuf> {
+    let staging_dir = config.data_dir.join("updates");
+    tokio::fs::create_dir_all(&staging_dir)
+        .await
+        .with_context(|| format!("creating {}", staging_dir.display()))?;
+
+    let response = reqwest::get(&payload.binary_url)
+        .await
+        .and_then(reqwest::Response::error_for_status)
+        .with_context(|| format!("downloading {}", payload.binary_url))?;
+    let bytes = response
+        .bytes()
+        .await
+        .with_context(|| format!("reading body of {}", payload.binary_url))?;
+
+    let digest = hex_digest(&bytes);
+    if !digest.eq_ignore_ascii_case(payload.binary_sha256.trim()) {
+        bail!(
+            "downloaded binary digest {digest} does not match the gateway-pinned {} for version {}",
+            payload.binary_sha256,
+            payload.expected_version,
+        );
+    }
+
+    let staged = staging_dir.join(format!("arcbox-fleet-agent-{}", payload.expected_version));
+    tokio::fs::write(&staged, &bytes)
+        .await
+        .with_context(|| format!("writing {}", staged.display()))?;
+    // HTTP carries no file modes; the exec bit is always set here.
+    let executable = std::fs::Permissions::from_mode(0o755);
+    tokio::fs::set_permissions(&staged, executable)
+        .await
+        .with_context(|| format!("marking {} executable", staged.display()))?;
+    Ok(staged)
+}
+
+use std::os::unix::fs::PermissionsExt;
+
+fn hex_digest(bytes: &[u8]) -> String {
+    use std::fmt::Write;
+    Sha256::digest(bytes)
+        .iter()
+        .fold(String::with_capacity(64), |mut hex, byte| {
+            write!(hex, "{byte:02x}").expect("writing to a String cannot fail");
+            hex
+        })
+}
+
+/// Run the downloaded binary with `--version` and require it to report
+/// exactly the expected version. Catches a wrong-arch binary (exec fails), a
+/// truncated or corrupt file, and — critically — a release registered under
+/// a version its binary does not report, which would otherwise exec-loop.
+async fn probe_version(binary: &Path, expected: &str) -> Result<()> {
+    let output = tokio::process::Command::new(binary)
+        .arg("--version")
+        .output()
+        .await
+        .with_context(|| format!("probing {} --version", binary.display()))?;
+    if !output.status.success() {
+        bail!(
+            "downloaded binary failed the --version probe ({}): {}",
+            output.status,
+            String::from_utf8_lossy(&output.stderr).trim(),
+        );
+    }
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    // clap prints "arcbox-fleet-agent <version>"; compare the version token.
+    let reported = stdout.trim().rsplit(' ').next().unwrap_or_default();
+    if reported != expected {
+        bail!("downloaded binary reports version {reported}, expected {expected}");
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use tokio::io::AsyncWriteExt;
+
+    use super::*;
+
+    fn test_config(data_dir: &Path) -> AgentConfig {
+        AgentConfig {
+            gateway: "http://127.0.0.1:1".to_owned(),
+            runner_script: None,
+            load_ceiling: 0.9,
+            mem_floor_mib: 2048,
+            data_dir: data_dir.to_path_buf(),
+            docker: crate::config::DockerConfig {
+                mode: crate::config::DockerMode::Disabled,
+                linux_runner_image: "img".to_owned(),
+            },
+            vm: crate::config::VmConfig {
+                mode: crate::config::VmMode::Disabled,
+                macos_runner_image: "tahoe-base".to_owned(),
+                daemon_socket: PathBuf::from("/nonexistent/arcbox.sock"),
+            },
+            credential_store: crate::config::CredentialMode::File,
+        }
+    }
+
+    /// Serve `body` once over plain HTTP/1.1 and return the URL.
+    async fn serve_once(body: Vec<u8>) -> String {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let url = format!(
+            "http://{}/arcbox-fleet-agent-darwin-arm64",
+            listener.local_addr().unwrap()
+        );
+        tokio::spawn(async move {
+            let (mut socket, _) = listener.accept().await.unwrap();
+            let header = format!(
+                "HTTP/1.1 200 OK\r\ncontent-length: {}\r\nconnection: close\r\n\r\n",
+                body.len()
+            );
+            socket.write_all(header.as_bytes()).await.unwrap();
+            socket.write_all(&body).await.unwrap();
+            socket.shutdown().await.unwrap();
+        });
+        url
+    }
+
+    fn payload(url: String, body: &[u8], version: &str) -> UpdatePayload {
+        UpdatePayload {
+            expected_version: version.to_owned(),
+            binary_url: url,
+            binary_sha256: hex_digest(body),
+        }
+    }
+
+    #[test]
+    fn from_wire_requires_a_url() {
+        assert!(
+            UpdatePayload::from_wire(&AgentUpdate {
+                expected_version: "0.5.1".into(),
+                binary_url: String::new(),
+                binary_sha256: String::new(),
+            })
+            .is_none()
+        );
+        let payload = UpdatePayload::from_wire(&AgentUpdate {
+            expected_version: "0.5.1".into(),
+            binary_url: "https://example.com/x".into(),
+            binary_sha256: "aa".into(),
+        })
+        .expect("url present");
+        assert_eq!(payload.expected_version, "0.5.1");
+    }
+
+    #[tokio::test]
+    async fn download_rejects_a_wrong_checksum() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = test_config(dir.path());
+        let url = serve_once(b"binary bytes".to_vec()).await;
+        let mut bad = payload(url, b"binary bytes", "0.5.1");
+        bad.binary_sha256 = hex_digest(b"different bytes");
+
+        let error = download_verified(&config, &bad)
+            .await
+            .expect_err("checksum mismatch must fail");
+        assert!(error.to_string().contains("does not match"));
+        // Nothing staged on failure.
+        assert!(
+            !config
+                .data_dir
+                .join("updates")
+                .join("arcbox-fleet-agent-0.5.1")
+                .exists()
+        );
+    }
+
+    #[tokio::test]
+    async fn download_stages_an_executable_verified_binary() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = test_config(dir.path());
+        let body = b"#!/bin/sh\necho arcbox-fleet-agent 0.5.1\n".to_vec();
+        let url = serve_once(body.clone()).await;
+
+        let staged = download_verified(&config, &payload(url, &body, "0.5.1"))
+            .await
+            .expect("download succeeds");
+        let mode = std::fs::metadata(&staged).unwrap().permissions().mode();
+        assert_eq!(mode & 0o777, 0o755);
+        assert_eq!(std::fs::read(&staged).unwrap(), body);
+    }
+
+    #[tokio::test]
+    async fn probe_accepts_matching_version_and_rejects_drift() {
+        let dir = tempfile::tempdir().unwrap();
+        let fake = dir.path().join("fake-agent");
+        std::fs::write(&fake, "#!/bin/sh\necho arcbox-fleet-agent 0.5.1\n").unwrap();
+        std::fs::set_permissions(&fake, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+        probe_version(&fake, "0.5.1")
+            .await
+            .expect("version matches");
+        let error = probe_version(&fake, "0.5.2")
+            .await
+            .expect_err("version drift must fail the probe");
+        assert!(error.to_string().contains("reports version 0.5.1"));
+    }
+
+    #[tokio::test]
+    async fn unmanaged_binary_is_a_typed_refusal() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = test_config(dir.path());
+        let url = serve_once(Vec::new()).await;
+        let error = apply(&config, &payload(url, &[], "0.5.1"))
+            .await
+            .expect_err("test binary does not run from the managed path");
+        assert!(
+            error
+                .chain()
+                .any(|c| c.downcast_ref::<UnmanagedBinary>().is_some()),
+            "expected UnmanagedBinary, got: {error:#}"
+        );
+    }
+}

--- a/fleet/arcbox-fleet-agent/src/update.rs
+++ b/fleet/arcbox-fleet-agent/src/update.rs
@@ -1,11 +1,24 @@
 //! Self-update executor: download → verify → probe → swap → re-exec.
 //!
-//! Runs when the gateway pushes an [`AgentUpdate`] carrying a download
-//! (`binary_url` + `binary_sha256`). The checksum from the gateway — not the
-//! download host — is the integrity root; the `--version` probe of the
-//! downloaded binary is the loop-breaker (a mis-registered release whose
-//! binary reports the wrong version can never be installed, so the agent can
-//! never exec itself into an update cycle).
+//! Two trigger paths feed the same download-verify-swap pipeline, and they
+//! rest on **different trust models** — reason about them separately:
+//!
+//! - **Gateway-push** ([`UpdatePayload::from_wire`]): the gateway supplies
+//!   both the URL and the sha256, and the CDN only supplies the bytes. A
+//!   compromised CDN can't serve a payload the gateway hasn't sanctioned —
+//!   the checksum is an independent integrity root.
+//! - **Manual/recovery** ([`resolve_latest`]): the CDN is the sole authority
+//!   — the `.sha256` sidecar is fetched from the same origin as the binary,
+//!   so verification only adds TLS-transport + corruption integrity beyond
+//!   what HTTPS already provides. The trust model is equivalent to
+//!   `curl https://cdn/... | sh` from that origin. Acceptable for a
+//!   recovery/bootstrap path that the operator invokes deliberately; the
+//!   gateway path remains the authoritative rollout mechanism.
+//!
+//! Common to both: the `--version` probe of the downloaded binary is the
+//! loop-breaker — a mis-registered release whose binary reports the wrong
+//! version can never be installed, so the agent can never exec itself into
+//! an update cycle.
 //!
 //! Self-update only manages binaries it owns: the running executable must be
 //! the managed path (`<data_dir>/bin/arcbox-fleet-agent`, where
@@ -160,9 +173,15 @@ async fn apply(config: &AgentConfig, payload: &UpdatePayload) -> Result<PathBuf>
     let staged = download_verified(config, payload).await?;
     probe_version(&staged, &payload.expected_version).await?;
 
-    // Two renames, not a copy: the running image keeps its (now unlinked
-    // via .prev) inode, and the managed path atomically becomes the new
-    // binary — there is no instant where the path is missing or truncated.
+    // Two same-directory renames, not a copy: the running image keeps its
+    // (now unlinked via .prev) inode, and the managed path becomes the new
+    // binary. A single-syscall atomic swap would eliminate the transient
+    // absence between the two renames, but macOS's `renamex_np` and Linux's
+    // `renameat2` diverge enough that going through them is not worth the
+    // portability tax for a window that only opens on same-fs `rename(2)`
+    // failure — effectively ENOSPC/EIO. Recovery from a failed second
+    // rename is `quick install-service` (or manually moving `.prev` back
+    // into place); the caller sees the propagated error.
     let previous = managed.with_file_name(PREVIOUS_SUFFIX);
     tokio::fs::rename(&managed, &previous)
         .await

--- a/fleet/arcbox-fleet-agent/src/update.rs
+++ b/fleet/arcbox-fleet-agent/src/update.rs
@@ -67,6 +67,70 @@ pub fn managed_binary(config: &AgentConfig) -> PathBuf {
     config.data_dir.join("bin").join("arcbox-fleet-agent")
 }
 
+/// Root of the release CDN's fleet-agent layout. The manual self-update
+/// path (`quick self-update`) resolves versions and asset URLs here, in
+/// lockstep with the publish pipeline (see `.github/workflows/
+/// release-fleet-agent.yml`). Gateway-pushed updates use the URL the
+/// gateway sends and don't depend on this constant.
+const CDN_FLEET_AGENT_BASE: &str = "https://release.arcboxcdn.com/runner/fleet-agent";
+
+/// Resolve the latest published version from the CDN and build the
+/// corresponding [`UpdatePayload`] for this host's platform. Two client →
+/// CDN contracts are pinned here: `latest.json`'s `{"version": "vX.Y.Z"}`
+/// schema, and the `arcbox-fleet-agent-<os>-<arch>` asset layout with a
+/// `<hex>  <name>` `.sha256` sidecar. Kept narrow: this is the
+/// recovery/bootstrap path — gateway pushes remain the authoritative
+/// rollout mechanism.
+pub async fn resolve_latest(host_os: &str, host_arch: &str) -> Result<UpdatePayload> {
+    #[derive(serde::Deserialize)]
+    struct Latest {
+        version: String,
+    }
+
+    let latest_url = format!("{CDN_FLEET_AGENT_BASE}/latest.json");
+    let latest_body = reqwest::get(&latest_url)
+        .await
+        .and_then(reqwest::Response::error_for_status)
+        .with_context(|| format!("fetching {latest_url}"))?
+        .text()
+        .await
+        .with_context(|| format!("reading body of {latest_url}"))?;
+    let latest: Latest = serde_json::from_str(&latest_body)
+        .with_context(|| format!("parsing {latest_url}"))?;
+
+    let asset_name = format!("arcbox-fleet-agent-{host_os}-{host_arch}");
+    let binary_url = format!("{CDN_FLEET_AGENT_BASE}/{}/{asset_name}", latest.version);
+    let sha_url = format!("{binary_url}.sha256");
+    let sha_body = reqwest::get(&sha_url)
+        .await
+        .and_then(reqwest::Response::error_for_status)
+        .with_context(|| format!("fetching {sha_url}"))?
+        .text()
+        .await
+        .with_context(|| format!("reading body of {sha_url}"))?;
+    // `shasum -a 256`-style sidecar: `<hex>  <name>`, hash first.
+    let binary_sha256 = sha_body
+        .split_whitespace()
+        .next()
+        .with_context(|| format!("empty sha256 sidecar at {sha_url}"))?
+        .to_owned();
+
+    // `latest.json`'s `version` carries the `v` prefix (the tag minus
+    // `fleet-agent-`); `--version` output is bare `CARGO_PKG_VERSION`, and
+    // `probe_version` compares the two directly.
+    let expected_version = latest
+        .version
+        .strip_prefix('v')
+        .unwrap_or(&latest.version)
+        .to_owned();
+
+    Ok(UpdatePayload {
+        expected_version,
+        binary_url,
+        binary_sha256,
+    })
+}
+
 /// Download, verify, probe, and swap `payload` into the managed path, then
 /// re-exec it with this process's arguments. Returns only on failure; on
 /// success the process image is replaced (same PID, so launchd's job

--- a/fleet/arcbox-fleet-agent/src/update.rs
+++ b/fleet/arcbox-fleet-agent/src/update.rs
@@ -95,8 +95,8 @@ pub async fn resolve_latest(host_os: &str, host_arch: &str) -> Result<UpdatePayl
         .text()
         .await
         .with_context(|| format!("reading body of {latest_url}"))?;
-    let latest: Latest = serde_json::from_str(&latest_body)
-        .with_context(|| format!("parsing {latest_url}"))?;
+    let latest: Latest =
+        serde_json::from_str(&latest_body).with_context(|| format!("parsing {latest_url}"))?;
 
     let asset_name = format!("arcbox-fleet-agent-{host_os}-{host_arch}");
     let binary_url = format!("{CDN_FLEET_AGENT_BASE}/{}/{asset_name}", latest.version);

--- a/fleet/arcbox-fleet-agent/src/update.rs
+++ b/fleet/arcbox-fleet-agent/src/update.rs
@@ -9,9 +9,9 @@
 //!
 //! Self-update only manages binaries it owns: the running executable must be
 //! the managed path (`<data_dir>/bin/arcbox-fleet-agent`, where
-//! `install-service` and the install script place it). A dev build or a
-//! hand-installed binary elsewhere parks on the expected version exactly as
-//! before self-update existed.
+//! `quick install-service` and the install script place it). A dev build or
+//! a hand-installed binary elsewhere parks on the expected version exactly
+//! as before self-update existed.
 
 use std::path::{Path, PathBuf};
 
@@ -62,7 +62,7 @@ pub struct UnmanagedBinary {
     managed: String,
 }
 
-/// The path `install-service` and the self-updater own.
+/// The path `quick install-service` and the self-updater own.
 pub fn managed_binary(config: &AgentConfig) -> PathBuf {
     config.data_dir.join("bin").join("arcbox-fleet-agent")
 }

--- a/fleet/arcbox-fleet-agent/src/vm.rs
+++ b/fleet/arcbox-fleet-agent/src/vm.rs
@@ -177,7 +177,17 @@ impl VmRunner {
         if spec.encoded_jit_config.contains('\'') {
             bail!("encoded JIT config contains a quote — not a base64 payload");
         }
+        let command = format!(
+            "{GUEST_RUNNER_SCRIPT} --jitconfig '{}'",
+            spec.encoded_jit_config
+        );
+        self.start_with_command(&spec, &command).await
+    }
 
+    /// [`start`](Self::start) with the guest command explicit, so the
+    /// daemon-backed integration test below can exercise the full
+    /// provision→ssh→exec→destroy cycle without a real runner invocation.
+    async fn start_with_command(&self, spec: &RunSpec<'_>, command: &str) -> Result<RunningVm> {
         let name = machine_name(spec.job_id);
         let mut client = self.client.clone();
 
@@ -213,13 +223,7 @@ impl VmRunner {
                 .await
                 .context("opening SSH session channel")?;
             channel
-                .exec(
-                    true,
-                    format!(
-                        "{GUEST_RUNNER_SCRIPT} --jitconfig '{}'",
-                        spec.encoded_jit_config
-                    ),
-                )
+                .exec(true, command)
                 .await
                 .context("starting the runner over SSH")?;
             info!(job_id = spec.job_id, guest = %name, ip, "runner started (vm)");
@@ -473,6 +477,32 @@ mod tests {
     fn stream_name_strips_pinned_version() {
         assert_eq!(stream_name("tahoe-base"), "tahoe-base");
         assert_eq!(stream_name("tahoe-base@2026.07.02"), "tahoe-base");
+    }
+
+    /// Full provision→ssh→exec→destroy cycle against a live daemon.
+    /// Requires `arcbox-daemon` running with the default image pulled
+    /// (`arcbox macos image pull tahoe-base`); run manually:
+    /// `cargo test -p arcbox-fleet-agent vm_round_trip -- --ignored`.
+    #[tokio::test]
+    #[ignore = "needs a live arcbox-daemon with the tahoe-base image installed"]
+    async fn vm_round_trip_boots_and_execs_over_ssh() {
+        let socket = arcbox_constants::paths::HostLayout::from_env_or_default().grpc_socket;
+        let runner = VmRunner::new(&socket, "tahoe-base")
+            .await
+            .expect("daemon probe");
+        let mut running = runner
+            .start_with_command(
+                &RunSpec {
+                    job_id: "itest",
+                    encoded_jit_config: "",
+                    runner_image: "tahoe-base",
+                },
+                "/usr/bin/true",
+            )
+            .await
+            .expect("provision guest and exec");
+        assert_eq!(running.wait().await, Some(0));
+        running.destroy().await;
     }
 
     #[test]

--- a/fleet/arcbox-fleet-agent/src/vm.rs
+++ b/fleet/arcbox-fleet-agent/src/vm.rs
@@ -144,6 +144,26 @@ impl VmRunner {
         remove_vm(&mut client, &machine_name(job_id)).await;
     }
 
+    /// Pull `reference` through the daemon, returning its progress stream
+    /// (terminal event: stage `"done"`). `FleetImageService.Prepare` drives
+    /// this to converge `macos_runner_image` onto its target; a pull the
+    /// daemon already has registered completes immediately, so
+    /// re-preparation is cheap when nothing changed.
+    pub async fn pull(
+        &self,
+        reference: &str,
+    ) -> Result<tonic::Streaming<arcbox_protocol::v1::MacosImagePullEvent>> {
+        let mut client = self.client.clone();
+        let stream = client
+            .image_pull(arcbox_protocol::v1::MacosImagePullRequest {
+                reference: reference.to_owned(),
+                manifest_url: String::new(),
+            })
+            .await
+            .with_context(|| format!("pulling macOS image '{reference}' through the daemon"))?;
+        Ok(stream.into_inner())
+    }
+
     /// Provision a guest for `spec` and start the runner in it, returning a
     /// handle to await. Returning `Ok` means the runner command has been
     /// issued over SSH — the caller can then accept the offer. Any failure

--- a/fleet/arcbox-fleet-agent/src/vm.rs
+++ b/fleet/arcbox-fleet-agent/src/vm.rs
@@ -1,0 +1,470 @@
+//! macOS VM-based execution of darwin runner jobs.
+//!
+//! Each accepted darwin job boots a disposable macOS guest through the local
+//! `arcbox-daemon` (its `MacosService` gRPC on the daemon socket), then runs
+//! the Actions runner **baked into the base image** over SSH:
+//!
+//! 1. copy-on-write clone + boot (`Create`/`Start` — the daemon enforces the
+//!    two-guests-per-host Apple license cap, so a `Start` failure is an
+//!    admission signal, not a fault),
+//! 2. resolve the guest address (`Inspect` reports its DHCP lease),
+//! 3. `ssh admin@guest run.sh --jitconfig …` — the session's exit is the
+//!    job's completion,
+//! 4. `Remove(force)` — destroying the guest is teardown *and* cancellation;
+//!    there is no in-guest process management.
+//!
+//! The guest contract is the ArcBox macOS runner image
+//! (`macos-runner-image-builder`): runner preinstalled at
+//! [`GUEST_RUNNER_SCRIPT`], SSH login `admin`/`admin` — a deliberate,
+//! documented choice for disposable CI guests, which are reachable only from
+//! their own host over vmnet NAT. Password auth is why SSH goes through
+//! `russh` rather than the OpenSSH binary (which cannot take a password
+//! non-interactively).
+
+use std::path::Path;
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::{Context, Result, bail};
+use arcbox_grpc::MacosServiceClient;
+use arcbox_protocol::v1::{
+    CreateMacosMachineRequest, Empty, InspectMacosMachineRequest, MacosImageSummary,
+    RemoveMacosMachineRequest, StartMacosMachineRequest,
+};
+use russh::client::{Config as SshConfig, Handle as SshHandle};
+use russh::{ChannelMsg, Disconnect};
+use tonic::transport::Channel;
+use tracing::{debug, info, warn};
+
+use crate::host;
+
+/// Guest login and runner location — the ArcBox macOS runner image contract
+/// (see the module doc).
+const GUEST_SSH_USER: &str = "admin";
+const GUEST_SSH_PASSWORD: &str = "admin";
+const GUEST_RUNNER_SCRIPT: &str = "/Users/admin/actions-runner/run.sh";
+const SSH_PORT: u16 = 22;
+
+/// Budget for a freshly started guest to acquire its DHCP lease and answer
+/// SSH. First boots take minutes; the DHCP lease appears well before
+/// login-dependent services, so one budget spans both waits.
+const GUEST_READY_BUDGET: Duration = Duration::from_secs(300);
+const READY_POLL_INTERVAL: Duration = Duration::from_secs(2);
+
+/// Deterministic per-job guest name, so redeliveries and interrupted
+/// startups can always find (and remove) whatever an earlier attempt
+/// created — and a crashed agent's leftovers are recognizable at startup.
+fn machine_name(job_id: &str) -> String {
+    format!("fleet-{job_id}")
+}
+
+/// Everything the VM runner needs to execute one job.
+pub struct RunSpec<'a> {
+    /// Job identifier, used as the guest name suffix.
+    pub job_id: &'a str,
+    /// Base64-encoded JIT runner config, passed through to `run.sh`.
+    pub encoded_jit_config: &'a str,
+    /// Base image the guest boots from — the live-settable
+    /// `macos_runner_image`, read fresh by the caller for each job.
+    pub runner_image: &'a str,
+}
+
+/// The stream part of an image reference: `"tahoe-base@2026.07.02"` →
+/// `"tahoe-base"`. Installed images are registered under their stream name.
+fn stream_name(reference: &str) -> &str {
+    reference.split_once('@').map_or(reference, |(s, _)| s)
+}
+
+/// Runs darwin jobs in disposable macOS guests via the local arcbox-daemon.
+#[derive(Clone)]
+pub struct VmRunner {
+    client: MacosServiceClient<Channel>,
+}
+
+impl VmRunner {
+    /// Connect to the daemon socket and prove it can serve VM jobs: its
+    /// `MacosService` must answer, and `default_image` must be installed.
+    /// Also sweeps `fleet-*` guests left behind by a crashed agent.
+    ///
+    /// `default_image` is a readiness parameter, not stored: live jobs use
+    /// whatever `macos_runner_image` is current at dispatch time
+    /// ([`RunSpec::runner_image`]).
+    pub async fn new(daemon_socket: &Path, default_image: &str) -> Result<Self> {
+        let channel = crate::control::client::connect(daemon_socket).await?;
+        let mut client = MacosServiceClient::new(channel);
+
+        // One call proves the daemon is up *and* speaks MacosService (an
+        // older daemon without it answers Unimplemented), and provides the
+        // installed-image check.
+        let images = client
+            .image_list(Empty {})
+            .await
+            .context("daemon does not serve macOS guests (MacosService.ImageList failed)")?
+            .into_inner()
+            .images;
+        if !images.iter().any(|i| i.name == stream_name(default_image)) {
+            bail!(
+                "macOS runner image '{default_image}' is not installed in the daemon — \
+                 run `arcbox-fleet-agent prepare macos-runner-image` (or `arcbox macos \
+                 image pull {default_image}`) first"
+            );
+        }
+
+        let runner = Self { client };
+        runner.sweep_leftovers().await;
+        info!(image = default_image, "macOS VM backend available");
+        Ok(runner)
+    }
+
+    /// Force-remove every `fleet-*` guest. Only this agent creates such
+    /// names (the control socket is a per-host singleton), so anything
+    /// matching is an orphan from a previous process.
+    async fn sweep_leftovers(&self) {
+        let mut client = self.client.clone();
+        let machines = match client.list(Empty {}).await {
+            Ok(response) => response.into_inner().machines,
+            Err(e) => {
+                warn!(error = %e, "listing leftover fleet guests failed");
+                return;
+            }
+        };
+        for machine in machines {
+            if machine.name.starts_with("fleet-") {
+                warn!(name = %machine.name, "removing leftover fleet guest");
+                remove_vm(&mut client, &machine.name).await;
+            }
+        }
+    }
+
+    /// Force-remove the guest named for `job_id`, if any — awaited and
+    /// idempotent. Remove-before-bind ahead of a create, and the cleanup
+    /// when cancellation interrupts [`start`](Self::start) mid-flight.
+    pub async fn remove_job_vm(&self, job_id: &str) {
+        let mut client = self.client.clone();
+        remove_vm(&mut client, &machine_name(job_id)).await;
+    }
+
+    /// Provision a guest for `spec` and start the runner in it, returning a
+    /// handle to await. Returning `Ok` means the runner command has been
+    /// issued over SSH — the caller can then accept the offer. Any failure
+    /// up to there is an error so the caller rejects and the platform
+    /// re-offers (a `Start` refused by the daemon's two-guest cap lands
+    /// here too). On error nothing is left behind; on a dropped future the
+    /// caller owns cleanup via [`Self::remove_job_vm`] (the returned
+    /// handle's guard covers only post-return panics).
+    pub async fn start(&self, spec: RunSpec<'_>) -> Result<RunningVm> {
+        // Base64 is shell-quote-safe; anything else never reaches the guest.
+        if spec.encoded_jit_config.contains('\'') {
+            bail!("encoded JIT config contains a quote — not a base64 payload");
+        }
+
+        let name = machine_name(spec.job_id);
+        let mut client = self.client.clone();
+
+        // The name is deterministic per job, so a redelivery after a crash
+        // that left an orphan would otherwise collide on create.
+        remove_vm(&mut client, &name).await;
+
+        let image = self.installed_image(spec.runner_image).await?;
+        let (cpus, memory_mib) = guest_size(&image, host::cpu_cores(), host::mem_mib());
+        client
+            .create(CreateMacosMachineRequest {
+                name: name.clone(),
+                image: image.name.clone(),
+                cpus,
+                memory_mib,
+            })
+            .await
+            .context("creating macOS guest")?;
+
+        // Everything from here on owns a guest; tear it down on any error.
+        let provisioned = async {
+            client
+                .start(StartMacosMachineRequest { name: name.clone() })
+                .await
+                .context("starting macOS guest (a two-guest license-cap refusal lands here)")?;
+
+            let deadline = tokio::time::Instant::now() + GUEST_READY_BUDGET;
+            let ip = self.await_ip(&name, deadline).await?;
+            let ssh = connect_ssh(&ip, deadline).await?;
+
+            let channel = ssh
+                .channel_open_session()
+                .await
+                .context("opening SSH session channel")?;
+            channel
+                .exec(
+                    true,
+                    format!(
+                        "{GUEST_RUNNER_SCRIPT} --jitconfig '{}'",
+                        spec.encoded_jit_config
+                    ),
+                )
+                .await
+                .context("starting the runner over SSH")?;
+            info!(job_id = spec.job_id, guest = %name, ip, "runner started (vm)");
+            Ok(RunningVm {
+                client: client.clone(),
+                guard: VmGuard::new(client.clone(), name.clone()),
+                name: name.clone(),
+                ssh,
+                channel,
+            })
+        }
+        .await;
+
+        if provisioned.is_err() {
+            remove_vm(&mut client, &name).await;
+        }
+        provisioned
+    }
+
+    /// The installed image `reference` resolves to, with its manifest
+    /// minimums. Not being installed is a per-job failure (reject), not a
+    /// backend fault: the image may have been removed since the probe.
+    async fn installed_image(&self, reference: &str) -> Result<MacosImageSummary> {
+        let mut client = self.client.clone();
+        let images = client
+            .image_list(Empty {})
+            .await
+            .context("listing daemon macOS images")?
+            .into_inner()
+            .images;
+        images
+            .into_iter()
+            .find(|i| i.name == stream_name(reference))
+            .with_context(|| format!("macOS runner image '{reference}' is not installed"))
+    }
+
+    /// Poll `Inspect` until the guest reports its DHCP-lease address.
+    async fn await_ip(&self, name: &str, deadline: tokio::time::Instant) -> Result<String> {
+        let mut client = self.client.clone();
+        loop {
+            let info = client
+                .inspect(InspectMacosMachineRequest {
+                    name: name.to_owned(),
+                })
+                .await
+                .context("inspecting macOS guest")?
+                .into_inner();
+            if !info.ip_address.is_empty() {
+                return Ok(info.ip_address);
+            }
+            if info.state == "stopped" {
+                bail!("macOS guest stopped before acquiring an address");
+            }
+            if tokio::time::Instant::now() >= deadline {
+                bail!(
+                    "macOS guest did not acquire an address within {}s",
+                    GUEST_READY_BUDGET.as_secs()
+                );
+            }
+            tokio::time::sleep(READY_POLL_INTERVAL).await;
+        }
+    }
+}
+
+/// Guest sizing: all host cores (VZ time-shares them), half the host's
+/// memory (at most two guests run concurrently), floored to the image
+/// manifest's minimums.
+fn guest_size(image: &MacosImageSummary, host_cores: u32, host_mem_mib: u64) -> (u32, u64) {
+    let cpus = host_cores.max(u32::try_from(image.minimum_cpu_count).unwrap_or(u32::MAX));
+    let memory_mib = (host_mem_mib / 2).max(image.minimum_memory_mib);
+    (cpus, memory_mib)
+}
+
+/// Retry SSH connect+auth until the guest's sshd answers or the deadline
+/// passes. A booting guest refuses connections long after it has an
+/// address, so failures here are the wait, not errors.
+async fn connect_ssh(ip: &str, deadline: tokio::time::Instant) -> Result<SshHandle<SshClient>> {
+    let config = Arc::new(SshConfig {
+        // Long-idle sessions are normal (a quiet job step); keepalives
+        // detect a wedged guest instead of an inactivity timeout killing
+        // healthy sessions.
+        keepalive_interval: Some(Duration::from_secs(15)),
+        ..SshConfig::default()
+    });
+    loop {
+        match try_ssh(Arc::clone(&config), ip).await {
+            Ok(handle) => return Ok(handle),
+            Err(e) => {
+                if tokio::time::Instant::now() >= deadline {
+                    return Err(e).context(format!(
+                        "guest sshd did not answer within {}s",
+                        GUEST_READY_BUDGET.as_secs()
+                    ));
+                }
+                debug!(ip, error = %e, "guest ssh not ready; retrying");
+                tokio::time::sleep(READY_POLL_INTERVAL).await;
+            }
+        }
+    }
+}
+
+async fn try_ssh(config: Arc<SshConfig>, ip: &str) -> Result<SshHandle<SshClient>> {
+    let mut handle = russh::client::connect(config, (ip, SSH_PORT), SshClient)
+        .await
+        .context("ssh connect")?;
+    let auth = handle
+        .authenticate_password(GUEST_SSH_USER, GUEST_SSH_PASSWORD)
+        .await
+        .context("ssh auth")?;
+    if !auth.success() {
+        bail!("guest rejected the image-contract ssh credentials");
+    }
+    Ok(handle)
+}
+
+/// Accepts any host key: each guest is freshly cloned (its host keys are
+/// meaningless), and the connection never leaves this host's vmnet NAT.
+struct SshClient;
+
+impl russh::client::Handler for SshClient {
+    type Error = russh::Error;
+
+    async fn check_server_key(
+        &mut self,
+        _server_public_key: &russh::keys::ssh_key::PublicKey,
+    ) -> Result<bool, Self::Error> {
+        Ok(true)
+    }
+}
+
+/// A guest whose runner has been started. Held by the caller while the job
+/// runs: [`wait`](Self::wait) observes the runner's exit, then
+/// [`destroy`](Self::destroy) tears the guest down — awaited, so the
+/// caller's bookkeeping settles only after the guest is actually gone. The
+/// embedded [`VmGuard`] is a panic safety net, not the teardown path.
+pub struct RunningVm {
+    client: MacosServiceClient<Channel>,
+    guard: VmGuard,
+    name: String,
+    ssh: SshHandle<SshClient>,
+    channel: russh::Channel<russh::client::Msg>,
+}
+
+impl RunningVm {
+    /// Block until the runner command exits and return its exit status, if
+    /// the guest reported one before the session closed. No cleanup —
+    /// follow with [`destroy`](Self::destroy). The agent reports no outcome
+    /// upstream (the GitHub webhook is authoritative); the code is for
+    /// logging.
+    pub async fn wait(&mut self) -> Option<u32> {
+        let mut code = None;
+        while let Some(msg) = self.channel.wait().await {
+            match msg {
+                // Runner output stays in the disposable guest; nothing to
+                // collect here.
+                ChannelMsg::Data { .. } | ChannelMsg::ExtendedData { .. } => {}
+                ChannelMsg::ExitStatus { exit_status } => code = Some(exit_status),
+                _ => {}
+            }
+        }
+        code
+    }
+
+    /// Destroy the guest, awaited — the completion, cancellation, and
+    /// shutdown teardown alike (removing the VM kills the runner and every
+    /// process in it). Once this returns the guest is gone, or its removal
+    /// failed loudly in the log.
+    pub async fn destroy(self) {
+        let Self {
+            mut client,
+            guard,
+            name,
+            ssh,
+            channel,
+        } = self;
+        guard.defuse();
+        drop(channel);
+        let _ = ssh.disconnect(Disconnect::ByApplication, "", "en").await;
+        remove_vm(&mut client, &name).await;
+    }
+}
+
+/// Force-remove a guest, awaited and idempotent: "not found" is the normal
+/// no-leftover case, anything else is logged — the job itself already
+/// concluded, so removal failures must not fail the caller.
+async fn remove_vm(client: &mut MacosServiceClient<Channel>, name: &str) {
+    let request = RemoveMacosMachineRequest {
+        name: name.to_owned(),
+        force: true,
+    };
+    match client.remove(request).await {
+        Ok(_) => {}
+        Err(status) if status.code() == tonic::Code::NotFound => {}
+        // The daemon maps not-found to Internal today; match on message
+        // until it grows structured codes.
+        Err(status) if status.message().contains("not found") => {}
+        Err(status) => warn!(guest = name, error = %status, "failed to remove macOS guest"),
+    }
+}
+
+/// Removes the guest on drop — the panic safety net. Every deliberate exit
+/// ([`RunningVm::destroy`]) defuses the guard and awaits the teardown
+/// itself; this drop path only fires when the runner task dies without
+/// reaching one. The spawned cleanup is fire-and-forget by necessity (drop
+/// cannot await); it must never be the path a correctness guarantee rides
+/// on.
+struct VmGuard {
+    client: MacosServiceClient<Channel>,
+    name: String,
+    defused: bool,
+}
+
+impl VmGuard {
+    fn new(client: MacosServiceClient<Channel>, name: String) -> Self {
+        Self {
+            client,
+            name,
+            defused: false,
+        }
+    }
+
+    /// Disarm the guard after normal completion.
+    fn defuse(mut self) {
+        self.defused = true;
+    }
+}
+
+impl Drop for VmGuard {
+    fn drop(&mut self) {
+        if self.defused {
+            return;
+        }
+        let mut client = self.client.clone();
+        let name = std::mem::take(&mut self.name);
+        tokio::spawn(async move {
+            remove_vm(&mut client, &name).await;
+        });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn machine_names_are_deterministic_and_prefixed() {
+        assert_eq!(machine_name("rjob_abc"), "fleet-rjob_abc");
+    }
+
+    #[test]
+    fn stream_name_strips_pinned_version() {
+        assert_eq!(stream_name("tahoe-base"), "tahoe-base");
+        assert_eq!(stream_name("tahoe-base@2026.07.02"), "tahoe-base");
+    }
+
+    #[test]
+    fn guest_size_floors_to_image_minimums() {
+        let image = MacosImageSummary {
+            minimum_cpu_count: 2,
+            minimum_memory_mib: 4096,
+            ..Default::default()
+        };
+        // Big host: all cores, half the memory.
+        assert_eq!(guest_size(&image, 12, 49152), (12, 24576));
+        // Tiny host: the image minimums win.
+        assert_eq!(guest_size(&image, 1, 4096), (2, 4096));
+    }
+}

--- a/fleet/arcbox-fleet-agent/tests/control.rs
+++ b/fleet/arcbox-fleet-agent/tests/control.rs
@@ -261,7 +261,15 @@ async fn unenrolled_agent_reports_status_and_rejects_drain() {
     while let Some(event) = prepare.message().await.expect("prepare stream") {
         stages.push(event.stage);
     }
-    assert_eq!(stages, ["skipped", "promoted"]);
+    // Empty kinds expand to every kind this host supports — the Linux image
+    // everywhere, plus the macOS image on macOS hosts. With neither runtime
+    // configured each kind is skipped and promoted.
+    let expected: &[&str] = if cfg!(target_os = "macos") {
+        &["skipped", "promoted", "skipped", "promoted"]
+    } else {
+        &["skipped", "promoted"]
+    };
+    assert_eq!(stages, expected);
 
     let prepared = settings_client
         .get_settings(GetSettingsRequest {})

--- a/fleet/arcbox-fleet-control-proto/proto/arcbox/fleet/control/v1/control.proto
+++ b/fleet/arcbox-fleet-control-proto/proto/arcbox/fleet/control/v1/control.proto
@@ -129,6 +129,10 @@ enum Enrollment {
   // credential on disk until an explicit Unenroll, so a server-side auth
   // regression can never make agents wipe their own credentials.
   ENROLLMENT_CREDENTIAL_REJECTED = 5;
+  // The gateway pinned a different agent build and pushed its download; the
+  // agent is draining in-flight jobs, then swaps its binary and re-execs.
+  // Transient: the replacement process reports Attaching → Attached.
+  ENROLLMENT_UPDATING = 6;
 }
 
 // What execution backend serves a capability. Deliberately redefined here

--- a/fleet/arcbox-fleet-control-proto/proto/arcbox/fleet/control/v1/control.proto
+++ b/fleet/arcbox-fleet-control-proto/proto/arcbox/fleet/control/v1/control.proto
@@ -206,6 +206,20 @@ enum DockerMode {
   DOCKER_MODE_DISABLED = 3;
 }
 
+// Whether darwin jobs run in disposable macOS VMs provisioned through the
+// local arcbox-daemon (isolation), instead of the pre-installed host
+// runner. Restart-scoped, like DockerMode.
+enum VmMode {
+  VM_MODE_UNSPECIFIED = 0;
+  // Probe the daemon at startup; fall back to the host runner if the
+  // daemon is unreachable or the macOS runner image is not installed.
+  VM_MODE_AUTO = 1;
+  // Require the daemon; fail startup if it cannot serve VMs.
+  VM_MODE_ENABLED = 2;
+  // Never run darwin jobs in VMs, even if the daemon could.
+  VM_MODE_DISABLED = 3;
+}
+
 // A client only ever writes `target`; `current` is engine-observed and
 // only changes because the engine itself reports a new value. Rejected
 // with INVALID_ARGUMENT as a whole (no partial apply) if the resulting
@@ -232,6 +246,10 @@ message UpdateSettingsRequest {
   // actually completes. This is deliberately the one lifecycle-touching
   // setting (see FleetSettingsService's doc).
   optional bool participate = 7;
+  // macOS base-image stream for darwin VM jobs. Writes `target` only —
+  // FleetImageService.Prepare pulls it through the daemon and promotes.
+  optional string macos_runner_image = 8;
+  optional VmMode vm_mode = 9;
 }
 
 // Reused across every setting regardless of type, so a client's rendering
@@ -253,6 +271,10 @@ message DockerModeSetting {
   DockerMode current = 1;
   DockerMode target = 2;
 }
+message VmModeSetting {
+  VmMode current = 1;
+  VmMode target = 2;
+}
 message BoolSetting {
   bool current = 1;
   bool target = 2;
@@ -270,6 +292,11 @@ message AgentSettings {
   DockerModeSetting docker_mode = 5;
   StringSetting runner_script = 6;
   BoolSetting participate = 7;
+  // macOS base-image stream darwin VM jobs boot from (e.g. "tahoe-base",
+  // optionally pinned: "tahoe-base@2026.07.02"). Same target/current
+  // semantics as linux_runner_image; prepared through the daemon.
+  StringSetting macos_runner_image = 8;
+  VmModeSetting vm_mode = 9;
 }
 
 // Long-running image preparation, split out of FleetSettingsService so
@@ -286,13 +313,15 @@ service FleetImageService {
 }
 
 // Which image setting a Prepare call (or event) concerns. One value per
-// preparable image setting; the macOS image kind arrives with the VM
-// backend.
+// preparable image setting.
 enum ImageKind {
   IMAGE_KIND_UNSPECIFIED = 0;
   // `linux_runner_image`, prepared by pulling it for every
   // currently-advertised Docker-served Linux arch.
   IMAGE_KIND_LINUX_RUNNER_IMAGE = 1;
+  // `macos_runner_image`, prepared by pulling it through the local
+  // arcbox-daemon's MacosService.ImagePull.
+  IMAGE_KIND_MACOS_RUNNER_IMAGE = 2;
 }
 
 message PrepareRequest {

--- a/fleet/arcbox-fleet-proto/buf.yaml
+++ b/fleet/arcbox-fleet-proto/buf.yaml
@@ -3,5 +3,9 @@
 # copy from the registry with `make fleet-proto-sync`
 # (buf export buf.build/arcboxlabs/fleet -o proto).
 version: v2
+modules:
+  # Module root is proto/ so file paths (arcbox/fleet/v1/…) match the
+  # declared package name for buf lint's PACKAGE_DIRECTORY_MATCH rule.
+  - path: proto
 deps:
   - buf.build/arcboxlabs/fleet

--- a/fleet/arcbox-fleet-proto/proto/arcbox/fleet/v1/fleet.proto
+++ b/fleet/arcbox-fleet-proto/proto/arcbox/fleet/v1/fleet.proto
@@ -14,8 +14,9 @@ service FleetGatewayService {
   // credential in the `x-arcbox-machine-token` metadata key. The client's
   // first message must be `Attach`; the gateway replies with `AttachAccepted`
   // (steady state proceeds with Heartbeats) or `AgentUpdate` (build version
-  // mismatch — client logs the expected version, disconnects, does not
-  // reconnect on the same binary).
+  // mismatch — the client self-updates to the carried binary and re-attaches,
+  // or parks on the expected version when the payload has no URL; it never
+  // re-attaches on the same binary).
   // (Named Attach because tonic reserves `connect` on generated clients.)
   rpc Attach(stream AttachRequest) returns (stream AttachResponse);
 
@@ -47,8 +48,13 @@ message EnrollRequest {
   // Agent build version (semver, `CARGO_PKG_VERSION`). The gateway pins one
   // expected build at a time; a mismatch is answered with `AgentUpdate` in
   // place of `Enrolled`, so a mis-versioned agent fails at enrollment
-  // rather than joining and then being kicked at Attach.
+  // rather than joining and then being kicked at Attach. When the payload
+  // carries a `binary_url` the agent self-updates and retries enrollment
+  // on the new build (the enrollment token is multi-use).
   string agent_version = 8;
+  // The platform the agent binary runs on (`darwin` | `linux`, lowercase
+  // RunnerOs). Pairs with `host_arch` to select `AgentUpdate.binary_url`.
+  string host_os = 9;
 }
 
 message EnrollResponse {
@@ -71,17 +77,26 @@ message Enrolled {
 }
 
 // Server → client. "Your build isn't what I expect; here's what you should
-// be running." Fires from both `EnrollResponse.result.update_required` and
-// `AttachResponse.msg.attach_rejected`, so the client's update-handling code
-// lives in one place. Grows into the push-update payload without touching
-// the wire shape — future fields:
-//   string tarball_url = 2;
-//   string tarball_sha256 = 3;
+// be running — and where to get it." Fires from
+// `EnrollResponse.result.update_required`, `AttachResponse.msg.attach_rejected`,
+// `AttachAccepted.update`, and `HeartbeatAck.update`, so the client's
+// update-handling code lives in one place. A payload with a `binary_url`
+// drives the agent's self-update (download → verify → swap → re-exec); an
+// empty `binary_url` (gateway has no registered release for the platform)
+// makes the agent log the expected version and park for the operator.
 message AgentUpdate {
   // The build version the gateway expects. Empty when the gateway is
   // pre-versioning (should not happen in practice; kept nullable so the
   // client tolerates a stub server).
   string expected_version = 1;
+  // Download URL of the raw agent binary for the requesting machine's
+  // (host_os, host_arch). Resolved from the registered release for
+  // `expected_version`.
+  string binary_url = 2;
+  // Hex SHA-256 of the binary at `binary_url`. The agent verifies the
+  // download against this value — the gateway, not the download host, is
+  // the integrity root.
+  string binary_sha256 = 3;
 }
 
 // What execution backend serves a capability. Routing only — capacity is the
@@ -143,6 +158,14 @@ message Attach {
   // "constant for the process lifetime" reasoning as `capabilities` —
   // reported once here, not on every Heartbeat.
   string host_info_json = 3;
+  // The platform the agent binary itself runs on (`darwin` | `linux`,
+  // lowercase RunnerOs), as opposed to `capabilities`, which describe what
+  // the host can serve (a darwin host serves linux jobs via docker but
+  // still needs the darwin binary). Selects the `AgentUpdate.binary_url`.
+  string host_os = 4;
+  // The agent binary's CPU architecture (`arm64` | `amd64`, lowercase
+  // RunnerArch). Together with `host_os` this names the release asset.
+  string host_arch = 5;
 }
 
 // Live telemetry pulse. The only wire field that changes over time; sent
@@ -189,14 +212,21 @@ message AttachResponse {
 }
 
 // Marker for a successful Attach handshake. Empty today; kept as a distinct
-// message so future admit-time signals (fleet-scoped tunables, target
-// version hint, etc.) grow here without piggy-backing on HeartbeatAck.
+// message so future admit-time signals (fleet-scoped tunables, etc.) grow
+// here without piggy-backing on HeartbeatAck.
 message AttachAccepted {}
 
 // Server's ack for each heartbeat. Empty in steady state. Doubles as the
 // server→client keepalive on the stream so a proxy in front of the gateway
 // (e.g. Cloudflare) does not idle-cut the direction (PLAT-34).
-message HeartbeatAck {}
+message HeartbeatAck {
+  // Set when the pinned target version moved while this agent was attached.
+  // The agent drains (finishes in-flight jobs, takes no new offers), then
+  // self-updates and re-attaches with the new build. Attach itself still
+  // hard-gates on exact version — this field exists so already-connected
+  // agents converge gracefully instead of being evicted.
+  AgentUpdate update = 1;
+}
 
 // Tells the agent to stop resending an offer verdict
 // (RunnerAccepted/RunnerRejected): the gateway either durably handed it off to

--- a/fleet/arcbox-fleet-proto/proto/arcbox/fleet/v1/fleet.proto
+++ b/fleet/arcbox-fleet-proto/proto/arcbox/fleet/v1/fleet.proto
@@ -11,7 +11,11 @@ service FleetGatewayService {
   rpc Enroll(EnrollRequest) returns (EnrollResponse);
 
   // Long-lived bidirectional stream. Authenticated with the machine
-  // credential in the `x-arcbox-machine-token` metadata key.
+  // credential in the `x-arcbox-machine-token` metadata key. The client's
+  // first message must be `Attach`; the gateway replies with `AttachAccepted`
+  // (steady state proceeds with Heartbeats) or `AgentUpdate` (build version
+  // mismatch — client logs the expected version, disconnects, does not
+  // reconnect on the same binary).
   // (Named Attach because tonic reserves `connect` on generated clients.)
   rpc Attach(stream AttachRequest) returns (stream AttachResponse);
 
@@ -40,16 +44,44 @@ message EnrollRequest {
   repeated Capability capabilities = 6;
   // Free-form host facts as JSON (macOS version, chip, ...).
   string host_info_json = 7;
-  // Wire-protocol version the agent speaks; the gateway rejects unsupported.
-  uint32 protocol_version = 8;
+  // Agent build version (semver, `CARGO_PKG_VERSION`). The gateway pins one
+  // expected build at a time; a mismatch is answered with `AgentUpdate` in
+  // place of `Enrolled`, so a mis-versioned agent fails at enrollment
+  // rather than joining and then being kicked at Attach.
+  string agent_version = 8;
 }
 
 message EnrollResponse {
+  oneof result {
+    // Enrollment succeeded — machine credential minted.
+    Enrolled enrolled = 1;
+    // Enrollment refused because the agent's build doesn't match the
+    // expected version. Client should surface the expected version to the
+    // operator and exit non-zero.
+    AgentUpdate update_required = 2;
+  }
+}
+
+message Enrolled {
   // Prefixed machine id (`fltm_...`).
   string machine_id = 1;
   // Long-lived machine credential; transmitted exactly once, only its
   // hash is stored server-side.
   string machine_token = 2;
+}
+
+// Server → client. "Your build isn't what I expect; here's what you should
+// be running." Fires from both `EnrollResponse.result.update_required` and
+// `AttachResponse.msg.attach_rejected`, so the client's update-handling code
+// lives in one place. Grows into the push-update payload without touching
+// the wire shape — future fields:
+//   string tarball_url = 2;
+//   string tarball_sha256 = 3;
+message AgentUpdate {
+  // The build version the gateway expects. Empty when the gateway is
+  // pre-versioning (should not happen in practice; kept nullable so the
+  // client tolerates a stub server).
+  string expected_version = 1;
 }
 
 // What execution backend serves a capability. Routing only — capacity is the
@@ -83,19 +115,41 @@ message HostTelemetry {
 
 message AttachRequest {
   oneof msg {
-    Heartbeat heartbeat = 1;
-    RunnerAccepted runner_accepted = 2;
-    RunnerRejected runner_rejected = 3;
+    // First message on the stream. Carries the client's build identity so
+    // the gateway can gate participation on version.
+    Attach attach = 1;
+    Heartbeat heartbeat = 2;
+    RunnerAccepted runner_accepted = 3;
+    RunnerRejected runner_rejected = 4;
   }
 }
 
-// Periodic capability + liveness report. The reported capability set is
-// declarative — it replaces what is stored, so losing a backend (e.g. Docker
-// dies) simply drops the capabilities it served.
+// First client-initiated message after stream open. Auth stays in gRPC
+// metadata (`x-arcbox-machine-token`); this message carries everything
+// about the connecting agent that is constant for the process lifetime —
+// the build identity the gateway gates on, and the declarative
+// (capability set, host facts) state the machine row should reflect
+// while this stream is live.
+message Attach {
+  // Agent build version (semver, `CARGO_PKG_VERSION`).
+  string agent_version = 1;
+  // What the host can serve, e.g. darwin/arm64 via vm + linux/arm64 via
+  // docker. Declarative — the gateway replaces the stored set on handshake
+  // and any subsequent reconnect refreshes it. Not resent on Heartbeat
+  // because backends are frozen at process start (docker_mode /
+  // runner_script only apply on a full restart).
+  repeated Capability capabilities = 2;
+  // Free-form host facts as JSON (macOS version, chip, ...). Same
+  // "constant for the process lifetime" reasoning as `capabilities` —
+  // reported once here, not on every Heartbeat.
+  string host_info_json = 3;
+}
+
+// Live telemetry pulse. The only wire field that changes over time; sent
+// every ~15s so the gateway (and any proxy in front of it) sees liveness
+// and the server has a fresh utilization snapshot for placement ranking.
 message Heartbeat {
-  repeated Capability capabilities = 1;
-  string host_info_json = 2;
-  HostTelemetry telemetry = 3;
+  HostTelemetry telemetry = 1;
 }
 
 // The agent admitted the offer and has started the runner. Echoes the offer
@@ -119,13 +173,30 @@ message RunnerRejected {
 
 message AttachResponse {
   oneof msg {
-    ProvisionRunner provision_runner = 1;
-    CancelRunner cancel = 2;
-    Drain drain = 3;
-    OfferVerdictAck offer_verdict_ack = 4;
-    Keepalive keepalive = 5;
+    // Handshake success — client proceeds to the heartbeat loop.
+    AttachAccepted attach_accepted = 1;
+    // Handshake refused because the agent's build doesn't match. Client
+    // logs the expected version and disconnects; no reconnect loop.
+    AgentUpdate attach_rejected = 2;
+    // Per-heartbeat ack. Empty today; grows into a push-update signal
+    // channel later without inventing a new variant.
+    HeartbeatAck heartbeat_ack = 3;
+    ProvisionRunner provision_runner = 4;
+    CancelRunner cancel = 5;
+    Drain drain = 6;
+    OfferVerdictAck offer_verdict_ack = 7;
   }
 }
+
+// Marker for a successful Attach handshake. Empty today; kept as a distinct
+// message so future admit-time signals (fleet-scoped tunables, target
+// version hint, etc.) grow here without piggy-backing on HeartbeatAck.
+message AttachAccepted {}
+
+// Server's ack for each heartbeat. Empty in steady state. Doubles as the
+// server→client keepalive on the stream so a proxy in front of the gateway
+// (e.g. Cloudflare) does not idle-cut the direction (PLAT-34).
+message HeartbeatAck {}
 
 // Tells the agent to stop resending an offer verdict
 // (RunnerAccepted/RunnerRejected): the gateway either durably handed it off to
@@ -159,9 +230,3 @@ message CancelRunner {
 
 // Stop accepting new work ahead of removal.
 message Drain {}
-
-// No-op the gateway sends back for every Heartbeat, riding the agent's own
-// cadence so a proxy in front of the gateway (e.g. Cloudflare) sees
-// server->client traffic and never idle-times-out the stream. The agent
-// ignores it.
-message Keepalive {}


### PR DESCRIPTION
Rebased onto master (#354 and #359 have landed). Bundles the RUN-31 macOS VM backend with the operational-readiness work needed to run the agent as a managed service.

## RUN-31 — macOS VM backend

The fleet agent runs each darwin job in a disposable macOS guest, consuming `arcbox-daemon` as a plain gRPC client over its existing socket. **No new daemon RPCs**: the design (settled after discussion, superseding the RUN-31 issue text) is SSH-exec — the runner is baked into the base image, the agent sshes in and runs `run.sh --jitconfig …`, the session's exit is job completion, and `Remove(force)` is teardown *and* cancellation.

- `vm_mode` (auto|enabled|disabled, restart-scoped) + `macos_runner_image` (target/current) settings across proto/config/state/CLI (`8f50e1eb`)
- `vm.rs`: daemon probe (ImageList + image installed + crashed-agent `fleet-*` sweep), Create → Start (the daemon's two-guest license cap is the admission signal) → Inspect-poll for the DHCP-lease address → russh password auth (`admin`/`admin`, the runner-image contract; guests are host-only reachable via vmnet NAT) → exec (`f8857a76`)
- Routing: vm capability replaces host_runner for darwin/arm64 when active; `run_vm_job` mirrors the Docker backend's cancellation discipline, plus a 6.5 h runtime watchdog; `vm-backend` GetAgentInfo feature flag (`4261fe1c`)
- `FleetImageService.Prepare` relays the daemon's `ImagePull` stream for `IMAGE_KIND_MACOS_RUNNER_IMAGE` and promotes on completion (`ba01a46d`)
- End-to-end ignored test against a live daemon (`62e76a62`)

## Gateway handshake & attachment

- Default gateway now `gateway.fleet.arcbox.dev` (`be7dbf5e`)
- Send the first heartbeat before waiting on `Attach`'s response — closes a startup race where the gateway's initial ack could arrive before the agent had told it anything (`b79b793c`)
- Handshake redesigned around `agent_version` (`7b85dd57`): `EnrollResponse` becomes a union of `Enrolled` / `UpdateRequired`, so a version-refused enrollment can carry the expected build's download URL back to the client. Client surfaces the expected version and — when a download is present — the self-update path picks it up.

## Self-update

- `install-service` / `uninstall-service` subcommands: install the invoking binary into the managed path (`<data_dir>/bin/arcbox-fleet-agent`), render a per-user LaunchAgent against it, and `launchctl bootstrap` it into the current GUI session (`21c3c508`)
- Sync self-update proto + report `host_os` alongside `host_arch` in Enroll/Attach so the gateway can pick the right platform tarball (`d25806d5`)
- Self-update executor + managed binary layout (`a793caad`): download → verify sha256 → atomically replace the managed binary → re-exec the current invocation. Wired into the enroll path so a refused enrollment self-heals before returning the error.
- `AttachResponse.update_available`: the running `serve` process drains in-flight jobs, self-updates, and re-execs `serve` on the new build (`1bd4a450`)

## Verification

- `cargo check --workspace` and clippy `-D warnings` on `arcbox-fleet-agent` are clean.
- Existing unit + control-socket integration tests pass; end-to-end VM round-trip runs against a live daemon with `tahoe-base@2026.07.02` (**provision → ssh exec → exit 0 → destroy in 9.7 s**, no leftover guests — `vm_round_trip_boots_and_execs_over_ssh`, ignored; needs a daemon + pulled image).

Closes RUN-31.