### PR TITLE
fix(daemon): arm signal handling for the whole startup window (ABX-407)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -452,12 +452,15 @@ name = "arcbox-e2e"
 version = "0.4.16"
 dependencies = [
  "anyhow",
+ "arcbox-constants",
  "arcbox-core",
  "arcbox-grpc",
  "arcbox-protocol",
  "arcbox-vmm",
  "hyper-util",
  "libc",
+ "serde",
+ "serde_json",
  "tempfile",
  "tokio",
  "toml_edit 0.25.12+spec-1.1.0",
@@ -2048,8 +2051,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8cb01cd46b0cf372153850f4c6c272d9cbea2da513e07538405148f95bd789f3"
 dependencies = [
  "atomic",
+ "parking_lot",
  "pear",
  "serde",
+ "tempfile",
  "toml 0.8.23",
  "uncased",
  "version_check",

--- a/app/arcbox-daemon/src/context.rs
+++ b/app/arcbox-daemon/src/context.rs
@@ -20,6 +20,34 @@ use tokio_util::sync::CancellationToken;
 
 use crate::startup::DaemonLock;
 
+/// Handles created before the startup pipeline runs and shared with it.
+///
+/// A shutdown signal can arrive while the pipeline is still building the
+/// daemon. `main` holds a clone so the interrupt path can reach whatever
+/// the pipeline has published so far: the runtime (for a bounded stop of a
+/// VM that keeps booting in its lifecycle tasks even after the startup
+/// future is dropped) and the cancellation token (for services that are
+/// already running).
+#[derive(Clone)]
+pub struct StartupHandles {
+    pub shared_runtime: SharedRuntime,
+    /// Filled right after runtime construction, before the VM boots.
+    pub early_runtime: SharedRuntime,
+    pub setup_state: Arc<SetupState>,
+    pub shutdown: CancellationToken,
+}
+
+impl StartupHandles {
+    pub fn new(setup_state: Arc<SetupState>) -> Self {
+        Self {
+            shared_runtime: Arc::new(std::sync::OnceLock::new()),
+            early_runtime: Arc::new(std::sync::OnceLock::new()),
+            setup_state,
+            shutdown: CancellationToken::new(),
+        }
+    }
+}
+
 /// Pre-lock context produced by the startup pipeline.
 ///
 /// Contains everything needed to start the gRPC SystemService (so

--- a/app/arcbox-daemon/src/context.rs
+++ b/app/arcbox-daemon/src/context.rs
@@ -20,14 +20,22 @@ use tokio_util::sync::CancellationToken;
 
 use crate::startup::DaemonLock;
 
+/// Daemon lock shared between the startup pipeline and `main`.
+///
+/// Filled by the lease phase; kept alive by [`StartupHandles`] so the
+/// flock survives the startup future being dropped on a signal.
+pub type SharedDaemonLock = Arc<std::sync::OnceLock<Arc<DaemonLock>>>;
+
 /// Handles created before the startup pipeline runs and shared with it.
 ///
 /// A shutdown signal can arrive while the pipeline is still building the
 /// daemon. `main` holds a clone so the interrupt path can reach whatever
 /// the pipeline has published so far: the runtime (for a bounded stop of a
 /// VM that keeps booting in its lifecycle tasks even after the startup
-/// future is dropped) and the cancellation token (for services that are
-/// already running).
+/// future is dropped), the cancellation token (for services that are
+/// already running), and the daemon lock (dropping the startup future
+/// would otherwise release the flock while this process still tears down
+/// its VM, letting a concurrent daemon boot into the same resources).
 #[derive(Clone)]
 pub struct StartupHandles {
     pub shared_runtime: SharedRuntime,
@@ -35,6 +43,10 @@ pub struct StartupHandles {
     pub early_runtime: SharedRuntime,
     pub setup_state: Arc<SetupState>,
     pub shutdown: CancellationToken,
+    /// Filled by the lease phase. Held here (not only in the pipeline's
+    /// context) so the exclusive flock lives until process exit even when
+    /// the startup future is cancelled mid-flight.
+    pub daemon_lock: SharedDaemonLock,
 }
 
 impl StartupHandles {
@@ -44,6 +56,7 @@ impl StartupHandles {
             early_runtime: Arc::new(std::sync::OnceLock::new()),
             setup_state,
             shutdown: CancellationToken::new(),
+            daemon_lock: Arc::new(std::sync::OnceLock::new()),
         }
     }
 }
@@ -64,6 +77,8 @@ pub struct EarlyContext {
     pub early_runtime: SharedRuntime,
     pub setup_state: Arc<SetupState>,
     pub shutdown: CancellationToken,
+    /// Empty slot the lease phase publishes the acquired lock into.
+    pub daemon_lock_slot: SharedDaemonLock,
     pub dns_domain: String,
     pub dns_port: u16,
     pub docker_integration: bool,
@@ -78,9 +93,10 @@ pub struct DaemonContext {
     pub profile: ArcboxProfile,
     pub layout: HostLayout,
     /// Exclusive lock held for the daemon's lifetime.
-    /// Held via RAII — the flock is released when this value drops.
-    #[allow(dead_code)] // held for drop semantics
-    pub daemon_lock: DaemonLock,
+    /// Held via RAII — the flock is released when the last clone drops;
+    /// `StartupHandles` holds a sibling clone so a cancelled startup
+    /// future cannot release it early.
+    pub daemon_lock: Arc<DaemonLock>,
     /// Shared with gRPC services. Empty after `acquire_lock`, filled by `init_runtime`.
     pub shared_runtime: SharedRuntime,
     /// Filled by `init_runtime` right after runtime construction, before

--- a/app/arcbox-daemon/src/main.rs
+++ b/app/arcbox-daemon/src/main.rs
@@ -121,27 +121,36 @@ fn sentry_environment() -> Option<String> {
 }
 
 async fn run(args: DaemonArgs) -> Result<()> {
-    let setup_state = Arc::new(SetupState::new());
+    let handles = context::StartupHandles::new(Arc::new(SetupState::new()));
 
-    let ready = match start(args, Arc::clone(&setup_state)).await {
-        Ok(ready) => ready,
-        Err(e) => {
-            // Publish the failure on the setup stream before exiting so a
-            // WatchSetupStatus client (desktop app, e2e harness) learns the
-            // cause instead of seeing a bare disconnect. The brief grace
-            // period lets already-connected streams flush the final event;
-            // with no clients it only delays the error exit.
-            setup_state.set_failed(&format!("{e:#}"));
-            tokio::time::sleep(std::time::Duration::from_millis(200)).await;
-            return Err(e);
+    // The signal watcher must be armed for the whole startup window: the
+    // pipeline boots the VM, and without a handler the default SIGTERM
+    // disposition kills the process mid-boot, orphaning the VM and the
+    // Virtualization.framework helpers holding its disk images.
+    let ready = tokio::select! {
+        ready = start(args, handles.clone()) => match ready {
+            Ok(ready) => ready,
+            Err(e) => {
+                // Publish the failure on the setup stream before exiting so a
+                // WatchSetupStatus client (desktop app, e2e harness) learns the
+                // cause instead of seeing a bare disconnect. The brief grace
+                // period lets already-connected streams flush the final event;
+                // with no clients it only delays the error exit.
+                handles.setup_state.set_failed(&format!("{e:#}"));
+                tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+                return Err(e);
+            }
+        },
+        () = shutdown::wait_for_signal() => {
+            return shutdown::interrupt_startup(&handles).await;
         }
     };
 
     shutdown::run(ready.ctx, ready.handles).await
 }
 
-async fn start(args: DaemonArgs, setup_state: Arc<SetupState>) -> Result<startup::ReadyDaemon> {
-    startup::Startup::from_args(args, setup_state)
+async fn start(args: DaemonArgs, handles: context::StartupHandles) -> Result<startup::ReadyDaemon> {
+    startup::Startup::from_args(args, handles)
         .prepare_host()
         .await?
         .acquire_daemon_lease()

--- a/app/arcbox-daemon/src/shutdown.rs
+++ b/app/arcbox-daemon/src/shutdown.rs
@@ -3,7 +3,13 @@
 //! First signal triggers graceful shutdown with visible feedback.
 //! Second signal force-quits: skips the VM graceful stop but still runs
 //! full cleanup (port forwarding, network manager, routes, sockets).
+//!
+//! Signals arriving before startup completes are handled by
+//! [`interrupt_startup`] — `main::run` keeps a signal watcher armed for
+//! the whole startup window so a mid-boot SIGTERM cannot fall through to
+//! the default disposition and orphan the VM.
 
+use std::sync::Arc;
 use std::time::Duration;
 
 use anyhow::Result;
@@ -11,9 +17,15 @@ use arcbox_docker::DockerContextManager;
 use tokio::signal;
 use tracing::{info, warn};
 
-use crate::context::{DaemonContext, ServiceHandles};
+use crate::context::{DaemonContext, ServiceHandles, StartupHandles};
 
 const DRAIN_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// How long a startup interrupt waits for a graceful runtime stop before
+/// force-killing the VM. A boot in flight parks graceful `Stop` behind
+/// itself in the VM lifecycle actor, so an unbounded wait could last the
+/// whole boot timeout — longer than launchd's own SIGKILL patience.
+const STARTUP_ABORT_GRACE: Duration = Duration::from_secs(10);
 
 /// Waits for a shutdown signal, drains services, and cleans up.
 pub async fn run(ctx: DaemonContext, mut handles: ServiceHandles) -> Result<()> {
@@ -101,7 +113,85 @@ fn remove_sockets(ctx: &DaemonContext) {
     // file. Removing it would race with a concurrent startup.
 }
 
-async fn wait_for_signal() {
+/// Tears down a daemon whose startup was interrupted by a signal.
+///
+/// The startup future has been dropped at an await point, but a VM that
+/// began booting lives on in its lifecycle tasks — reach it through the
+/// pre-pipeline [`StartupHandles`] and stop it so no orphaned VM or
+/// Virtualization.framework helper keeps holding disk images.
+///
+/// Mirrors [`run`]'s two-signal contract: the graceful stop is bounded by
+/// [`STARTUP_ABORT_GRACE`] (or cut short by a second signal), then the VM
+/// is force-killed.
+pub async fn interrupt_startup(handles: &StartupHandles) -> Result<()> {
+    println!("Shutting down... (press Ctrl+C again to force quit)");
+    info!("Shutdown signal received during startup, aborting");
+
+    // Publish the cause on the setup stream, then give already-connected
+    // WatchSetupStatus clients a moment to flush before the gRPC server
+    // (which observes the cancellation token) shuts down.
+    handles
+        .setup_state
+        .set_failed("startup interrupted by shutdown signal");
+    tokio::time::sleep(Duration::from_millis(200)).await;
+    handles.shutdown.cancel();
+
+    // `early_runtime` is filled before the VM boots, so it covers every
+    // window in which a VM can exist; empty means nothing to tear down.
+    let Some(runtime) = handles.early_runtime.get() else {
+        info!("ArcBox daemon stopped");
+        return Ok(());
+    };
+    let runtime = Arc::clone(runtime);
+
+    let graceful = tokio::spawn({
+        let runtime = Arc::clone(&runtime);
+        async move { runtime.shutdown().await }
+    });
+
+    let forced = tokio::select! {
+        result = tokio::time::timeout(STARTUP_ABORT_GRACE, graceful) => match result {
+            Ok(Ok(Err(e))) => {
+                warn!("Runtime shutdown error during startup abort: {e}");
+                false
+            }
+            Ok(Err(e)) => {
+                warn!("Runtime shutdown task panicked during startup abort: {e}");
+                true
+            }
+            Err(_) => {
+                warn!(
+                    "Graceful stop did not finish within {}s during startup abort, forcing",
+                    STARTUP_ABORT_GRACE.as_secs()
+                );
+                true
+            }
+            Ok(Ok(Ok(()))) => false,
+        },
+        () = wait_for_signal() => {
+            println!("Force shutting down...");
+            warn!("Second signal received during startup abort, forcing shutdown");
+            true
+        }
+    };
+
+    if forced {
+        let _ = runtime.shutdown_force().await;
+    }
+
+    info!("ArcBox daemon stopped");
+
+    if forced {
+        // The abandoned graceful-stop task may still be blocked waiting for
+        // the VM (it occupies a worker thread); exit directly rather than
+        // hanging in runtime drop, mirroring the force path of `run`.
+        std::process::exit(0);
+    }
+
+    Ok(())
+}
+
+pub async fn wait_for_signal() {
     let ctrl_c = async {
         signal::ctrl_c()
             .await

--- a/app/arcbox-daemon/src/startup/mod.rs
+++ b/app/arcbox-daemon/src/startup/mod.rs
@@ -14,15 +14,14 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use anyhow::{Context, Result};
-use arcbox_api::{SetupPhase, SetupState};
+use arcbox_api::SetupPhase;
 use arcbox_constants::paths::{ArcboxProfile, HostLayout};
 use arcbox_core::{Config, Runtime};
 use macos_resolver::to_env_prefix;
-use tokio_util::sync::CancellationToken;
 use tracing::{info, warn};
 
 use crate::DaemonArgs;
-use crate::context::{DaemonContext, EarlyContext, VmArgs};
+use crate::context::{DaemonContext, EarlyContext, StartupHandles, VmArgs};
 
 const DNS_PREFIX: &str = "arcbox";
 const DEFAULT_DNS_DOMAIN: &str = "arcbox.local";
@@ -32,7 +31,7 @@ const DEFAULT_DNS_DOMAIN: &str = "arcbox.local";
 /// Returns an [`EarlyContext`] sufficient to start the gRPC
 /// SystemService so clients can observe the full startup progression.
 /// Call [`acquire_lock`] next to obtain a [`DaemonContext`].
-async fn init_early(args: DaemonArgs, setup_state: Arc<SetupState>) -> Result<EarlyContext> {
+async fn init_early(args: DaemonArgs, handles: StartupHandles) -> Result<EarlyContext> {
     let profile = args
         .profile
         .unwrap_or_else(ArcboxProfile::from_env_or_default);
@@ -58,10 +57,10 @@ async fn init_early(args: DaemonArgs, setup_state: Arc<SetupState>) -> Result<Ea
     Ok(EarlyContext {
         profile,
         layout,
-        shared_runtime: Arc::new(std::sync::OnceLock::new()),
-        early_runtime: Arc::new(std::sync::OnceLock::new()),
-        setup_state,
-        shutdown: CancellationToken::new(),
+        shared_runtime: handles.shared_runtime,
+        early_runtime: handles.early_runtime,
+        setup_state: handles.setup_state,
+        shutdown: handles.shutdown,
         dns_domain,
         dns_port,
         docker_integration: args.docker_integration,

--- a/app/arcbox-daemon/src/startup/mod.rs
+++ b/app/arcbox-daemon/src/startup/mod.rs
@@ -61,6 +61,7 @@ async fn init_early(args: DaemonArgs, handles: StartupHandles) -> Result<EarlyCo
         early_runtime: handles.early_runtime,
         setup_state: handles.setup_state,
         shutdown: handles.shutdown,
+        daemon_lock_slot: handles.daemon_lock,
         dns_domain,
         dns_port,
         docker_integration: args.docker_integration,
@@ -84,6 +85,14 @@ async fn acquire_lock(early: EarlyContext) -> Result<DaemonContext> {
         .await
         .context("lock task panicked")?
         .context("failed to acquire daemon lock")?;
+    let lock = Arc::new(lock);
+    // Publish a sibling clone into the pre-pipeline handles: a signal drops
+    // this pipeline's context mid-flight, and the flock must outlive that
+    // drop for as long as the interrupt path is still tearing down the VM.
+    early
+        .daemon_lock_slot
+        .set(Arc::clone(&lock))
+        .map_err(|_| anyhow::anyhow!("acquire_lock called twice"))?;
     Ok(DaemonContext {
         profile: early.profile,
         layout: early.layout,

--- a/app/arcbox-daemon/src/startup/pipeline.rs
+++ b/app/arcbox-daemon/src/startup/pipeline.rs
@@ -8,12 +8,12 @@ use std::sync::Arc;
 use std::time::Instant;
 
 use anyhow::Result;
-use arcbox_api::{SetupPhase, SetupState};
+use arcbox_api::SetupPhase;
 use arcbox_core::Runtime;
 use macos_resolver::FileResolver;
 use tracing::{info, warn};
 
-use crate::context::{DaemonContext, EarlyContext, ServiceHandles};
+use crate::context::{DaemonContext, EarlyContext, ServiceHandles, StartupHandles};
 use crate::{DaemonArgs, recovery, services};
 
 use super::{acquire_lock, assets, init_early, init_runtime, prepare_assets, wait_for_resources};
@@ -21,7 +21,7 @@ use super::{acquire_lock, assets, init_early, init_runtime, prepare_assets, wait
 /// Entry point for the daemon startup lifecycle.
 pub struct Startup {
     args: DaemonArgs,
-    setup_state: Arc<SetupState>,
+    handles: StartupHandles,
 }
 
 pub struct ReadyDaemon {
@@ -32,17 +32,18 @@ pub struct ReadyDaemon {
 impl Startup {
     /// Creates a startup pipeline from parsed daemon arguments.
     ///
-    /// `setup_state` is owned by the caller so it can publish a FAILED
-    /// phase if any pipeline step errors out.
-    pub fn from_args(args: DaemonArgs, setup_state: Arc<SetupState>) -> Self {
-        Self { args, setup_state }
+    /// `handles` is created by the caller before the pipeline runs so a
+    /// shutdown signal arriving mid-startup can reach the pipeline's
+    /// published state (setup stream, cancellation token, runtime).
+    pub fn from_args(args: DaemonArgs, handles: StartupHandles) -> Self {
+        Self { args, handles }
     }
 
     /// Prepares host directories and pre-lock context.
     pub async fn prepare_host(self) -> Result<HostPrepared> {
         info!("Starting ArcBox daemon...");
         let early =
-            record_startup_phase("prepare_host", init_early(self.args, self.setup_state)).await?;
+            record_startup_phase("prepare_host", init_early(self.args, self.handles)).await?;
         Ok(HostPrepared { early })
     }
 }

--- a/docs/daemon-lifecycle.md
+++ b/docs/daemon-lifecycle.md
@@ -102,6 +102,28 @@ signal received
 
 No manual intervention needed.
 
+## Signal During Startup
+
+The signal watcher is armed before the startup pipeline runs (`main::run`
+selects the pipeline against `wait_for_signal`), so SIGTERM / Ctrl+C
+arriving mid-startup triggers an orderly abort instead of the default
+kill-and-orphan:
+
+```
+signal received during startup
+  ├─ SetupState.set_failed("startup interrupted…")  → WatchSetupStatus clients see the cause
+  ├─ cancel CancellationToken                       → gRPC (if started) drains
+  ├─ early_runtime empty?  → exit (nothing to tear down)
+  ├─ runtime.shutdown()    → bounded to 10 s: an in-flight boot parks
+  │                          graceful Stop behind itself, so an unbounded
+  │                          wait could last the whole boot timeout
+  └─ on timeout / second signal → runtime.shutdown_force()  → VM killed,
+                                  no orphaned XPC helpers holding docker.img
+```
+
+`early_runtime` is filled right after `Runtime` construction, before the
+VM boots, so it covers every window in which a VM can exist.
+
 ## Crash / SIGKILL
 
 When the daemon is killed without graceful shutdown:

--- a/docs/daemon-lifecycle.md
+++ b/docs/daemon-lifecycle.md
@@ -124,6 +124,12 @@ signal received during startup
 `early_runtime` is filled right after `Runtime` construction, before the
 VM boots, so it covers every window in which a VM can exist.
 
+The daemon lease survives the abort: the lock is shared into the
+pre-pipeline handles when acquired, so cancelling the startup future
+does not release the flock — a concurrent daemon cannot take the lease
+while this process is still tearing down its VM. The flock releases at
+process exit, as in every other path.
+
 ## Crash / SIGKILL
 
 When the daemon is killed without graceful shutdown:


### PR DESCRIPTION
## Problem

The daemon installed its only signal handler in `shutdown::run`, **after** the full 5-phase startup pipeline (asset download + VM boot included) completed. During the multi-second boot window the process had the default SIGTERM disposition: a signal (logout/reboot, `launchctl bootout`, or a takeover SIGTERM from a racing `arcbox daemon start`) killed it instantly, orphaning the mid-boot VM and the Virtualization.framework XPC helpers holding `docker.img`. The next start then fights the locked image (see `docs/daemon-lifecycle.md`).

Found in the 2026-07-07 distribution/startup audit. Linear: ABX-407.

## Fix

- New `StartupHandles` (shutdown token + the two runtime `OnceLock`s + setup state) created in `main::run` **before** the pipeline, threaded into `init_early` — so the interrupt path can reach whatever the pipeline has published so far.
- `main::run` selects the pipeline against `wait_for_signal`; the watcher is armed for the whole startup window.
- `shutdown::interrupt_startup`: publishes the cause via `SetupState::set_failed` (per app/AGENTS.md), cancels the token (drains gRPC if started), then stops any runtime published via `early_runtime` — graceful first, **bounded to 10 s** (an in-flight boot parks graceful `Stop` behind itself in the lifecycle actor, so an unbounded wait could last the whole boot timeout), force-stop on timeout or second signal. Mirrors `shutdown::run`'s two-signal contract.
- `docs/daemon-lifecycle.md`: new "Signal During Startup" section.

`early_runtime` is filled right after `Runtime` construction and before the VM boots, so it covers every window in which a VM can exist.

## Validation

- `cargo clippy -p arcbox-daemon --all-targets` zero warnings; `cargo test -p arcbox-daemon` 23/23.
- The signal path itself needs a signed daemon + live VM to exercise (SIGTERM mid-boot → orderly teardown, no orphaned XPC holder). Planned as a manual/e2e-harness run — the OSS dev daemon cannot boot the guest agent locally.