### PR TITLE
feat(rpc): daemon↔agent protocol handshake + buf breaking CI gate (ABX-410)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,32 @@ env:
   RUST_BACKTRACE: 1
 
 jobs:
+  proto-breaking:
+    name: Proto Breaking-Change Check
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    # The host↔agent channel has no runtime version negotiation beyond the
+    # ping handshake, so proto evolution must stay wire-compatible and
+    # additive-only. Compares the PR's protos against master.
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Fetch master for comparison
+        run: git fetch origin master:refs/remotes/origin/master
+
+      - name: Install buf
+        uses: bufbuild/buf-action@v1
+        with:
+          setup_only: true
+
+      - name: Check for breaking proto changes against master
+        run: |
+          buf breaking rpc/arcbox-protocol/proto \
+            --against '.git#branch=origin/master,subdir=rpc/arcbox-protocol/proto'
+
   ci:
     name: Build, Lint, and Test
     runs-on: macos-26

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,25 +17,30 @@ jobs:
     timeout-minutes: 5
     # The host↔agent channel has no runtime version negotiation beyond the
     # ping handshake, so proto evolution must stay wire-compatible and
-    # additive-only. Compares the PR's protos against master.
+    # additive-only. PRs compare against their base branch; branch pushes
+    # compare against the branch's previous state on origin.
     steps:
       - name: Checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      - name: Fetch master for comparison
-        run: git fetch origin master:refs/remotes/origin/master
+      - name: Fetch base branch for comparison
+        env:
+          BASE_REF: ${{ github.base_ref || github.ref_name }}
+        run: git fetch origin "$BASE_REF:refs/remotes/origin/$BASE_REF" || true
 
       - name: Install buf
         uses: bufbuild/buf-action@v1
         with:
           setup_only: true
 
-      - name: Check for breaking proto changes against master
+      - name: Check for breaking proto changes against the base branch
+        env:
+          BASE_REF: ${{ github.base_ref || github.ref_name }}
         run: |
           buf breaking rpc/arcbox-protocol/proto \
-            --against '.git#branch=origin/master,subdir=rpc/arcbox-protocol/proto'
+            --against ".git#branch=origin/$BASE_REF,subdir=rpc/arcbox-protocol/proto"
 
   ci:
     name: Build, Lint, and Test

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -452,12 +452,15 @@ name = "arcbox-e2e"
 version = "0.4.16"
 dependencies = [
  "anyhow",
+ "arcbox-constants",
  "arcbox-core",
  "arcbox-grpc",
  "arcbox-protocol",
  "arcbox-vmm",
  "hyper-util",
  "libc",
+ "serde",
+ "serde_json",
  "tempfile",
  "tokio",
  "toml_edit 0.25.12+spec-1.1.0",
@@ -2048,8 +2051,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8cb01cd46b0cf372153850f4c6c272d9cbea2da513e07538405148f95bd789f3"
 dependencies = [
  "atomic",
+ "parking_lot",
  "pear",
  "serde",
+ "tempfile",
  "toml 0.8.23",
  "uncased",
  "version_check",

--- a/app/arcbox-core/src/agent_client.rs
+++ b/app/arcbox-core/src/agent_client.rs
@@ -293,6 +293,44 @@ impl AgentClient {
         Self::decode_response(&resp_payload)
     }
 
+    /// Verifies the agent's protocol version from a ping response.
+    ///
+    /// Rejects agents older than
+    /// [`arcbox_constants::wire::MIN_AGENT_PROTOCOL_VERSION`] — including
+    /// pre-handshake agents that report `0` — so a stale staged agent
+    /// fails the boot with an actionable error instead of silently
+    /// misdecoding newer requests (proto3 defaults unknown fields).
+    /// A *newer* agent than the host only warns: protocol evolution is
+    /// additive, so newer agents understand older hosts.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the agent's protocol version is below the
+    /// host's minimum supported version.
+    pub fn check_agent_protocol(resp: &PingResponse) -> Result<()> {
+        use arcbox_constants::wire::{AGENT_PROTOCOL_VERSION, MIN_AGENT_PROTOCOL_VERSION};
+
+        if resp.protocol_version < MIN_AGENT_PROTOCOL_VERSION {
+            return Err(CoreError::Machine(format!(
+                "guest agent is incompatible with this daemon: agent protocol {} \
+                 (agent version {:?}), daemon requires >= {}. The staged agent \
+                 binary is stale — reinstall or update ArcBox so the bundled \
+                 agent is staged again",
+                resp.protocol_version, resp.version, MIN_AGENT_PROTOCOL_VERSION,
+            )));
+        }
+        if resp.protocol_version > AGENT_PROTOCOL_VERSION {
+            tracing::warn!(
+                agent_protocol = resp.protocol_version,
+                host_protocol = AGENT_PROTOCOL_VERSION,
+                agent_version = %resp.version,
+                "guest agent speaks a newer protocol than this daemon; \
+                 continuing (protocol evolution is additive)"
+            );
+        }
+        Ok(())
+    }
+
     /// Synchronous ping — uses blocking transport's native deadline.
     /// Call from `spawn_blocking` or any non-async context.
     pub fn ping_blocking(&mut self) -> Result<PingResponse> {
@@ -1106,5 +1144,35 @@ mod tests {
         let client = AgentClient::new(3);
         assert_eq!(client.cid(), 3);
         assert!(!client.connected);
+    }
+
+    fn ping_response(protocol_version: u32) -> PingResponse {
+        PingResponse {
+            message: "pong".to_string(),
+            version: "0.4.16".to_string(),
+            protocol_version,
+        }
+    }
+
+    #[test]
+    fn pre_handshake_agent_is_rejected() {
+        // Agents older than the handshake never set the field → proto3
+        // default 0 → must be rejected, not silently accepted.
+        let err = AgentClient::check_agent_protocol(&ping_response(0))
+            .expect_err("protocol 0 must be rejected");
+        assert!(err.to_string().contains("incompatible"));
+    }
+
+    #[test]
+    fn current_protocol_is_accepted() {
+        let resp = ping_response(arcbox_constants::wire::AGENT_PROTOCOL_VERSION);
+        AgentClient::check_agent_protocol(&resp).expect("current protocol must pass");
+    }
+
+    #[test]
+    fn newer_agent_protocol_is_accepted_with_warning() {
+        // Additive evolution: a newer agent understands an older host.
+        let resp = ping_response(arcbox_constants::wire::AGENT_PROTOCOL_VERSION + 1);
+        AgentClient::check_agent_protocol(&resp).expect("newer protocol must pass");
     }
 }

--- a/app/arcbox-core/src/agent_client.rs
+++ b/app/arcbox-core/src/agent_client.rs
@@ -313,7 +313,7 @@ impl AgentClient {
         if resp.protocol_version < MIN_AGENT_PROTOCOL_VERSION {
             return Err(CoreError::Machine(format!(
                 "guest agent is incompatible with this daemon: agent protocol {} \
-                 (agent version {:?}), daemon requires >= {}. The staged agent \
+                 (agent version {}), daemon requires >= {}. The staged agent \
                  binary is stale — reinstall or update ArcBox so the bundled \
                  agent is staged again",
                 resp.protocol_version, resp.version, MIN_AGENT_PROTOCOL_VERSION,

--- a/app/arcbox-core/src/machine.rs
+++ b/app/arcbox-core/src/machine.rs
@@ -414,6 +414,9 @@ impl MachineManager {
                 match self.connect_agent(name) {
                     Ok(mut agent) if agent.is_blocking() => match agent.ping_blocking() {
                         Ok(resp) => {
+                            // Stale agents fail machine start loudly instead
+                            // of misbehaving under proto field skew.
+                            crate::agent_client::AgentClient::check_agent_protocol(&resp)?;
                             tracing::debug!(
                                 "Machine '{}' agent reachable (version: {}, attempt {})",
                                 name,

--- a/app/arcbox-core/src/vm_lifecycle/boot.rs
+++ b/app/arcbox-core/src/vm_lifecycle/boot.rs
@@ -486,7 +486,24 @@ impl LifecycleShared {
                 // deadline elapses. HV's AF_UNIX transport stays on this
                 // blocking thread; async transports are handed back to tokio.
                 match mm.connect_agent(&machine_name) {
-                    Ok(agent) if agent.is_blocking() => {
+                    Ok(mut agent) if agent.is_blocking() => {
+                        // Protocol handshake before the readiness watch: Ping
+                        // is understood by every agent generation, so a stale
+                        // staged agent fails the boot here with an actionable
+                        // protocol error instead of an opaque readiness
+                        // timeout (the ABX-385 failure mode). A ping transport
+                        // error is the usual "not listening yet" race — retry.
+                        match agent.ping_blocking() {
+                            Ok(resp) => {
+                                crate::agent_client::AgentClient::check_agent_protocol(&resp)?;
+                            }
+                            Err(e) => {
+                                tracing::debug!("agent not answering ping yet: {e}");
+                                last_readiness_err = Some(e.to_string());
+                                std::thread::sleep(poll_interval);
+                                continue;
+                            }
+                        }
                         let remaining =
                             deadline.saturating_duration_since(std::time::Instant::now());
                         if remaining.is_zero() {
@@ -529,7 +546,7 @@ impl LifecycleShared {
                     }
                     // Reuse the connection from the probe loop on the first
                     // iteration, then reconnect on each retry.
-                    let agent = match next_agent.take() {
+                    let mut agent = match next_agent.take() {
                         Some(agent) => agent,
                         None => match self.machine_manager.connect_agent(&self.machine_name) {
                             Ok(agent) => agent,
@@ -540,6 +557,20 @@ impl LifecycleShared {
                             }
                         },
                     };
+                    // Protocol handshake before the readiness watch — mirrors
+                    // the blocking arm: a stale agent fails loudly here, a
+                    // ping transport error is a "not listening yet" retry.
+                    match agent.ping().await {
+                        Ok(resp) => {
+                            crate::agent_client::AgentClient::check_agent_protocol(&resp)?;
+                        }
+                        Err(e) => {
+                            tracing::debug!("agent not answering ping yet: {e}");
+                            last_readiness_err = Some(e.to_string());
+                            tokio::time::sleep(Duration::from_millis(25)).await;
+                            continue;
+                        }
+                    }
                     // Recompute the budget after a potentially slow reconnect so
                     // watch_readiness doesn't block past the deadline.
                     let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());

--- a/app/arcbox-core/src/vm_lifecycle/boot.rs
+++ b/app/arcbox-core/src/vm_lifecycle/boot.rs
@@ -560,15 +560,28 @@ impl LifecycleShared {
                     // Protocol handshake before the readiness watch — mirrors
                     // the blocking arm: a stale agent fails loudly here, a
                     // ping transport error is a "not listening yet" retry.
-                    match agent.ping().await {
-                        Ok(resp) => {
+                    // The async unary ping has no native deadline (the
+                    // blocking transport does), so bound it by the remaining
+                    // boot budget or a silent agent could hang the handshake
+                    // past the startup timeout.
+                    let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+                    if remaining.is_zero() {
+                        return Err(agent_timeout_error(last_readiness_err.as_deref()));
+                    }
+                    match tokio::time::timeout(remaining, agent.ping()).await {
+                        Ok(Ok(resp)) => {
                             crate::agent_client::AgentClient::check_agent_protocol(&resp)?;
                         }
-                        Err(e) => {
+                        Ok(Err(e)) => {
                             tracing::debug!("agent not answering ping yet: {e}");
                             last_readiness_err = Some(e.to_string());
                             tokio::time::sleep(Duration::from_millis(25)).await;
                             continue;
+                        }
+                        Err(_) => {
+                            return Err(agent_timeout_error(Some(
+                                "handshake ping timed out before the agent answered",
+                            )));
                         }
                     }
                     // Recompute the budget after a potentially slow reconnect so

--- a/common/arcbox-constants/src/wire.rs
+++ b/common/arcbox-constants/src/wire.rs
@@ -1,3 +1,20 @@
+/// Host↔agent RPC protocol version this build speaks.
+///
+/// Carried in `AgentPingResponse.protocol_version` and checked by the
+/// host during the boot handshake. Bump when a change alters the
+/// *meaning* of existing messages (new required semantics, repurposed
+/// fields, behavioral contracts) — purely additive, ignorable changes
+/// don't need a bump. Unknown `MessageType`s already fail cleanly; this
+/// version catches the silent proto3 field-skew class instead.
+pub const AGENT_PROTOCOL_VERSION: u32 = 1;
+
+/// Oldest agent protocol version this host still accepts.
+///
+/// Agents reporting less (including `0` — agents that predate the
+/// handshake field) are rejected at boot with an actionable error
+/// instead of silently misbehaving under field skew.
+pub const MIN_AGENT_PROTOCOL_VERSION: u32 = 1;
+
 /// Number of bytes in the fixed RPC frame header (`length` + `type`).
 pub const FRAME_HEADER_SIZE: usize = 8;
 

--- a/guest/arcbox-agent/src/agent/linux/rpc.rs
+++ b/guest/arcbox-agent/src/agent/linux/rpc.rs
@@ -415,5 +415,6 @@ fn handle_ping(req: arcbox_protocol::agent::PingRequest) -> RpcResponse {
             format!("pong: {}", req.message)
         },
         version: AGENT_VERSION.to_string(),
+        protocol_version: arcbox_constants::wire::AGENT_PROTOCOL_VERSION,
     })
 }

--- a/rpc/arcbox-protocol/README.md
+++ b/rpc/arcbox-protocol/README.md
@@ -22,6 +22,22 @@ re-exported through:
 | `agent` | `agent.proto` | Guest agent health/runtime messages |
 | `api` | `api.proto` | Network/system/volume/migration API messages |
 
+## Protocol evolution
+
+The daemon and the in-VM `arcbox-agent` are distributed separately, so a
+running guest may speak an older schema than the host. Two mechanisms keep
+skew safe:
+
+- **Additive-only schemas.** CI runs `buf breaking` against `master`
+  (`.github/workflows/ci.yml`): never remove or renumber fields; use
+  `reserved` when retiring them.
+- **Boot handshake.** The agent reports
+  `AgentPingResponse.protocol_version`
+  (`arcbox_constants::wire::AGENT_PROTOCOL_VERSION`); the host rejects
+  agents below `MIN_AGENT_PROTOCOL_VERSION` before watching readiness.
+  Bump the protocol version when a change alters the *meaning* of
+  existing messages; purely additive, ignorable fields don't need one.
+
 ## Usage
 
 ```rust

--- a/rpc/arcbox-protocol/proto/agent.proto
+++ b/rpc/arcbox-protocol/proto/agent.proto
@@ -63,6 +63,11 @@ message AgentPingResponse {
     string message = 1;
     // Agent version.
     string version = 2;
+    // Host↔agent protocol version the agent speaks
+    // (`arcbox_constants::wire::AGENT_PROTOCOL_VERSION`). Absent (0) on
+    // agents that predate the handshake; the host rejects agents below
+    // its minimum supported version at boot.
+    uint32 protocol_version = 3;
 }
 
 // System information from the guest.

--- a/rpc/arcbox-protocol/src/generated/arcbox.v1.rs
+++ b/rpc/arcbox-protocol/src/generated/arcbox.v1.rs
@@ -1442,6 +1442,12 @@ pub struct AgentPingResponse {
     /// Agent version.
     #[prost(string, tag = "2")]
     pub version: ::prost::alloc::string::String,
+    /// Host↔agent protocol version the agent speaks
+    /// (`arcbox_constants::wire::AGENT_PROTOCOL_VERSION`). Absent (0) on
+    /// agents that predate the handshake; the host rejects agents below
+    /// its minimum supported version at boot.
+    #[prost(uint32, tag = "3")]
+    pub protocol_version: u32,
 }
 /// System information from the guest.
 #[derive(serde::Serialize, serde::Deserialize)]


### PR DESCRIPTION
## Problem

The daemon↔guest-agent channel (length-prefixed protobuf over vsock) has **no version negotiation**. Unknown `MessageType`s fail cleanly on both sides, but proto3 **field-level skew is silent**: an old agent decodes fields it doesn't know as defaults and misbehaves with zero diagnostics. This is the structural gap behind ABX-385 (release daemon + stale staged agent → infinite boot loop, diagnosed only via guest logs). `AgentPingResponse.version` existed but its only consumer was a debug log line.

Found in the 2026-07-07 distribution/startup audit. Linear: ABX-410 (related: ABX-385).

## Change

**Handshake:**
- `AgentPingResponse.protocol_version` (new field 3), set by the agent from `arcbox_constants::wire::AGENT_PROTOCOL_VERSION` (= 1) — one shared constant for both sides.
- The host now **pings before every readiness watch** — Ping (0x0001) is understood by every agent generation, so a stale agent fails here with an actionable error ("staged agent is stale — reinstall/update") instead of an opaque readiness timeout. Wired into both `wait_for_agent` arms (blocking HV socketpair + async VZ/Linux) and the machine-VM ready probe.
- Policy: agents below `MIN_AGENT_PROTOCOL_VERSION` (incl. pre-handshake agents reporting proto3-default 0) are **rejected**; agents newer than the host **warn only** (evolution is additive). Bump the version when a change alters the *meaning* of existing messages; purely additive fields need no bump.
- Side benefit: the handshake ping carries `timestamp_secs`, so the HV guest wall clock now syncs *before* runtime start instead of only after readiness (the post-readiness sync ping remains per ABX-416).

**CI:**
- New `proto-breaking` job: `buf breaking rpc/arcbox-protocol/proto --against '.git#branch=origin/master,...'` — enforces wire-compatible, additive-only proto evolution. Command validated locally against current `origin/master` (passes with this PR's additive field).
- Protocol evolution policy documented in `rpc/arcbox-protocol/README.md`.

**Not in this PR** (tracked in ABX-410): sha/version verification of the staged agent binary itself — the handshake makes any skew loud at boot, which was the load-bearing gap.

## Validation

- 3 new unit tests on the gate (reject 0/pre-handshake, accept current, accept-and-warn newer); `cargo test -p arcbox-core --lib agent_client` 5/5.
- `cargo clippy` clean on arcbox-core/constants (host) and no new warnings on the agent musl target; `cargo fmt --check` clean; generated proto code regenerated and committed.
- Live-boot validation (old agent → clean "incompatible" error; current agent → normal boot) needs the signed daemon/desktop pipeline — same e2e pass as #365/#366.

⚠️ **Rollout note:** this changes guest behavior; agents built before this PR report protocol 0 and will be **rejected** by a daemon carrying this change. Daemon + agent (bundle/rootfs) must ship together — which is exactly the invariant this PR starts enforcing.