### PR TITLE
fix(agent): gate docker readiness on API /_ping, not socket-connectable (ABX-408)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -452,12 +452,15 @@ name = "arcbox-e2e"
 version = "0.4.16"
 dependencies = [
  "anyhow",
+ "arcbox-constants",
  "arcbox-core",
  "arcbox-grpc",
  "arcbox-protocol",
  "arcbox-vmm",
  "hyper-util",
  "libc",
+ "serde",
+ "serde_json",
  "tempfile",
  "tokio",
  "toml_edit 0.25.12+spec-1.1.0",
@@ -2048,8 +2051,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8cb01cd46b0cf372153850f4c6c272d9cbea2da513e07538405148f95bd789f3"
 dependencies = [
  "atomic",
+ "parking_lot",
  "pear",
  "serde",
+ "tempfile",
  "toml 0.8.23",
  "uncased",
  "version_check",

--- a/app/arcbox-core/src/config.rs
+++ b/app/arcbox-core/src/config.rs
@@ -314,6 +314,12 @@ pub struct ContainerRuntimeConfig {
     /// Guest dockerd API vsock port.
     pub guest_docker_vsock_port: u32,
     /// Backend startup timeout in milliseconds.
+    ///
+    /// Must exceed the guest agent's ~90 s ensure-runtime budget: readiness
+    /// gates on dockerd answering `/_ping`, which on large data volumes can
+    /// take well over a minute (containerd content-store scan + dockerd
+    /// loading containers). A shorter host timeout would abort boots the
+    /// guest was still going to finish.
     pub startup_timeout_ms: u64,
 }
 
@@ -321,7 +327,7 @@ impl Default for ContainerRuntimeConfig {
     fn default() -> Self {
         Self {
             guest_docker_vsock_port: DOCKER_API_VSOCK_PORT,
-            startup_timeout_ms: 60_000,
+            startup_timeout_ms: 120_000,
         }
     }
 }

--- a/app/arcbox-core/src/config.rs
+++ b/app/arcbox-core/src/config.rs
@@ -315,11 +315,12 @@ pub struct ContainerRuntimeConfig {
     pub guest_docker_vsock_port: u32,
     /// Backend startup timeout in milliseconds.
     ///
-    /// Must exceed the guest agent's ~90 s ensure-runtime budget: readiness
-    /// gates on dockerd answering `/_ping`, which on large data volumes can
-    /// take well over a minute (containerd content-store scan + dockerd
-    /// loading containers). A shorter host timeout would abort boots the
-    /// guest was still going to finish.
+    /// Must exceed the guest agent's worst-case runtime bring-up with
+    /// headroom: readiness gates on dockerd answering `/_ping`, and the
+    /// guest can spend up to ~30 s waiting for containerd plus its ~90 s
+    /// dockerd readiness poll (~120 s total) on large data volumes. A
+    /// shorter host timeout would abort boots the guest was still going
+    /// to finish.
     pub startup_timeout_ms: u64,
 }
 
@@ -327,7 +328,7 @@ impl Default for ContainerRuntimeConfig {
     fn default() -> Self {
         Self {
             guest_docker_vsock_port: DOCKER_API_VSOCK_PORT,
-            startup_timeout_ms: 120_000,
+            startup_timeout_ms: 150_000,
         }
     }
 }

--- a/guest/arcbox-agent/src/agent/linux/runtime.rs
+++ b/guest/arcbox-agent/src/agent/linux/runtime.rs
@@ -272,7 +272,12 @@ async fn collect_runtime_status() -> RuntimeStatusResponse {
     } else {
         false
     };
-    let docker_ready = docker_api_ok;
+    let docker_probe = DockerProbe {
+        socket_exists: Path::new(DOCKER_API_UNIX_SOCKET).exists(),
+        socket_ok: docker_socket_ok,
+        api_ok: docker_api_ok,
+    };
+    let docker_ready = docker_probe.ready();
     let runtime_dir = PathBuf::from(ARCBOX_RUNTIME_BIN_DIR);
     let missing_runtime_binaries = missing_runtime_binaries_at(&runtime_dir);
 
@@ -304,12 +309,6 @@ async fn collect_runtime_status() -> RuntimeStatusResponse {
             detail: format!("no reachable socket found; checked: {}", socket_paths),
         }
     });
-
-    let docker_probe = DockerProbe {
-        socket_exists: Path::new(DOCKER_API_UNIX_SOCKET).exists(),
-        socket_ok: docker_socket_ok,
-        api_ok: docker_api_ok,
-    };
 
     services.push(docker_probe.service_status());
 

--- a/guest/arcbox-agent/src/agent/linux/runtime.rs
+++ b/guest/arcbox-agent/src/agent/linux/runtime.rs
@@ -61,8 +61,8 @@ pub(super) async fn handle_ensure_runtime(req: RuntimeEnsureRequest) -> RpcRespo
     let response = ensure_runtime::ensure_runtime(
         guard,
         req.start_if_needed,
-        || do_ensure_runtime_start(),
-        || do_ensure_runtime_probe(),
+        do_ensure_runtime_start,
+        do_ensure_runtime_probe,
     )
     .await;
 
@@ -77,10 +77,10 @@ async fn do_ensure_runtime_start() -> RuntimeEnsureResponse {
         notes.push(note);
     }
 
-    // Poll until docker socket is ready (up to ~90 seconds).
+    // Poll until the docker API answers /_ping (up to ~90 seconds).
     // On large data volumes with VirtIO block I/O, containerd may need
     // up to 30s to scan its content store, and dockerd may need additional
-    // time to load containers from Btrfs.
+    // time to load containers from Btrfs before it starts serving.
     let mut status = collect_runtime_status().await;
     for _ in 0..180 {
         if status.docker_ready {
@@ -260,16 +260,19 @@ async fn collect_runtime_status() -> RuntimeStatusResponse {
 
     let containerd_ready = probe_first_ready_socket(&CONTAINERD_SOCKET_CANDIDATES).await;
     // Two-level check: socket connectable (fast) + HTTP API probe (strong).
-    // Use socket connectable as the ready gate so the daemon doesn't stall
-    // when dockerd takes >30s to fully initialize (Loading containers on
-    // large data volumes). The HTTP probe result is included in the detail.
+    // The API probe is the ready gate: dockerd binds its socket before it
+    // finishes initializing (Loading containers…), so a socket-only gate
+    // reports ready while the first API calls still fail. Slow dockerd
+    // starts are covered by budget, not by weakening the gate — the
+    // ensure-runtime driver polls ~90s and the host startup timeout
+    // exceeds it (`ContainerRuntimeConfig::startup_timeout_ms`).
     let docker_socket_ok = probe_unix_socket(DOCKER_API_UNIX_SOCKET).await;
     let docker_api_ok = if docker_socket_ok {
         probe_docker_api_ready(DOCKER_API_UNIX_SOCKET).await
     } else {
         false
     };
-    let docker_ready = docker_socket_ok;
+    let docker_ready = docker_api_ok;
     let runtime_dir = PathBuf::from(ARCBOX_RUNTIME_BIN_DIR);
     let missing_runtime_binaries = missing_runtime_binaries_at(&runtime_dir);
 
@@ -302,52 +305,15 @@ async fn collect_runtime_status() -> RuntimeStatusResponse {
         }
     });
 
-    // dockerd status — distinguish socket-connectable vs API-ready.
-    let docker_detail = if docker_api_ok {
-        format!("API /_ping OK: {}", DOCKER_API_UNIX_SOCKET)
-    } else if docker_socket_ok {
-        format!(
-            "socket connectable, API initializing: {}",
-            DOCKER_API_UNIX_SOCKET
-        )
-    } else if Path::new(DOCKER_API_UNIX_SOCKET).exists() {
-        format!(
-            "socket exists but not connectable: {}",
-            DOCKER_API_UNIX_SOCKET
-        )
-    } else {
-        format!("socket missing: {}", DOCKER_API_UNIX_SOCKET)
+    let docker_probe = DockerProbe {
+        socket_exists: Path::new(DOCKER_API_UNIX_SOCKET).exists(),
+        socket_ok: docker_socket_ok,
+        api_ok: docker_api_ok,
     };
 
-    services.push(ServiceStatus {
-        name: "dockerd".to_string(),
-        status: if docker_ready {
-            SERVICE_READY.to_string()
-        } else if Path::new(DOCKER_API_UNIX_SOCKET).exists() {
-            SERVICE_ERROR.to_string()
-        } else {
-            SERVICE_NOT_READY.to_string()
-        },
-        detail: docker_detail,
-    });
+    services.push(docker_probe.service_status());
 
-    // Build the summary detail string.
-    let detail = if docker_ready {
-        "docker socket ready".to_string()
-    } else if Path::new(DOCKER_API_UNIX_SOCKET).exists() {
-        format!(
-            "docker socket exists but not reachable: {}",
-            DOCKER_API_UNIX_SOCKET
-        )
-    } else if !missing_runtime_binaries.is_empty() {
-        format!(
-            "docker socket missing: {}; {}",
-            DOCKER_API_UNIX_SOCKET,
-            runtime_missing_detail_from(&missing_runtime_binaries)
-        )
-    } else {
-        format!("docker socket missing: {}", DOCKER_API_UNIX_SOCKET)
-    };
+    let detail = docker_probe.summary_detail(&missing_runtime_binaries);
 
     RuntimeStatusResponse {
         containerd_ready,
@@ -355,6 +321,83 @@ async fn collect_runtime_status() -> RuntimeStatusResponse {
         endpoint: format!("vsock:{}", docker_api_vsock_port()),
         detail,
         services,
+    }
+}
+
+/// Observed dockerd probe results, classified into status/detail strings.
+///
+/// Ready means the API answered `/_ping` — a bound-but-initializing socket
+/// (dockerd loading containers) is explicitly *not ready*, only reported
+/// in the detail so operators can tell "starting up" from "broken".
+struct DockerProbe {
+    socket_exists: bool,
+    socket_ok: bool,
+    api_ok: bool,
+}
+
+impl DockerProbe {
+    fn ready(&self) -> bool {
+        self.api_ok
+    }
+
+    fn service_status(&self) -> arcbox_protocol::agent::ServiceStatus {
+        let status = if self.ready() {
+            SERVICE_READY
+        } else if self.socket_ok {
+            // Bound socket, API still initializing — progress, not an error.
+            SERVICE_NOT_READY
+        } else if self.socket_exists {
+            // Socket file present but connections fail: dockerd died.
+            SERVICE_ERROR
+        } else {
+            SERVICE_NOT_READY
+        };
+
+        let detail = if self.ready() {
+            format!("API /_ping OK: {}", DOCKER_API_UNIX_SOCKET)
+        } else if self.socket_ok {
+            format!(
+                "socket connectable, API initializing: {}",
+                DOCKER_API_UNIX_SOCKET
+            )
+        } else if self.socket_exists {
+            format!(
+                "socket exists but not connectable: {}",
+                DOCKER_API_UNIX_SOCKET
+            )
+        } else {
+            format!("socket missing: {}", DOCKER_API_UNIX_SOCKET)
+        };
+
+        arcbox_protocol::agent::ServiceStatus {
+            name: "dockerd".to_string(),
+            status: status.to_string(),
+            detail,
+        }
+    }
+
+    fn summary_detail(&self, missing_runtime_binaries: &[&'static str]) -> String {
+        if self.ready() {
+            "docker engine ready (API /_ping OK)".to_string()
+        } else if self.socket_ok {
+            format!(
+                "docker API initializing (socket connectable): {}",
+                DOCKER_API_UNIX_SOCKET
+            )
+        } else if self.socket_exists {
+            format!(
+                "docker socket exists but not reachable: {}",
+                DOCKER_API_UNIX_SOCKET
+            )
+        } else if !missing_runtime_binaries.is_empty() {
+            format!(
+                "docker socket missing: {}; {}",
+                DOCKER_API_UNIX_SOCKET,
+                runtime_missing_detail_from(missing_runtime_binaries)
+            )
+        } else {
+            format!("docker socket missing: {}", DOCKER_API_UNIX_SOCKET)
+        }
     }
 }
 
@@ -614,7 +657,9 @@ async fn try_start_bundled_runtime() -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::shared_containerd_config;
+    use arcbox_constants::status::{SERVICE_ERROR, SERVICE_NOT_READY, SERVICE_READY};
+
+    use super::{DockerProbe, shared_containerd_config};
 
     #[test]
     fn shared_containerd_config_uses_k3s_cni_paths() {
@@ -622,5 +667,53 @@ mod tests {
         assert!(config.contains("bin_dir = \"/var/lib/rancher/k3s/data/cni\""));
         assert!(config.contains("conf_dir = \"/var/lib/rancher/k3s/agent/etc/cni/net.d\""));
         assert!(config.contains("max_conf_num = 1"));
+    }
+
+    fn probe(socket_exists: bool, socket_ok: bool, api_ok: bool) -> DockerProbe {
+        DockerProbe {
+            socket_exists,
+            socket_ok,
+            api_ok,
+        }
+    }
+
+    #[test]
+    fn docker_ready_requires_api_ping_not_just_socket() {
+        // Bound-but-initializing socket (dockerd loading containers) must
+        // not report ready — the regression behind the "500s right after
+        // engine ready" flake.
+        assert!(!probe(true, true, false).ready());
+        assert!(probe(true, true, true).ready());
+    }
+
+    #[test]
+    fn initializing_socket_is_not_ready_but_also_not_an_error() {
+        let status = probe(true, true, false).service_status();
+        assert_eq!(status.status, SERVICE_NOT_READY);
+        assert!(status.detail.contains("API initializing"));
+    }
+
+    #[test]
+    fn dead_socket_file_is_an_error() {
+        let status = probe(true, false, false).service_status();
+        assert_eq!(status.status, SERVICE_ERROR);
+        assert!(status.detail.contains("not connectable"));
+    }
+
+    #[test]
+    fn ready_probe_reports_ready_service() {
+        let status = probe(true, true, true).service_status();
+        assert_eq!(status.status, SERVICE_READY);
+        assert!(status.detail.contains("/_ping OK"));
+    }
+
+    #[test]
+    fn summary_mentions_missing_binaries_when_socket_absent() {
+        let summary = probe(false, false, false).summary_detail(&["dockerd", "runc"]);
+        assert!(summary.contains("socket missing"));
+        assert!(summary.contains("dockerd, runc"));
+
+        let initializing = probe(true, true, false).summary_detail(&[]);
+        assert!(initializing.contains("initializing"));
     }
 }


### PR DESCRIPTION
## Problem

`collect_runtime_status` computed `docker_api_ok` (a real `GET /_ping`) and then **discarded it** — the readiness gate was `docker_ready = docker_socket_ok`. dockerd binds its unix socket before it finishes initializing (Loading containers…), so `RuntimeReady` + the `vsock:2375` endpoint fired early and the first proxied API calls hit a mid-init dockerd → intermittent 500/EOF right after "engine ready". Most plausible API-layer surface of the "Starting Docker engine" flake.

The socket-only gate was a deliberate tradeoff (avoid stalling on >30 s dockerd loads), but it traded correctness for latency: a false ready is worse than a slower true one.

Found in the 2026-07-07 distribution/startup audit. Linear: ABX-408.

## Fix

- Gate `docker_ready` on the `/_ping` result.
- Slow starts are covered by **budget, not a weak gate**: raise `ContainerRuntimeConfig::startup_timeout_ms` 60 s → 120 s so the host watch deadline exceeds the guest's ~90 s ensure-runtime budget. (The old 60 s host deadline vs 90 s guest budget was itself an audit finding: it could produce a spurious `RuntimeFailed` while dockerd was still legitimately booting.)
- Extract the probe classification into `DockerProbe` so it is unit-testable; a bound-but-initializing socket now reports `NOT_READY` ("API initializing") instead of falling into the `ERROR` branch.

## Validation

- 5 new unit tests on the `DockerProbe` classification (compiled for the Linux target; they run wherever agent tests run on Linux).
- `cargo clippy -p arcbox-agent --target aarch64-unknown-linux-musl --all-targets`: no warnings on changed lines (pre-existing pedantic warnings in `sandbox.rs`/older `runtime.rs` lines are untouched — the musl target isn't in the current lint gate).
- `cargo test -p arcbox-core --lib config`: 18/18.
- End-to-end (boot → first `docker ps` immediately after ready) needs a signed daemon + rootfs pipeline; to be exercised via the e2e harness/desktop build. Note: this changes guest behavior, so it ships with the next agent/rootfs release — old agents keep the old gate until then (tracked by the version-skew issue ABX-410).