### PR TITLE
fix(asset): unique download temp files + manifest pin in prepare_binaries (ABX-411, ABX-412)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -216,6 +216,7 @@ dependencies = [
  "futures-util",
  "reqwest",
  "sha2",
+ "tempfile",
  "thiserror",
  "tokio",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -452,12 +452,15 @@ name = "arcbox-e2e"
 version = "0.4.16"
 dependencies = [
  "anyhow",
+ "arcbox-constants",
  "arcbox-core",
  "arcbox-grpc",
  "arcbox-protocol",
  "arcbox-vmm",
  "hyper-util",
  "libc",
+ "serde",
+ "serde_json",
  "tempfile",
  "tokio",
  "toml_edit 0.25.12+spec-1.1.0",
@@ -2048,8 +2051,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8cb01cd46b0cf372153850f4c6c272d9cbea2da513e07538405148f95bd789f3"
 dependencies = [
  "atomic",
+ "parking_lot",
  "pear",
  "serde",
+ "tempfile",
  "toml 0.8.23",
  "uncased",
  "version_check",

--- a/app/arcbox-core/src/boot_assets/provider.rs
+++ b/app/arcbox-core/src/boot_assets/provider.rs
@@ -115,18 +115,29 @@ impl BootAssetProvider {
         dest_dir: &Path,
         progress: Option<ProgressCallback>,
     ) -> Result<()> {
+        // The binaries are verified against manifest-supplied hashes, so
+        // their integrity is only as good as the manifest itself — check
+        // the pin on both sides of the inner call. Before: reject an
+        // already-tampered cached manifest without downloading anything it
+        // names. After: catch tampering that raced the prepare (the inner
+        // manager re-reads the file). The residual window — swapping the
+        // file between the inner read and either check — closes only when
+        // arcbox-boot verifies the bytes it parses (tracked in ABX-411).
+        if self.cached_manifest_path().exists() {
+            self.verify_manifest_pin()?;
+        }
+
         let cb: Option<InnerProgressCallback> = progress.map(|p| -> InnerProgressCallback { p });
         self.manager
             .prepare_binaries(dest_dir, cb)
             .await
             .map_err(|e| CoreError::config(format!("binary prepare error: {e}")))?;
 
-        // The binaries above were verified against manifest-supplied hashes,
-        // so their integrity is only as good as the manifest itself. Check
-        // the pin here too — previously only `get_assets` did, leaving this
-        // path with an implicit "a verified get_assets ran first" ordering
-        // dependency. A mismatch fails startup before the binaries are used.
         self.verify_manifest_pin()
+    }
+
+    fn cached_manifest_path(&self) -> PathBuf {
+        self.config.version_cache_dir().join("manifest.json")
     }
 
     /// Verifies the cached `manifest.json` against the sha256 pin compiled
@@ -141,8 +152,7 @@ impl BootAssetProvider {
             );
             return Ok(());
         };
-        let manifest_path = self.config.version_cache_dir().join("manifest.json");
-        let bytes = std::fs::read(&manifest_path)
+        let bytes = std::fs::read(self.cached_manifest_path())
             .map_err(|e| CoreError::config(format!("read manifest: {e}")))?;
         let actual = format!("{:x}", sha2::Sha256::digest(&bytes));
         if actual == expected {

--- a/app/arcbox-core/src/boot_assets/provider.rs
+++ b/app/arcbox-core/src/boot_assets/provider.rs
@@ -93,17 +93,7 @@ impl BootAssetProvider {
             .await
             .map_err(|e| CoreError::config(format!("boot asset error: {e}")))?;
 
-        if let Some(expected) = boot_asset_manifest_sha256() {
-            let manifest_path = self.config.version_cache_dir().join("manifest.json");
-            let bytes = std::fs::read(&manifest_path)
-                .map_err(|e| CoreError::config(format!("read manifest: {e}")))?;
-            let actual = format!("{:x}", sha2::Sha256::digest(&bytes));
-            if actual != expected {
-                return Err(CoreError::config(format!(
-                    "manifest SHA256 mismatch: expected {expected}, got {actual}"
-                )));
-            }
-        }
+        self.verify_manifest_pin()?;
 
         Ok(BootAssets {
             kernel: prepared.kernel,
@@ -129,7 +119,39 @@ impl BootAssetProvider {
         self.manager
             .prepare_binaries(dest_dir, cb)
             .await
-            .map_err(|e| CoreError::config(format!("binary prepare error: {e}")))
+            .map_err(|e| CoreError::config(format!("binary prepare error: {e}")))?;
+
+        // The binaries above were verified against manifest-supplied hashes,
+        // so their integrity is only as good as the manifest itself. Check
+        // the pin here too — previously only `get_assets` did, leaving this
+        // path with an implicit "a verified get_assets ran first" ordering
+        // dependency. A mismatch fails startup before the binaries are used.
+        self.verify_manifest_pin()
+    }
+
+    /// Verifies the cached `manifest.json` against the sha256 pin compiled
+    /// in from `assets.lock`. Fail-closed on mismatch; a missing pin only
+    /// warns — dev workflows drop the pin deliberately to boot locally
+    /// built assets.
+    fn verify_manifest_pin(&self) -> Result<()> {
+        let Some(expected) = boot_asset_manifest_sha256() else {
+            tracing::warn!(
+                "assets.lock carries no boot manifest_sha256 pin; skipping manifest \
+                 verification (expected only in local development builds)"
+            );
+            return Ok(());
+        };
+        let manifest_path = self.config.version_cache_dir().join("manifest.json");
+        let bytes = std::fs::read(&manifest_path)
+            .map_err(|e| CoreError::config(format!("read manifest: {e}")))?;
+        let actual = format!("{:x}", sha2::Sha256::digest(&bytes));
+        if actual == expected {
+            Ok(())
+        } else {
+            Err(CoreError::config(format!(
+                "manifest SHA256 mismatch: expected {expected}, got {actual}"
+            )))
+        }
     }
 
     /// Returns true if the current version's boot assets are fully cached

--- a/common/arcbox-asset/Cargo.toml
+++ b/common/arcbox-asset/Cargo.toml
@@ -27,3 +27,7 @@ futures-util = { version = "0.3", optional = true }
 
 [lints]
 workspace = true
+
+[dev-dependencies]
+tempfile.workspace = true
+tokio = { version = "1", features = ["net", "rt-multi-thread", "macros", "fs", "io-util"] }

--- a/common/arcbox-asset/src/download.rs
+++ b/common/arcbox-asset/src/download.rs
@@ -3,7 +3,8 @@
 use crate::error::{AssetError, Result};
 use futures_util::StreamExt;
 use sha2::{Digest, Sha256};
-use std::path::Path;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
 use tokio::io::AsyncWriteExt;
 
 /// HTTP request timeout in seconds.
@@ -18,6 +19,24 @@ pub async fn sha256_file(path: &Path) -> Result<String> {
     Ok(format!("{:x}", Sha256::digest(&bytes)))
 }
 
+/// Returns a sibling temp path unique per process and per call.
+///
+/// A fixed shared temp name (`dest.tmp`) lets two concurrent downloads of
+/// the same destination truncate and interleave into one file — each
+/// writer's *stream* hash still verifies, so a corrupt file gets renamed
+/// into place as "verified". Uniqueness makes every writer's temp private;
+/// the final `rename` stays atomic, so concurrent installs degrade to
+/// last-writer-wins with a genuinely verified file.
+fn unique_temp_path(dest: &Path) -> PathBuf {
+    static SEQ: AtomicU64 = AtomicU64::new(0);
+    let seq = SEQ.fetch_add(1, Ordering::Relaxed);
+    let file_name = dest
+        .file_name()
+        .map(|n| n.to_string_lossy().into_owned())
+        .unwrap_or_default();
+    dest.with_file_name(format!("{file_name}.{}.{seq}.tmp", std::process::id()))
+}
+
 /// Download `url` to `dest`, verifying that the content matches
 /// `expected_sha256`. The hash is computed incrementally while streaming.
 ///
@@ -30,7 +49,7 @@ pub async fn download_and_verify(
     dest: &Path,
     expected_sha256: &str,
     name: &str,
-    on_progress: impl Fn(u64, Option<u64>),
+    on_progress: impl Fn(u64, Option<u64>) + Send + Sync,
 ) -> Result<()> {
     let client = reqwest::Client::builder()
         .timeout(std::time::Duration::from_secs(HTTP_TIMEOUT_SECS))
@@ -54,35 +73,43 @@ pub async fn download_and_verify(
     let total = response.content_length();
     let mut downloaded: u64 = 0;
 
-    // Write to temp file, then rename atomically.
-    let temp_path = dest.with_extension("tmp");
-    let mut file = tokio::fs::File::create(&temp_path).await?;
-    let mut stream = response.bytes_stream();
-    let mut hasher = Sha256::new();
+    // Write to a private temp file, then rename atomically.
+    let temp_path = unique_temp_path(dest);
+    let outcome: Result<()> = async {
+        let mut file = tokio::fs::File::create(&temp_path).await?;
+        let mut stream = response.bytes_stream();
+        let mut hasher = Sha256::new();
 
-    while let Some(chunk) = stream.next().await {
-        let chunk = chunk.map_err(|e| AssetError::Download(format!("stream error: {e}")))?;
-        hasher.update(&chunk);
-        file.write_all(&chunk).await?;
-        downloaded += chunk.len() as u64;
-        on_progress(downloaded, total);
+        while let Some(chunk) = stream.next().await {
+            let chunk = chunk.map_err(|e| AssetError::Download(format!("stream error: {e}")))?;
+            hasher.update(&chunk);
+            file.write_all(&chunk).await?;
+            downloaded += chunk.len() as u64;
+            on_progress(downloaded, total);
+        }
+
+        file.flush().await?;
+        drop(file);
+
+        let actual_sha = format!("{:x}", hasher.finalize());
+        if actual_sha != expected_sha256 {
+            return Err(AssetError::ChecksumMismatch {
+                name: name.to_string(),
+                expected: expected_sha256.to_string(),
+                actual: actual_sha,
+            });
+        }
+
+        tokio::fs::rename(&temp_path, dest).await?;
+        Ok(())
     }
+    .await;
 
-    file.flush().await?;
-    drop(file);
-
-    let actual_sha = format!("{:x}", hasher.finalize());
-    if actual_sha != expected_sha256 {
+    // Unique temp names would otherwise accumulate on failure.
+    if outcome.is_err() {
         let _ = tokio::fs::remove_file(&temp_path).await;
-        return Err(AssetError::ChecksumMismatch {
-            name: name.to_string(),
-            expected: expected_sha256.to_string(),
-            actual: actual_sha,
-        });
     }
-
-    tokio::fs::rename(&temp_path, dest).await?;
-    Ok(())
+    outcome
 }
 
 /// Download `url` to `dest` without checksum verification.
@@ -109,18 +136,117 @@ pub async fn download_raw(url: &str, dest: &Path) -> Result<()> {
         )));
     }
 
-    let temp_path = dest.with_extension("tmp");
-    let mut file = tokio::fs::File::create(&temp_path).await?;
-    let mut stream = response.bytes_stream();
+    let temp_path = unique_temp_path(dest);
+    let outcome: Result<()> = async {
+        let mut file = tokio::fs::File::create(&temp_path).await?;
+        let mut stream = response.bytes_stream();
 
-    while let Some(chunk) = stream.next().await {
-        let chunk = chunk.map_err(|e| AssetError::Download(format!("stream error: {e}")))?;
-        file.write_all(&chunk).await?;
+        while let Some(chunk) = stream.next().await {
+            let chunk = chunk.map_err(|e| AssetError::Download(format!("stream error: {e}")))?;
+            file.write_all(&chunk).await?;
+        }
+
+        file.flush().await?;
+        drop(file);
+
+        tokio::fs::rename(&temp_path, dest).await?;
+        Ok(())
+    }
+    .await;
+
+    if outcome.is_err() {
+        let _ = tokio::fs::remove_file(&temp_path).await;
+    }
+    outcome
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tokio::io::AsyncReadExt;
+
+    /// Serves `body` over HTTP to every incoming connection until dropped.
+    async fn serve_fixture(body: &'static [u8]) -> String {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind fixture listener");
+        let addr = listener.local_addr().expect("fixture addr");
+        tokio::spawn(async move {
+            loop {
+                let Ok((mut sock, _)) = listener.accept().await else {
+                    return;
+                };
+                tokio::spawn(async move {
+                    let mut buf = [0u8; 1024];
+                    let _ = sock.read(&mut buf).await;
+                    let header = format!(
+                        "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+                        body.len()
+                    );
+                    let _ = sock.write_all(header.as_bytes()).await;
+                    let _ = sock.write_all(body).await;
+                });
+            }
+        });
+        format!("http://{addr}/asset")
     }
 
-    file.flush().await?;
-    drop(file);
+    fn leftover_temp_files(dir: &Path) -> Vec<PathBuf> {
+        std::fs::read_dir(dir)
+            .expect("read dir")
+            .filter_map(|e| e.ok().map(|e| e.path()))
+            .filter(|p| p.extension().is_some_and(|ext| ext == "tmp"))
+            .collect()
+    }
 
-    tokio::fs::rename(&temp_path, dest).await?;
-    Ok(())
+    #[tokio::test]
+    async fn checksum_mismatch_removes_temp_file() {
+        const BODY: &[u8] = b"asset-bytes";
+        let url = serve_fixture(BODY).await;
+        let dir = tempfile::tempdir().expect("tempdir");
+        let dest = dir.path().join("asset.bin");
+
+        let err = download_and_verify(&url, &dest, "deadbeef", "asset", |_, _| {})
+            .await
+            .expect_err("wrong sha must fail");
+        assert!(matches!(err, AssetError::ChecksumMismatch { .. }));
+        assert!(!dest.exists(), "dest must not be created on failure");
+        assert!(
+            leftover_temp_files(dir.path()).is_empty(),
+            "failed download must not leak temp files"
+        );
+    }
+
+    #[tokio::test]
+    async fn concurrent_downloads_of_same_dest_yield_verified_file() {
+        // Regression: a fixed `dest.tmp` let two concurrent writers truncate
+        // and interleave the same temp file, then rename a corrupt file that
+        // each writer's own stream hash had "verified".
+        const BODY: &[u8] = b"shared-destination-bytes";
+        let url = serve_fixture(BODY).await;
+        let sha = format!("{:x}", Sha256::digest(BODY));
+        let dir = tempfile::tempdir().expect("tempdir");
+        let dest = dir.path().join("tool");
+
+        let tasks: Vec<_> = (0..8)
+            .map(|_| {
+                let url = url.clone();
+                let sha = sha.clone();
+                let dest = dest.clone();
+                tokio::spawn(async move {
+                    download_and_verify(&url, &dest, &sha, "tool", |_, _| {}).await
+                })
+            })
+            .collect();
+        for t in tasks {
+            t.await.expect("task").expect("download");
+        }
+
+        let on_disk = tokio::fs::read(&dest).await.expect("read dest");
+        assert_eq!(on_disk, BODY, "installed file must match the payload");
+        assert!(
+            leftover_temp_files(dir.path()).is_empty(),
+            "successful downloads must not leak temp files"
+        );
+    }
 }


### PR DESCRIPTION
## Problems

**ABX-411 — concurrent downloads can install a corrupt-but-"verified" file.** Both download primitives wrote to a **fixed** `dest.tmp` and computed the SHA-256 from the in-memory byte stream, not the on-disk file. Four uncoordinated entry points (daemon recovery `ensure_docker_tools`, runtime-init `prepare_binaries`, CLI `docker setup`, CLI `kubernetes`) install into the same `~/.arcbox/runtime/bin`. Two concurrent downloads of the same tool truncate and interleave one temp file; each writer's *stream* hash verifies, and the first `rename` installs a corrupt file as "verified".

**ABX-412 — `prepare_binaries` trusted the cached CDN manifest unverified.** dockerd/containerd/runc/k3s/FEX were checked against manifest-supplied hashes, but the manifest's own `assets.lock` pin was only checked in `get_assets` — an implicit "a verified get_assets ran first" ordering dependency with a TOCTOU window on the cached `manifest.json`. The pin is also `Option`: an empty value silently disabled all manifest verification.

Found in the 2026-07-07 distribution/startup audit.

## Fixes

- `arcbox-asset`: per-call unique temp names (`{name}.{pid}.{seq}.tmp`) — every writer's temp is private, and the atomic rename degrades concurrent installs to last-writer-wins with a genuinely verified file. Temp files are now removed on **every** error path (previously only checksum mismatch), and `download_and_verify`'s progress callback gains `Send + Sync` bounds (fixes the `future_not_send` nursery lint surfaced by feature-enabled clippy).
- `boot_assets` provider: pin verification extracted into `verify_manifest_pin` and called from **both** `get_assets` and `prepare_binaries` (after the inner prepare, so a tampered manifest fails startup before the binaries are used — same fail-closed model as kernel/rootfs). A missing pin now logs a loud warning instead of silently skipping (kept as a warning, not an error: dev workflows drop the pin deliberately to boot locally built assets).

## Out of scope (upstream)

The `arcbox-boot` registry crate (0.5.1) has the same fixed-temp-name pattern in its own `download.rs`/`asset_manager.rs` — needs the identical fix in its home repo. Flagged in ABX-411.

## Validation

- 2 new regression tests against a local HTTP fixture: 8 concurrent downloads of the same dest → intact verified file, no leaked temps; checksum mismatch → no dest, no leaked temps. `cargo test -p arcbox-asset --features download` 3/3.
- `cargo test -p arcbox-core --lib boot_assets` 5/5; clippy clean on arcbox-asset (with the `download` feature), arcbox-docker-tools, arcbox-core; `cargo fmt --check` clean.