### PR TITLE
feat(e2e): programmatic daemon harness — gRPC readiness, signing fixture, HV probe

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -452,8 +452,17 @@ name = "arcbox-e2e"
 version = "0.4.16"
 dependencies = [
  "anyhow",
+ "arcbox-core",
+ "arcbox-grpc",
+ "arcbox-protocol",
+ "arcbox-vmm",
+ "hyper-util",
+ "libc",
  "tempfile",
+ "tokio",
  "toml_edit 0.25.12+spec-1.1.0",
+ "tonic",
+ "tower 0.5.3",
  "tracing",
  "tracing-subscriber",
  "xshell",

--- a/app/arcbox-api/src/system.rs
+++ b/app/arcbox-api/src/system.rs
@@ -37,6 +37,7 @@ impl SetupState {
             vm_running: false,
             message: "Daemon starting...".to_string(),
             docker_tools_installed: false,
+            error: String::new(),
         };
         let (tx, _) = watch::channel(initial);
         Self { tx: Arc::new(tx) }
@@ -47,6 +48,17 @@ impl SetupState {
         self.tx.send_modify(|s| {
             s.phase = phase.into();
             message.clone_into(&mut s.message);
+        });
+    }
+
+    /// Marks startup as fatally failed. The daemon exits shortly after;
+    /// the error rides the final watch update so streaming clients learn
+    /// the cause instead of seeing a bare disconnect.
+    pub fn set_failed(&self, error: &str) {
+        self.tx.send_modify(|s| {
+            s.phase = setup_status::Phase::Failed.into();
+            "Daemon startup failed".clone_into(&mut s.message);
+            error.clone_into(&mut s.error);
         });
     }
 

--- a/app/arcbox-daemon/src/main.rs
+++ b/app/arcbox-daemon/src/main.rs
@@ -9,7 +9,10 @@ mod services;
 mod shutdown;
 mod startup;
 
+use std::sync::Arc;
+
 use anyhow::Result;
+use arcbox_api::SetupState;
 use arcbox_constants::paths::ArcboxProfile;
 use arcbox_logging::LogConfig;
 use clap::Parser;
@@ -118,7 +121,27 @@ fn sentry_environment() -> Option<String> {
 }
 
 async fn run(args: DaemonArgs) -> Result<()> {
-    let ready = startup::Startup::from_args(args)
+    let setup_state = Arc::new(SetupState::new());
+
+    let ready = match start(args, Arc::clone(&setup_state)).await {
+        Ok(ready) => ready,
+        Err(e) => {
+            // Publish the failure on the setup stream before exiting so a
+            // WatchSetupStatus client (desktop app, e2e harness) learns the
+            // cause instead of seeing a bare disconnect. The brief grace
+            // period lets already-connected streams flush the final event;
+            // with no clients it only delays the error exit.
+            setup_state.set_failed(&format!("{e:#}"));
+            tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+            return Err(e);
+        }
+    };
+
+    shutdown::run(ready.ctx, ready.handles).await
+}
+
+async fn start(args: DaemonArgs, setup_state: Arc<SetupState>) -> Result<startup::ReadyDaemon> {
+    startup::Startup::from_args(args, setup_state)
         .prepare_host()
         .await?
         .acquire_daemon_lease()
@@ -134,7 +157,5 @@ async fn run(args: DaemonArgs) -> Result<()> {
         .start_runtime_services()
         .await?
         .mark_ready()
-        .await?;
-
-    shutdown::run(ready.ctx, ready.handles).await
+        .await
 }

--- a/app/arcbox-daemon/src/startup/mod.rs
+++ b/app/arcbox-daemon/src/startup/mod.rs
@@ -8,7 +8,7 @@ mod resource_cleanup;
 
 pub use assets::find_bundle_contents;
 pub use lock::DaemonLock;
-pub use pipeline::Startup;
+pub use pipeline::{ReadyDaemon, Startup};
 
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -32,9 +32,7 @@ const DEFAULT_DNS_DOMAIN: &str = "arcbox.local";
 /// Returns an [`EarlyContext`] sufficient to start the gRPC
 /// SystemService so clients can observe the full startup progression.
 /// Call [`acquire_lock`] next to obtain a [`DaemonContext`].
-async fn init_early(args: DaemonArgs) -> Result<EarlyContext> {
-    let setup_state = Arc::new(SetupState::new());
-
+async fn init_early(args: DaemonArgs, setup_state: Arc<SetupState>) -> Result<EarlyContext> {
     let profile = args
         .profile
         .unwrap_or_else(ArcboxProfile::from_env_or_default);

--- a/app/arcbox-daemon/src/startup/pipeline.rs
+++ b/app/arcbox-daemon/src/startup/pipeline.rs
@@ -8,7 +8,7 @@ use std::sync::Arc;
 use std::time::Instant;
 
 use anyhow::Result;
-use arcbox_api::SetupPhase;
+use arcbox_api::{SetupPhase, SetupState};
 use arcbox_core::Runtime;
 use macos_resolver::FileResolver;
 use tracing::{info, warn};
@@ -21,6 +21,7 @@ use super::{acquire_lock, assets, init_early, init_runtime, prepare_assets, wait
 /// Entry point for the daemon startup lifecycle.
 pub struct Startup {
     args: DaemonArgs,
+    setup_state: Arc<SetupState>,
 }
 
 pub struct ReadyDaemon {
@@ -30,14 +31,18 @@ pub struct ReadyDaemon {
 
 impl Startup {
     /// Creates a startup pipeline from parsed daemon arguments.
-    pub fn from_args(args: DaemonArgs) -> Self {
-        Self { args }
+    ///
+    /// `setup_state` is owned by the caller so it can publish a FAILED
+    /// phase if any pipeline step errors out.
+    pub fn from_args(args: DaemonArgs, setup_state: Arc<SetupState>) -> Self {
+        Self { args, setup_state }
     }
 
     /// Prepares host directories and pre-lock context.
     pub async fn prepare_host(self) -> Result<HostPrepared> {
         info!("Starting ArcBox daemon...");
-        let early = record_startup_phase("prepare_host", init_early(self.args)).await?;
+        let early =
+            record_startup_phase("prepare_host", init_early(self.args, self.setup_state)).await?;
         Ok(HostPrepared { early })
     }
 }

--- a/docs/daemon-lifecycle.md
+++ b/docs/daemon-lifecycle.md
@@ -25,6 +25,12 @@ start_services    DNS, Docker API, Docker CLI integration     ~instant
 Ready             SetupPhase::Ready
 ```
 
+If any phase fails, the daemon publishes `SetupPhase::Failed` with the
+error text in `SetupStatus.error`, waits ~200 ms so connected
+`WatchSetupStatus` streams flush the final event, and exits non-zero.
+Clients should treat FAILED (or stream EOF plus daemon exit) as
+startup failure.
+
 ### Why gRPC starts before resource cleanup
 
 The desktop app polls the daemon's gRPC `WatchSetupStatus` stream with a

--- a/rpc/arcbox-protocol/proto/api.proto
+++ b/rpc/arcbox-protocol/proto/api.proto
@@ -598,6 +598,9 @@ message SetupStatus {
         DEGRADED = 7;
         DOWNLOADING_ASSETS = 8;
         CLEANING_UP = 9;
+        // Startup failed fatally; the daemon exits shortly after
+        // publishing this phase. See the `error` field for the cause.
+        FAILED = 10;
     }
 
     // Current daemon phase.
@@ -614,4 +617,8 @@ message SetupStatus {
     string message = 6;
     // Whether Docker CLI tools are installed.
     bool docker_tools_installed = 7;
+    // Fatal startup error description. Set only when phase == FAILED,
+    // so streaming clients learn the cause instead of seeing a bare
+    // disconnect when the daemon exits.
+    string error = 8;
 }

--- a/rpc/arcbox-protocol/src/generated/arcbox.v1.rs
+++ b/rpc/arcbox-protocol/src/generated/arcbox.v1.rs
@@ -2527,6 +2527,11 @@ pub struct SetupStatus {
     /// Whether Docker CLI tools are installed.
     #[prost(bool, tag = "7")]
     pub docker_tools_installed: bool,
+    /// Fatal startup error description. Set only when phase == FAILED,
+    /// so streaming clients learn the cause instead of seeing a bare
+    /// disconnect when the daemon exits.
+    #[prost(string, tag = "8")]
+    pub error: ::prost::alloc::string::String,
 }
 /// Nested message and enum types in `SetupStatus`.
 pub mod setup_status {
@@ -2546,6 +2551,9 @@ pub mod setup_status {
         Degraded = 7,
         DownloadingAssets = 8,
         CleaningUp = 9,
+        /// Startup failed fatally; the daemon exits shortly after
+        /// publishing this phase. See the `error` field for the cause.
+        Failed = 10,
     }
     impl Phase {
         /// String value of the enum field names used in the ProtoBuf definition.
@@ -2564,6 +2572,7 @@ pub mod setup_status {
                 Self::Degraded => "DEGRADED",
                 Self::DownloadingAssets => "DOWNLOADING_ASSETS",
                 Self::CleaningUp => "CLEANING_UP",
+                Self::Failed => "FAILED",
             }
         }
         /// Creates an enum from field names used in the ProtoBuf definition.
@@ -2579,6 +2588,7 @@ pub mod setup_status {
                 "DEGRADED" => Some(Self::Degraded),
                 "DOWNLOADING_ASSETS" => Some(Self::DownloadingAssets),
                 "CLEANING_UP" => Some(Self::CleaningUp),
+                "FAILED" => Some(Self::Failed),
                 _ => None,
             }
         }

--- a/tests/e2e/Cargo.toml
+++ b/tests/e2e/Cargo.toml
@@ -13,7 +13,7 @@ arcbox-core.workspace = true
 arcbox-grpc.workspace = true
 arcbox-protocol.workspace = true
 arcbox-vmm.workspace = true
-hyper-util = "0.1.20"
+hyper-util = { version = "0.1.20", features = ["tokio"] }
 libc.workspace = true
 tempfile.workspace = true
 tokio.workspace = true

--- a/tests/e2e/Cargo.toml
+++ b/tests/e2e/Cargo.toml
@@ -9,8 +9,17 @@ authors.workspace = true
 
 [dependencies]
 anyhow.workspace = true
+arcbox-core.workspace = true
+arcbox-grpc.workspace = true
+arcbox-protocol.workspace = true
+arcbox-vmm.workspace = true
+hyper-util = "0.1.20"
+libc.workspace = true
 tempfile.workspace = true
+tokio.workspace = true
 toml_edit = "0.25.12"
+tonic.workspace = true
+tower.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
 xshell = "0.2.7"

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -5,22 +5,39 @@ assets, Docker, and external test fixtures. Keep long-running test process
 management here rather than in `xtask`.
 
 E2E tests use Rust's standard test harness instead of a custom runner. Tests are
-ignored by default because they build release binaries, boot a VM, and require a
-local Docker CLI plus macOS virtualization support.
+ignored by default because they build release binaries, boot a VM, and require
+macOS virtualization support (plus a local Docker CLI for the daemon-level test).
+
+## Fixtures
+
+- `signing::ensure_signed` — idempotently signs a test binary with the
+  virtualization entitlements: Developer ID when the ArcBox identity is in the
+  keychain, otherwise ad-hoc with `bundle/arcbox.dev.entitlements` (sufficient
+  for HV/VZ; only bridged vmnet needs Developer ID).
+- `daemon::DaemonHandle` — spawns a signed `arcbox-daemon` under an isolated
+  `--data-dir` and waits for readiness on the daemon's `WatchSetupStatus` gRPC
+  stream, failing fast on a FAILED phase or daemon exit (with the log tail).
+  Drop terminates the daemon gracefully (SIGTERM, then SIGKILL). The isolated
+  data dir means tests never touch `~/.arcbox` and can run alongside a
+  developer's daemon.
 
 ## Commands
 
-Run the boot assets VM and Docker lifecycle integration test:
+Daemon-level test — boots the VM through a real daemon and runs Docker
+lifecycle checks over the Docker API socket:
 
 ```bash
 cargo test -p arcbox-e2e --test boot_assets -- --ignored --nocapture
 ```
 
-When using the repository development shell:
+VMM-level HV probe — drives the HV backend directly (no daemon): boot, vsock
+agent RPC, DAX, agent supervision, pause/resume, stop:
 
 ```bash
-devenv shell -- cargo test -p arcbox-e2e --test boot_assets -- --ignored --nocapture
+cargo test -p arcbox-e2e --test hv_vmm -- --ignored --nocapture
 ```
+
+When using the repository development shell, prefix with `devenv shell --`.
 
 List available E2E tests without running ignored tests:
 
@@ -30,13 +47,16 @@ cargo test -p arcbox-e2e -- --list
 
 ## Configuration
 
-The boot assets test reads configuration from environment variables:
+Environment variables read by the tests:
 
 - `SKIP_BUILD=1` — reuse existing `target/release` binaries.
-- `KEEP_TEST_DIR=1` — preserve the temporary test directory for debugging.
+- `KEEP_TEST_DIR=1` — always preserve the temporary test directory (it is
+  preserved automatically when the test fails).
 - `ARCBOX_BOOT_ASSET_VERSION=<version>` — override `assets.lock`
   `[boot].version`.
 - `ARCBOX_GUEST_DOCKER_VSOCK_PORT=<port>` — pass a custom guest Docker vsock
   port to `arcbox-daemon`.
+- `ARCBOX_HV_E2E_KERNEL` / `ARCBOX_HV_E2E_ROOTFS` / `ARCBOX_HV_E2E_TIMEOUT` /
+  `ARCBOX_DATA_DIR` — HV probe overrides; see `src/bin/hv_e2e.rs`.
 
 Tracing is controlled with `RUST_LOG`; it defaults to `info` when unset.

--- a/tests/e2e/src/bin/hv_e2e.rs
+++ b/tests/e2e/src/bin/hv_e2e.rs
@@ -16,13 +16,14 @@
 //!    (Exercises ABX-360.)
 //! 7. `Vmm::stop()` shuts down cleanly.
 //!
-//! Usage:
-//!   cargo build --release --example hv_e2e -p arcbox-core
+//! Usage — via the ignored e2e test, which builds, signs, and runs it:
+//!   cargo test -p arcbox-e2e --test hv_vmm -- --ignored --nocapture
+//! Or manually:
+//!   cargo build --release -p arcbox-e2e --bin hv_e2e
 //!   codesign --force --options runtime \
-//!       --entitlements bundle/arcbox.entitlements \
-//!       --sign "Developer ID Application: ArcBox, Inc. (422ACSY6Y5)" \
-//!       target/release/examples/hv_e2e
-//!   ./target/release/examples/hv_e2e
+//!       --entitlements bundle/arcbox.dev.entitlements \
+//!       -s - target/release/hv_e2e
+//!   ./target/release/hv_e2e
 //!
 //! Environment:
 //!   ARCBOX_HV_E2E_KERNEL    override kernel path

--- a/tests/e2e/src/boot_assets.rs
+++ b/tests/e2e/src/boot_assets.rs
@@ -13,7 +13,7 @@ use toml_edit::DocumentMut;
 use tracing::{info, warn};
 
 use crate::daemon::{DaemonConfig, DaemonHandle};
-use crate::repo_root;
+use crate::{env_flag, repo_root};
 
 const DOCKER_TIMEOUT: Duration = Duration::from_secs(30);
 /// Generous ceiling for the daemon's full startup (asset seeding + VM boot
@@ -196,16 +196,6 @@ fn run_scenario(ctx: &mut TestContext) -> Result<()> {
 
     info!(daemon_log = %ctx.test_dir.join("log/daemon.log").display(), "boot assets integration test passed");
     Ok(())
-}
-
-fn env_flag(name: &str) -> bool {
-    env::var(name).is_ok_and(|value| {
-        value.is_empty()
-            || matches!(
-                value.to_ascii_lowercase().as_str(),
-                "1" | "true" | "yes" | "on"
-            )
-    })
 }
 
 fn boot_version(lockfile: &Path) -> Result<String> {

--- a/tests/e2e/src/boot_assets.rs
+++ b/tests/e2e/src/boot_assets.rs
@@ -83,10 +83,7 @@ impl TestContext {
 
     fn docker_host(&self) -> String {
         // Default HostLayout: the Docker socket lives under <data_dir>/run.
-        format!(
-            "unix://{}",
-            self.test_dir.join("run/docker.sock").display()
-        )
+        format!("unix://{}", self.test_dir.join("run/docker.sock").display())
     }
 
     fn docker_output(&self, args: &[&str], timeout: Duration) -> Result<String> {
@@ -277,10 +274,7 @@ fn start_daemon(ctx: &mut TestContext) -> Result<()> {
             "--guest-docker-vsock-port".to_owned(),
             ctx.guest_docker_vsock_port.to_string(),
         ],
-        env: vec![(
-            "ARCBOX_BOOT_ASSET_VERSION".to_owned(),
-            ctx.version.clone(),
-        )],
+        env: vec![("ARCBOX_BOOT_ASSET_VERSION".to_owned(), ctx.version.clone())],
     })?;
 
     let started = Instant::now();

--- a/tests/e2e/src/boot_assets.rs
+++ b/tests/e2e/src/boot_assets.rs
@@ -1,8 +1,8 @@
 use std::{
     env,
-    fs::{self, File},
+    fs::{self},
     path::{Path, PathBuf},
-    process::{Child, Command, Stdio},
+    process::{Command, Stdio},
     thread,
     time::{Duration, Instant},
 };
@@ -10,11 +10,15 @@ use std::{
 use anyhow::{Context, Result, anyhow, bail};
 use tempfile::TempDir;
 use toml_edit::DocumentMut;
-use tracing::{error, info, warn};
+use tracing::{info, warn};
 
+use crate::daemon::{DaemonConfig, DaemonHandle};
 use crate::repo_root;
 
 const DOCKER_TIMEOUT: Duration = Duration::from_secs(30);
+/// Generous ceiling for the daemon's full startup (asset seeding + VM boot
+/// + agent readiness), observed via `WatchSetupStatus`.
+const READY_TIMEOUT: Duration = Duration::from_secs(180);
 
 pub struct BootAssetsConfig {
     skip_build: bool,
@@ -48,7 +52,7 @@ struct TestContext {
     label: String,
     guest_docker_vsock_port: u32,
     keep_test_dir: bool,
-    daemon: Option<Child>,
+    daemon: Option<DaemonHandle>,
 }
 
 impl TestContext {
@@ -78,7 +82,11 @@ impl TestContext {
     }
 
     fn docker_host(&self) -> String {
-        format!("unix://{}", self.test_dir.join("docker.sock").display())
+        // Default HostLayout: the Docker socket lives under <data_dir>/run.
+        format!(
+            "unix://{}",
+            self.test_dir.join("run/docker.sock").display()
+        )
     }
 
     fn docker_output(&self, args: &[&str], timeout: Duration) -> Result<String> {
@@ -132,15 +140,17 @@ impl Drop for TestContext {
             }
         }
 
-        if let Some(mut daemon) = self.daemon.take() {
-            let _ = daemon.kill();
-            let _ = daemon.wait();
+        if let Some(daemon) = self.daemon.take() {
+            match daemon.shutdown() {
+                Ok(status) => info!(%status, "daemon stopped"),
+                Err(error) => warn!("daemon shutdown failed: {error:#}"),
+            }
         }
 
         if self.keep_test_dir {
             if let Some(temp_dir) = self.temp_dir.take() {
                 let path = temp_dir.keep();
-                warn!(path = %path.display(), "KEEP_TEST_DIR set, preserving test directory");
+                warn!(path = %path.display(), "preserving test directory");
             }
         }
     }
@@ -161,20 +171,30 @@ pub fn run(config: BootAssetsConfig) -> Result<()> {
     }
 
     let mut ctx = TestContext::new(config)?;
-    check_prerequisites(&ctx)?;
-    setup_test_env(&ctx)?;
-    start_daemon(&mut ctx)?;
+    let result = run_scenario(&mut ctx);
+    if result.is_err() {
+        // Preserve the workspace (daemon + guest logs, disk images) so the
+        // failure can be inspected; the path is logged by TestContext::drop.
+        ctx.keep_test_dir = true;
+    }
+    result
+}
 
-    pull_alpine(&ctx)?;
-    trigger_vm_boot(&ctx)?;
+fn run_scenario(ctx: &mut TestContext) -> Result<()> {
+    check_prerequisites(ctx)?;
+    setup_test_env(ctx)?;
+    start_daemon(ctx)?;
 
-    test_container_run(&ctx).context("container run lifecycle test")?;
-    test_background_container(&ctx).context("background container lifecycle test")?;
-    test_docker_logs(&ctx).context("docker logs lifecycle test")?;
-    test_docker_exec(&ctx).context("docker exec lifecycle test")?;
-    test_stop_rm(&ctx).context("docker stop/rm lifecycle test")?;
+    pull_alpine(ctx)?;
+    smoke_container_create(ctx)?;
 
-    info!(daemon_log = %ctx.test_dir.join("daemon.log").display(), "boot assets integration test passed");
+    test_container_run(ctx).context("container run lifecycle test")?;
+    test_background_container(ctx).context("background container lifecycle test")?;
+    test_docker_logs(ctx).context("docker logs lifecycle test")?;
+    test_docker_exec(ctx).context("docker exec lifecycle test")?;
+    test_stop_rm(ctx).context("docker stop/rm lifecycle test")?;
+
+    info!(daemon_log = %ctx.test_dir.join("log/daemon.log").display(), "boot assets integration test passed");
     Ok(())
 }
 
@@ -206,28 +226,6 @@ fn check_prerequisites(ctx: &TestContext) -> Result<()> {
     if !daemon.is_file() {
         bail!("arcbox-daemon binary not found at {}", daemon.display());
     }
-
-    let output = Command::new("codesign")
-        .args(["-d", "--entitlements", ":-"])
-        .arg(&daemon)
-        .output()
-        .with_context(|| format!("reading entitlements from {}", daemon.display()))?;
-    let entitlements = String::from_utf8_lossy(&output.stderr);
-    if !entitlements.contains("com.apple.security.virtualization") {
-        warn!("binary not signed with virtualization entitlement; signing");
-        let entitlements_file = ctx.root.join("bundle/arcbox.entitlements");
-        let status = Command::new("codesign")
-            .arg("--entitlements")
-            .arg(&entitlements_file)
-            .args(["--force", "-s", "-"])
-            .arg(&daemon)
-            .status()
-            .with_context(|| format!("signing {}", daemon.display()))?;
-        if !status.success() {
-            bail!("codesign failed for {}", daemon.display());
-        }
-    }
-
     info!("prerequisites OK");
     Ok(())
 }
@@ -278,36 +276,30 @@ fn setup_test_env(ctx: &TestContext) -> Result<()> {
     Ok(())
 }
 
+/// Spawns the daemon and blocks until it reports READY on the setup
+/// status stream — VM booted, agent up, services started.
 fn start_daemon(ctx: &mut TestContext) -> Result<()> {
     info!("starting daemon");
-    let log = File::create(ctx.test_dir.join("daemon.log"))?;
-    let stderr = log.try_clone()?;
-    let daemon = Command::new(ctx.root.join("target/release/arcbox-daemon"))
-        .env("ARCBOX_BOOT_ASSET_VERSION", &ctx.version)
-        .arg("--data-dir")
-        .arg(&ctx.test_dir)
-        .arg("--socket")
-        .arg(ctx.test_dir.join("docker.sock"))
-        .arg("--guest-docker-vsock-port")
-        .arg(ctx.guest_docker_vsock_port.to_string())
-        .stdout(log)
-        .stderr(stderr)
-        .spawn()
-        .context("starting arcbox-daemon")?;
-    let pid = daemon.id();
-    fs::write(ctx.test_dir.join("daemon.pid"), pid.to_string())?;
+    let mut daemon = DaemonHandle::spawn(DaemonConfig {
+        binary: ctx.root.join("target/release/arcbox-daemon"),
+        data_dir: ctx.test_dir.clone(),
+        args: vec![
+            "--guest-docker-vsock-port".to_owned(),
+            ctx.guest_docker_vsock_port.to_string(),
+        ],
+        env: vec![(
+            "ARCBOX_BOOT_ASSET_VERSION".to_owned(),
+            ctx.version.clone(),
+        )],
+    })?;
+
+    let started = Instant::now();
+    daemon.wait_ready_blocking(READY_TIMEOUT)?;
+    info!(
+        elapsed_seconds = started.elapsed().as_secs(),
+        "daemon is ready"
+    );
     ctx.daemon = Some(daemon);
-    thread::sleep(Duration::from_secs(2));
-
-    if let Some(daemon) = ctx.daemon.as_mut() {
-        if let Some(status) = daemon.try_wait()? {
-            error!("daemon failed to start");
-            print_file(&ctx.test_dir.join("daemon.log"));
-            bail!("arcbox-daemon exited with {status}");
-        }
-    }
-
-    info!(pid, "daemon started");
     Ok(())
 }
 
@@ -323,63 +315,29 @@ fn pull_alpine(ctx: &TestContext) -> Result<()> {
         Err(error) => {
             fs::write(ctx.test_dir.join("pull.log"), format!("{error:#}"))
                 .with_context(|| format!("writing {}", ctx.test_dir.join("pull.log").display()))?;
-            error!("docker pull failed");
-            Err(error)
+            Err(error).context("docker pull")
         }
     }
 }
 
-fn trigger_vm_boot(ctx: &TestContext) -> Result<()> {
-    info!("creating container to trigger VM boot");
-    let container_id_path = ctx.test_dir.join("container_id");
-    let container_err_path = ctx.test_dir.join("container_create.err");
-    let mut create = Command::new("docker")
-        .env("DOCKER_HOST", ctx.docker_host())
-        .args(["create", "--label", &ctx.label, "alpine", "echo", "test"])
-        .stdout(File::create(&container_id_path)?)
-        .stderr(File::create(&container_err_path)?)
-        .spawn()
-        .context("starting docker create")?;
-
-    if !wait_for_agent(ctx) {
-        let _ = create.kill();
-        let _ = create.wait();
-        bail!("agent connection timeout");
-    }
-
-    if create.wait()?.success() {
-        let cid = fs::read_to_string(&container_id_path)
-            .unwrap_or_default()
-            .trim()
-            .to_owned();
-        info!(
-            container_id = cid_prefix(&cid),
-            "container create completed"
-        );
-        Ok(())
-    } else {
-        let stderr = fs::read_to_string(&container_err_path).unwrap_or_default();
-        bail!("container create failed: {stderr}");
-    }
-}
-
-fn wait_for_agent(ctx: &TestContext) -> bool {
-    info!("waiting for agent connection");
-    for elapsed in 0..60 {
-        if fs::read_to_string(ctx.test_dir.join("daemon.log"))
-            .unwrap_or_default()
-            .contains("Agent is ready")
-        {
-            info!(elapsed_seconds = elapsed, "agent connected");
-            return true;
-        }
-        thread::sleep(Duration::from_secs(1));
-    }
-
-    error!("agent connection timeout");
-    error!("daemon log follows");
-    print_file(&ctx.test_dir.join("daemon.log"));
-    false
+/// First `docker create` against the ready daemon — exercises the full
+/// API → runtime → guest agent path once before the lifecycle tests.
+fn smoke_container_create(ctx: &TestContext) -> Result<()> {
+    info!("creating container against the ready daemon");
+    let cid = ctx
+        .docker_output(
+            &["create", "--label", &ctx.label, "alpine", "echo", "test"],
+            DOCKER_TIMEOUT,
+        )?
+        .lines()
+        .next()
+        .unwrap_or_default()
+        .to_owned();
+    info!(
+        container_id = cid_prefix(&cid),
+        "container create completed"
+    );
+    Ok(())
 }
 
 fn test_container_run(ctx: &TestContext) -> Result<()> {
@@ -554,12 +512,6 @@ fn run_with_timeout(command: &mut Command, timeout: Duration) -> Result<std::pro
     let _ = child.kill();
     let _ = child.wait();
     Err(anyhow!("command timed out after {}s", timeout.as_secs()))
-}
-
-fn print_file(path: &Path) {
-    if let Ok(contents) = fs::read_to_string(path) {
-        print!("{contents}");
-    }
 }
 
 fn cid_prefix(cid: &str) -> &str {

--- a/tests/e2e/src/daemon.rs
+++ b/tests/e2e/src/daemon.rs
@@ -1,0 +1,276 @@
+//! Spawns and supervises an `arcbox-daemon` under test.
+//!
+//! Readiness comes from the daemon's own `WatchSetupStatus` gRPC stream
+//! instead of log grepping: the harness connects to the gRPC socket as
+//! soon as it appears, then follows the phase progression until READY —
+//! failing fast on a FAILED phase or a daemon exit, with the log tail
+//! attached to the error.
+//!
+//! Every handle gets an isolated `--data-dir`, so lock file, sockets, and
+//! logs never collide with a developer's `~/.arcbox` daemon and multiple
+//! harnesses can run in parallel.
+
+use std::fs::File;
+use std::future::Future;
+use std::path::{Path, PathBuf};
+use std::pin::Pin;
+use std::process::{Child, Command, ExitStatus, Stdio};
+use std::task::{Context as TaskContext, Poll};
+use std::time::{Duration, Instant};
+
+use anyhow::{Context, Result, bail};
+use arcbox_grpc::v1::system_service_client::SystemServiceClient;
+use arcbox_protocol::v1::{Empty, setup_status};
+use hyper_util::rt::TokioIo;
+use tokio::net::UnixStream;
+use tonic::transport::{Channel, Endpoint, Uri};
+use tower::Service;
+use tracing::info;
+
+use crate::signing::ensure_signed;
+
+/// Interval between liveness / stream polls while waiting for readiness.
+const POLL_TICK: Duration = Duration::from_millis(200);
+/// Grace period for SIGTERM before falling back to SIGKILL.
+const SHUTDOWN_GRACE: Duration = Duration::from_secs(15);
+
+/// Launch parameters for a daemon under test.
+pub struct DaemonConfig {
+    /// Path to the `arcbox-daemon` binary; signed in place on spawn when
+    /// it lacks the virtualization entitlement.
+    pub binary: PathBuf,
+    /// Isolated data directory. Lock file, both sockets, and logs live
+    /// under it (`run/`, `log/`), per the default `HostLayout`.
+    pub data_dir: PathBuf,
+    /// Extra CLI arguments appended after `--data-dir`.
+    pub args: Vec<String>,
+    /// Extra environment variables for the daemon process.
+    pub env: Vec<(String, String)>,
+}
+
+/// A running daemon owned by the harness. Dropping the handle terminates
+/// the daemon (SIGTERM, then SIGKILL after a grace period).
+pub struct DaemonHandle {
+    child: Child,
+    data_dir: PathBuf,
+    log_path: PathBuf,
+}
+
+impl DaemonHandle {
+    /// Signs the binary if needed and spawns it with an isolated
+    /// `--data-dir` and `--foreground`, capturing stdout/stderr to
+    /// `harness-daemon.log` inside the data directory.
+    pub fn spawn(config: DaemonConfig) -> Result<Self> {
+        ensure_signed(&config.binary)?;
+        std::fs::create_dir_all(&config.data_dir)
+            .with_context(|| format!("creating {}", config.data_dir.display()))?;
+
+        // Separate from the daemon's own rotating log/daemon.log: this file
+        // captures the process's stdout/stderr (panics, early failures that
+        // precede logging init).
+        let log_path = config.data_dir.join("harness-daemon.log");
+        let log = File::create(&log_path)
+            .with_context(|| format!("creating {}", log_path.display()))?;
+        let stderr = log.try_clone()?;
+
+        let mut command = Command::new(&config.binary);
+        command
+            .arg("--data-dir")
+            .arg(&config.data_dir)
+            .arg("--foreground")
+            .args(&config.args)
+            .stdout(Stdio::from(log))
+            .stderr(Stdio::from(stderr));
+        for (key, value) in &config.env {
+            command.env(key, value);
+        }
+
+        let child = command.spawn().with_context(|| {
+            format!("spawning arcbox-daemon from {}", config.binary.display())
+        })?;
+        info!(pid = child.id(), data_dir = %config.data_dir.display(), "daemon spawned");
+
+        Ok(Self {
+            child,
+            data_dir: config.data_dir,
+            log_path,
+        })
+    }
+
+    /// The Docker API socket under the handle's data directory.
+    pub fn docker_socket(&self) -> PathBuf {
+        self.data_dir.join("run/docker.sock")
+    }
+
+    /// The gRPC API socket under the handle's data directory.
+    pub fn grpc_socket(&self) -> PathBuf {
+        self.data_dir.join("run/arcbox.sock")
+    }
+
+    /// Blocking wrapper around [`Self::wait_ready`] for synchronous tests.
+    pub fn wait_ready_blocking(&mut self, timeout: Duration) -> Result<()> {
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .context("building tokio runtime for readiness wait")?
+            .block_on(self.wait_ready(timeout))
+    }
+
+    /// Follows `WatchSetupStatus` until the daemon reports READY.
+    ///
+    /// Fails fast when the daemon publishes FAILED (with the reported
+    /// error), exits (with its status and log tail), or `timeout` passes.
+    pub async fn wait_ready(&mut self, timeout: Duration) -> Result<()> {
+        let deadline = Instant::now() + timeout;
+        let socket = self.grpc_socket();
+
+        // First the socket must appear and accept a connection; the gRPC
+        // server starts early in the daemon's startup sequence.
+        let channel = loop {
+            self.check_alive()?;
+            if Instant::now() >= deadline {
+                bail!(
+                    "timed out after {timeout:?} waiting for gRPC socket {} (log: {})",
+                    socket.display(),
+                    self.log_path.display()
+                );
+            }
+            if socket.exists() {
+                if let Ok(channel) = connect_unix(&socket).await {
+                    break channel;
+                }
+            }
+            tokio::time::sleep(POLL_TICK).await;
+        };
+
+        let mut client = SystemServiceClient::new(channel);
+        let mut stream = client
+            .watch_setup_status(Empty {})
+            .await
+            .context("opening WatchSetupStatus stream")?
+            .into_inner();
+
+        loop {
+            self.check_alive()?;
+            if Instant::now() >= deadline {
+                bail!(
+                    "timed out after {timeout:?} waiting for READY (log: {})",
+                    self.log_path.display()
+                );
+            }
+            match tokio::time::timeout(POLL_TICK, stream.message()).await {
+                // Poll tick elapsed without an update: re-check liveness.
+                Err(_) => {}
+                Ok(Ok(Some(status))) => match status.phase() {
+                    setup_status::Phase::Ready => {
+                        info!("daemon reported READY");
+                        return Ok(());
+                    }
+                    setup_status::Phase::Failed => {
+                        bail!(
+                            "daemon startup failed: {} (log: {})",
+                            status.error,
+                            self.log_path.display()
+                        );
+                    }
+                    phase => info!(?phase, message = %status.message, "setup phase"),
+                },
+                // Stream ended or errored — the daemon is going away; the
+                // next liveness check reports its exit status and log tail.
+                Ok(Ok(None)) | Ok(Err(_)) => {
+                    tokio::time::sleep(POLL_TICK).await;
+                }
+            }
+        }
+    }
+
+    /// Terminates the daemon: SIGTERM, wait for the grace period, then
+    /// SIGKILL. Returns the exit status.
+    pub fn shutdown(mut self) -> Result<ExitStatus> {
+        self.terminate()
+    }
+
+    /// Errors with the exit status and log tail if the daemon has exited.
+    fn check_alive(&mut self) -> Result<()> {
+        if let Some(status) = self.child.try_wait().context("polling daemon")? {
+            bail!(
+                "arcbox-daemon exited with {status} before becoming ready\n--- log tail ({}) ---\n{}",
+                self.log_path.display(),
+                self.log_tail(40)
+            );
+        }
+        Ok(())
+    }
+
+    /// Last `lines` lines of the captured daemon output.
+    fn log_tail(&self, lines: usize) -> String {
+        let Ok(contents) = std::fs::read_to_string(&self.log_path) else {
+            return String::from("<log unreadable>");
+        };
+        let all: Vec<&str> = contents.lines().collect();
+        let start = all.len().saturating_sub(lines);
+        all[start..].join("\n")
+    }
+
+    fn terminate(&mut self) -> Result<ExitStatus> {
+        if let Some(status) = self.child.try_wait()? {
+            return Ok(status);
+        }
+        // SAFETY: the pid belongs to a child we own; SIGTERM to a dead pid
+        // is harmless (kill(2) returns ESRCH).
+        unsafe { libc::kill(self.child.id() as libc::pid_t, libc::SIGTERM) };
+
+        let deadline = Instant::now() + SHUTDOWN_GRACE;
+        while Instant::now() < deadline {
+            if let Some(status) = self.child.try_wait()? {
+                return Ok(status);
+            }
+            std::thread::sleep(Duration::from_millis(100));
+        }
+        tracing::warn!("daemon ignored SIGTERM for {SHUTDOWN_GRACE:?}; killing");
+        let _ = self.child.kill();
+        Ok(self.child.wait()?)
+    }
+}
+
+impl Drop for DaemonHandle {
+    fn drop(&mut self) {
+        let _ = self.terminate();
+    }
+}
+
+/// Connects a tonic channel over a Unix domain socket.
+async fn connect_unix(socket: &Path) -> Result<Channel> {
+    // The URI is required by the HTTP/2 layer but unused: the connector
+    // below ignores it and dials the Unix socket.
+    let channel = Endpoint::from_static("http://[::]:50051")
+        .connect_with_connector(UnixConnector {
+            socket_path: socket.to_path_buf(),
+        })
+        .await?;
+    Ok(channel)
+}
+
+/// Minimal tower connector dialing a fixed Unix socket (same shape as the
+/// CLI's connector in `arcbox-cli`).
+struct UnixConnector {
+    socket_path: PathBuf,
+}
+
+impl Service<Uri> for UnixConnector {
+    type Response = TokioIo<UnixStream>;
+    type Error = std::io::Error;
+    type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send>>;
+
+    fn poll_ready(&mut self, _cx: &mut TaskContext<'_>) -> Poll<Result<(), Self::Error>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn call(&mut self, _: Uri) -> Self::Future {
+        let socket_path = self.socket_path.clone();
+        Box::pin(async move {
+            let stream = UnixStream::connect(socket_path).await?;
+            Ok(TokioIo::new(stream))
+        })
+    }
+}

--- a/tests/e2e/src/daemon.rs
+++ b/tests/e2e/src/daemon.rs
@@ -69,8 +69,8 @@ impl DaemonHandle {
         // captures the process's stdout/stderr (panics, early failures that
         // precede logging init).
         let log_path = config.data_dir.join("harness-daemon.log");
-        let log = File::create(&log_path)
-            .with_context(|| format!("creating {}", log_path.display()))?;
+        let log =
+            File::create(&log_path).with_context(|| format!("creating {}", log_path.display()))?;
         let stderr = log.try_clone()?;
 
         let mut command = Command::new(&config.binary);
@@ -85,9 +85,9 @@ impl DaemonHandle {
             command.env(key, value);
         }
 
-        let child = command.spawn().with_context(|| {
-            format!("spawning arcbox-daemon from {}", config.binary.display())
-        })?;
+        let child = command
+            .spawn()
+            .with_context(|| format!("spawning arcbox-daemon from {}", config.binary.display()))?;
         info!(pid = child.id(), data_dir = %config.data_dir.display(), "daemon spawned");
 
         Ok(Self {
@@ -177,7 +177,7 @@ impl DaemonHandle {
                 },
                 // Stream ended or errored — the daemon is going away; the
                 // next liveness check reports its exit status and log tail.
-                Ok(Ok(None)) | Ok(Err(_)) => {
+                Ok(Ok(None) | Err(_)) => {
                     tokio::time::sleep(POLL_TICK).await;
                 }
             }
@@ -218,7 +218,7 @@ impl DaemonHandle {
         }
         // SAFETY: the pid belongs to a child we own; SIGTERM to a dead pid
         // is harmless (kill(2) returns ESRCH).
-        unsafe { libc::kill(self.child.id() as libc::pid_t, libc::SIGTERM) };
+        unsafe { libc::kill(self.child.id().cast_signed(), libc::SIGTERM) };
 
         let deadline = Instant::now() + SHUTDOWN_GRACE;
         while Instant::now() < deadline {

--- a/tests/e2e/src/lib.rs
+++ b/tests/e2e/src/lib.rs
@@ -1,6 +1,8 @@
 use std::path::PathBuf;
 
 pub mod boot_assets;
+pub mod daemon;
+pub mod signing;
 
 pub fn repo_root() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR"))

--- a/tests/e2e/src/lib.rs
+++ b/tests/e2e/src/lib.rs
@@ -11,3 +11,15 @@ pub fn repo_root() -> PathBuf {
         .expect("tests/e2e lives two levels below the repository root")
         .to_owned()
 }
+
+/// True when the environment variable is set to a truthy value (or set
+/// but empty), e.g. `SKIP_BUILD=1` / `KEEP_TEST_DIR=yes`.
+pub fn env_flag(name: &str) -> bool {
+    std::env::var(name).is_ok_and(|value| {
+        value.is_empty()
+            || matches!(
+                value.to_ascii_lowercase().as_str(),
+                "1" | "true" | "yes" | "on"
+            )
+    })
+}

--- a/tests/e2e/src/signing.rs
+++ b/tests/e2e/src/signing.rs
@@ -1,0 +1,86 @@
+//! Idempotent code signing for locally built test binaries.
+//!
+//! Booting VMs requires the `com.apple.security.virtualization` /
+//! `com.apple.security.hypervisor` entitlements on the binary. Only
+//! `com.apple.vm.networking` (bridged vmnet) needs a Developer ID
+//! signature backed by a provisioning profile; the dev entitlements omit
+//! it, so an ad-hoc signature boots HV/VZ VMs on any Apple Silicon
+//! machine. Mirrors `make sign-daemon` (Developer ID) / `make sign`
+//! (ad-hoc), both of which sign with `bundle/arcbox.dev.entitlements`.
+
+use std::path::Path;
+use std::process::Command;
+
+use anyhow::{Context, Result, bail};
+
+use crate::repo_root;
+
+/// Ensures `binary` carries the virtualization entitlement, signing it in
+/// place when necessary.
+///
+/// A cargo relink leaves only the bare linker ad-hoc signature without
+/// entitlements, so callers run this before every spawn; a binary that
+/// already verifies with the entitlement is left untouched.
+pub fn ensure_signed(binary: &Path) -> Result<()> {
+    if is_signed_for_virtualization(binary) {
+        return Ok(());
+    }
+
+    let entitlements = repo_root().join("bundle/arcbox.dev.entitlements");
+    let identity = developer_id_identity().unwrap_or_else(|| "-".to_string());
+    tracing::info!(
+        binary = %binary.display(),
+        identity = %identity,
+        "signing test binary with virtualization entitlements"
+    );
+    let status = Command::new("codesign")
+        .args(["--force", "--options", "runtime", "--entitlements"])
+        .arg(&entitlements)
+        .args(["--sign", &identity])
+        .arg(binary)
+        .status()
+        .with_context(|| format!("running codesign on {}", binary.display()))?;
+    if !status.success() {
+        bail!("codesign failed for {} with {status}", binary.display());
+    }
+    Ok(())
+}
+
+/// True when the binary's signature verifies and its entitlements include
+/// `com.apple.security.virtualization`.
+fn is_signed_for_virtualization(binary: &Path) -> bool {
+    let verified = Command::new("codesign")
+        .args(["--verify", "--strict"])
+        .arg(binary)
+        .status()
+        .is_ok_and(|s| s.success());
+    if !verified {
+        return false;
+    }
+    Command::new("codesign")
+        .args(["-d", "--entitlements", ":-"])
+        .arg(binary)
+        .output()
+        .is_ok_and(|out| {
+            // codesign has printed entitlements to stdout or stderr
+            // depending on the macOS release; check both.
+            let text = [out.stdout, out.stderr].concat();
+            String::from_utf8_lossy(&text).contains("com.apple.security.virtualization")
+        })
+}
+
+/// First `Developer ID Application: ArcBox` identity in the keychain, if
+/// any — the same detection as `make sign-daemon`.
+fn developer_id_identity() -> Option<String> {
+    let out = Command::new("security")
+        .args(["find-identity", "-v", "-p", "codesigning"])
+        .output()
+        .ok()?;
+    let text = String::from_utf8_lossy(&out.stdout);
+    text.lines().find_map(|line| {
+        let start = line.find("\"Developer ID Application: ArcBox")?;
+        let rest = &line[start + 1..];
+        let end = rest.find('"')?;
+        Some(rest[..end].to_string())
+    })
+}

--- a/tests/e2e/tests/daemon_failure.rs
+++ b/tests/e2e/tests/daemon_failure.rs
@@ -1,0 +1,64 @@
+//! Verifies the harness fail-fast path end to end: a daemon pointed at a
+//! nonexistent boot-asset version must publish FAILED on the
+//! `WatchSetupStatus` stream (or exit), and `DaemonHandle::wait_ready`
+//! must surface that as an error instead of hanging until the timeout.
+
+use std::sync::Once;
+use std::time::Duration;
+
+use anyhow::Result;
+use arcbox_e2e::daemon::{DaemonConfig, DaemonHandle};
+use tracing_subscriber::EnvFilter;
+
+static TRACING: Once = Once::new();
+
+#[test]
+#[ignore = "spawns a signed daemon; requires macOS codesign"]
+fn daemon_reports_startup_failure() -> Result<()> {
+    init_tracing();
+
+    let root = arcbox_e2e::repo_root();
+    if !arcbox_e2e::env_flag("SKIP_BUILD") {
+        let shell = xshell::Shell::new()?;
+        shell.change_dir(&root);
+        xshell::cmd!(shell, "cargo build -p arcbox-daemon").run()?;
+    }
+
+    let data_dir = tempfile::Builder::new()
+        .prefix("arcbox-fail-test-")
+        .tempdir()?;
+
+    let mut daemon = DaemonHandle::spawn(DaemonConfig {
+        binary: root.join("target/debug/arcbox-daemon"),
+        data_dir: data_dir.path().to_owned(),
+        args: Vec::new(),
+        // No bundle and no downloadable asset under this version: startup
+        // must fail in asset preparation.
+        env: vec![(
+            "ARCBOX_BOOT_ASSET_VERSION".to_owned(),
+            "0.0.0-e2e-nonexistent".to_owned(),
+        )],
+    })?;
+
+    let error = daemon
+        .wait_ready_blocking(Duration::from_secs(60))
+        .expect_err("daemon with a nonexistent asset version must not become ready");
+    let text = format!("{error:#}");
+    tracing::info!(%text, "harness surfaced the startup failure");
+    assert!(
+        text.contains("daemon startup failed") || text.contains("exited with"),
+        "error should carry the FAILED phase or the exit status, got: {text}"
+    );
+    Ok(())
+}
+
+fn init_tracing() {
+    TRACING.call_once(|| {
+        let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info"));
+        tracing_subscriber::fmt()
+            .with_env_filter(filter)
+            .with_target(false)
+            .compact()
+            .init();
+    });
+}

--- a/tests/e2e/tests/hv_vmm.rs
+++ b/tests/e2e/tests/hv_vmm.rs
@@ -1,0 +1,50 @@
+//! Wrapper for the VMM-layer HV probe (`src/bin/hv_e2e.rs`): builds the
+//! probe, signs it with the virtualization entitlements, runs it, and
+//! asserts a clean exit. The probe drives the HV backend directly (no
+//! daemon): boot, vsock agent RPC, DAX, supervision, pause/resume, stop.
+
+use std::process::Command;
+use std::sync::Once;
+
+use anyhow::{Context, Result, bail};
+use tracing_subscriber::EnvFilter;
+
+static TRACING: Once = Once::new();
+
+#[test]
+#[ignore = "boots an HV VM; needs Apple Silicon, dev boot assets, and a built guest agent"]
+fn hv_vmm() -> Result<()> {
+    init_tracing();
+
+    let root = arcbox_e2e::repo_root();
+    if !arcbox_e2e::env_flag("SKIP_BUILD") {
+        tracing::info!("building hv_e2e probe (release)");
+        let shell = xshell::Shell::new()?;
+        shell.change_dir(&root);
+        xshell::cmd!(shell, "cargo build --release -p arcbox-e2e --bin hv_e2e").run()?;
+    }
+
+    let binary = root.join("target/release/hv_e2e");
+    arcbox_e2e::signing::ensure_signed(&binary)?;
+
+    // The probe resolves boot-assets/dev paths relative to the repo root.
+    let status = Command::new(&binary)
+        .current_dir(&root)
+        .status()
+        .context("running hv_e2e probe")?;
+    if !status.success() {
+        bail!("hv_e2e probe failed with {status}");
+    }
+    Ok(())
+}
+
+fn init_tracing() {
+    TRACING.call_once(|| {
+        let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info"));
+        tracing_subscriber::fmt()
+            .with_env_filter(filter)
+            .with_target(false)
+            .compact()
+            .init();
+    });
+}


### PR DESCRIPTION
## Summary

Foundation work for the HV fix campaign: the E2E harness now drives and observes the daemon through code instead of log grepping.

- **SetupStatus failure channel** — new `FAILED` phase + `error` field on `SetupStatus`. `main()` owns the `SetupState` and publishes fatal startup errors on the `WatchSetupStatus` stream (with a short flush grace) before exiting, so clients learn the cause instead of seeing a bare disconnect. `docs/daemon-lifecycle.md` updated.
- **`signing::ensure_signed`** — idempotent signing for test binaries: Developer ID when the ArcBox identity is in the keychain, otherwise ad-hoc, always with `bundle/arcbox.dev.entitlements`. Removes the old fallback that ad-hoc-signed with the full production entitlements (`com.apple.vm.networking` without a provisioning profile ⇒ AMFI kill).
- **`daemon::DaemonHandle`** — spawns a signed daemon under an isolated `--data-dir` and waits for readiness on `WatchSetupStatus`, failing fast on FAILED or daemon exit with the log tail attached. Teardown is SIGTERM-then-SIGKILL (graceful VM stop instead of `kill -9`). `boot_assets` now rides this fixture; the `"Agent is ready"` log grep and blind sleeps are gone, and the test dir is preserved automatically on failure.
- **`hv_e2e` probe migrated** from a manually-run `arcbox-core` example into an `arcbox-e2e` bin behind an ignored standard-harness test (`--test hv_vmm`) sharing the signing fixture.
- **Live fail-fast check** (`--test daemon_failure`): spawns a real signed daemon at a nonexistent asset version and asserts the harness surfaces the FAILED phase — verified locally end to end (failure surfaced in ~2 s with the daemon's own 404 error text).

## Verification

- `cargo fmt --check`, `cargo clippy --workspace --exclude arcbox-agent --all-targets -- -D warnings`: clean
- `cargo test --workspace --exclude arcbox-agent`: 1604 passed
- `cargo test -p arcbox-e2e --test daemon_failure -- --ignored`: passed live (signing → spawn → WatchSetupStatus → FAILED phase → teardown)
- VM-boot happy path (`--test boot_assets`, `--test hv_vmm`) unchanged in coverage; needs dev boot assets + Apple Silicon to run locally