### PR TITLE
fix(vz): fix MTU override selector detection

### DIFF
--- a/virt/arcbox-vz/src/device/network.rs
+++ b/virt/arcbox-vz/src/device/network.rs
@@ -16,7 +16,7 @@ use std::os::unix::io::RawFd;
 /// This reduces frame count by ~2.7x vs the default 1500, directly reducing
 /// per-frame overhead through the entire datapath.
 /// The enhanced MTU value set on VZ network devices when the selector is
-/// available (macOS 14+). Exported so the VMM can pass it to the datapath.
+/// available (macOS 13+). Exported so the VMM can pass it to the datapath.
 pub const VZ_NETWORK_MTU: u64 = 4000;
 
 /// Configuration for a `VirtIO` network device.
@@ -104,10 +104,10 @@ impl NetworkDeviceConfiguration {
             msg_send_void!(obj, setAttachment: attachment);
 
             // Set MTU to reduce frame count through the datapath (~2.7x fewer
-            // frames vs default 1500). Available since macOS 14 (Sonoma).
+            // frames vs default 1500). Available since macOS 13 (Ventura).
             // On older macOS, the selector doesn't exist — we must check
             // respondsToSelector: to avoid an unrecognized-selector crash.
-            // Check if the VZ config class supports the MTU setter (macOS 14+).
+            // Check if the VZ config class supports the MTU setter (macOS 13+).
             // msg_send_bool! doesn't support Sel arguments, so we dispatch manually.
             let mtu_sel = objc2::sel!(setMaximumTransmissionUnit:);
             let responds: bool = {
@@ -120,19 +120,19 @@ impl NetworkDeviceConfiguration {
                     crate::ffi::runtime::objc_msgSend as *const std::ffi::c_void,
                 );
                 func(
-                    obj as *const _ as *const objc2::runtime::AnyObject,
+                    attachment as *const _ as *const objc2::runtime::AnyObject,
                     check_sel,
                     mtu_sel,
                 )
                 .as_bool()
             };
             let mtu = if responds {
-                msg_send_void_u64!(obj, setMaximumTransmissionUnit: VZ_NETWORK_MTU);
+                msg_send_void_u64!(attachment, setMaximumTransmissionUnit: VZ_NETWORK_MTU);
                 tracing::info!("VZ network MTU set to {VZ_NETWORK_MTU}");
                 VZ_NETWORK_MTU as usize
             } else {
                 tracing::info!(
-                    "VZ network MTU setter unavailable (macOS < 14), using default 1500"
+                    "VZ network MTU setter unavailable (macOS < 13), using default 1500"
                 );
                 1500
             };


### PR DESCRIPTION
VZFileHandleNetworkDeviceAttachment has maximumTransmissionUnit on macOS 13+. Probing VZVirtioNetworkDeviceConfiguration for this selector instead made supported hosts report the selector unavailable and fall back to 1500.

Probe and send setMaximumTransmissionUnit: on the attachment instead, and correct the availability text from macOS 14 to macOS 13.