### PR TITLE
feat(sandbox): Sandbox V1 — usable E2B-style microVM sandboxes (CORE-1..15)

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -6,3 +6,11 @@ linker = "aarch64-linux-musl-gcc"
 
 [target.x86_64-unknown-linux-musl]
 linker = "x86_64-linux-musl-gcc"
+
+# C build scripts (cc crate) must use the same musl toolchain as the linker
+# above; the host clang cannot compile for *-linux-musl (no musl headers).
+[env]
+CC_aarch64_unknown_linux_musl = "aarch64-linux-musl-gcc"
+AR_aarch64_unknown_linux_musl = "aarch64-linux-musl-ar"
+CC_x86_64_unknown_linux_musl = "x86_64-linux-musl-gcc"
+AR_x86_64_unknown_linux_musl = "x86_64-linux-musl-ar"

--- a/.github/workflows/test-vm-linux.yml
+++ b/.github/workflows/test-vm-linux.yml
@@ -177,17 +177,17 @@ jobs:
           curl -sL "$BASE/vmlinux-6.1.102"              -o /tmp/fc-assets/vmlinux
           curl -sL "$BASE/ubuntu-22.04.ext4"            -o /tmp/fc-assets/rootfs-base.ext4
 
-      - name: Build vmm-guest-agent (Linux x86_64)
-        run: cargo build -p arcbox-vm --bin vmm-guest-agent --release
+      - name: Build vm-agent (Linux x86_64)
+        run: cargo build -p arcbox-vm --bin vm-agent --release
 
-      - name: Inject vmm-guest-agent into rootfs
+      - name: Inject vm-agent into rootfs
         run: |
           cp /tmp/fc-assets/rootfs-base.ext4 /tmp/fc-assets/rootfs.ext4
           sudo e2fsck -f -y /tmp/fc-assets/rootfs.ext4 || true
           sudo resize2fs /tmp/fc-assets/rootfs.ext4 512M
           mkdir -p /tmp/fc-mnt
           sudo mount -o loop /tmp/fc-assets/rootfs.ext4 /tmp/fc-mnt
-          sudo cp target/release/vmm-guest-agent /tmp/fc-mnt/sbin/vm-agent
+          sudo cp target/release/vm-agent /tmp/fc-mnt/sbin/vm-agent
           sudo chmod +x /tmp/fc-mnt/sbin/vm-agent
           sudo umount /tmp/fc-mnt
 
@@ -253,17 +253,17 @@ jobs:
 
       - name: Build binaries
         run: |
-          cargo build -p arcbox-vm --bin vmm-guest-agent --release
+          cargo build -p arcbox-vm --bin vm-agent --release
           cargo test -p arcbox-agent --test sandbox_service_manager --no-run
 
-      - name: Inject vmm-guest-agent into rootfs
+      - name: Inject vm-agent into rootfs
         run: |
           cp /tmp/fc-assets/rootfs-base.ext4 /tmp/fc-assets/rootfs.ext4
           sudo e2fsck -f -y /tmp/fc-assets/rootfs.ext4 || true
           sudo resize2fs /tmp/fc-assets/rootfs.ext4 512M
           mkdir -p /tmp/fc-mnt
           sudo mount -o loop /tmp/fc-assets/rootfs.ext4 /tmp/fc-mnt
-          sudo cp target/release/vmm-guest-agent /tmp/fc-mnt/sbin/vm-agent
+          sudo cp target/release/vm-agent /tmp/fc-mnt/sbin/vm-agent
           sudo chmod +x /tmp/fc-mnt/sbin/vm-agent
           sudo umount /tmp/fc-mnt
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -355,6 +355,7 @@ dependencies = [
  "arcbox-core",
  "arcbox-docker",
  "arcbox-docker-tools",
+ "arcbox-grpc",
  "arcbox-helper",
  "arcbox-logging",
  "arcbox-net",
@@ -375,6 +376,7 @@ dependencies = [
  "tokio-stream",
  "tokio-util",
  "tonic",
+ "tonic-reflection",
  "tracing",
  "tracing-subscriber",
 ]
@@ -5555,6 +5557,19 @@ dependencies = [
  "prost-types",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tonic-reflection"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "878d81f52e7fcfd80026b7fdb6a9b578b3c3653ba987f87f0dce4b64043cba27"
+dependencies = [
+ "prost",
+ "prost-types",
+ "tokio",
+ "tokio-stream",
+ "tonic",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6724,6 +6724,7 @@ name = "xtask"
 version = "0.4.16"
 dependencies = [
  "anyhow",
+ "arcbox-constants",
  "clap",
  "dirs",
  "flate2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -158,6 +158,7 @@ dependencies = [
  "anyhow",
  "arcbox-constants",
  "arcbox-dns",
+ "arcbox-ext4",
  "arcbox-protocol",
  "arcbox-vm",
  "async-trait",
@@ -170,6 +171,7 @@ dependencies = [
  "nix 0.29.0",
  "notify",
  "num_cpus",
+ "oci2rootfs",
  "pin-project-lite",
  "prost",
  "serde",
@@ -477,6 +479,17 @@ name = "arcbox-error"
 version = "0.4.16"
 dependencies = [
  "thiserror",
+]
+
+[[package]]
+name = "arcbox-ext4"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9dce000de67c1a27347fed86e9ce76199463fbb5a3d7f13cb0f3d1c16b6dae3"
+dependencies = [
+ "tar",
+ "thiserror",
+ "uuid",
 ]
 
 [[package]]
@@ -1419,6 +1432,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1e928d4b69e3077709075a938a05ffbedfa53a84c8f766efbf8220bb1ff60e1"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -1600,6 +1615,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
 dependencies = [
  "crossbeam-utils",
+]
+
+[[package]]
+name = "containerregistry-image"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1199b7cfc7bced15304d6cf5db698e5221b08e0eb143c054aaf46296f0fd48a9"
+dependencies = [
+ "hex",
+ "serde",
+ "serde_json",
+ "sha2",
+ "thiserror",
+]
+
+[[package]]
+name = "containerregistry-layout"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4875a5a717d943e673869dcde59f9db1a1ffeedec86f4faf43d6783d33614740"
+dependencies = [
+ "containerregistry-image",
+ "serde",
+ "serde_json",
+ "thiserror",
 ]
 
 [[package]]
@@ -2955,6 +2995,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "jobserver"
+version = "0.1.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c00acbd29eabad4a2392fa0e921c874934dbbf4194312ad20f04a0ed67a3cb3"
+dependencies = [
+ "getrandom 0.4.2",
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3592,6 +3642,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "oci2rootfs"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32117a443cb043dbc1876d75bf0c55b58ecc662642cac06d8f569ce6f9b9ac6e"
+dependencies = [
+ "arcbox-ext4",
+ "containerregistry-image",
+ "containerregistry-layout",
+ "flate2",
+ "tar",
+ "thiserror",
+ "tracing",
+ "uuid",
+ "zstd",
 ]
 
 [[package]]
@@ -6852,6 +6919,34 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.16+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+dependencies = [
+ "cc",
+ "pkg-config",
+]
 
 [[package]]
 name = "zvariant"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -468,6 +468,7 @@ dependencies = [
  "serde_json",
  "tempfile",
  "tokio",
+ "tokio-stream",
  "toml_edit 0.25.12+spec-1.1.0",
  "tonic",
  "tower 0.5.3",

--- a/app/arcbox-api/src/error.rs
+++ b/app/arcbox-api/src/error.rs
@@ -50,6 +50,15 @@ impl From<ApiError> for tonic::Status {
                 CommonError::PermissionDenied(_) => Self::permission_denied(message),
                 _ => Self::internal(message),
             },
+            // Agent-reported errors carry an HTTP-style code over the wire.
+            ApiError::Core(arcbox_core::CoreError::Agent { code, .. }) => match code {
+                400 => Self::invalid_argument(message),
+                404 => Self::not_found(message),
+                409 => Self::already_exists(message),
+                412 => Self::failed_precondition(message),
+                503 => Self::unavailable(message),
+                _ => Self::internal(message),
+            },
             ApiError::Grpc(_) => Self::unavailable(message),
             _ => Self::internal(message),
         }

--- a/app/arcbox-api/src/grpc/sandbox.rs
+++ b/app/arcbox-api/src/grpc/sandbox.rs
@@ -5,9 +5,10 @@ use std::pin::Pin;
 use arcbox_grpc::SandboxService;
 use arcbox_protocol::sandbox_v1::Empty as SandboxEmpty;
 use arcbox_protocol::sandbox_v1::{
-    CreateSandboxRequest, CreateSandboxResponse, ExecInput, ExecOutput, InspectSandboxRequest,
-    ListSandboxesRequest, ListSandboxesResponse, RemoveSandboxRequest, RunOutput, RunRequest,
-    SandboxEvent, SandboxEventsRequest, SandboxInfo, StopSandboxRequest, exec_input,
+    CreateSandboxRequest, CreateSandboxResponse, ExecInput, ExecOutput, FileChunk,
+    InspectSandboxRequest, ListSandboxesRequest, ListSandboxesResponse, ReadFileRequest,
+    RemoveSandboxRequest, RunOutput, RunRequest, SandboxEvent, SandboxEventsRequest, SandboxInfo,
+    StopSandboxRequest, WriteFileRequest, exec_input, write_file_request,
 };
 use tokio_stream::Stream;
 use tokio_stream::StreamExt as _;
@@ -220,6 +221,77 @@ impl SandboxService for SandboxServiceImpl {
             .await
             .map_err(ApiError::from)?;
         Ok(Response::new(resp))
+    }
+
+    type ReadFileStream = Pin<Box<dyn Stream<Item = Result<FileChunk, Status>> + Send + 'static>>;
+
+    async fn read_file(
+        &self,
+        request: Request<ReadFileRequest>,
+    ) -> Result<Response<Self::ReadFileStream>, Status> {
+        let machine = request.machine_id()?;
+        let agent = self
+            .runtime
+            .ready()?
+            .get_agent(&machine)
+            .map_err(ApiError::from)?;
+        let rx = agent
+            .sandbox_read_file(request.into_inner())
+            .await
+            .map_err(ApiError::from)?;
+        let stream = UnboundedReceiverStream::new(rx)
+            .map(|r| r.map_err(|e| Status::from(ApiError::from(e))));
+        Ok(Response::new(Box::pin(stream)))
+    }
+
+    async fn write_file(
+        &self,
+        request: Request<Streaming<WriteFileRequest>>,
+    ) -> Result<Response<SandboxEmpty>, Status> {
+        let machine = request.machine_id()?;
+        let agent = self
+            .runtime
+            .ready()?
+            .get_agent(&machine)
+            .map_err(ApiError::from)?;
+
+        let mut stream = request.into_inner();
+
+        // The first message in the stream must carry the Open payload.
+        let first = stream.next().await.ok_or_else(|| {
+            Status::invalid_argument("write_file: stream closed before Open message")
+        })??;
+        let open = match first.payload {
+            Some(write_file_request::Payload::Open(open)) => open,
+            _ => {
+                return Err(Status::invalid_argument(
+                    "write_file: first message must be Open",
+                ));
+            }
+        };
+
+        // Bridge gRPC chunks into the agent write stream; dropping the
+        // sender ends the transfer and triggers the terminating frame.
+        let (tx, rx) = tokio::sync::mpsc::channel(16);
+        tokio::spawn(async move {
+            while let Some(Ok(msg)) = stream.next().await {
+                if let Some(write_file_request::Payload::Chunk(chunk)) = msg.payload {
+                    let done = chunk.done;
+                    if !chunk.data.is_empty() && tx.send(chunk.data.clone()).await.is_err() {
+                        return;
+                    }
+                    if done {
+                        break;
+                    }
+                }
+            }
+        });
+
+        agent
+            .sandbox_write_file(open, rx)
+            .await
+            .map_err(ApiError::from)?;
+        Ok(Response::new(SandboxEmpty {}))
     }
 
     type EventsStream = Pin<Box<dyn Stream<Item = Result<SandboxEvent, Status>> + Send + 'static>>;

--- a/app/arcbox-api/src/grpc/sandbox.rs
+++ b/app/arcbox-api/src/grpc/sandbox.rs
@@ -5,10 +5,12 @@ use std::pin::Pin;
 use arcbox_grpc::SandboxService;
 use arcbox_protocol::sandbox_v1::Empty as SandboxEmpty;
 use arcbox_protocol::sandbox_v1::{
-    CreateSandboxRequest, CreateSandboxResponse, ExecInput, ExecOutput, FileChunk,
-    InspectSandboxRequest, ListSandboxesRequest, ListSandboxesResponse, ReadFileRequest,
-    RemoveSandboxRequest, RunOutput, RunRequest, SandboxEvent, SandboxEventsRequest, SandboxInfo,
-    StopSandboxRequest, WriteFileRequest, exec_input, write_file_request,
+    CreateSandboxRequest, CreateSandboxResponse, ExecInput, ExecOutput, ExposePortRequest,
+    ExposePortResponse, FileChunk, InspectSandboxRequest, ListSandboxesRequest,
+    ListSandboxesResponse, ReadFileRequest, RemoveSandboxRequest, RunOutput, RunRequest,
+    SandboxEvent, SandboxEventsRequest, SandboxInfo, SandboxPortForwardRemoveRequest,
+    SandboxPortForwardRequest, StopSandboxRequest, UnexposePortRequest, WriteFileRequest,
+    exec_input, write_file_request,
 };
 use tokio_stream::Stream;
 use tokio_stream::StreamExt as _;
@@ -16,7 +18,7 @@ use tokio_stream::wrappers::UnboundedReceiverStream;
 use tonic::codec::Streaming;
 use tonic::{Request, Response, Status};
 
-use arcbox_core::ExecSessionInput;
+use arcbox_core::{ExecSessionInput, SandboxPortExposure};
 
 use crate::ApiError;
 
@@ -157,10 +159,9 @@ impl SandboxService for SandboxServiceImpl {
             .await
             .map_err(ApiError::from)?;
 
-        self.runtime
-            .ready()?
-            .deregister_dns_by_id(&sandbox_id)
-            .await;
+        let runtime = self.runtime.ready()?;
+        runtime.deregister_dns_by_id(&sandbox_id).await;
+        runtime.remove_sandbox_ports(&sandbox_id).await;
 
         Ok(Response::new(SandboxEmpty {}))
     }
@@ -181,10 +182,9 @@ impl SandboxService for SandboxServiceImpl {
             .await
             .map_err(ApiError::from)?;
 
-        self.runtime
-            .ready()?
-            .deregister_dns_by_id(&sandbox_id)
-            .await;
+        let runtime = self.runtime.ready()?;
+        runtime.deregister_dns_by_id(&sandbox_id).await;
+        runtime.remove_sandbox_ports(&sandbox_id).await;
 
         Ok(Response::new(SandboxEmpty {}))
     }
@@ -291,6 +291,121 @@ impl SandboxService for SandboxServiceImpl {
             .sandbox_write_file(open, rx)
             .await
             .map_err(ApiError::from)?;
+        Ok(Response::new(SandboxEmpty {}))
+    }
+
+    async fn expose_port(
+        &self,
+        request: Request<ExposePortRequest>,
+    ) -> Result<Response<ExposePortResponse>, Status> {
+        let machine = request.machine_id()?;
+        let req = request.into_inner();
+        let sandbox_port = u16::try_from(req.sandbox_port)
+            .ok()
+            .filter(|p| *p != 0)
+            .ok_or_else(|| Status::invalid_argument("sandbox_port must be 1-65535"))?;
+        let host_port = u16::try_from(req.host_port)
+            .map_err(|_| Status::invalid_argument("host_port must be 0-65535"))?;
+        let protocol = if req.protocol.is_empty() {
+            "tcp".to_owned()
+        } else {
+            req.protocol.to_ascii_lowercase()
+        };
+
+        // Guest half: allocate the reserved relay port and install the DNAT.
+        let mut agent = self
+            .runtime
+            .ready()?
+            .get_agent(&machine)
+            .map_err(ApiError::from)?;
+        let forwarded = agent
+            .sandbox_port_forward(SandboxPortForwardRequest {
+                id: req.id.clone(),
+                sandbox_port: u32::from(sandbox_port),
+                protocol: protocol.clone(),
+            })
+            .await
+            .map_err(ApiError::from)?;
+        let guest_port = u16::try_from(forwarded.guest_port)
+            .map_err(|_| Status::internal("agent returned an invalid guest port"))?;
+
+        // Host half: bind the listener; default the host port to the relay
+        // port for a stable, collision-free mapping.
+        let host_port = if host_port == 0 {
+            guest_port
+        } else {
+            host_port
+        };
+        let exposure = SandboxPortExposure {
+            sandbox_id: req.id.clone(),
+            sandbox_port,
+            protocol: protocol.clone(),
+            host_port,
+            guest_port,
+        };
+        if let Err(e) = self
+            .runtime
+            .ready()?
+            .expose_sandbox_port(&machine, &exposure)
+            .await
+        {
+            // Roll back the guest DNAT so a failed bind leaves no half rule.
+            let mut agent = self
+                .runtime
+                .ready()?
+                .get_agent(&machine)
+                .map_err(ApiError::from)?;
+            let _ = agent
+                .sandbox_port_forward_remove(SandboxPortForwardRemoveRequest {
+                    id: req.id,
+                    sandbox_port: u32::from(sandbox_port),
+                    protocol,
+                })
+                .await;
+            return Err(ApiError::from(e).into());
+        }
+
+        Ok(Response::new(ExposePortResponse {
+            host_port: u32::from(host_port),
+            guest_port: u32::from(guest_port),
+        }))
+    }
+
+    async fn unexpose_port(
+        &self,
+        request: Request<UnexposePortRequest>,
+    ) -> Result<Response<SandboxEmpty>, Status> {
+        let machine = request.machine_id()?;
+        let req = request.into_inner();
+        let sandbox_port = u16::try_from(req.sandbox_port)
+            .ok()
+            .filter(|p| *p != 0)
+            .ok_or_else(|| Status::invalid_argument("sandbox_port must be 1-65535"))?;
+        let protocol = if req.protocol.is_empty() {
+            "tcp".to_owned()
+        } else {
+            req.protocol.to_ascii_lowercase()
+        };
+
+        let mut agent = self
+            .runtime
+            .ready()?
+            .get_agent(&machine)
+            .map_err(ApiError::from)?;
+        agent
+            .sandbox_port_forward_remove(SandboxPortForwardRemoveRequest {
+                id: req.id.clone(),
+                sandbox_port: u32::from(sandbox_port),
+                protocol: protocol.clone(),
+            })
+            .await
+            .map_err(ApiError::from)?;
+
+        self.runtime
+            .ready()?
+            .unexpose_sandbox_port(&req.id, sandbox_port, &protocol)
+            .await;
+
         Ok(Response::new(SandboxEmpty {}))
     }
 

--- a/app/arcbox-api/src/grpc/sandbox.rs
+++ b/app/arcbox-api/src/grpc/sandbox.rs
@@ -83,7 +83,7 @@ impl SandboxService for SandboxServiceImpl {
             .await
             .map_err(ApiError::from)?;
         let stream = UnboundedReceiverStream::new(rx)
-            .map(|r| r.map_err(|e| Status::internal(e.to_string())));
+            .map(|r| r.map_err(|e| Status::from(ApiError::from(e))));
         Ok(Response::new(Box::pin(stream)))
     }
 
@@ -139,7 +139,7 @@ impl SandboxService for SandboxServiceImpl {
             .map_err(ApiError::from)?;
 
         let out_stream = UnboundedReceiverStream::new(out_rx)
-            .map(|r| r.map_err(|e| Status::internal(e.to_string())));
+            .map(|r| r.map_err(|e| Status::from(ApiError::from(e))));
         Ok(Response::new(Box::pin(out_stream)))
     }
 
@@ -439,7 +439,7 @@ impl SandboxService for SandboxServiceImpl {
             .await
             .map_err(ApiError::from)?;
         let stream = UnboundedReceiverStream::new(rx)
-            .map(|r| r.map_err(|e| Status::internal(e.to_string())));
+            .map(|r| r.map_err(|e| Status::from(ApiError::from(e))));
         Ok(Response::new(Box::pin(stream)))
     }
 }

--- a/app/arcbox-api/src/grpc/sandbox.rs
+++ b/app/arcbox-api/src/grpc/sandbox.rs
@@ -15,6 +15,8 @@ use tokio_stream::wrappers::UnboundedReceiverStream;
 use tonic::codec::Streaming;
 use tonic::{Request, Response, Status};
 
+use arcbox_core::ExecSessionInput;
+
 use crate::ApiError;
 
 use super::{RequestExt, SharedRuntime, SharedRuntimeExt};
@@ -108,17 +110,24 @@ impl SandboxService for SandboxServiceImpl {
             _ => return Err(Status::invalid_argument("exec: first message must be Init")),
         };
 
-        // Feed remaining gRPC input into a channel for the core layer.
+        // Feed remaining gRPC input (stdin + TTY resizes) into a channel for
+        // the core layer. Stream end sends the empty-stdin EOF sentinel.
         let (in_tx, in_rx) = tokio::sync::mpsc::channel(16);
         tokio::spawn(async move {
             while let Some(Ok(input)) = stream.next().await {
-                if let Some(exec_input::Payload::Stdin(data)) = input.payload {
-                    if in_tx.send(data).await.is_err() {
-                        return;
-                    }
+                let msg = match input.payload {
+                    Some(exec_input::Payload::Stdin(data)) => ExecSessionInput::Stdin(data),
+                    Some(exec_input::Payload::Resize(size)) => ExecSessionInput::Resize {
+                        width: u16::try_from(size.width).unwrap_or(u16::MAX),
+                        height: u16::try_from(size.height).unwrap_or(u16::MAX),
+                    },
+                    _ => continue,
+                };
+                if in_tx.send(msg).await.is_err() {
+                    return;
                 }
             }
-            let _ = in_tx.send(Vec::new()).await;
+            let _ = in_tx.send(ExecSessionInput::Stdin(Vec::new())).await;
         });
 
         let out_rx = agent

--- a/app/arcbox-api/src/grpc/sandbox.rs
+++ b/app/arcbox-api/src/grpc/sandbox.rs
@@ -18,7 +18,7 @@ use tokio_stream::wrappers::UnboundedReceiverStream;
 use tonic::codec::Streaming;
 use tonic::{Request, Response, Status};
 
-use arcbox_core::{ExecSessionInput, SandboxPortExposure};
+use arcbox_core::{ExecSessionInput, SandboxPortExposure, WriteFileChunk};
 
 use crate::ApiError;
 
@@ -270,18 +270,31 @@ impl SandboxService for SandboxServiceImpl {
             }
         };
 
-        // Bridge gRPC chunks into the agent write stream; dropping the
-        // sender ends the transfer and triggers the terminating frame.
+        // Bridge gRPC chunks into the agent write stream. A clean end (the
+        // client's `done` chunk) closes the channel, which triggers the
+        // terminating frame; a client error or a stream that ends *before*
+        // `done` sends `Abort` so the partial upload is never finalized.
         let (tx, rx) = tokio::sync::mpsc::channel(16);
         tokio::spawn(async move {
-            while let Some(Ok(msg)) = stream.next().await {
-                if let Some(write_file_request::Payload::Chunk(chunk)) = msg.payload {
-                    let done = chunk.done;
-                    if !chunk.data.is_empty() && tx.send(chunk.data.clone()).await.is_err() {
-                        return;
+            loop {
+                match stream.next().await {
+                    Some(Ok(msg)) => {
+                        if let Some(write_file_request::Payload::Chunk(chunk)) = msg.payload {
+                            let done = chunk.done;
+                            if !chunk.data.is_empty()
+                                && tx.send(WriteFileChunk::Data(chunk.data)).await.is_err()
+                            {
+                                return;
+                            }
+                            if done {
+                                return; // clean completion: drop tx → done frame
+                            }
+                        }
                     }
-                    if done {
-                        break;
+                    // Client RST/cancel, or the stream closed without `done`.
+                    Some(Err(_)) | None => {
+                        let _ = tx.send(WriteFileChunk::Abort).await;
+                        return;
                     }
                 }
             }

--- a/app/arcbox-api/src/grpc/sandbox.rs
+++ b/app/arcbox-api/src/grpc/sandbox.rs
@@ -14,7 +14,7 @@ use arcbox_protocol::sandbox_v1::{
 };
 use tokio_stream::Stream;
 use tokio_stream::StreamExt as _;
-use tokio_stream::wrappers::UnboundedReceiverStream;
+use tokio_stream::wrappers::ReceiverStream;
 use tonic::codec::Streaming;
 use tonic::{Request, Response, Status};
 
@@ -82,8 +82,8 @@ impl SandboxService for SandboxServiceImpl {
             .sandbox_run(request.into_inner())
             .await
             .map_err(ApiError::from)?;
-        let stream = UnboundedReceiverStream::new(rx)
-            .map(|r| r.map_err(|e| Status::from(ApiError::from(e))));
+        let stream =
+            ReceiverStream::new(rx).map(|r| r.map_err(|e| Status::from(ApiError::from(e))));
         Ok(Response::new(Box::pin(stream)))
     }
 
@@ -138,8 +138,8 @@ impl SandboxService for SandboxServiceImpl {
             .await
             .map_err(ApiError::from)?;
 
-        let out_stream = UnboundedReceiverStream::new(out_rx)
-            .map(|r| r.map_err(|e| Status::from(ApiError::from(e))));
+        let out_stream =
+            ReceiverStream::new(out_rx).map(|r| r.map_err(|e| Status::from(ApiError::from(e))));
         Ok(Response::new(Box::pin(out_stream)))
     }
 
@@ -239,8 +239,8 @@ impl SandboxService for SandboxServiceImpl {
             .sandbox_read_file(request.into_inner())
             .await
             .map_err(ApiError::from)?;
-        let stream = UnboundedReceiverStream::new(rx)
-            .map(|r| r.map_err(|e| Status::from(ApiError::from(e))));
+        let stream =
+            ReceiverStream::new(rx).map(|r| r.map_err(|e| Status::from(ApiError::from(e))));
         Ok(Response::new(Box::pin(stream)))
     }
 
@@ -438,8 +438,8 @@ impl SandboxService for SandboxServiceImpl {
             .sandbox_events(request.into_inner())
             .await
             .map_err(ApiError::from)?;
-        let stream = UnboundedReceiverStream::new(rx)
-            .map(|r| r.map_err(|e| Status::from(ApiError::from(e))));
+        let stream =
+            ReceiverStream::new(rx).map(|r| r.map_err(|e| Status::from(ApiError::from(e))));
         Ok(Response::new(Box::pin(stream)))
     }
 }

--- a/app/arcbox-cli/src/commands/sandbox.rs
+++ b/app/arcbox-cli/src/commands/sandbox.rs
@@ -490,10 +490,30 @@ async fn execute_exec(args: ExecArgs) -> Result<()> {
         None
     };
 
+    // Resize pump: SIGWINCH → gRPC resize frames (TTY sessions only).
+    if args.tty {
+        let resize_tx = msg_tx.clone();
+        match arcbox_cli::terminal::ResizeWatcher::new() {
+            Ok(mut watcher) => {
+                tokio::spawn(async move {
+                    while let Some(size) = watcher.recv().await {
+                        let msg = ExecInput {
+                            payload: Some(exec_input::Payload::Resize(ProtoTerminalSize {
+                                width: u32::from(size.cols),
+                                height: u32::from(size.rows),
+                            })),
+                        };
+                        if resize_tx.send(msg).await.is_err() {
+                            break;
+                        }
+                    }
+                });
+            }
+            Err(e) => tracing::warn!(error = %e, "terminal resize forwarding disabled"),
+        }
+    }
+
     // Stdin pump: local terminal → gRPC stream.
-    // NOTE: TTY resize (SIGWINCH) is not yet forwarded — the gRPC→agent
-    // pipeline has no resize wire message. Will be added when the full
-    // resize path is wired up.
     let stdin_tx = msg_tx;
     tokio::spawn(async move {
         let mut stdin = tokio::io::stdin();

--- a/app/arcbox-cli/src/commands/sandbox.rs
+++ b/app/arcbox-cli/src/commands/sandbox.rs
@@ -8,10 +8,10 @@ use arcbox_core::vm_lifecycle::DEFAULT_MACHINE_NAME;
 use arcbox_grpc::{SandboxServiceClient, SandboxSnapshotServiceClient};
 use arcbox_protocol::sandbox_v1::{
     CheckpointRequest, CreateSandboxRequest, DeleteSnapshotRequest, ExecInput, ExecRequest,
-    FileChunk, InspectSandboxRequest, ListSandboxesRequest, ListSnapshotsRequest, ReadFileRequest,
-    RemoveSandboxRequest, ResourceLimits, RestoreRequest, RunRequest, SandboxEventsRequest,
-    StopSandboxRequest, TerminalSize as ProtoTerminalSize, WriteFileOpen, WriteFileRequest,
-    exec_input, write_file_request,
+    ExposePortRequest, FileChunk, InspectSandboxRequest, ListSandboxesRequest,
+    ListSnapshotsRequest, ReadFileRequest, RemoveSandboxRequest, ResourceLimits, RestoreRequest,
+    RunRequest, SandboxEventsRequest, StopSandboxRequest, TerminalSize as ProtoTerminalSize,
+    UnexposePortRequest, WriteFileOpen, WriteFileRequest, exec_input, write_file_request,
 };
 use clap::{Args, Subcommand};
 use std::collections::HashMap;
@@ -69,6 +69,10 @@ pub enum SandboxCommands {
     Events(EventsArgs),
     /// Copy a file into or out of a sandbox (<id>:<path> denotes the sandbox side)
     Cp(CpArgs),
+    /// Expose a sandbox port on the host (via loopback)
+    Expose(ExposeArgs),
+    /// Remove an exposed sandbox port
+    Unexpose(UnexposeArgs),
     /// Checkpoint a sandbox into a snapshot
     Checkpoint(CheckpointArgs),
     /// Restore a sandbox from a snapshot
@@ -195,6 +199,31 @@ pub struct CpArgs {
 }
 
 #[derive(Args)]
+pub struct ExposeArgs {
+    /// Sandbox ID
+    pub id: String,
+    /// Port the workload listens on inside the sandbox
+    pub port: u16,
+    /// Host port to bind (0 = pick the guest relay port)
+    #[arg(long, default_value = "0")]
+    pub host_port: u16,
+    /// Protocol: tcp or udp
+    #[arg(long, default_value = "tcp")]
+    pub protocol: String,
+}
+
+#[derive(Args)]
+pub struct UnexposeArgs {
+    /// Sandbox ID
+    pub id: String,
+    /// The sandbox port previously exposed
+    pub port: u16,
+    /// Protocol: tcp or udp
+    #[arg(long, default_value = "tcp")]
+    pub protocol: String,
+}
+
+#[derive(Args)]
 pub struct CheckpointArgs {
     /// Sandbox ID to checkpoint
     pub id: String,
@@ -240,6 +269,8 @@ pub async fn execute(cmd: SandboxCommands) -> Result<()> {
         SandboxCommands::Exec(args) => execute_exec(args).await,
         SandboxCommands::Events(args) => execute_events(args).await,
         SandboxCommands::Cp(args) => execute_cp(args).await,
+        SandboxCommands::Expose(args) => execute_expose(args).await,
+        SandboxCommands::Unexpose(args) => execute_unexpose(args).await,
         SandboxCommands::Checkpoint(args) => execute_checkpoint(args).await,
         SandboxCommands::Restore(args) => execute_restore(args).await,
         SandboxCommands::ListSnapshots(args) => execute_list_snapshots(args).await,
@@ -840,5 +871,42 @@ async fn execute_cp(args: CpArgs) -> Result<()> {
             anyhow::bail!("sandbox-to-sandbox copies are not supported");
         }
     }
+    Ok(())
+}
+
+async fn execute_expose(args: ExposeArgs) -> Result<()> {
+    let channel = sandbox_channel().await?;
+    let mut client = SandboxServiceClient::new(channel);
+    let request = attach_machine(tonic::Request::new(ExposePortRequest {
+        id: args.id.clone(),
+        sandbox_port: u32::from(args.port),
+        host_port: u32::from(args.host_port),
+        protocol: args.protocol.clone(),
+    }));
+    let resp = client
+        .expose_port(request)
+        .await
+        .context("Failed to expose sandbox port")?
+        .into_inner();
+    println!(
+        "{}:{}/{} exposed on localhost:{}",
+        args.id, args.port, args.protocol, resp.host_port
+    );
+    Ok(())
+}
+
+async fn execute_unexpose(args: UnexposeArgs) -> Result<()> {
+    let channel = sandbox_channel().await?;
+    let mut client = SandboxServiceClient::new(channel);
+    let request = attach_machine(tonic::Request::new(UnexposePortRequest {
+        id: args.id.clone(),
+        sandbox_port: u32::from(args.port),
+        protocol: args.protocol.clone(),
+    }));
+    client
+        .unexpose_port(request)
+        .await
+        .context("Failed to unexpose sandbox port")?;
+    println!("{}:{}/{} unexposed", args.id, args.port, args.protocol);
     Ok(())
 }

--- a/app/arcbox-cli/src/commands/sandbox.rs
+++ b/app/arcbox-cli/src/commands/sandbox.rs
@@ -8,9 +8,10 @@ use arcbox_core::vm_lifecycle::DEFAULT_MACHINE_NAME;
 use arcbox_grpc::{SandboxServiceClient, SandboxSnapshotServiceClient};
 use arcbox_protocol::sandbox_v1::{
     CheckpointRequest, CreateSandboxRequest, DeleteSnapshotRequest, ExecInput, ExecRequest,
-    InspectSandboxRequest, ListSandboxesRequest, ListSnapshotsRequest, RemoveSandboxRequest,
-    ResourceLimits, RestoreRequest, RunRequest, SandboxEventsRequest, StopSandboxRequest,
-    TerminalSize as ProtoTerminalSize, exec_input,
+    FileChunk, InspectSandboxRequest, ListSandboxesRequest, ListSnapshotsRequest, ReadFileRequest,
+    RemoveSandboxRequest, ResourceLimits, RestoreRequest, RunRequest, SandboxEventsRequest,
+    StopSandboxRequest, TerminalSize as ProtoTerminalSize, WriteFileOpen, WriteFileRequest,
+    exec_input, write_file_request,
 };
 use clap::{Args, Subcommand};
 use std::collections::HashMap;
@@ -66,6 +67,8 @@ pub enum SandboxCommands {
     Exec(ExecArgs),
     /// Subscribe to sandbox lifecycle events
     Events(EventsArgs),
+    /// Copy a file into or out of a sandbox (<id>:<path> denotes the sandbox side)
+    Cp(CpArgs),
     /// Checkpoint a sandbox into a snapshot
     Checkpoint(CheckpointArgs),
     /// Restore a sandbox from a snapshot
@@ -184,6 +187,14 @@ pub struct EventsArgs {
 }
 
 #[derive(Args)]
+pub struct CpArgs {
+    /// Source: a local path or <sandbox-id>:<absolute-path>
+    pub src: String,
+    /// Destination: a local path or <sandbox-id>:<absolute-path>
+    pub dst: String,
+}
+
+#[derive(Args)]
 pub struct CheckpointArgs {
     /// Sandbox ID to checkpoint
     pub id: String,
@@ -228,6 +239,7 @@ pub async fn execute(cmd: SandboxCommands) -> Result<()> {
         SandboxCommands::Run(args) => execute_run(args).await,
         SandboxCommands::Exec(args) => execute_exec(args).await,
         SandboxCommands::Events(args) => execute_events(args).await,
+        SandboxCommands::Cp(args) => execute_cp(args).await,
         SandboxCommands::Checkpoint(args) => execute_checkpoint(args).await,
         SandboxCommands::Restore(args) => execute_restore(args).await,
         SandboxCommands::ListSnapshots(args) => execute_list_snapshots(args).await,
@@ -709,5 +721,124 @@ async fn execute_delete_snapshot(args: DeleteSnapshotArgs) -> Result<()> {
         .context("Failed to delete snapshot")?;
 
     println!("Snapshot '{}' deleted", args.snapshot_id);
+    Ok(())
+}
+
+/// One side of a `cp` transfer: local path or `<sandbox-id>:<path>`.
+enum CpEndpoint {
+    Local(String),
+    Sandbox { id: String, path: String },
+}
+
+/// Parse docker-cp style endpoints: `<id>:<path>` is a sandbox side when the
+/// prefix contains no path separator (so `./a:b` stays a local file).
+fn parse_cp_endpoint(spec: &str) -> CpEndpoint {
+    if let Some((id, path)) = spec.split_once(':')
+        && !id.is_empty()
+        && !id.contains('/')
+    {
+        return CpEndpoint::Sandbox {
+            id: id.to_owned(),
+            path: path.to_owned(),
+        };
+    }
+    CpEndpoint::Local(spec.to_owned())
+}
+
+async fn execute_cp(args: CpArgs) -> Result<()> {
+    let channel = sandbox_channel().await?;
+    let mut client = SandboxServiceClient::new(channel);
+
+    match (parse_cp_endpoint(&args.src), parse_cp_endpoint(&args.dst)) {
+        (CpEndpoint::Local(src), CpEndpoint::Sandbox { id, path }) => {
+            let data = tokio::fs::read(&src)
+                .await
+                .with_context(|| format!("Failed to read {src}"))?;
+            let mode = {
+                use std::os::unix::fs::PermissionsExt;
+                tokio::fs::metadata(&src)
+                    .await
+                    .map_or(0o644, |m| m.permissions().mode() & 0o777)
+            };
+            let total = data.len();
+
+            let (tx, rx) = tokio::sync::mpsc::channel::<WriteFileRequest>(16);
+            let sender = tokio::spawn(async move {
+                let open = WriteFileRequest {
+                    payload: Some(write_file_request::Payload::Open(WriteFileOpen {
+                        id,
+                        path,
+                        mode,
+                    })),
+                };
+                if tx.send(open).await.is_err() {
+                    return;
+                }
+                const CHUNK: usize = 1024 * 1024;
+                for part in data.chunks(CHUNK) {
+                    let msg = WriteFileRequest {
+                        payload: Some(write_file_request::Payload::Chunk(FileChunk {
+                            data: part.to_vec(),
+                            done: false,
+                        })),
+                    };
+                    if tx.send(msg).await.is_err() {
+                        return;
+                    }
+                }
+                let done = WriteFileRequest {
+                    payload: Some(write_file_request::Payload::Chunk(FileChunk {
+                        data: Vec::new(),
+                        done: true,
+                    })),
+                };
+                let _ = tx.send(done).await;
+            });
+
+            let request = attach_machine(tonic::Request::new(ReceiverStream::new(rx)));
+            client
+                .write_file(request)
+                .await
+                .context("Failed to write file into sandbox")?;
+            let _ = sender.await;
+            println!("Copied {total} bytes to {}", args.dst);
+        }
+        (CpEndpoint::Sandbox { id, path }, CpEndpoint::Local(dst)) => {
+            let request = attach_machine(tonic::Request::new(ReadFileRequest { id, path }));
+            let mut stream = client
+                .read_file(request)
+                .await
+                .context("Failed to read file from sandbox")?
+                .into_inner();
+
+            let mut out = tokio::fs::File::create(&dst)
+                .await
+                .with_context(|| format!("Failed to create {dst}"))?;
+            let mut total = 0usize;
+            while let Some(chunk) = stream
+                .message()
+                .await
+                .context("Failed to read file stream")?
+            {
+                if !chunk.data.is_empty() {
+                    tokio::io::AsyncWriteExt::write_all(&mut out, &chunk.data)
+                        .await
+                        .context("Failed to write local file")?;
+                    total += chunk.data.len();
+                }
+                if chunk.done {
+                    break;
+                }
+            }
+            tokio::io::AsyncWriteExt::flush(&mut out).await?;
+            println!("Copied {total} bytes to {dst}");
+        }
+        (CpEndpoint::Local(_), CpEndpoint::Local(_)) => {
+            anyhow::bail!("one side must be a sandbox path (<sandbox-id>:<path>)");
+        }
+        (CpEndpoint::Sandbox { .. }, CpEndpoint::Sandbox { .. }) => {
+            anyhow::bail!("sandbox-to-sandbox copies are not supported");
+        }
+    }
     Ok(())
 }

--- a/app/arcbox-core/examples/hv_coldboot_once.rs
+++ b/app/arcbox-core/examples/hv_coldboot_once.rs
@@ -252,7 +252,7 @@ fn ensure_runtime_once(vmm: &Vmm, deadline: Duration) -> Result<(bool, String), 
         .map_err(|e| format!("connect_vsock: {e}"))?;
     set_socket_timeout(fd, deadline).map_err(|e| format!("set_socket_timeout: {e}"))?;
     let mut client =
-        AgentClient::from_fd(GUEST_CID, fd).map_err(|e| format!("AgentClient::from_fd: {e}"))?;
+        AgentClient::from_fd_blocking(GUEST_CID, fd).map_err(|e| format!("AgentClient::from_fd_blocking: {e}"))?;
     let resp = client
         .ensure_runtime_blocking(true)
         .map_err(|e| format!("ensure_runtime: {e}"))?;
@@ -280,7 +280,7 @@ fn ping_once(vmm: &Vmm, deadline: Duration) -> Result<(), String> {
         .map_err(|e| format!("connect_vsock: {e}"))?;
     set_socket_timeout(fd, deadline).map_err(|e| format!("set_socket_timeout: {e}"))?;
     let mut client =
-        AgentClient::from_fd(GUEST_CID, fd).map_err(|e| format!("AgentClient::from_fd: {e}"))?;
+        AgentClient::from_fd_blocking(GUEST_CID, fd).map_err(|e| format!("AgentClient::from_fd_blocking: {e}"))?;
     client
         .ping_blocking()
         .map(|_| ())

--- a/app/arcbox-core/examples/hv_coldboot_once.rs
+++ b/app/arcbox-core/examples/hv_coldboot_once.rs
@@ -251,8 +251,8 @@ fn ensure_runtime_once(vmm: &Vmm, deadline: Duration) -> Result<(bool, String), 
         .connect_vsock(AGENT_PORT)
         .map_err(|e| format!("connect_vsock: {e}"))?;
     set_socket_timeout(fd, deadline).map_err(|e| format!("set_socket_timeout: {e}"))?;
-    let mut client =
-        AgentClient::from_fd_blocking(GUEST_CID, fd).map_err(|e| format!("AgentClient::from_fd_blocking: {e}"))?;
+    let mut client = AgentClient::from_fd_blocking(GUEST_CID, fd)
+        .map_err(|e| format!("AgentClient::from_fd_blocking: {e}"))?;
     let resp = client
         .ensure_runtime_blocking(true)
         .map_err(|e| format!("ensure_runtime: {e}"))?;
@@ -279,8 +279,8 @@ fn ping_once(vmm: &Vmm, deadline: Duration) -> Result<(), String> {
         .connect_vsock(AGENT_PORT)
         .map_err(|e| format!("connect_vsock: {e}"))?;
     set_socket_timeout(fd, deadline).map_err(|e| format!("set_socket_timeout: {e}"))?;
-    let mut client =
-        AgentClient::from_fd_blocking(GUEST_CID, fd).map_err(|e| format!("AgentClient::from_fd_blocking: {e}"))?;
+    let mut client = AgentClient::from_fd_blocking(GUEST_CID, fd)
+        .map_err(|e| format!("AgentClient::from_fd_blocking: {e}"))?;
     client
         .ping_blocking()
         .map(|_| ())

--- a/app/arcbox-core/src/agent_client.rs
+++ b/app/arcbox-core/src/agent_client.rs
@@ -48,6 +48,17 @@ pub enum ExecSessionInput {
     },
 }
 
+/// A chunk in a sandbox file-write stream.
+#[derive(Debug)]
+pub enum WriteFileChunk {
+    /// Payload bytes to append to the file.
+    Data(Vec<u8>),
+    /// The client stream ended without a terminating `done` chunk (a cancelled
+    /// or reset upload). The write must be aborted rather than finalized, so a
+    /// partially-received file is never committed as if it were complete.
+    Abort,
+}
+
 /// Agent client for a single VM.
 pub struct AgentClient {
     /// VM CID (Context ID).
@@ -905,7 +916,7 @@ impl AgentClient {
     pub async fn sandbox_write_file(
         mut self,
         open: WriteFileOpen,
-        mut data_rx: mpsc::Receiver<Vec<u8>>,
+        mut data_rx: mpsc::Receiver<WriteFileChunk>,
     ) -> Result<()> {
         if !self.connected {
             self.connect().await?;
@@ -918,7 +929,19 @@ impl AgentClient {
             .await
             .map_err(|e| CoreError::Machine(format!("failed to send write-file open: {e}")))?;
 
-        while let Some(data) = data_rx.recv().await {
+        while let Some(item) = data_rx.recv().await {
+            let data = match item {
+                WriteFileChunk::Data(data) => data,
+                WriteFileChunk::Abort => {
+                    // Do not send the terminating `done` frame. Returning drops
+                    // the connection; the guest sees the stream end before
+                    // `done` and discards the partial file instead of
+                    // committing a truncated one.
+                    return Err(CoreError::Machine(
+                        "write_file aborted: client stream ended before completion".to_owned(),
+                    ));
+                }
+            };
             let chunk = FileChunk { data, done: false };
             let frame =
                 wire::build_message(MessageType::SandboxFileChunk, "", &chunk.encode_to_vec());

--- a/app/arcbox-core/src/agent_client.rs
+++ b/app/arcbox-core/src/agent_client.rs
@@ -48,6 +48,12 @@ pub enum ExecSessionInput {
     },
 }
 
+/// Bound on frames buffered between the guest transport and a streaming RPC's
+/// consumer. When the consumer stalls, the relay task blocks on a full channel,
+/// which propagates backpressure to the guest (vsock flow control) instead of
+/// letting an untrusted sandbox's output grow daemon memory without limit.
+const STREAM_CHANNEL_CAPACITY: usize = 64;
+
 /// A chunk in a sandbox file-write stream.
 #[derive(Debug)]
 pub enum WriteFileChunk {
@@ -846,7 +852,7 @@ impl AgentClient {
     pub async fn sandbox_read_file(
         mut self,
         req: ReadFileRequest,
-    ) -> Result<mpsc::UnboundedReceiver<Result<FileChunk>>> {
+    ) -> Result<mpsc::Receiver<Result<FileChunk>>> {
         if !self.connected {
             self.connect().await?;
         }
@@ -858,44 +864,50 @@ impl AgentClient {
             .await
             .map_err(|e| CoreError::Machine(format!("failed to send read-file request: {e}")))?;
 
-        let (tx, rx) = mpsc::unbounded_channel();
+        let (tx, rx) = mpsc::channel(STREAM_CHANNEL_CAPACITY);
         tokio::spawn(async move {
             loop {
                 let raw = match self.transport.async_recv().await {
                     Ok(r) => r,
                     Err(e) => {
-                        let _ = tx.send(Err(CoreError::Machine(format!("recv error: {e}"))));
+                        let _ = tx
+                            .send(Err(CoreError::Machine(format!("recv error: {e}"))))
+                            .await;
                         break;
                     }
                 };
                 let (resp_type, _, resp_payload) = match wire::parse_response(&raw) {
                     Ok(p) => p,
                     Err(e) => {
-                        let _ = tx.send(Err(e));
+                        let _ = tx.send(Err(e)).await;
                         break;
                     }
                 };
                 if resp_type == MessageType::Error as u32 {
                     let (code, message) = wire::parse_error_response(&resp_payload)
                         .unwrap_or_else(|_| (500, "unknown error".to_string()));
-                    let _ = tx.send(Err(CoreError::Agent { code, message }));
+                    let _ = tx.send(Err(CoreError::Agent { code, message })).await;
                     break;
                 }
                 if resp_type != MessageType::SandboxFileData as u32 {
-                    let _ = tx.send(Err(CoreError::Machine(format!(
-                        "unexpected response type: 0x{resp_type:04x}"
-                    ))));
+                    let _ = tx
+                        .send(Err(CoreError::Machine(format!(
+                            "unexpected response type: 0x{resp_type:04x}"
+                        ))))
+                        .await;
                     break;
                 }
                 match FileChunk::decode(&resp_payload[..]) {
                     Ok(chunk) => {
                         let done = chunk.done;
-                        if tx.send(Ok(chunk)).is_err() || done {
+                        if tx.send(Ok(chunk)).await.is_err() || done {
                             break;
                         }
                     }
                     Err(e) => {
-                        let _ = tx.send(Err(CoreError::Machine(format!("decode error: {e}"))));
+                        let _ = tx
+                            .send(Err(CoreError::Machine(format!("decode error: {e}"))))
+                            .await;
                         break;
                     }
                 }
@@ -988,7 +1000,7 @@ impl AgentClient {
     pub async fn sandbox_run(
         mut self,
         req: RunRequest,
-    ) -> Result<mpsc::UnboundedReceiver<Result<RunOutput>>> {
+    ) -> Result<mpsc::Receiver<Result<RunOutput>>> {
         if !self.connected {
             self.connect().await?;
         }
@@ -1000,13 +1012,15 @@ impl AgentClient {
             .await
             .map_err(|e| CoreError::Machine(format!("failed to send run request: {}", e)))?;
 
-        let (tx, rx) = mpsc::unbounded_channel();
+        let (tx, rx) = mpsc::channel(STREAM_CHANNEL_CAPACITY);
         tokio::spawn(async move {
             loop {
                 let raw = match self.transport.async_recv().await {
                     Ok(r) => r,
                     Err(e) => {
-                        let _ = tx.send(Err(CoreError::Machine(format!("recv error: {}", e))));
+                        let _ = tx
+                            .send(Err(CoreError::Machine(format!("recv error: {}", e))))
+                            .await;
                         break;
                     }
                 };
@@ -1014,7 +1028,7 @@ impl AgentClient {
                 let (resp_type, _, resp_payload) = match wire::parse_response(&raw) {
                     Ok(p) => p,
                     Err(e) => {
-                        let _ = tx.send(Err(e));
+                        let _ = tx.send(Err(e)).await;
                         break;
                     }
                 };
@@ -1022,28 +1036,33 @@ impl AgentClient {
                 if resp_type == MessageType::Error as u32 {
                     let (code, message) = wire::parse_error_response(&resp_payload)
                         .unwrap_or_else(|_| (500, "unknown error".to_string()));
-                    let _ = tx.send(Err(CoreError::Agent { code, message }));
+                    let _ = tx.send(Err(CoreError::Agent { code, message })).await;
                     break;
                 }
 
                 if resp_type != MessageType::SandboxRunOutput as u32 {
-                    let _ = tx.send(Err(CoreError::Machine(format!(
-                        "unexpected response type: 0x{:04x}",
-                        resp_type
-                    ))));
+                    let _ = tx
+                        .send(Err(CoreError::Machine(format!(
+                            "unexpected response type: 0x{:04x}",
+                            resp_type
+                        ))))
+                        .await;
                     break;
                 }
 
                 match RunOutput::decode(&resp_payload[..]) {
                     Ok(output) => {
                         let done = output.done;
-                        let _ = tx.send(Ok(output));
-                        if done {
+                        // Stop reading if the consumer dropped, so a spewing
+                        // sandbox isn't drained into the void indefinitely.
+                        if tx.send(Ok(output)).await.is_err() || done {
                             break;
                         }
                     }
                     Err(e) => {
-                        let _ = tx.send(Err(CoreError::Machine(format!("decode error: {}", e))));
+                        let _ = tx
+                            .send(Err(CoreError::Machine(format!("decode error: {}", e))))
+                            .await;
                         break;
                     }
                 }
@@ -1063,7 +1082,7 @@ impl AgentClient {
     pub async fn sandbox_events(
         mut self,
         req: SandboxEventsRequest,
-    ) -> Result<mpsc::UnboundedReceiver<Result<SandboxEvent>>> {
+    ) -> Result<mpsc::Receiver<Result<SandboxEvent>>> {
         if !self.connected {
             self.connect().await?;
         }
@@ -1075,13 +1094,15 @@ impl AgentClient {
             .await
             .map_err(|e| CoreError::Machine(format!("failed to send events request: {}", e)))?;
 
-        let (tx, rx) = mpsc::unbounded_channel();
+        let (tx, rx) = mpsc::channel(STREAM_CHANNEL_CAPACITY);
         tokio::spawn(async move {
             loop {
                 let raw = match self.transport.async_recv().await {
                     Ok(r) => r,
                     Err(e) => {
-                        let _ = tx.send(Err(CoreError::Machine(format!("recv error: {}", e))));
+                        let _ = tx
+                            .send(Err(CoreError::Machine(format!("recv error: {}", e))))
+                            .await;
                         break;
                     }
                 };
@@ -1089,7 +1110,7 @@ impl AgentClient {
                 let (resp_type, _, resp_payload) = match wire::parse_response(&raw) {
                     Ok(p) => p,
                     Err(e) => {
-                        let _ = tx.send(Err(e));
+                        let _ = tx.send(Err(e)).await;
                         break;
                     }
                 };
@@ -1097,24 +1118,32 @@ impl AgentClient {
                 if resp_type == MessageType::Error as u32 {
                     let (code, message) = wire::parse_error_response(&resp_payload)
                         .unwrap_or_else(|_| (500, "unknown error".to_string()));
-                    let _ = tx.send(Err(CoreError::Agent { code, message }));
+                    let _ = tx.send(Err(CoreError::Agent { code, message })).await;
                     break;
                 }
 
                 if resp_type != MessageType::SandboxEvent as u32 {
-                    let _ = tx.send(Err(CoreError::Machine(format!(
-                        "unexpected response type: 0x{:04x}",
-                        resp_type
-                    ))));
+                    let _ = tx
+                        .send(Err(CoreError::Machine(format!(
+                            "unexpected response type: 0x{:04x}",
+                            resp_type
+                        ))))
+                        .await;
                     break;
                 }
 
                 match SandboxEvent::decode(&resp_payload[..]) {
                     Ok(event) => {
-                        let _ = tx.send(Ok(event));
+                        // Stop when the subscriber drops instead of draining the
+                        // event stream forever.
+                        if tx.send(Ok(event)).await.is_err() {
+                            break;
+                        }
                     }
                     Err(e) => {
-                        let _ = tx.send(Err(CoreError::Machine(format!("decode error: {}", e))));
+                        let _ = tx
+                            .send(Err(CoreError::Machine(format!("decode error: {}", e))))
+                            .await;
                         break;
                     }
                 }
@@ -1138,7 +1167,7 @@ impl AgentClient {
         mut self,
         req: ExecRequest,
         mut input_rx: mpsc::Receiver<ExecSessionInput>,
-    ) -> Result<mpsc::UnboundedReceiver<Result<ExecOutput>>> {
+    ) -> Result<mpsc::Receiver<Result<ExecOutput>>> {
         if !self.connected {
             self.connect().await?;
         }
@@ -1155,7 +1184,7 @@ impl AgentClient {
             .into_split()
             .map_err(|e| CoreError::Machine(format!("failed to split transport: {e}")))?;
 
-        let (out_tx, out_rx) = mpsc::unbounded_channel();
+        let (out_tx, out_rx) = mpsc::channel(STREAM_CHANNEL_CAPACITY);
 
         // Input pump: channel → SandboxExecInput / SandboxExecResize frames.
         let stdin_handle = tokio::spawn(async move {
@@ -1201,7 +1230,9 @@ impl AgentClient {
                 let raw = match receiver.recv().await {
                     Ok(r) => r,
                     Err(e) => {
-                        let _ = out_tx.send(Err(CoreError::Machine(format!("recv error: {}", e))));
+                        let _ = out_tx
+                            .send(Err(CoreError::Machine(format!("recv error: {}", e))))
+                            .await;
                         break;
                     }
                 };
@@ -1209,7 +1240,7 @@ impl AgentClient {
                 let (resp_type, _, resp_payload) = match wire::parse_response(&raw) {
                     Ok(p) => p,
                     Err(e) => {
-                        let _ = out_tx.send(Err(e));
+                        let _ = out_tx.send(Err(e)).await;
                         break;
                     }
                 };
@@ -1217,22 +1248,24 @@ impl AgentClient {
                 if resp_type == MessageType::Error as u32 {
                     let (code, message) = wire::parse_error_response(&resp_payload)
                         .unwrap_or_else(|_| (500, "unknown error".to_string()));
-                    let _ = out_tx.send(Err(CoreError::Agent { code, message }));
+                    let _ = out_tx.send(Err(CoreError::Agent { code, message })).await;
                     break;
                 }
 
                 if resp_type != MessageType::SandboxExecOutput as u32 {
-                    let _ = out_tx.send(Err(CoreError::Machine(format!(
-                        "unexpected response type: 0x{:04x}",
-                        resp_type
-                    ))));
+                    let _ = out_tx
+                        .send(Err(CoreError::Machine(format!(
+                            "unexpected response type: 0x{:04x}",
+                            resp_type
+                        ))))
+                        .await;
                     break;
                 }
 
                 match ExecOutput::decode(&resp_payload[..]) {
                     Ok(output) => {
                         let done = output.done;
-                        if out_tx.send(Ok(output)).is_err() {
+                        if out_tx.send(Ok(output)).await.is_err() {
                             break;
                         }
                         if done {
@@ -1240,8 +1273,9 @@ impl AgentClient {
                         }
                     }
                     Err(e) => {
-                        let _ =
-                            out_tx.send(Err(CoreError::Machine(format!("decode error: {}", e))));
+                        let _ = out_tx
+                            .send(Err(CoreError::Machine(format!("decode error: {}", e))))
+                            .await;
                         break;
                     }
                 }

--- a/app/arcbox-core/src/agent_client.rs
+++ b/app/arcbox-core/src/agent_client.rs
@@ -22,7 +22,8 @@ use arcbox_protocol::sandbox_v1::{
     DeleteSnapshotRequest, ExecOutput, ExecRequest, FileChunk, InspectSandboxRequest,
     ListSandboxesRequest, ListSandboxesResponse, ListSnapshotsRequest, ListSnapshotsResponse,
     ReadFileRequest, RemoveSandboxRequest, RestoreRequest, RestoreResponse, RunOutput, RunRequest,
-    SandboxEvent, SandboxEventsRequest, SandboxInfo, StopSandboxRequest, TerminalSize,
+    SandboxEvent, SandboxEventsRequest, SandboxInfo, SandboxPortForwardRemoveRequest,
+    SandboxPortForwardRequest, SandboxPortForwardResponse, StopSandboxRequest, TerminalSize,
     WriteFileOpen,
 };
 use arcbox_transport::Transport;
@@ -740,6 +741,40 @@ impl AgentClient {
             MessageType::SandboxCreateResponse,
         )
         .await
+    }
+
+    /// Asks the guest agent to DNAT a reserved guest port to a sandbox port.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the request fails.
+    pub async fn sandbox_port_forward(
+        &mut self,
+        req: SandboxPortForwardRequest,
+    ) -> Result<SandboxPortForwardResponse> {
+        let payload = req.encode_to_vec();
+        self.unary_rpc(
+            MessageType::SandboxPortForwardRequest,
+            &payload,
+            MessageType::SandboxPortForwardResponse,
+        )
+        .await
+    }
+
+    /// Asks the guest agent to remove a sandbox DNAT mapping.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the request fails.
+    pub async fn sandbox_port_forward_remove(
+        &mut self,
+        req: SandboxPortForwardRemoveRequest,
+    ) -> Result<()> {
+        let payload = req.encode_to_vec();
+        let (resp_type, _) = self
+            .rpc_call(MessageType::SandboxPortForwardRemoveRequest, &payload)
+            .await?;
+        Self::expect_ack_response_type(resp_type, MessageType::SandboxPortForwardRemoveResponse)
     }
 
     /// Stops a sandbox in the guest VM.

--- a/app/arcbox-core/src/agent_client.rs
+++ b/app/arcbox-core/src/agent_client.rs
@@ -70,55 +70,43 @@ impl AgentClient {
         }
     }
 
-    /// Creates an agent client from an existing vsock file descriptor.
+    /// Creates an agent client over an existing fd using the **blocking**
+    /// transport.
     ///
-    /// Detects the socket domain via `getsockname`:
-    /// - `AF_UNIX` → blocking transport (HV backend socketpair)
-    /// - anything else → async tokio transport (VZ / AF_VSOCK)
+    /// For the HV backend's AF_UNIX socketpair: the blocking path avoids the
+    /// tokio/kqueue reactor stall on rapid connect/teardown cycles. Callers
+    /// must route streaming RPCs elsewhere — the blocking transport rejects
+    /// them.
     #[cfg(target_os = "macos")]
-    pub fn from_fd(cid: u32, fd: std::os::unix::io::RawFd) -> Result<Self> {
-        let is_unix = {
-            let mut addr: libc::sockaddr_storage = unsafe { std::mem::zeroed() };
-            let mut len: libc::socklen_t =
-                std::mem::size_of::<libc::sockaddr_storage>() as libc::socklen_t;
-            let ret = unsafe {
-                libc::getsockname(fd, (&raw mut addr).cast::<libc::sockaddr>(), &raw mut len)
-            };
-            // Hard-fail on getsockname errors rather than silently falling
-            // through to async transport. If the HV backend handed us an
-            // AF_UNIX socketpair and getsockname fails, mis-routing to async
-            // transport would re-enter the exact kqueue/tokio stall the
-            // blocking path was designed to avoid.
-            if ret != 0 {
-                let err = std::io::Error::last_os_error();
-                return Err(CoreError::Machine(format!(
-                    "getsockname failed on vsock fd {fd}: {err}"
-                )));
-            }
-            addr.ss_family == libc::AF_UNIX as libc::sa_family_t
-        };
+    pub fn from_fd_blocking(cid: u32, fd: std::os::unix::io::RawFd) -> Result<Self> {
+        let transport = unsafe { BlockingVsockTransport::from_raw_fd(fd) }
+            .map_err(|e| CoreError::Machine(format!("invalid vsock fd: {e}")))?;
+        Ok(Self {
+            cid,
+            transport: AgentTransport::Blocking(transport),
+            connected: true,
+        })
+    }
 
-        if is_unix {
-            // HV backend socketpair — use blocking transport to avoid
-            // tokio/kqueue reactor stall on rapid connect/teardown cycles.
-            let transport = unsafe { BlockingVsockTransport::from_raw_fd(fd) }
-                .map_err(|e| CoreError::Machine(format!("invalid vsock fd: {e}")))?;
-            Ok(Self {
-                cid,
-                transport: AgentTransport::Blocking(transport),
-                connected: true,
-            })
-        } else {
-            // VZ backend or AF_VSOCK — use async tokio transport.
-            let addr = VsockAddr::new(cid, AGENT_PORT);
-            let transport = VsockTransport::from_raw_fd(fd, addr)
-                .map_err(|e| CoreError::Machine(format!("invalid vsock fd: {e}")))?;
-            Ok(Self {
-                cid,
-                transport: AgentTransport::Async(transport),
-                connected: true,
-            })
-        }
+    /// Creates an agent client over an existing fd using the **async** tokio
+    /// transport.
+    ///
+    /// For the VZ backend's bridged socket fd (and any true AF_VSOCK fd):
+    /// supports the full RPC surface including streaming sandbox calls.
+    ///
+    /// The choice between this and [`Self::from_fd_blocking`] must come from
+    /// the VM backend — both backends hand over unnamed AF_UNIX fds, so the
+    /// socket domain cannot distinguish them.
+    #[cfg(target_os = "macos")]
+    pub fn from_fd_async(cid: u32, fd: std::os::unix::io::RawFd) -> Result<Self> {
+        let addr = VsockAddr::new(cid, AGENT_PORT);
+        let transport = VsockTransport::from_raw_fd(fd, addr)
+            .map_err(|e| CoreError::Machine(format!("invalid vsock fd: {e}")))?;
+        Ok(Self {
+            cid,
+            transport: AgentTransport::Async(transport),
+            connected: true,
+        })
     }
 
     /// Returns the VM CID.

--- a/app/arcbox-core/src/agent_client.rs
+++ b/app/arcbox-core/src/agent_client.rs
@@ -206,8 +206,8 @@ impl AgentClient {
 
         // Check for error response.
         if resp_type == MessageType::Error as u32 {
-            let error_msg = wire::parse_error_response(&payload)?;
-            return Err(CoreError::Machine(error_msg));
+            let (code, message) = wire::parse_error_response(&payload)?;
+            return Err(CoreError::Agent { code, message });
         }
 
         Ok((resp_type, payload))
@@ -240,8 +240,8 @@ impl AgentClient {
 
         let (resp_type, _resp_trace, payload) = wire::parse_response(&response)?;
         if resp_type == MessageType::Error as u32 {
-            let error_msg = wire::parse_error_response(&payload)?;
-            return Err(CoreError::Machine(error_msg));
+            let (code, message) = wire::parse_error_response(&payload)?;
+            return Err(CoreError::Agent { code, message });
         }
         Ok((resp_type, payload))
     }
@@ -606,8 +606,8 @@ impl AgentClient {
     fn decode_readiness_event(raw: &[u8]) -> Result<ReadinessEvent> {
         let (resp_type, _, resp_payload) = wire::parse_response(raw)?;
         if resp_type == MessageType::Error as u32 {
-            let error_msg = wire::parse_error_response(&resp_payload)?;
-            return Err(CoreError::Machine(error_msg));
+            let (code, message) = wire::parse_error_response(&resp_payload)?;
+            return Err(CoreError::Agent { code, message });
         }
         if resp_type != MessageType::ReadinessEvent as u32 {
             return Err(CoreError::Machine(format!(
@@ -827,9 +827,9 @@ impl AgentClient {
                 };
 
                 if resp_type == MessageType::Error as u32 {
-                    let msg = wire::parse_error_response(&resp_payload)
-                        .unwrap_or_else(|_| "unknown error".to_string());
-                    let _ = tx.send(Err(CoreError::Machine(msg)));
+                    let (code, message) = wire::parse_error_response(&resp_payload)
+                        .unwrap_or_else(|_| (500, "unknown error".to_string()));
+                    let _ = tx.send(Err(CoreError::Agent { code, message }));
                     break;
                 }
 
@@ -902,9 +902,9 @@ impl AgentClient {
                 };
 
                 if resp_type == MessageType::Error as u32 {
-                    let msg = wire::parse_error_response(&resp_payload)
-                        .unwrap_or_else(|_| "unknown error".to_string());
-                    let _ = tx.send(Err(CoreError::Machine(msg)));
+                    let (code, message) = wire::parse_error_response(&resp_payload)
+                        .unwrap_or_else(|_| (500, "unknown error".to_string()));
+                    let _ = tx.send(Err(CoreError::Agent { code, message }));
                     break;
                 }
 
@@ -1009,9 +1009,9 @@ impl AgentClient {
                 };
 
                 if resp_type == MessageType::Error as u32 {
-                    let msg = wire::parse_error_response(&resp_payload)
-                        .unwrap_or_else(|_| "unknown error".to_string());
-                    let _ = out_tx.send(Err(CoreError::Machine(msg)));
+                    let (code, message) = wire::parse_error_response(&resp_payload)
+                        .unwrap_or_else(|_| (500, "unknown error".to_string()));
+                    let _ = out_tx.send(Err(CoreError::Agent { code, message }));
                     break;
                 }
 

--- a/app/arcbox-core/src/agent_client.rs
+++ b/app/arcbox-core/src/agent_client.rs
@@ -22,7 +22,7 @@ use arcbox_protocol::sandbox_v1::{
     DeleteSnapshotRequest, ExecOutput, ExecRequest, InspectSandboxRequest, ListSandboxesRequest,
     ListSandboxesResponse, ListSnapshotsRequest, ListSnapshotsResponse, RemoveSandboxRequest,
     RestoreRequest, RestoreResponse, RunOutput, RunRequest, SandboxEvent, SandboxEventsRequest,
-    SandboxInfo, StopSandboxRequest,
+    SandboxInfo, StopSandboxRequest, TerminalSize,
 };
 use arcbox_transport::Transport;
 use arcbox_transport::vsock::{BlockingVsockTransport, VsockAddr, VsockTransport};
@@ -30,6 +30,21 @@ use bytes::Bytes;
 use prost::Message;
 use std::time::{Duration, Instant};
 use tokio::sync::mpsc;
+
+/// A single client→sandbox message during an interactive exec session.
+#[derive(Debug)]
+pub enum ExecSessionInput {
+    /// Raw bytes for the process's stdin. An empty payload signals EOF and
+    /// ends the input stream.
+    Stdin(Vec<u8>),
+    /// Resize the pseudo-TTY (only meaningful for `tty = true` sessions).
+    Resize {
+        /// Terminal width in columns.
+        width: u16,
+        /// Terminal height in rows.
+        height: u16,
+    },
+}
 
 /// Agent client for a single VM.
 pub struct AgentClient {
@@ -934,8 +949,9 @@ impl AgentClient {
     /// Starts an interactive exec session inside a sandbox.
     ///
     /// Consumes the client because the stream task requires exclusive transport
-    /// access.  The caller supplies a receiver of raw stdin bytes (empty `Vec`
-    /// signals EOF).  Returns an output receiver of [`ExecOutput`] frames.
+    /// access.  The caller supplies a receiver of [`ExecSessionInput`]s (stdin
+    /// bytes, TTY resizes, or EOF).  Returns an output receiver of
+    /// [`ExecOutput`] frames.
     ///
     /// # Errors
     ///
@@ -943,7 +959,7 @@ impl AgentClient {
     pub async fn sandbox_exec(
         mut self,
         req: ExecRequest,
-        mut stdin_rx: mpsc::Receiver<Vec<u8>>,
+        mut input_rx: mpsc::Receiver<ExecSessionInput>,
     ) -> Result<mpsc::UnboundedReceiver<Result<ExecOutput>>> {
         if !self.connected {
             self.connect().await?;
@@ -963,16 +979,28 @@ impl AgentClient {
 
         let (out_tx, out_rx) = mpsc::unbounded_channel();
 
-        // Stdin pump: channel → SandboxExecInput frames.
+        // Input pump: channel → SandboxExecInput / SandboxExecResize frames.
         let stdin_handle = tokio::spawn(async move {
             loop {
-                match stdin_rx.recv().await {
-                    Some(data) => {
+                match input_rx.recv().await {
+                    Some(ExecSessionInput::Stdin(data)) => {
+                        let is_eof = data.is_empty();
                         let frame = wire::build_message(MessageType::SandboxExecInput, "", &data);
-                        if sender.send(frame).await.is_err() {
+                        if sender.send(frame).await.is_err() || is_eof {
                             break;
                         }
-                        if data.is_empty() {
+                    }
+                    Some(ExecSessionInput::Resize { width, height }) => {
+                        let size = TerminalSize {
+                            width: u32::from(width),
+                            height: u32::from(height),
+                        };
+                        let frame = wire::build_message(
+                            MessageType::SandboxExecResize,
+                            "",
+                            &size.encode_to_vec(),
+                        );
+                        if sender.send(frame).await.is_err() {
                             break;
                         }
                     }

--- a/app/arcbox-core/src/agent_client.rs
+++ b/app/arcbox-core/src/agent_client.rs
@@ -19,10 +19,11 @@ use arcbox_protocol::agent::{
 };
 use arcbox_protocol::sandbox_v1::{
     CheckpointRequest, CheckpointResponse, CreateSandboxRequest, CreateSandboxResponse,
-    DeleteSnapshotRequest, ExecOutput, ExecRequest, InspectSandboxRequest, ListSandboxesRequest,
-    ListSandboxesResponse, ListSnapshotsRequest, ListSnapshotsResponse, RemoveSandboxRequest,
-    RestoreRequest, RestoreResponse, RunOutput, RunRequest, SandboxEvent, SandboxEventsRequest,
-    SandboxInfo, StopSandboxRequest, TerminalSize,
+    DeleteSnapshotRequest, ExecOutput, ExecRequest, FileChunk, InspectSandboxRequest,
+    ListSandboxesRequest, ListSandboxesResponse, ListSnapshotsRequest, ListSnapshotsResponse,
+    ReadFileRequest, RemoveSandboxRequest, RestoreRequest, RestoreResponse, RunOutput, RunRequest,
+    SandboxEvent, SandboxEventsRequest, SandboxInfo, StopSandboxRequest, TerminalSize,
+    WriteFileOpen,
 };
 use arcbox_transport::Transport;
 use arcbox_transport::vsock::{BlockingVsockTransport, VsockAddr, VsockTransport};
@@ -798,6 +799,137 @@ impl AgentClient {
             MessageType::SandboxListResponse,
         )
         .await
+    }
+
+    /// Streams a file out of a sandbox as decoded [`FileChunk`]s.
+    ///
+    /// The final chunk carries `done == true`. Consumes the client because
+    /// the stream task requires exclusive transport access.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the initial send fails.
+    pub async fn sandbox_read_file(
+        mut self,
+        req: ReadFileRequest,
+    ) -> Result<mpsc::UnboundedReceiver<Result<FileChunk>>> {
+        if !self.connected {
+            self.connect().await?;
+        }
+
+        let payload = req.encode_to_vec();
+        let buf = wire::build_message(MessageType::SandboxFileReadRequest, "", &payload);
+        self.transport
+            .async_send(buf)
+            .await
+            .map_err(|e| CoreError::Machine(format!("failed to send read-file request: {e}")))?;
+
+        let (tx, rx) = mpsc::unbounded_channel();
+        tokio::spawn(async move {
+            loop {
+                let raw = match self.transport.async_recv().await {
+                    Ok(r) => r,
+                    Err(e) => {
+                        let _ = tx.send(Err(CoreError::Machine(format!("recv error: {e}"))));
+                        break;
+                    }
+                };
+                let (resp_type, _, resp_payload) = match wire::parse_response(&raw) {
+                    Ok(p) => p,
+                    Err(e) => {
+                        let _ = tx.send(Err(e));
+                        break;
+                    }
+                };
+                if resp_type == MessageType::Error as u32 {
+                    let (code, message) = wire::parse_error_response(&resp_payload)
+                        .unwrap_or_else(|_| (500, "unknown error".to_string()));
+                    let _ = tx.send(Err(CoreError::Agent { code, message }));
+                    break;
+                }
+                if resp_type != MessageType::SandboxFileData as u32 {
+                    let _ = tx.send(Err(CoreError::Machine(format!(
+                        "unexpected response type: 0x{resp_type:04x}"
+                    ))));
+                    break;
+                }
+                match FileChunk::decode(&resp_payload[..]) {
+                    Ok(chunk) => {
+                        let done = chunk.done;
+                        if tx.send(Ok(chunk)).is_err() || done {
+                            break;
+                        }
+                    }
+                    Err(e) => {
+                        let _ = tx.send(Err(CoreError::Machine(format!("decode error: {e}"))));
+                        break;
+                    }
+                }
+            }
+        });
+
+        Ok(rx)
+    }
+
+    /// Writes a file into a sandbox from a channel of data chunks.
+    ///
+    /// The channel closing marks end-of-data; the client then sends the
+    /// terminating chunk and waits for the agent's acknowledgement.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if any send fails or the agent reports a failure.
+    pub async fn sandbox_write_file(
+        mut self,
+        open: WriteFileOpen,
+        mut data_rx: mpsc::Receiver<Vec<u8>>,
+    ) -> Result<()> {
+        if !self.connected {
+            self.connect().await?;
+        }
+
+        let payload = open.encode_to_vec();
+        let buf = wire::build_message(MessageType::SandboxFileWriteRequest, "", &payload);
+        self.transport
+            .async_send(buf)
+            .await
+            .map_err(|e| CoreError::Machine(format!("failed to send write-file open: {e}")))?;
+
+        while let Some(data) = data_rx.recv().await {
+            let chunk = FileChunk { data, done: false };
+            let frame =
+                wire::build_message(MessageType::SandboxFileChunk, "", &chunk.encode_to_vec());
+            self.transport
+                .async_send(frame)
+                .await
+                .map_err(|e| CoreError::Machine(format!("failed to send file chunk: {e}")))?;
+        }
+        let done = FileChunk {
+            data: Vec::new(),
+            done: true,
+        };
+        let frame = wire::build_message(MessageType::SandboxFileChunk, "", &done.encode_to_vec());
+        self.transport
+            .async_send(frame)
+            .await
+            .map_err(|e| CoreError::Machine(format!("failed to send final chunk: {e}")))?;
+
+        let raw = self
+            .transport
+            .async_recv()
+            .await
+            .map_err(|e| CoreError::Machine(format!("recv error: {e}")))?;
+        let (resp_type, _, resp_payload) = wire::parse_response(&raw)?;
+        if resp_type == MessageType::Error as u32 {
+            let (code, message) = wire::parse_error_response(&resp_payload)?;
+            return Err(CoreError::Agent { code, message });
+        }
+        if resp_type != MessageType::SandboxFileWriteResponse as u32 {
+            return Err(CoreError::Machine(format!(
+                "unexpected response type: 0x{resp_type:04x}"
+            )));
+        }
+        Ok(())
     }
 
     /// Runs a command inside a sandbox and returns a channel of streaming output.

--- a/app/arcbox-core/src/agent_client/wire.rs
+++ b/app/arcbox-core/src/agent_client/wire.rs
@@ -66,20 +66,54 @@ pub(super) fn parse_response(response: &[u8]) -> Result<(u32, String, Vec<u8>)> 
     Ok((resp_type, trace_id, payload))
 }
 
-/// Parses an error response from the agent.
-pub(super) fn parse_error_response(payload: &[u8]) -> Result<String> {
+/// Parses an error response from the agent into `(status code, message)`.
+///
+/// The code is HTTP-style (400/404/409/412/500/503) and is mapped onto a
+/// gRPC status by the API layer via `CoreError::Agent`.
+pub(super) fn parse_error_response(payload: &[u8]) -> Result<(i32, String)> {
     if payload.len() < ERROR_HEADER_SIZE {
-        return Ok("unknown error".to_string());
+        return Ok((500, "unknown error".to_string()));
     }
 
     let mut cursor = std::io::Cursor::new(payload);
-    let _code = cursor.get_i32();
+    let code = cursor.get_i32();
     let msg_len = cursor.get_u32() as usize;
 
     if payload.len() < ERROR_HEADER_SIZE + msg_len {
-        return Ok("truncated error message".to_string());
+        return Ok((code, "truncated error message".to_string()));
     }
 
-    String::from_utf8(payload[ERROR_HEADER_SIZE..ERROR_HEADER_SIZE + msg_len].to_vec())
-        .map_err(|_| CoreError::Machine("invalid error message encoding".to_string()))
+    let message =
+        String::from_utf8(payload[ERROR_HEADER_SIZE..ERROR_HEADER_SIZE + msg_len].to_vec())
+            .map_err(|_| CoreError::Machine("invalid error message encoding".to_string()))?;
+    Ok((code, message))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Mirror of the agent's `ErrorResponse::encode` framing.
+    fn encode_error(code: i32, message: &str) -> Vec<u8> {
+        let mut buf = Vec::new();
+        buf.extend_from_slice(&code.to_be_bytes());
+        buf.extend_from_slice(&(message.len() as u32).to_be_bytes());
+        buf.extend_from_slice(message.as_bytes());
+        buf
+    }
+
+    #[test]
+    fn error_response_roundtrips_code_and_message() {
+        let payload = encode_error(412, "nested virtualization required");
+        let (code, message) = parse_error_response(&payload).unwrap();
+        assert_eq!(code, 412);
+        assert_eq!(message, "nested virtualization required");
+    }
+
+    #[test]
+    fn short_error_payload_degrades_to_500() {
+        let (code, message) = parse_error_response(&[0x01]).unwrap();
+        assert_eq!(code, 500);
+        assert_eq!(message, "unknown error");
+    }
 }

--- a/app/arcbox-core/src/error.rs
+++ b/app/arcbox-core/src/error.rs
@@ -29,6 +29,17 @@ pub enum CoreError {
     #[error("machine error: {0}")]
     Machine(String),
 
+    /// Error reported by the guest agent over the vsock wire, carrying an
+    /// HTTP-style status code (400/404/409/412/500/503) that the API layer
+    /// maps onto the matching gRPC status.
+    #[error("{message}")]
+    Agent {
+        /// HTTP-style status code from the agent's `ErrorResponse`.
+        code: i32,
+        /// Human-readable error message.
+        message: String,
+    },
+
     /// Persistence deserialization error.
     #[error("persistence error: {0}")]
     Persistence(#[from] toml::de::Error),

--- a/app/arcbox-core/src/lib.rs
+++ b/app/arcbox-core/src/lib.rs
@@ -46,7 +46,7 @@ pub mod trace;
 pub mod vm;
 pub mod vm_lifecycle;
 
-pub use agent_client::AgentClient;
+pub use agent_client::{AgentClient, ExecSessionInput};
 pub use arcbox_vmm::{DeviceDebug, QueueDebug, VmBackend};
 pub use boot_assets::{
     BootAssetConfig, BootAssetManifest, BootAssetProvider, BootAssets, DownloadProgress,

--- a/app/arcbox-core/src/lib.rs
+++ b/app/arcbox-core/src/lib.rs
@@ -46,7 +46,7 @@ pub mod trace;
 pub mod vm;
 pub mod vm_lifecycle;
 
-pub use agent_client::{AgentClient, ExecSessionInput};
+pub use agent_client::{AgentClient, ExecSessionInput, WriteFileChunk};
 pub use arcbox_vmm::{DeviceDebug, QueueDebug, VmBackend};
 pub use boot_assets::{
     BootAssetConfig, BootAssetManifest, BootAssetProvider, BootAssets, DownloadProgress,

--- a/app/arcbox-core/src/lib.rs
+++ b/app/arcbox-core/src/lib.rs
@@ -56,7 +56,7 @@ pub use config::{Config, ContainerRuntimeConfig};
 pub use error::{CoreError, Result};
 pub use machine::MachineManager;
 pub use migration::MigrationManager;
-pub use runtime::Runtime;
+pub use runtime::{Runtime, SandboxPortExposure};
 pub use vm::{SharedDirConfig, VmConfig, VmManager};
 pub use vm_lifecycle::{
     DEFAULT_MACHINE_NAME, DefaultVmConfig, HealthMonitor, VmLifecycleConfig, VmLifecycleManager,

--- a/app/arcbox-core/src/machine.rs
+++ b/app/arcbox-core/src/machine.rs
@@ -562,8 +562,23 @@ impl MachineManager {
         let cid = self
             .get_cid(name)
             .ok_or_else(|| CoreError::invalid_state("CID not assigned"))?;
+        let backend = {
+            let machines = self.machines.read().map_err(|_| CoreError::LockPoisoned)?;
+            let machine = machines
+                .get(name)
+                .ok_or_else(|| CoreError::not_found(name.to_string()))?;
+            self.vm_manager.backend(&machine.vm_id)?
+        };
         let fd = self.connect_vsock_port(name, AGENT_PORT)?;
-        AgentClient::from_fd(cid, fd)
+        // The transport must follow the backend, not the fd's socket domain:
+        // both backends hand over unnamed AF_UNIX fds, but only the HV
+        // socketpair needs the blocking transport (tokio/kqueue stalls on
+        // rapid connect/teardown cycles), and only the async transport
+        // supports the streaming sandbox RPCs VZ clients rely on.
+        match backend {
+            arcbox_vmm::VmBackend::Hv => AgentClient::from_fd_blocking(cid, fd),
+            arcbox_vmm::VmBackend::Vz => AgentClient::from_fd_async(cid, fd),
+        }
     }
 
     /// Connects to a vsock port on a running machine (macOS).

--- a/app/arcbox-core/src/runtime.rs
+++ b/app/arcbox-core/src/runtime.rs
@@ -83,6 +83,9 @@ pub struct Runtime {
     /// Port forwarders for each container (non-macOS fallback).
     #[cfg(not(target_os = "macos"))]
     port_forwarders: Arc<TokioRwLock<HashMap<String, PortForwarder>>>,
+    /// Host listener keys of exposed sandbox ports, keyed by sandbox ID, so
+    /// Stop/Remove can tear down every listener a sandbox owns.
+    sandbox_port_keys: Arc<TokioRwLock<HashMap<String, Vec<String>>>>,
     /// Tracks DNS registrations: canonical container ID → hostnames.
     dns_entries: Arc<TokioRwLock<HashMap<String, Vec<String>>>>,
     /// Maps a container's unique name to its canonical ID, so teardown can
@@ -90,6 +93,23 @@ pub struct Runtime {
     /// round-trip. Populated at registration, updated on rename, cleared with
     /// the rest of the container's host state.
     container_aliases: Arc<TokioRwLock<HashMap<String, String>>>,
+}
+
+/// Parameters of one sandbox port exposure (the host listener half).
+///
+/// The guest half — DNAT from `guest_port` to the sandbox — is installed by
+/// the guest agent before this is applied.
+pub struct SandboxPortExposure {
+    /// Sandbox that owns the mapping.
+    pub sandbox_id: String,
+    /// Port the workload listens on inside the sandbox.
+    pub sandbox_port: u16,
+    /// `"tcp"` or `"udp"`.
+    pub protocol: String,
+    /// Host port to bind (loopback-reachable).
+    pub host_port: u16,
+    /// Reserved-range guest relay port the agent allocated.
+    pub guest_port: u16,
 }
 
 impl Runtime {
@@ -174,6 +194,7 @@ impl Runtime {
             inbound_rules: Arc::new(TokioRwLock::new(HashMap::new())),
             #[cfg(not(target_os = "macos"))]
             port_forwarders: Arc::new(TokioRwLock::new(HashMap::new())),
+            sandbox_port_keys: Arc::new(TokioRwLock::new(HashMap::new())),
             dns_entries: Arc::new(TokioRwLock::new(HashMap::new())),
             container_aliases: Arc::new(TokioRwLock::new(HashMap::new())),
         })
@@ -872,6 +893,63 @@ impl Runtime {
                 tracing::debug!("Stopped port forwarding for container {}", container_id);
             }
         }
+    }
+
+    /// Binds the host listener half of a sandbox port exposure.
+    ///
+    /// The guest half (reserved-port DNAT to the sandbox IP) is installed by
+    /// the agent; this forwards `host_port` into the guest relay port using
+    /// the same machinery as published container ports. Listeners are keyed
+    /// per exposure so `unexpose_sandbox_port` removes exactly one mapping.
+    pub async fn expose_sandbox_port(
+        &self,
+        machine_name: &str,
+        exposure: &SandboxPortExposure,
+    ) -> Result<()> {
+        let key = Self::sandbox_port_key(
+            &exposure.sandbox_id,
+            exposure.sandbox_port,
+            &exposure.protocol,
+        );
+        self.start_port_forwarding_for(
+            machine_name,
+            &key,
+            &[(
+                String::new(),
+                exposure.host_port,
+                exposure.guest_port,
+                exposure.protocol.clone(),
+            )],
+        )
+        .await?;
+        self.sandbox_port_keys
+            .write()
+            .await
+            .entry(exposure.sandbox_id.clone())
+            .or_default()
+            .push(key);
+        Ok(())
+    }
+
+    /// Removes the host listener of one sandbox port exposure.
+    pub async fn unexpose_sandbox_port(&self, sandbox_id: &str, sandbox_port: u16, protocol: &str) {
+        let key = Self::sandbox_port_key(sandbox_id, sandbox_port, protocol);
+        self.stop_port_forwarding_by_id(&key).await;
+        if let Some(keys) = self.sandbox_port_keys.write().await.get_mut(sandbox_id) {
+            keys.retain(|k| k != &key);
+        }
+    }
+
+    /// Removes every host listener a sandbox owns (Stop/Remove teardown).
+    pub async fn remove_sandbox_ports(&self, sandbox_id: &str) {
+        let keys = self.sandbox_port_keys.write().await.remove(sandbox_id);
+        for key in keys.unwrap_or_default() {
+            self.stop_port_forwarding_by_id(&key).await;
+        }
+    }
+
+    fn sandbox_port_key(sandbox_id: &str, sandbox_port: u16, protocol: &str) -> String {
+        format!("sandbox:{sandbox_id}:{sandbox_port}/{protocol}")
     }
 
     /// Registers DNS entries for a container.

--- a/app/arcbox-core/src/runtime.rs
+++ b/app/arcbox-core/src/runtime.rs
@@ -770,6 +770,7 @@ impl Runtime {
         }
 
         let mut added_rules = Vec::new();
+        let mut bind_errors: Vec<String> = Vec::new();
 
         for (host_ip_str, host_port, container_port, protocol) in bindings {
             let proto = match protocol.to_lowercase().as_str() {
@@ -802,9 +803,21 @@ impl Runtime {
                     protocol,
                     e,
                 );
+                bind_errors.push(format!("{host_ip_str}:{host_port}/{protocol}: {e}"));
                 continue;
             }
             added_rules.push((host_ip, *host_port, proto));
+        }
+
+        // Surface a total bind failure instead of reporting success. A sandbox
+        // expose is a single binding, so a swallowed port conflict would claim
+        // "exposed on localhost" while nothing is actually listening. Docker
+        // multi-port publish stays best-effort as long as one port binds.
+        if added_rules.is_empty() && !bindings.is_empty() {
+            return Err(CoreError::Machine(format!(
+                "no requested port could be bound: {}",
+                bind_errors.join("; ")
+            )));
         }
 
         if !added_rules.is_empty() {

--- a/app/arcbox-core/src/runtime.rs
+++ b/app/arcbox-core/src/runtime.rs
@@ -37,6 +37,20 @@ use tokio::sync::RwLock as TokioRwLock;
 #[cfg(not(target_os = "macos"))]
 const DEFAULT_GUEST_IP: Ipv4Addr = Ipv4Addr::new(192, 168, 64, 2);
 
+/// Resolve a host-IP binding string for a forwarded port.
+///
+/// Empty or `"0.0.0.0"` means "all interfaces" (`UNSPECIFIED`); anything else
+/// must parse as an IPv4 address (returns `None` if it does not). Sandbox
+/// exposures pass `"127.0.0.1"` so untrusted workloads are reachable only on
+/// loopback, while published container ports keep binding all interfaces.
+fn resolve_bind_ip(host_ip_str: &str) -> Option<Ipv4Addr> {
+    if host_ip_str.is_empty() || host_ip_str == "0.0.0.0" {
+        Some(Ipv4Addr::UNSPECIFIED)
+    } else {
+        host_ip_str.parse().ok()
+    }
+}
+
 /// Inbound port-forwarding rules per container.
 ///
 /// Maps the canonical container ID to the machine that holds the rules and
@@ -763,11 +777,7 @@ impl Runtime {
                 _ => InboundProtocol::Tcp,
             };
 
-            let host_ip: Ipv4Addr = if host_ip_str.is_empty() || host_ip_str == "0.0.0.0" {
-                Ipv4Addr::UNSPECIFIED
-            } else if let Ok(ip) = host_ip_str.parse() {
-                ip
-            } else {
+            let Some(host_ip) = resolve_bind_ip(host_ip_str) else {
                 tracing::warn!(
                     "Skipping inbound rule: invalid HostIp '{}' for port {}:{}",
                     host_ip_str,
@@ -820,21 +830,14 @@ impl Runtime {
         let mut forwarder = PortForwarder::new();
 
         for (host_ip_str, host_port, container_port, protocol) in bindings {
-            let host_ip: Ipv4Addr = if host_ip_str.is_empty() || host_ip_str == "0.0.0.0" {
-                Ipv4Addr::UNSPECIFIED
-            } else {
-                match host_ip_str.parse() {
-                    Ok(ip) => ip,
-                    Err(_) => {
-                        tracing::warn!(
-                            "Skipping port forward rule: invalid HostIp '{}' for port {}:{}",
-                            host_ip_str,
-                            host_port,
-                            protocol,
-                        );
-                        continue;
-                    }
-                }
+            let Some(host_ip) = resolve_bind_ip(host_ip_str) else {
+                tracing::warn!(
+                    "Skipping port forward rule: invalid HostIp '{}' for port {}:{}",
+                    host_ip_str,
+                    host_port,
+                    protocol,
+                );
+                continue;
             };
 
             let host_addr = SocketAddr::V4(SocketAddrV4::new(host_ip, *host_port));
@@ -911,11 +914,15 @@ impl Runtime {
             exposure.sandbox_port,
             &exposure.protocol,
         );
+        // Bind the exposed port on loopback only. A sandbox runs untrusted
+        // code; unlike published container ports (which intentionally bind all
+        // interfaces), a sandbox port must not be reachable from the LAN. The
+        // proto/docs/CLI all promise "localhost".
         self.start_port_forwarding_for(
             machine_name,
             &key,
             &[(
-                String::new(),
+                "127.0.0.1".to_owned(),
                 exposure.host_port,
                 exposure.guest_port,
                 exposure.protocol.clone(),

--- a/app/arcbox-core/src/runtime/tests.rs
+++ b/app/arcbox-core/src/runtime/tests.rs
@@ -197,3 +197,25 @@ fn test_runtime_new_propagates_config_vm_defaults() {
         Some(PathBuf::from("/tmp/arcbox-test-kernel"))
     );
 }
+
+#[test]
+fn resolve_bind_ip_defaults_and_loopback() {
+    use std::net::Ipv4Addr;
+    // Sandbox exposures pass "127.0.0.1" and must bind loopback only.
+    assert_eq!(
+        super::resolve_bind_ip("127.0.0.1"),
+        Some(Ipv4Addr::LOCALHOST)
+    );
+    // Published container ports (empty / explicit 0.0.0.0) bind all interfaces.
+    assert_eq!(super::resolve_bind_ip(""), Some(Ipv4Addr::UNSPECIFIED));
+    assert_eq!(
+        super::resolve_bind_ip("0.0.0.0"),
+        Some(Ipv4Addr::UNSPECIFIED)
+    );
+    // A specific address is honored; garbage is rejected.
+    assert_eq!(
+        super::resolve_bind_ip("10.0.0.5"),
+        Some(Ipv4Addr::new(10, 0, 0, 5))
+    );
+    assert_eq!(super::resolve_bind_ip("not-an-ip"), None);
+}

--- a/app/arcbox-core/src/vm.rs
+++ b/app/arcbox-core/src/vm.rs
@@ -105,6 +105,18 @@ impl VmManager {
     /// # Errors
     ///
     /// Returns an error if the VM is running/starting or not found.
+    /// Returns the backend a VM is configured to run on.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the VM is not found.
+    pub fn backend(&self, id: &VmId) -> Result<arcbox_vmm::VmBackend> {
+        let vms = self.vms.read().map_err(|_| CoreError::LockPoisoned)?;
+        vms.get(id)
+            .map(|entry| entry.config.backend)
+            .ok_or_else(|| CoreError::not_found(id.to_string()))
+    }
+
     pub fn set_backend(&self, id: &VmId, backend: arcbox_vmm::VmBackend) -> Result<()> {
         let mut vms = self.vms.write().map_err(|_| CoreError::LockPoisoned)?;
 

--- a/app/arcbox-daemon/Cargo.toml
+++ b/app/arcbox-daemon/Cargo.toml
@@ -38,6 +38,8 @@ http-body-util = "0.1"
 tokio-util = "0.7"
 arcbox-docker-tools.workspace = true
 filetime = "0.2.29"
+arcbox-grpc = { version = "0.4.16", path = "../../rpc/arcbox-grpc" }
+tonic-reflection = "0.12"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 macos-resolver = { workspace = true }

--- a/app/arcbox-daemon/src/services.rs
+++ b/app/arcbox-daemon/src/services.rs
@@ -61,6 +61,18 @@ pub async fn start_grpc(
     );
     let icon_service = IconServiceImpl::new();
 
+    // Server reflection lets SDK authors and grpcurl discover the API
+    // without vendoring the protos (both v1 and the legacy v1alpha are
+    // served — grpcurl still speaks v1alpha by default).
+    let reflection_v1 = tonic_reflection::server::Builder::configure()
+        .register_encoded_file_descriptor_set(arcbox_grpc::FILE_DESCRIPTOR_SET)
+        .build_v1()
+        .context("building gRPC reflection service")?;
+    let reflection_v1alpha = tonic_reflection::server::Builder::configure()
+        .register_encoded_file_descriptor_set(arcbox_grpc::FILE_DESCRIPTOR_SET)
+        .build_v1alpha()
+        .context("building gRPC reflection service (v1alpha)")?;
+
     let shutdown = ctx.shutdown.clone();
     let handle = tokio::spawn(async move {
         let result = Server::builder()
@@ -71,6 +83,8 @@ pub async fn start_grpc(
             .add_service(SandboxSnapshotServiceServer::new(sandbox_snapshot_service))
             .add_service(SystemServiceServer::new(system_service))
             .add_service(IconServiceServer::new(icon_service))
+            .add_service(reflection_v1)
+            .add_service(reflection_v1alpha)
             .serve_with_incoming_shutdown(incoming, shutdown.cancelled())
             .await;
 

--- a/app/arcbox-daemon/src/startup/assets.rs
+++ b/app/arcbox-daemon/src/startup/assets.rs
@@ -97,6 +97,7 @@ pub fn find_bundle_contents() -> Option<PathBuf> {
 /// Contents/Resources/assets/{version}/  → ~/.arcbox/boot/{version}/
 /// Contents/Resources/runtime/           → ~/.arcbox/runtime/
 /// Contents/Resources/bin/arcbox-agent   → ~/.arcbox/bin/arcbox-agent
+/// Contents/Resources/bin/vm-agent      → ~/.arcbox/bin/vm-agent
 /// ```
 pub(super) fn seed_from_bundle(data_dir: &Path) -> Result<BundleSeed> {
     let Some(contents) = find_bundle_contents() else {
@@ -130,6 +131,19 @@ pub(super) fn seed_from_bundle(data_dir: &Path) -> Result<BundleSeed> {
     if agent_src.exists() {
         seed.agent = seed_agent_from_bundle(&agent_src, data_dir)
             .context("Failed to seed arcbox-agent from bundle")?;
+    }
+
+    // 4. Sandbox microVM init (optional — sandboxes degrade without it).
+    // The guest resolves it at /arcbox/bin/vm-agent via the VirtioFS
+    // data-dir mount.
+    let vm_agent_src = contents.join("Resources/bin/vm-agent");
+    if vm_agent_src.exists() {
+        seed_dir_files(
+            &contents.join("Resources/bin"),
+            &data_dir.join("bin"),
+            &["vm-agent"],
+            "sandbox vm-agent",
+        );
     }
 
     Ok(seed)

--- a/app/arcbox-daemon/src/startup/mod.rs
+++ b/app/arcbox-daemon/src/startup/mod.rs
@@ -47,6 +47,15 @@ async fn init_early(args: DaemonArgs, handles: StartupHandles) -> Result<EarlyCo
 
     std::fs::create_dir_all(&layout.data_dir).context("Failed to create data directory")?;
     std::fs::create_dir_all(&layout.run_dir).context("Failed to create run directory")?;
+    // The gRPC/Docker sockets live in run_dir and are the daemon's only access
+    // control (a connected client gets full sandbox read/write/exec). Restrict
+    // the directory to the owner so the posture doesn't depend on the umask.
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&layout.run_dir, std::fs::Permissions::from_mode(0o700))
+            .context("Failed to restrict run directory permissions")?;
+    }
     std::fs::create_dir_all(&layout.log_dir).context("Failed to create log directory")?;
     std::fs::create_dir_all(&layout.data_subdir)
         .context("Failed to create persistent data directory")?;

--- a/common/arcbox-constants/src/wire.rs
+++ b/common/arcbox-constants/src/wire.rs
@@ -73,6 +73,16 @@ pub enum MessageType {
     /// TTY resize frame sent by the host during an exec session. Payload is
     /// a prost-encoded `sandbox.v1.TerminalSize`.
     SandboxExecResize = 0x0034,
+    /// Read a file from a sandbox (payload: `sandbox.v1.ReadFileRequest`).
+    /// The agent answers with a stream of [`Self::SandboxFileData`] frames.
+    SandboxFileReadRequest = 0x0035,
+    /// Open a file-write stream into a sandbox (payload:
+    /// `sandbox.v1.WriteFileOpen`), followed by [`Self::SandboxFileChunk`]
+    /// frames and answered with [`Self::SandboxFileWriteResponse`].
+    SandboxFileWriteRequest = 0x0036,
+    /// One chunk of file content during a write stream (payload:
+    /// `sandbox.v1.FileChunk`; `done == true` on the last chunk).
+    SandboxFileChunk = 0x0037,
 
     // Sandbox snapshot request types (0x0040 - 0x0043).
     SandboxCheckpointRequest = 0x0040,
@@ -113,6 +123,11 @@ pub enum MessageType {
     SandboxRunOutput = 0x1035,
     SandboxExecOutput = 0x1036,
     SandboxEvent = 0x1037,
+    /// One chunk of file content answering [`Self::SandboxFileReadRequest`]
+    /// (payload: `sandbox.v1.FileChunk`; `done == true` on the last chunk).
+    SandboxFileData = 0x1038,
+    /// Acknowledges a completed file-write stream (empty payload).
+    SandboxFileWriteResponse = 0x1039,
 
     // Sandbox snapshot response types (0x1040 - 0x1043).
     SandboxCheckpointResponse = 0x1040,
@@ -156,6 +171,9 @@ impl MessageType {
             0x0032 => Some(Self::SandboxEventsRequest),
             0x0033 => Some(Self::SandboxExecInput),
             0x0034 => Some(Self::SandboxExecResize),
+            0x0035 => Some(Self::SandboxFileReadRequest),
+            0x0036 => Some(Self::SandboxFileWriteRequest),
+            0x0037 => Some(Self::SandboxFileChunk),
             // Sandbox snapshot requests.
             0x0040 => Some(Self::SandboxCheckpointRequest),
             0x0041 => Some(Self::SandboxRestoreRequest),
@@ -188,6 +206,8 @@ impl MessageType {
             0x1035 => Some(Self::SandboxRunOutput),
             0x1036 => Some(Self::SandboxExecOutput),
             0x1037 => Some(Self::SandboxEvent),
+            0x1038 => Some(Self::SandboxFileData),
+            0x1039 => Some(Self::SandboxFileWriteResponse),
             // Sandbox snapshot responses.
             0x1040 => Some(Self::SandboxCheckpointResponse),
             0x1041 => Some(Self::SandboxRestoreResponse),
@@ -213,6 +233,8 @@ impl MessageType {
                 | Self::SandboxRunRequest
                 | Self::SandboxExecRequest
                 | Self::SandboxEventsRequest
+                | Self::SandboxFileReadRequest
+                | Self::SandboxFileWriteRequest
                 | Self::SandboxCheckpointRequest
                 | Self::SandboxRestoreRequest
                 | Self::SandboxListSnapshotsRequest
@@ -290,9 +312,14 @@ mod tests {
             (0x0032, MessageType::SandboxEventsRequest),
             (0x0033, MessageType::SandboxExecInput),
             (0x0034, MessageType::SandboxExecResize),
+            (0x0035, MessageType::SandboxFileReadRequest),
+            (0x0036, MessageType::SandboxFileWriteRequest),
+            (0x0037, MessageType::SandboxFileChunk),
             (0x1035, MessageType::SandboxRunOutput),
             (0x1036, MessageType::SandboxExecOutput),
             (0x1037, MessageType::SandboxEvent),
+            (0x1038, MessageType::SandboxFileData),
+            (0x1039, MessageType::SandboxFileWriteResponse),
             // Sandbox snapshots.
             (0x0040, MessageType::SandboxCheckpointRequest),
             (0x0041, MessageType::SandboxRestoreRequest),
@@ -319,6 +346,8 @@ mod tests {
     fn is_sandbox_request_classifies_correctly() {
         assert!(MessageType::SandboxCreateRequest.is_sandbox_request());
         assert!(MessageType::SandboxRunRequest.is_sandbox_request());
+        assert!(MessageType::SandboxFileReadRequest.is_sandbox_request());
+        assert!(MessageType::SandboxFileWriteRequest.is_sandbox_request());
         assert!(MessageType::SandboxCheckpointRequest.is_sandbox_request());
         assert!(!MessageType::PingRequest.is_sandbox_request());
         assert!(!MessageType::SandboxCreateResponse.is_sandbox_request());

--- a/common/arcbox-constants/src/wire.rs
+++ b/common/arcbox-constants/src/wire.rs
@@ -63,13 +63,16 @@ pub enum MessageType {
     SandboxInspectRequest = 0x0023,
     SandboxListRequest = 0x0024,
 
-    // Sandbox workload request types (0x0030 - 0x0033).
+    // Sandbox workload request types (0x0030 - 0x0034).
     SandboxRunRequest = 0x0030,
     SandboxExecRequest = 0x0031,
     SandboxEventsRequest = 0x0032,
     /// Streaming stdin frame sent by the host after [`SandboxExecRequest`]
     /// to forward user input to the running process.
     SandboxExecInput = 0x0033,
+    /// TTY resize frame sent by the host during an exec session. Payload is
+    /// a prost-encoded `sandbox.v1.TerminalSize`.
+    SandboxExecResize = 0x0034,
 
     // Sandbox snapshot request types (0x0040 - 0x0043).
     SandboxCheckpointRequest = 0x0040,
@@ -152,6 +155,7 @@ impl MessageType {
             0x0031 => Some(Self::SandboxExecRequest),
             0x0032 => Some(Self::SandboxEventsRequest),
             0x0033 => Some(Self::SandboxExecInput),
+            0x0034 => Some(Self::SandboxExecResize),
             // Sandbox snapshot requests.
             0x0040 => Some(Self::SandboxCheckpointRequest),
             0x0041 => Some(Self::SandboxRestoreRequest),
@@ -285,6 +289,7 @@ mod tests {
             (0x0031, MessageType::SandboxExecRequest),
             (0x0032, MessageType::SandboxEventsRequest),
             (0x0033, MessageType::SandboxExecInput),
+            (0x0034, MessageType::SandboxExecResize),
             (0x1035, MessageType::SandboxRunOutput),
             (0x1036, MessageType::SandboxExecOutput),
             (0x1037, MessageType::SandboxEvent),

--- a/common/arcbox-constants/src/wire.rs
+++ b/common/arcbox-constants/src/wire.rs
@@ -56,12 +56,18 @@ pub enum MessageType {
     /// any production CLI path.
     KillAgentRequest = 0x000E,
 
-    // Sandbox CRUD request types (0x0020 - 0x0024).
+    // Sandbox CRUD request types (0x0020 - 0x0026).
     SandboxCreateRequest = 0x0020,
     SandboxStopRequest = 0x0021,
     SandboxRemoveRequest = 0x0022,
     SandboxInspectRequest = 0x0023,
     SandboxListRequest = 0x0024,
+    /// DNAT a reserved guest port to a sandbox port (payload:
+    /// `sandbox.v1.SandboxPortForwardRequest`).
+    SandboxPortForwardRequest = 0x0025,
+    /// Remove a sandbox DNAT mapping (payload:
+    /// `sandbox.v1.SandboxPortForwardRemoveRequest`).
+    SandboxPortForwardRemoveRequest = 0x0026,
 
     // Sandbox workload request types (0x0030 - 0x0034).
     SandboxRunRequest = 0x0030,
@@ -112,12 +118,17 @@ pub enum MessageType {
     PortBindingsChanged = 0x1030,
     PortBindingsRemoved = 0x1031,
 
-    // Sandbox CRUD response types (0x1020 - 0x1024).
+    // Sandbox CRUD response types (0x1020 - 0x1026).
     SandboxCreateResponse = 0x1020,
     SandboxStopResponse = 0x1021,
     SandboxRemoveResponse = 0x1022,
     SandboxInspectResponse = 0x1023,
     SandboxListResponse = 0x1024,
+    /// Answers [`Self::SandboxPortForwardRequest`] (payload:
+    /// `sandbox.v1.SandboxPortForwardResponse`).
+    SandboxPortForwardResponse = 0x1025,
+    /// Acknowledges [`Self::SandboxPortForwardRemoveRequest`] (empty payload).
+    SandboxPortForwardRemoveResponse = 0x1026,
 
     // Sandbox workload response types (streaming).
     SandboxRunOutput = 0x1035,
@@ -165,6 +176,8 @@ impl MessageType {
             0x0022 => Some(Self::SandboxRemoveRequest),
             0x0023 => Some(Self::SandboxInspectRequest),
             0x0024 => Some(Self::SandboxListRequest),
+            0x0025 => Some(Self::SandboxPortForwardRequest),
+            0x0026 => Some(Self::SandboxPortForwardRemoveRequest),
             // Sandbox workload requests.
             0x0030 => Some(Self::SandboxRunRequest),
             0x0031 => Some(Self::SandboxExecRequest),
@@ -202,6 +215,8 @@ impl MessageType {
             0x1022 => Some(Self::SandboxRemoveResponse),
             0x1023 => Some(Self::SandboxInspectResponse),
             0x1024 => Some(Self::SandboxListResponse),
+            0x1025 => Some(Self::SandboxPortForwardResponse),
+            0x1026 => Some(Self::SandboxPortForwardRemoveResponse),
             // Sandbox workload responses (streaming).
             0x1035 => Some(Self::SandboxRunOutput),
             0x1036 => Some(Self::SandboxExecOutput),
@@ -235,6 +250,8 @@ impl MessageType {
                 | Self::SandboxEventsRequest
                 | Self::SandboxFileReadRequest
                 | Self::SandboxFileWriteRequest
+                | Self::SandboxPortForwardRequest
+                | Self::SandboxPortForwardRemoveRequest
                 | Self::SandboxCheckpointRequest
                 | Self::SandboxRestoreRequest
                 | Self::SandboxListSnapshotsRequest
@@ -306,6 +323,10 @@ mod tests {
             (0x1022, MessageType::SandboxRemoveResponse),
             (0x1023, MessageType::SandboxInspectResponse),
             (0x1024, MessageType::SandboxListResponse),
+            (0x0025, MessageType::SandboxPortForwardRequest),
+            (0x0026, MessageType::SandboxPortForwardRemoveRequest),
+            (0x1025, MessageType::SandboxPortForwardResponse),
+            (0x1026, MessageType::SandboxPortForwardRemoveResponse),
             // Sandbox workload.
             (0x0030, MessageType::SandboxRunRequest),
             (0x0031, MessageType::SandboxExecRequest),

--- a/docs/data-directories.md
+++ b/docs/data-directories.md
@@ -89,6 +89,7 @@ Exposed to the guest VM via VirtioFS at `/arcbox/runtime/bin`.
 | `bin/arcbox` | Compatibility symlink → abctl | cli (`abctl setup install`) |
 | `bin/arcbox-daemon` | Fallback daemon binary path | cli |
 | `bin/arcbox-agent` | Guest agent binary | daemon (bundle seed / boot cache) |
+| `bin/vm-agent` | Sandbox microVM init binary (guest sees `/arcbox/bin/vm-agent`) | daemon (bundle seed / boot cache) |
 
 ### 1.7 `shell/` — Shell Integration
 
@@ -248,10 +249,13 @@ Tags defined in `common/arcbox-constants/src/virtiofs.rs`.
 | `/run/arcbox/data` | Btrfs temporary mount point | agent |
 | `/run/arcbox/vmm.sock` | Guest VMM gRPC socket | agent |
 | `/var/lib/arcbox/sandboxes` | Firecracker sandbox data | agent |
-| `/var/lib/arcbox/kernel/vmlinux` | Sandbox kernel | agent |
-| `/var/lib/arcbox/images/sandbox.ext4` | Sandbox rootfs | agent |
-| `/usr/local/bin/firecracker` | Firecracker binary | EROFS rootfs |
-| `/etc/arcbox/vmm.toml` | Guest VMM configuration | EROFS rootfs |
+| `/var/lib/arcbox/sandbox/rootfs.ext4` | Default sandbox rootfs (busybox + vm-agent, auto-built) | agent |
+| `/var/lib/arcbox/sandbox/rootfs-<hash>.ext4` | Converted overlay2 rootfs cache | agent |
+| `/var/lib/arcbox/jailer` | Firecracker jailer chroots | agent |
+| `/arcbox/runtime/bin/{firecracker,jailer}` | Firecracker binaries (boot manifest, via VirtioFS) | host daemon |
+| `/arcbox/runtime/kernel/vmlinux` | Sandbox guest kernel (boot manifest, via VirtioFS) | host daemon |
+| `/arcbox/bin/vm-agent` | Sandbox init binary, staged next to `arcbox-agent` (via VirtioFS) | host daemon |
+| `/etc/arcbox/vmm.toml` | Optional guest VMM config override (not shipped; built-in defaults apply) | admin (manual) |
 
 ---
 

--- a/docs/sandbox-api.md
+++ b/docs/sandbox-api.md
@@ -1,0 +1,196 @@
+# Sandbox gRPC API
+
+ArcBox sandboxes are short-lived, strongly-isolated Firecracker microVMs
+running nested inside the guest VM, aimed at E2B-style local workloads:
+create in milliseconds-to-seconds, run commands, transfer files, expose
+ports, checkpoint and restore. This document is the integration reference
+for SDK authors and frontend clients.
+
+Proto source of truth: `rpc/arcbox-protocol/proto/sandbox.proto`
+(package `sandbox.v1`). Server implementation:
+`app/arcbox-api/src/grpc/{sandbox,snapshot}.rs`.
+
+## Requirements
+
+Sandboxes need **nested virtualization**: the VZ backend on Apple Silicon
+M3 or newer with macOS 15+. On the HV backend or Intel/M1/M2 hosts every
+sandbox RPC fails fast with `FAILED_PRECONDITION` and an explanatory
+message (`/dev/kvm` is absent in the guest).
+
+## Connection
+
+- Socket: `~/.arcbox/run/arcbox.sock` (Unix domain socket, HTTP/2).
+- Every request must carry the `x-machine` metadata header naming the
+  target machine (`default` unless you manage extra machines). Missing
+  header → `INVALID_ARGUMENT`.
+- **Transport & auth posture (V1)**: UDS only — there is no TCP listener,
+  and no authentication beyond the socket's file permissions. This is a
+  single-user local API; remote access requires your own proxy in front of
+  the socket.
+- **Discovery**: the daemon serves gRPC server reflection (v1 and
+  v1alpha), so `grpcurl` and reflection-aware SDKs work without vendoring
+  protos:
+
+  ```console
+  $ grpcurl -unix -plaintext ~/.arcbox/run/arcbox.sock list
+  $ grpcurl -unix -plaintext -H 'x-machine: default' \
+        -d '{}' ~/.arcbox/run/arcbox.sock sandbox.v1.SandboxService/List
+  ```
+
+## Proto stability
+
+`sandbox.v1` evolves additively: fields and RPCs are added, never removed
+or renumbered (CI enforces `buf breaking`). Fields documented as "NOT
+supported in Sandbox V1" (`image`, `mounts`, `ssh_public_key`) are
+rejected with `FAILED_PRECONDITION` rather than silently ignored, and
+will gain behavior in later releases without a wire break.
+
+## Sandbox state machine
+
+```
+starting ──► ready ──► running ──► ready   (workload exited; "idle" event)
+               │          │
+               └──────────┴──► stopping ──► stopped
+                                    │
+                                 failed
+```
+
+- A sandbox is **not destroyed** when its workload exits — it returns to
+  `ready` and accepts further `Run`/`Exec` calls.
+- Destruction happens via `Stop`/`Remove` or `ttl_seconds` expiry.
+- `stopped` sandboxes have released their TAP/IP, CoW device, and chroot;
+  only the inspectable record and logs remain until `Remove`.
+
+## SandboxService
+
+### Create
+
+`rpc Create(CreateSandboxRequest) returns (CreateSandboxResponse)`
+
+Returns immediately with `state: "starting"`; wait for readiness via
+`Events(action="ready")` or by polling `Inspect`.
+
+Key fields:
+
+| Field | Semantics |
+|---|---|
+| `id` | caller-supplied for idempotency; empty → UUID |
+| `limits.vcpus` / `limits.memory_mib` | 0 → daemon defaults (1 vCPU, 512 MiB) |
+| `rootfs` | ext4 image path (guest view), an overlay2 layer directory (auto-converted), or empty for the **default busybox rootfs** (auto-built with the vm-agent init) |
+| `cmd`, `env`, `working_dir`, `user` | initial workload launched automatically once ready; exit returns the sandbox to `ready` with an `idle` event |
+| `network.mode` | `"tap"` (default, IP from 172.20.0.0/16) or `"none"` |
+| `ttl_seconds` | auto-destroy timer from creation (not reset by activity) |
+| `image`, `mounts`, `ssh_public_key` | **rejected in V1** with `FAILED_PRECONDITION` (see Proto stability) |
+
+### Run
+
+`rpc Run(RunRequest) returns (stream RunOutput)`
+
+One-shot command with streamed output; no stdin. Requires state
+`ready`; a `running` sandbox answers `FAILED_PRECONDITION`. The final
+message has `done == true` and the exit code. `user` accepts Docker-style
+specs (`uid`, `uid:gid`, `name`, `name:group`) resolved against the
+sandbox rootfs.
+
+### Exec
+
+`rpc Exec(stream ExecInput) returns (stream ExecOutput)`
+
+Bidirectional interactive session:
+
+1. First message: `ExecInput{init: ExecRequest{...}}` (set `tty` and
+   `tty_size` for PTY sessions).
+2. Then `ExecInput{stdin: bytes}` for input — an **empty** `stdin`
+   payload signals EOF — and `ExecInput{resize: TerminalSize}` for live
+   TTY resizes (forwarded end-to-end to the PTY).
+
+Output mirrors `RunOutput`. A failed spawn or user resolution reports a
+`stderr` chunk plus exit code 126/127 instead of a bare stream end.
+
+### ReadFile / WriteFile
+
+```
+rpc ReadFile(ReadFileRequest) returns (stream FileChunk)
+rpc WriteFile(stream WriteFileRequest) returns (Empty)
+```
+
+File transfer with a 256 MiB per-file cap, usable while the sandbox is
+`ready` **or** `running`:
+
+- `ReadFile{id, path}` streams chunks; the last has `done == true`.
+- `WriteFile` starts with `WriteFileRequest{open: {id, path, mode}}`
+  (mode 0 → 0644), followed by `chunk` payloads, last one `done == true`.
+
+CLI: `arcbox sandbox cp ./local <id>:/path` and
+`arcbox sandbox cp <id>:/path ./local`.
+
+### ExposePort / UnexposePort
+
+```
+rpc ExposePort(ExposePortRequest) returns (ExposePortResponse)
+rpc UnexposePort(UnexposePortRequest) returns (Empty)
+```
+
+Makes a sandbox port reachable from the host via loopback:
+
+```
+host listener :H → inbound relay → guest :G (reserved 40000-49999)
+    → iptables DNAT → sandbox_ip:P
+```
+
+`host_port: 0` reuses the allocated guest relay port for a stable
+mapping. Mappings are removed automatically on Stop/Remove/TTL. CLI:
+`arcbox sandbox expose <id> <port>` / `unexpose`.
+
+### Stop / Remove
+
+- `Stop{id, timeout_seconds}` (default 30 s): drains an active workload
+  up to the budget, asks the guest to shut down, and force-kills only on
+  timeout. Releases network/CoW/chroot resources.
+- `Remove{id, force}`: destroys the sandbox and every remaining resource.
+  `force: true` removes even a `running` sandbox.
+
+### Inspect / List / Events
+
+- `Inspect` → full `SandboxInfo` (state, limits, network incl. IP,
+  timestamps, `last_exit_code`, `error`).
+- `List{state, labels}` → `SandboxSummary` per sandbox.
+- `Events{id, action}` → server stream of lifecycle events:
+  `created`, `ready`, `running`, `idle` (with `exit_code` attribute),
+  `stopping`, `stopped`, `failed` (with `error`), `removed`.
+
+## SandboxSnapshotService
+
+| RPC | Behavior |
+|---|---|
+| `Checkpoint{sandbox_id, name}` | pause → snapshot (vmstate + mem) → resume; requires state `ready` |
+| `Restore{snapshot_id, id, network_override, ttl_seconds}` | new sandbox in `ready` state with near-zero boot; set `network_override` for a fresh TAP/IP when restoring concurrently |
+| `ListSnapshots` / `DeleteSnapshot` | catalog management |
+
+Direct-mode (non-jailer) restores of the same snapshot cannot run
+concurrently with each other or the origin sandbox (the vmstate pins the
+origin vsock path); jailer-mode restores have no such constraint.
+
+## Error model
+
+Agent-reported failures carry HTTP-style codes over the internal wire and
+map onto gRPC statuses:
+
+| Condition | Status |
+|---|---|
+| malformed request / oversized file | `INVALID_ARGUMENT` |
+| unknown sandbox / snapshot | `NOT_FOUND` |
+| duplicate sandbox ID | `ALREADY_EXISTS` |
+| wrong state, missing nested virt, V1-unsupported field | `FAILED_PRECONDITION` |
+| sandbox service initialisation failure | `UNAVAILABLE` |
+| daemon still starting (runtime not ready) | `UNAVAILABLE` |
+| everything else | `INTERNAL` |
+
+## Typical client flow
+
+1. `Create({id, limits, cmd})` → `starting`
+2. `Events({id, action: "ready"})` → wait for readiness
+3. `WriteFile` project files in, `Run`/`Exec` workloads,
+   `ExposePort` for services, `ReadFile` results out
+4. `Checkpoint` a warmed-up sandbox; `Restore` clones later
+5. `Stop`/`Remove`, or let `ttl_seconds` reap it

--- a/docs/sandbox-api.md
+++ b/docs/sandbox-api.md
@@ -171,6 +171,13 @@ Direct-mode (non-jailer) restores of the same snapshot cannot run
 concurrently with each other or the origin sandbox (the vmstate pins the
 origin vsock path); jailer-mode restores have no such constraint.
 
+`network_override` (a fresh TAP/IP for the restored sandbox) relies on
+Firecracker's `network_overrides` snapshot-load field, which the pinned
+Firecracker 1.10.1 predates — it currently fails with an
+`unknown field network_overrides` API error. Restore without
+`network_override` (reusing the recorded NIC) works today; fresh-network
+restore unlocks when the bundled Firecracker is upgraded.
+
 ## Error model
 
 Agent-reported failures carry HTTP-style codes over the internal wire and

--- a/guest/arcbox-agent/Cargo.toml
+++ b/guest/arcbox-agent/Cargo.toml
@@ -41,6 +41,8 @@ tar = "0.4"
 num_cpus = "1"
 arcbox-dns = { workspace = true }
 wait-timeout = "0.2.1"
+oci2rootfs = { version = "0.2.1", default-features = false }
+arcbox-ext4 = "0.1.2"
 
 # vsock and arcbox-vm are Linux-only
 [target.'cfg(target_os = "linux")'.dependencies]

--- a/guest/arcbox-agent/src/agent/linux/agent.rs
+++ b/guest/arcbox-agent/src/agent/linux/agent.rs
@@ -37,6 +37,9 @@ impl Agent {
         // kernel is an orphan whose sandbox the crash-recovery sweep destroyed.
         super::port_forward::flush_orphan_rules().await;
 
+        // Drop half-written rootfs build artifacts from a previous crash.
+        crate::rootfs_builder::sweep_stale_tmp().await;
+
         // Start guest-side Docker API proxy (vsock -> unix socket).
         tokio::spawn(async {
             if let Err(e) = run_docker_api_proxy().await {

--- a/guest/arcbox-agent/src/agent/linux/agent.rs
+++ b/guest/arcbox-agent/src/agent/linux/agent.rs
@@ -32,6 +32,11 @@ impl Agent {
         // rather than on the first sandbox request.
         let _ = sandbox_service();
 
+        // Flush sandbox DNAT rules left over from a previous agent process: the
+        // in-memory forward table starts empty, so any tagged rule still in the
+        // kernel is an orphan whose sandbox the crash-recovery sweep destroyed.
+        super::port_forward::flush_orphan_rules().await;
+
         // Start guest-side Docker API proxy (vsock -> unix socket).
         tokio::spawn(async {
             if let Err(e) = run_docker_api_proxy().await {

--- a/guest/arcbox-agent/src/agent/linux/mod.rs
+++ b/guest/arcbox-agent/src/agent/linux/mod.rs
@@ -8,6 +8,7 @@ mod btrfs;
 mod cmdline;
 mod disk;
 mod kubernetes;
+mod port_forward;
 mod probe;
 mod proxy;
 mod rpc;

--- a/guest/arcbox-agent/src/agent/linux/port_forward.rs
+++ b/guest/arcbox-agent/src/agent/linux/port_forward.rs
@@ -24,6 +24,10 @@ use tokio::process::Command;
 const PORT_RANGE_START: u16 = 40000;
 /// Last port of the reserved guest relay range (inclusive).
 const PORT_RANGE_END: u16 = 49999;
+/// iptables `--comment` tag stamped on every sandbox DNAT rule, so rules left
+/// behind by a crashed/restarted agent can be identified and flushed (they are
+/// otherwise untracked kernel state that would misroute after IP reuse).
+const RULE_COMMENT: &str = "arcbox-sbx";
 
 /// Transport protocol of a forwarded port.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -114,19 +118,20 @@ impl PortForwardManager {
         protocol: Protocol,
     ) -> Result<()> {
         let key = (sandbox_id.to_owned(), sandbox_port, protocol);
-        if let Some(rule) = self.rules.remove(&key) {
-            run_iptables(&prepend(
-                &["-t", "nat", "-D", "PREROUTING"],
-                &rule.rule_args,
-            ))
+        let Some(rule) = self.rules.get(&key) else {
+            return Ok(()); // idempotent: nothing to remove
+        };
+        let del_args = prepend(&["-t", "nat", "-D", "PREROUTING"], &rule.rule_args);
+        let guest_port = rule.guest_port;
+
+        // Delete the kernel rule BEFORE dropping the record. If the delete fails
+        // (e.g. transient lock contention) the record is kept so a retry can
+        // still remove the rule instead of leaking it and reporting success.
+        run_iptables(&del_args)
             .await
             .context("removing DNAT rule")?;
-            tracing::info!(
-                sandbox_id,
-                guest_port = rule.guest_port,
-                "sandbox port forward removed"
-            );
-        }
+        self.rules.remove(&key);
+        tracing::info!(sandbox_id, guest_port, "sandbox port forward removed");
         Ok(())
     }
 
@@ -172,11 +177,68 @@ fn dnat_rule_args(
         protocol.iptables_name().into(),
         "--dport".into(),
         guest_port.to_string(),
+        "-m".into(),
+        "comment".into(),
+        "--comment".into(),
+        RULE_COMMENT.into(),
         "-j".into(),
         "DNAT".into(),
         "--to-destination".into(),
         format!("{sandbox_ip}:{sandbox_port}"),
     ]
+}
+
+/// If `line` (an `iptables -t nat -S PREROUTING` entry) is an arcbox sandbox
+/// DNAT rule, return the argv that deletes it. Used by [`flush_orphan_rules`]
+/// to reap rules a previous agent left behind.
+fn orphan_delete_args(line: &str) -> Option<Vec<String>> {
+    let spec = line.strip_prefix("-A PREROUTING ")?;
+    if !spec.contains(RULE_COMMENT) {
+        return None;
+    }
+    let mut args = vec![
+        "-t".to_owned(),
+        "nat".to_owned(),
+        "-D".to_owned(),
+        "PREROUTING".to_owned(),
+    ];
+    args.extend(spec.split_whitespace().map(str::to_owned));
+    Some(args)
+}
+
+/// Delete every arcbox sandbox DNAT rule left in `PREROUTING` by a previous
+/// agent process.
+///
+/// In-memory [`PortForwardManager`] state is authoritative and is empty at
+/// startup, so any tagged rule still in the kernel is an orphan: the sandbox it
+/// pointed at was torn down by the crash-recovery sweep, and leaving the rule
+/// would misroute traffic once its `172.20.x` IP is reassigned. Best-effort —
+/// a missing `iptables` (no rules to leak) or an individual delete failure only
+/// degrades cleanup.
+pub async fn flush_orphan_rules() {
+    let output = match Command::new("/sbin/iptables")
+        .args(["-t", "nat", "-S", "PREROUTING"])
+        .output()
+        .await
+    {
+        Ok(o) if o.status.success() => o,
+        _ => return,
+    };
+    let listing = String::from_utf8_lossy(&output.stdout);
+    let mut removed = 0usize;
+    for line in listing.lines() {
+        if let Some(args) = orphan_delete_args(line)
+            && run_iptables(&args).await.is_ok()
+        {
+            removed += 1;
+        }
+    }
+    if removed > 0 {
+        tracing::info!(
+            removed,
+            "flushed orphaned sandbox DNAT rules from a previous agent"
+        );
+    }
 }
 
 fn prepend(head: &[&str], tail: &[String]) -> Vec<String> {
@@ -215,7 +277,7 @@ mod tests {
     }
 
     #[test]
-    fn dnat_spec_is_symmetric_for_install_and_delete() {
+    fn dnat_spec_is_symmetric_and_tagged() {
         let args = dnat_rule_args(40000, Ipv4Addr::new(172, 20, 0, 2), 8080, Protocol::Tcp);
         assert_eq!(
             args,
@@ -224,12 +286,36 @@ mod tests {
                 "tcp",
                 "--dport",
                 "40000",
+                "-m",
+                "comment",
+                "--comment",
+                "arcbox-sbx",
                 "-j",
                 "DNAT",
                 "--to-destination",
                 "172.20.0.2:8080"
             ]
         );
+    }
+
+    #[test]
+    fn orphan_delete_targets_only_tagged_prerouting_rules() {
+        // A tagged arcbox rule (as `iptables -S` prints it, with the implicit
+        // `-m tcp`) is converted from -A to a -D argv.
+        let line = "-A PREROUTING -p tcp -m tcp --dport 40000 -m comment \
+                    --comment arcbox-sbx -j DNAT --to-destination 172.20.0.2:8080";
+        let args = orphan_delete_args(line).expect("tagged rule should match");
+        assert_eq!(args[..4], ["-t", "nat", "-D", "PREROUTING"]);
+        assert_eq!(args.last().unwrap(), "172.20.0.2:8080");
+        assert!(args.iter().any(|a| a == "arcbox-sbx"));
+
+        // A foreign rule (e.g. Docker's) is left untouched.
+        let docker = "-A PREROUTING -p tcp -m tcp --dport 8080 -j DNAT \
+                      --to-destination 172.17.0.2:80";
+        assert!(orphan_delete_args(docker).is_none());
+
+        // A non-PREROUTING line is ignored.
+        assert!(orphan_delete_args("-N DOCKER").is_none());
     }
 
     #[test]

--- a/guest/arcbox-agent/src/agent/linux/port_forward.rs
+++ b/guest/arcbox-agent/src/agent/linux/port_forward.rs
@@ -1,0 +1,251 @@
+//! Sandbox port forwarding via iptables DNAT.
+//!
+//! The macOS host cannot reach sandbox IPs (172.20.0.0/16) directly, but its
+//! inbound relay can inject connections to any *guest* port. Exposing a
+//! sandbox port therefore has two halves:
+//!
+//! ```text
+//! host listener :H → inbound relay → guest:G → [iptables DNAT] → sandbox:P
+//! ```
+//!
+//! This module owns the guest half: it allocates `G` from a reserved range
+//! (40000–49999), installs the `PREROUTING` DNAT rule, and removes it on
+//! request or when the sandbox stops (event-driven cleanup in the sandbox
+//! dispatcher). `FORWARD` traffic is already accepted by the blanket sandbox
+//! subnet rules installed at boot (`init.rs::setup_sandbox_forwarding`).
+
+use std::collections::HashMap;
+use std::net::Ipv4Addr;
+
+use anyhow::{Context, Result, bail};
+use tokio::process::Command;
+
+/// First port of the reserved guest relay range.
+const PORT_RANGE_START: u16 = 40000;
+/// Last port of the reserved guest relay range (inclusive).
+const PORT_RANGE_END: u16 = 49999;
+
+/// Transport protocol of a forwarded port.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Protocol {
+    Tcp,
+    Udp,
+}
+
+impl Protocol {
+    /// Parse a wire protocol string; empty selects TCP.
+    pub fn parse(value: &str) -> Result<Self> {
+        match value.to_ascii_lowercase().as_str() {
+            "" | "tcp" => Ok(Self::Tcp),
+            "udp" => Ok(Self::Udp),
+            other => bail!("unsupported protocol '{other}' (expected tcp or udp)"),
+        }
+    }
+
+    const fn iptables_name(self) -> &'static str {
+        match self {
+            Self::Tcp => "tcp",
+            Self::Udp => "udp",
+        }
+    }
+}
+
+/// One installed DNAT mapping.
+struct ForwardRule {
+    guest_port: u16,
+    /// The exact iptables rule spec, so removal deletes precisely this rule.
+    rule_args: Vec<String>,
+}
+
+/// Manages the reserved-range DNAT mappings for all sandboxes.
+#[derive(Default)]
+pub struct PortForwardManager {
+    /// `(sandbox_id, sandbox_port, protocol)` → installed rule.
+    rules: HashMap<(String, u16, Protocol), ForwardRule>,
+    /// Rotating allocation cursor within the reserved range.
+    next_offset: u16,
+}
+
+impl PortForwardManager {
+    /// Install (or return the existing) DNAT mapping for a sandbox port.
+    ///
+    /// Returns the reserved-range guest port carrying the relay.
+    pub async fn forward(
+        &mut self,
+        sandbox_id: &str,
+        sandbox_ip: Ipv4Addr,
+        sandbox_port: u16,
+        protocol: Protocol,
+    ) -> Result<u16> {
+        let key = (sandbox_id.to_owned(), sandbox_port, protocol);
+        if let Some(rule) = self.rules.get(&key) {
+            return Ok(rule.guest_port);
+        }
+
+        let guest_port = self.allocate_port()?;
+        let rule_args = dnat_rule_args(guest_port, sandbox_ip, sandbox_port, protocol);
+
+        run_iptables(&prepend(&["-t", "nat", "-I", "PREROUTING"], &rule_args))
+            .await
+            .context("installing DNAT rule")?;
+
+        tracing::info!(
+            sandbox_id,
+            guest_port,
+            sandbox_port,
+            %sandbox_ip,
+            "sandbox port forward installed"
+        );
+        self.rules.insert(
+            key,
+            ForwardRule {
+                guest_port,
+                rule_args,
+            },
+        );
+        Ok(guest_port)
+    }
+
+    /// Remove one mapping. Missing mappings are not an error (idempotent).
+    pub async fn remove(
+        &mut self,
+        sandbox_id: &str,
+        sandbox_port: u16,
+        protocol: Protocol,
+    ) -> Result<()> {
+        let key = (sandbox_id.to_owned(), sandbox_port, protocol);
+        if let Some(rule) = self.rules.remove(&key) {
+            run_iptables(&prepend(
+                &["-t", "nat", "-D", "PREROUTING"],
+                &rule.rule_args,
+            ))
+            .await
+            .context("removing DNAT rule")?;
+            tracing::info!(
+                sandbox_id,
+                guest_port = rule.guest_port,
+                "sandbox port forward removed"
+            );
+        }
+        Ok(())
+    }
+
+    /// Remove every mapping belonging to `sandbox_id` (stop/remove/TTL).
+    pub async fn remove_all_for(&mut self, sandbox_id: &str) {
+        let keys: Vec<_> = self
+            .rules
+            .keys()
+            .filter(|(id, _, _)| id == sandbox_id)
+            .cloned()
+            .collect();
+        for (id, port, proto) in keys {
+            if let Err(e) = self.remove(&id, port, proto).await {
+                tracing::warn!(sandbox_id, port, error = %e, "failed to remove port forward");
+            }
+        }
+    }
+
+    /// Pick a free port in the reserved range, scanning from a rotating cursor.
+    fn allocate_port(&mut self) -> Result<u16> {
+        let span = PORT_RANGE_END - PORT_RANGE_START + 1;
+        for probe in 0..span {
+            let offset = (self.next_offset + probe) % span;
+            let candidate = PORT_RANGE_START + offset;
+            if !self.rules.values().any(|r| r.guest_port == candidate) {
+                self.next_offset = (offset + 1) % span;
+                return Ok(candidate);
+            }
+        }
+        bail!("no free port in the reserved range {PORT_RANGE_START}-{PORT_RANGE_END}")
+    }
+}
+
+/// The protocol/port/destination spec shared by install and delete.
+fn dnat_rule_args(
+    guest_port: u16,
+    sandbox_ip: Ipv4Addr,
+    sandbox_port: u16,
+    protocol: Protocol,
+) -> Vec<String> {
+    vec![
+        "-p".into(),
+        protocol.iptables_name().into(),
+        "--dport".into(),
+        guest_port.to_string(),
+        "-j".into(),
+        "DNAT".into(),
+        "--to-destination".into(),
+        format!("{sandbox_ip}:{sandbox_port}"),
+    ]
+}
+
+fn prepend(head: &[&str], tail: &[String]) -> Vec<String> {
+    head.iter()
+        .map(|s| (*s).to_owned())
+        .chain(tail.iter().cloned())
+        .collect()
+}
+
+async fn run_iptables(args: &[String]) -> Result<()> {
+    let output = Command::new("/sbin/iptables")
+        .args(args)
+        .output()
+        .await
+        .context("failed to run iptables")?;
+    if !output.status.success() {
+        bail!(
+            "iptables {} failed: {}",
+            args.join(" "),
+            String::from_utf8_lossy(&output.stderr).trim()
+        );
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn protocol_parses_and_defaults_to_tcp() {
+        assert_eq!(Protocol::parse("").unwrap(), Protocol::Tcp);
+        assert_eq!(Protocol::parse("TCP").unwrap(), Protocol::Tcp);
+        assert_eq!(Protocol::parse("udp").unwrap(), Protocol::Udp);
+        assert!(Protocol::parse("sctp").is_err());
+    }
+
+    #[test]
+    fn dnat_spec_is_symmetric_for_install_and_delete() {
+        let args = dnat_rule_args(40000, Ipv4Addr::new(172, 20, 0, 2), 8080, Protocol::Tcp);
+        assert_eq!(
+            args,
+            [
+                "-p",
+                "tcp",
+                "--dport",
+                "40000",
+                "-j",
+                "DNAT",
+                "--to-destination",
+                "172.20.0.2:8080"
+            ]
+        );
+    }
+
+    #[test]
+    fn allocator_skips_used_ports_and_wraps() {
+        let mut mgr = PortForwardManager::default();
+        let first = mgr.allocate_port().unwrap();
+        assert_eq!(first, PORT_RANGE_START);
+        // Simulate the first port being taken.
+        mgr.rules.insert(
+            ("a".into(), 80, Protocol::Tcp),
+            ForwardRule {
+                guest_port: PORT_RANGE_START + 1,
+                rule_args: vec![],
+            },
+        );
+        let second = mgr.allocate_port().unwrap();
+        assert_eq!(second, PORT_RANGE_START + 2);
+    }
+}

--- a/guest/arcbox-agent/src/agent/linux/sandbox.rs
+++ b/guest/arcbox-agent/src/agent/linux/sandbox.rs
@@ -149,6 +149,15 @@ where
             svc.handle_exec(stream, trace_id, payload).await?;
         }
         // -----------------------------------------------------------------
+        // File I/O
+        // -----------------------------------------------------------------
+        MessageType::SandboxFileReadRequest => {
+            svc.handle_read_file(stream, trace_id, payload).await?;
+        }
+        MessageType::SandboxFileWriteRequest => {
+            svc.handle_write_file(stream, trace_id, payload).await?;
+        }
+        // -----------------------------------------------------------------
         // Snapshots
         // -----------------------------------------------------------------
         MessageType::SandboxCheckpointRequest => match svc.checkpoint(payload).await {

--- a/guest/arcbox-agent/src/agent/linux/sandbox.rs
+++ b/guest/arcbox-agent/src/agent/linux/sandbox.rs
@@ -14,22 +14,28 @@ use crate::sandbox::SandboxService;
 
 /// Returns the global [`SandboxService`] singleton.
 ///
-/// The service is initialised lazily on the first call.  Initialisation
-/// failures are logged as warnings and `None` is stored, so sandbox
-/// operations will return a 503 error rather than crashing the agent.
-pub(super) fn sandbox_service() -> Option<&'static Arc<SandboxService>> {
-    static SERVICE: OnceLock<Option<Arc<SandboxService>>> = OnceLock::new();
+/// The service is initialised lazily on the first call. The nested-virt
+/// prerequisite is probed first: without `/dev/kvm` every sandbox RPC is
+/// rejected with 412 (mapped to `FAILED_PRECONDITION` on the host) and an
+/// actionable reason. Initialisation failures store a 503 so sandbox
+/// operations degrade instead of crashing the agent.
+pub(super) fn sandbox_service() -> Result<&'static Arc<SandboxService>, &'static (i32, String)> {
+    static SERVICE: OnceLock<Result<Arc<SandboxService>, (i32, String)>> = OnceLock::new();
     SERVICE
         .get_or_init(|| {
+            if let Err(reason) = crate::sandbox::probe_kvm() {
+                tracing::warn!(reason, "sandbox prerequisite missing");
+                return Err((412, reason));
+            }
             let config = crate::config::load();
             match SandboxService::new(config) {
                 Ok(svc) => {
                     tracing::info!("sandbox service initialised");
-                    Some(Arc::new(svc))
+                    Ok(Arc::new(svc))
                 }
                 Err(e) => {
                     tracing::warn!(error = %e, "sandbox service unavailable");
-                    None
+                    Err((503, format!("sandbox service unavailable: {e}")))
                 }
             }
         })
@@ -51,9 +57,9 @@ where
     S: AsyncRead + AsyncWrite + Unpin,
 {
     let svc = match sandbox_service() {
-        Some(s) => Arc::clone(s),
-        None => {
-            let err = ErrorResponse::new(503, "sandbox service unavailable");
+        Ok(s) => Arc::clone(s),
+        Err((code, reason)) => {
+            let err = ErrorResponse::new(*code, reason.as_str());
             write_message(stream, MessageType::Error, trace_id, &err.encode()).await?;
             return Ok(());
         }

--- a/guest/arcbox-agent/src/agent/linux/sandbox.rs
+++ b/guest/arcbox-agent/src/agent/linux/sandbox.rs
@@ -7,10 +7,19 @@
 
 use std::sync::{Arc, OnceLock};
 
+use prost::Message as _;
 use tokio::io::{AsyncRead, AsyncWrite};
+use tokio::sync::Mutex;
 
+use super::port_forward::{PortForwardManager, Protocol};
 use crate::rpc::{ErrorResponse, MessageType, write_message};
 use crate::sandbox::SandboxService;
+
+/// Returns the global [`PortForwardManager`] singleton.
+fn port_forwards() -> &'static Mutex<PortForwardManager> {
+    static MANAGER: OnceLock<Mutex<PortForwardManager>> = OnceLock::new();
+    MANAGER.get_or_init(|| Mutex::new(PortForwardManager::default()))
+}
 
 /// Returns the global [`SandboxService`] singleton.
 ///
@@ -31,7 +40,9 @@ pub(super) fn sandbox_service() -> Result<&'static Arc<SandboxService>, &'static
             match SandboxService::new(config) {
                 Ok(svc) => {
                     tracing::info!("sandbox service initialised");
-                    Ok(Arc::new(svc))
+                    let svc = Arc::new(svc);
+                    spawn_port_forward_cleanup(&svc);
+                    Ok(svc)
                 }
                 Err(e) => {
                     tracing::warn!(error = %e, "sandbox service unavailable");
@@ -40,6 +51,38 @@ pub(super) fn sandbox_service() -> Result<&'static Arc<SandboxService>, &'static
             }
         })
         .as_ref()
+}
+
+/// Drop every DNAT mapping of a sandbox as soon as it stops.
+///
+/// Subscribing to lifecycle events covers all teardown paths — explicit
+/// Stop/Remove, TTL expiry, and boot failures — without threading cleanup
+/// hooks through each of them.
+fn spawn_port_forward_cleanup(svc: &Arc<SandboxService>) {
+    use arcbox_protocol::sandbox_v1::{SandboxEvent, SandboxEventsRequest};
+
+    let payload = SandboxEventsRequest::default().encode_to_vec();
+    let mut rx = match svc.subscribe_events(&payload) {
+        Ok(rx) => rx,
+        Err(e) => {
+            tracing::warn!(error = %e, "port-forward cleanup subscription failed");
+            return;
+        }
+    };
+    tokio::spawn(async move {
+        while let Some(encoded) = rx.recv().await {
+            let Ok(event) = SandboxEvent::decode(encoded.as_slice()) else {
+                continue;
+            };
+            if event.action == "stopped" || event.action == "removed" || event.action == "failed" {
+                port_forwards()
+                    .lock()
+                    .await
+                    .remove_all_for(&event.sandbox_id)
+                    .await;
+            }
+        }
+    });
 }
 
 /// Dispatches a sandbox RPC request.
@@ -158,6 +201,15 @@ where
             svc.handle_write_file(stream, trace_id, payload).await?;
         }
         // -----------------------------------------------------------------
+        // Port forwarding
+        // -----------------------------------------------------------------
+        MessageType::SandboxPortForwardRequest => {
+            handle_port_forward(stream, &svc, trace_id, payload).await?;
+        }
+        MessageType::SandboxPortForwardRemoveRequest => {
+            handle_port_forward_remove(stream, trace_id, payload).await?;
+        }
+        // -----------------------------------------------------------------
         // Snapshots
         // -----------------------------------------------------------------
         MessageType::SandboxCheckpointRequest => match svc.checkpoint(payload).await {
@@ -239,4 +291,121 @@ where
 {
     let err = ErrorResponse::new(code, message);
     write_message(stream, MessageType::Error, trace_id, &err.encode()).await
+}
+
+/// Install a DNAT mapping and answer with the allocated guest port.
+async fn handle_port_forward<S>(
+    stream: &mut S,
+    svc: &SandboxService,
+    trace_id: &str,
+    payload: &[u8],
+) -> anyhow::Result<()>
+where
+    S: AsyncWrite + Unpin,
+{
+    use arcbox_protocol::sandbox_v1::{SandboxPortForwardRequest, SandboxPortForwardResponse};
+
+    let (req, sandbox_port, protocol) = match SandboxPortForwardRequest::decode(payload)
+        .map_err(|e| format!("decode error: {e}"))
+        .and_then(|req| {
+            let port = u16::try_from(req.sandbox_port)
+                .ok()
+                .filter(|p| *p != 0)
+                .ok_or_else(|| format!("invalid sandbox port {}", req.sandbox_port))?;
+            let proto = Protocol::parse(&req.protocol).map_err(|e| e.to_string())?;
+            Ok((req, port, proto))
+        }) {
+        Ok(parsed) => parsed,
+        Err(msg) => {
+            let err = ErrorResponse::new(400, msg);
+            write_message(stream, MessageType::Error, trace_id, &err.encode()).await?;
+            return Ok(());
+        }
+    };
+
+    let ip = match svc.sandbox_ip(&req.id) {
+        Ok(ip) => ip,
+        Err(e) => {
+            let err = ErrorResponse::new(e.status_code(), e.to_string());
+            write_message(stream, MessageType::Error, trace_id, &err.encode()).await?;
+            return Ok(());
+        }
+    };
+
+    match port_forwards()
+        .lock()
+        .await
+        .forward(&req.id, ip, sandbox_port, protocol)
+        .await
+    {
+        Ok(guest_port) => {
+            let resp = SandboxPortForwardResponse {
+                guest_port: u32::from(guest_port),
+            };
+            write_message(
+                stream,
+                MessageType::SandboxPortForwardResponse,
+                trace_id,
+                &resp.encode_to_vec(),
+            )
+            .await?;
+        }
+        Err(e) => {
+            let err = ErrorResponse::new(500, e.to_string());
+            write_message(stream, MessageType::Error, trace_id, &err.encode()).await?;
+        }
+    }
+    Ok(())
+}
+
+/// Remove a DNAT mapping (idempotent) and acknowledge.
+async fn handle_port_forward_remove<S>(
+    stream: &mut S,
+    trace_id: &str,
+    payload: &[u8],
+) -> anyhow::Result<()>
+where
+    S: AsyncWrite + Unpin,
+{
+    use arcbox_protocol::sandbox_v1::SandboxPortForwardRemoveRequest;
+
+    let (req, sandbox_port, protocol) = match SandboxPortForwardRemoveRequest::decode(payload)
+        .map_err(|e| format!("decode error: {e}"))
+        .and_then(|req| {
+            let port = u16::try_from(req.sandbox_port)
+                .ok()
+                .filter(|p| *p != 0)
+                .ok_or_else(|| format!("invalid sandbox port {}", req.sandbox_port))?;
+            let proto = Protocol::parse(&req.protocol).map_err(|e| e.to_string())?;
+            Ok((req, port, proto))
+        }) {
+        Ok(parsed) => parsed,
+        Err(msg) => {
+            let err = ErrorResponse::new(400, msg);
+            write_message(stream, MessageType::Error, trace_id, &err.encode()).await?;
+            return Ok(());
+        }
+    };
+
+    match port_forwards()
+        .lock()
+        .await
+        .remove(&req.id, sandbox_port, protocol)
+        .await
+    {
+        Ok(()) => {
+            write_message(
+                stream,
+                MessageType::SandboxPortForwardRemoveResponse,
+                trace_id,
+                &[],
+            )
+            .await?;
+        }
+        Err(e) => {
+            let err = ErrorResponse::new(500, e.to_string());
+            write_message(stream, MessageType::Error, trace_id, &err.encode()).await?;
+        }
+    }
+    Ok(())
 }

--- a/guest/arcbox-agent/src/config.rs
+++ b/guest/arcbox-agent/src/config.rs
@@ -12,13 +12,22 @@ use arcbox_vm::config::{DefaultVmConfig, FirecrackerConfig, GrpcConfig, NetworkC
 
 /// Guest-specific VMM configuration defaults.
 ///
-/// These differ from [`VmmConfig::default()`] which targets the host-side daemon.
+/// These differ from [`VmmConfig::default()`] which targets the host-side
+/// daemon. Paths follow the guest view of host assets:
+///
+/// - Boot-manifest binaries (firecracker, jailer) download to
+///   `~/.arcbox/runtime/bin` and vmlinux to `~/.arcbox/runtime/kernel`
+///   (`install_dir = "kernel"`); the data dir is VirtioFS-mounted at
+///   `/arcbox`, so the guest sees `/arcbox/runtime/{bin,kernel}`.
+/// - The default sandbox rootfs is auto-built by the agent (busybox +
+///   vm-agent, see `rootfs_builder::ensure_default_rootfs`) on the writable
+///   btrfs data volume.
 fn guest_defaults() -> VmmConfig {
     VmmConfig {
         firecracker: FirecrackerConfig {
-            binary: "/arcbox/bin/firecracker".into(),
+            binary: "/arcbox/runtime/bin/firecracker".into(),
             jailer: Some(arcbox_vm::config::JailerConfig {
-                binary: "/arcbox/bin/jailer".into(),
+                binary: "/arcbox/runtime/bin/jailer".into(),
                 uid: 0,
                 gid: 0,
                 chroot_base_dir: Some("/var/lib/arcbox/jailer".into()),
@@ -48,8 +57,8 @@ fn guest_defaults() -> VmmConfig {
         defaults: DefaultVmConfig {
             vcpus: 1,
             memory_mib: 512,
-            kernel: "/arcbox/bin/vmlinux".into(),
-            rootfs: "/arcbox/bin/sandbox.ext4".into(),
+            kernel: "/arcbox/runtime/kernel/vmlinux".into(),
+            rootfs: "/var/lib/arcbox/sandbox/rootfs.ext4".into(),
             boot_args: "console=ttyS0 reboot=k panic=1 pci=off init=/sbin/vm-agent".into(),
         },
     }

--- a/guest/arcbox-agent/src/error.rs
+++ b/guest/arcbox-agent/src/error.rs
@@ -1,8 +1,9 @@
 //! Structured error types for the sandbox service.
 //!
-//! [`SandboxError`] distinguishes decode failures (bad client payload) from
-//! internal / runtime errors so the RPC layer can map them to the correct
-//! status code (400 vs 500).
+//! [`SandboxError`] carries an HTTP-style status code over the vsock wire so
+//! the host can map agent failures onto the right gRPC status instead of a
+//! blanket `INTERNAL` (see `CoreError::Agent` and the `ApiError → Status`
+//! mapping in `arcbox-api`).
 
 use std::fmt;
 
@@ -11,6 +12,14 @@ use std::fmt;
 pub enum SandboxError {
     /// The request payload could not be decoded (protobuf parse failure).
     Decode(String),
+    /// The referenced sandbox / snapshot does not exist.
+    NotFound(String),
+    /// A sandbox with the requested ID already exists.
+    AlreadyExists(String),
+    /// The sandbox is not in a state that allows the operation.
+    WrongState(String),
+    /// The host / guest lacks a prerequisite (e.g. nested virtualization).
+    Unsupported(String),
     /// A runtime or business-logic error.
     Internal(String),
 }
@@ -19,17 +28,40 @@ impl fmt::Display for SandboxError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::Decode(msg) => write!(f, "decode error: {msg}"),
-            Self::Internal(msg) => f.write_str(msg),
+            Self::NotFound(msg)
+            | Self::AlreadyExists(msg)
+            | Self::WrongState(msg)
+            | Self::Unsupported(msg)
+            | Self::Internal(msg) => f.write_str(msg),
         }
     }
 }
 
 impl SandboxError {
-    /// HTTP-style status code: 400 for decode errors, 500 for internal errors.
+    /// HTTP-style status code carried in the wire `ErrorResponse`.
+    ///
+    /// The host maps these onto gRPC statuses: 400 → `INVALID_ARGUMENT`,
+    /// 404 → `NOT_FOUND`, 409 → `ALREADY_EXISTS`, 412 → `FAILED_PRECONDITION`,
+    /// 503 → `UNAVAILABLE`, anything else → `INTERNAL`.
     pub const fn status_code(&self) -> i32 {
         match self {
             Self::Decode(_) => 400,
+            Self::NotFound(_) => 404,
+            Self::AlreadyExists(_) => 409,
+            Self::WrongState(_) | Self::Unsupported(_) => 412,
             Self::Internal(_) => 500,
+        }
+    }
+}
+
+impl From<arcbox_vm::VmmError> for SandboxError {
+    fn from(e: arcbox_vm::VmmError) -> Self {
+        use arcbox_vm::VmmError;
+        match &e {
+            VmmError::NotFound(_) => Self::NotFound(e.to_string()),
+            VmmError::AlreadyExists(_) => Self::AlreadyExists(e.to_string()),
+            VmmError::WrongState { .. } => Self::WrongState(e.to_string()),
+            _ => Self::Internal(e.to_string()),
         }
     }
 }

--- a/guest/arcbox-agent/src/error.rs
+++ b/guest/arcbox-agent/src/error.rs
@@ -12,6 +12,9 @@ use std::fmt;
 pub enum SandboxError {
     /// The request payload could not be decoded (protobuf parse failure).
     Decode(String),
+    /// The request is malformed or violates a constraint (e.g. an invalid
+    /// sandbox id or an out-of-range field).
+    InvalidArgument(String),
     /// The referenced sandbox / snapshot does not exist.
     NotFound(String),
     /// A sandbox with the requested ID already exists.
@@ -28,7 +31,8 @@ impl fmt::Display for SandboxError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::Decode(msg) => write!(f, "decode error: {msg}"),
-            Self::NotFound(msg)
+            Self::InvalidArgument(msg)
+            | Self::NotFound(msg)
             | Self::AlreadyExists(msg)
             | Self::WrongState(msg)
             | Self::Unsupported(msg)
@@ -45,7 +49,7 @@ impl SandboxError {
     /// 503 → `UNAVAILABLE`, anything else → `INTERNAL`.
     pub const fn status_code(&self) -> i32 {
         match self {
-            Self::Decode(_) => 400,
+            Self::Decode(_) | Self::InvalidArgument(_) => 400,
             Self::NotFound(_) => 404,
             Self::AlreadyExists(_) => 409,
             Self::WrongState(_) | Self::Unsupported(_) => 412,
@@ -61,7 +65,28 @@ impl From<arcbox_vm::VmmError> for SandboxError {
             VmmError::NotFound(_) => Self::NotFound(e.to_string()),
             VmmError::AlreadyExists(_) => Self::AlreadyExists(e.to_string()),
             VmmError::WrongState { .. } => Self::WrongState(e.to_string()),
+            // Invalid caller input (e.g. a rejected sandbox id) is a 400, not a
+            // 500 — otherwise a bad request surfaces as INTERNAL to the client.
+            VmmError::Config(_) => Self::InvalidArgument(e.to_string()),
             _ => Self::Internal(e.to_string()),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn invalid_config_maps_to_400_not_500() {
+        let err = SandboxError::from(arcbox_vm::VmmError::Config("bad id".into()));
+        assert!(matches!(err, SandboxError::InvalidArgument(_)));
+        assert_eq!(err.status_code(), 400);
+    }
+
+    #[test]
+    fn runtime_errors_stay_500() {
+        let err = SandboxError::from(arcbox_vm::VmmError::Vsock("boom".into()));
+        assert_eq!(err.status_code(), 500);
     }
 }

--- a/guest/arcbox-agent/src/lib.rs
+++ b/guest/arcbox-agent/src/lib.rs
@@ -11,7 +11,6 @@ pub mod dns;
 pub mod dns_server;
 #[cfg(target_os = "linux")]
 pub mod error;
-#[cfg(target_os = "linux")]
 pub mod rootfs_builder;
 #[cfg(target_os = "linux")]
 pub mod sandbox;

--- a/guest/arcbox-agent/src/rootfs_builder.rs
+++ b/guest/arcbox-agent/src/rootfs_builder.rs
@@ -155,8 +155,13 @@ pub async fn ensure_default_rootfs(path: &str) -> Result<()> {
     Ok(())
 }
 
-/// True when the default rootfs image exists, looks like ext4, and is newer
-/// than both source binaries (busybox and vm-agent).
+/// True when the default rootfs image can be used as-is (no rebuild needed).
+///
+/// A valid ext4 image is fresh unless a build source (busybox or vm-agent)
+/// is **present and newer** than it. A *missing* source is not staleness: we
+/// cannot rebuild from an absent binary, so an existing valid image — e.g. a
+/// caller-supplied default rootfs, or the production image on a host without
+/// the dev build sources — is kept rather than clobbered.
 fn is_default_rootfs_fresh(image: &Path) -> bool {
     if !has_ext4_magic(image) {
         return false;
@@ -165,11 +170,11 @@ fn is_default_rootfs_fresh(image: &Path) -> bool {
         return false;
     };
     for source in [GUEST_BUSYBOX, VM_AGENT_BIN] {
-        match std::fs::metadata(source).and_then(|m| m.modified()) {
-            Ok(mtime) if mtime <= image_mtime => {}
-            // Missing or newer source: rebuild (the build reports missing
-            // vm-agent with an actionable error).
-            _ => return false,
+        // Only a source that exists AND is newer forces a rebuild.
+        if let Ok(mtime) = std::fs::metadata(source).and_then(|m| m.modified())
+            && mtime > image_mtime
+        {
+            return false;
         }
     }
     true
@@ -429,5 +434,35 @@ mod tests {
                 .lookup(Path::new("/bin/nonexistent"))
                 .is_none()
         );
+    }
+
+    #[test]
+    fn existing_image_is_fresh_when_build_sources_are_absent() {
+        // A valid ext4 default rootfs must be reused as-is when the dev build
+        // sources (/bin/busybox, /arcbox/bin/vm-agent) don't exist — the case
+        // of a caller-supplied default rootfs on a host without the build
+        // toolchain. Regression for the sandbox_service_manager integration
+        // test, which passes an empty request rootfs backed by a real image.
+        let dir = tempfile::tempdir().unwrap();
+        let image = dir.path().join("rootfs.ext4");
+        let spec = DefaultRootfsSpec {
+            busybox: dir.path().join("busybox"),
+            vm_agent: dir.path().join("vm-agent"),
+            applets: vec!["sh".into()],
+            size: 8 * 1024 * 1024,
+        };
+        std::fs::write(&spec.busybox, b"stub").unwrap();
+        std::fs::write(&spec.vm_agent, b"stub").unwrap();
+        build_default_rootfs(&spec, &image).unwrap();
+        assert!(has_ext4_magic(&image));
+
+        // GUEST_BUSYBOX / VM_AGENT_BIN are absolute guest paths that do not
+        // exist in the host test environment, so this exercises the
+        // missing-source branch directly.
+        assert!(
+            is_default_rootfs_fresh(&image),
+            "a valid image with absent build sources must be reused, not rebuilt"
+        );
+        assert!(!is_default_rootfs_fresh(&dir.path().join("missing.ext4")));
     }
 }

--- a/guest/arcbox-agent/src/rootfs_builder.rs
+++ b/guest/arcbox-agent/src/rootfs_builder.rs
@@ -1,27 +1,42 @@
-//! Convert a Docker overlay2 layer directory to a bootable ext4 rootfs.
+//! Build bootable ext4 rootfs images for sandboxes.
 //!
-//! Runs `oci2rootfs` on the overlay2 layer path, then injects `/sbin/vm-agent`
-//! into the resulting ext4 via loop mount. Cached ext4 images are reused to
-//! avoid redundant conversions.
+//! Two builders live here, both backed by the pure-Rust `oci2rootfs` /
+//! `arcbox-ext4` stack (no external binary, no mount, no root required for
+//! the ext4 write itself):
+//!
+//! - [`convert_layer_to_rootfs`] — convert a Docker overlay2 layer directory
+//!   to ext4, then inject `/sbin/vm-agent` via loop mount. Cached ext4
+//!   images are reused to avoid redundant conversions.
+//! - [`ensure_default_rootfs`] — build the default busybox + vm-agent image
+//!   used when `CreateSandboxRequest` supplies no rootfs. Rebuilt when the
+//!   source binaries are newer than the cached image.
 
+use std::io::Read;
 use std::path::Path;
 
 use anyhow::{Context, Result, bail};
+use arcbox_ext4::constants::file_mode;
+use arcbox_ext4::{FormatOptions, Formatter};
 use tokio::process::Command;
 use uuid::Uuid;
 
-/// Path to the `oci2rootfs` binary (on VirtioFS).
-const OCI2ROOTFS_BIN: &str = "/arcbox/bin/oci2rootfs";
-
-/// Path to the `vm-agent` binary (on VirtioFS).
+/// Path to the `vm-agent` binary (host `~/.arcbox/bin` via VirtioFS).
 const VM_AGENT_BIN: &str = "/arcbox/bin/vm-agent";
 
-/// Directory for cached rootfs images.
-const ROOTFS_CACHE_DIR: &str = "/arcbox/bin";
+/// Static busybox shipped in the guest EROFS rootfs.
+const GUEST_BUSYBOX: &str = "/bin/busybox";
+
+/// Directory for generated rootfs images (btrfs data volume, writable).
+const ROOTFS_CACHE_DIR: &str = "/var/lib/arcbox/sandbox";
+
+/// Capacity of the default busybox rootfs image. The image file is written
+/// sparsely; per-sandbox writes land in the dm-snapshot COW overlay, so this
+/// bounds a sandbox's writable space, not host disk use.
+const DEFAULT_ROOTFS_SIZE: u64 = 512 * 1024 * 1024;
 
 /// Check if a file has a valid ext4 superblock magic (0x53EF at offset 0x438).
 pub fn has_ext4_magic(path: &Path) -> bool {
-    use std::io::{Read, Seek, SeekFrom};
+    use std::io::{Seek, SeekFrom};
     let Ok(mut file) = std::fs::File::open(path) else {
         return false;
     };
@@ -52,16 +67,36 @@ pub async fn convert_layer_to_rootfs(layer_path: &str) -> Result<String> {
         return Ok(ext4_path);
     }
 
+    tokio::fs::create_dir_all(ROOTFS_CACHE_DIR)
+        .await
+        .context("failed to create rootfs cache dir")?;
+
     let req_id = Uuid::new_v4().to_string();
     let ext4_tmp = format!("{ROOTFS_CACHE_DIR}/.rootfs-{req_id}.ext4.tmp");
 
-    // Run oci2rootfs.
+    // Convert via the oci2rootfs library (blocking CPU/IO work).
     tracing::info!(layer = %layer_path, ext4 = %ext4_path, "converting overlay2 layer to ext4");
-    run_oci2rootfs(layer_path, &ext4_tmp).await?;
+    {
+        let layer = layer_path.to_owned();
+        let out = ext4_tmp.clone();
+        tokio::task::spawn_blocking(move || -> Result<()> {
+            let source = oci2rootfs::Overlay2Source::open(&layer)
+                .context("failed to open overlay2 layer")?;
+            oci2rootfs::Converter::new(&out)
+                .convert(source)
+                .context("overlay2 → ext4 conversion failed")?;
+            Ok(())
+        })
+        .await
+        .context("conversion task panicked")??;
+    }
 
     // Inject vm-agent.
     tracing::info!("injecting vm-agent into rootfs");
-    inject_vm_agent(&ext4_tmp, &req_id).await?;
+    if let Err(e) = inject_vm_agent(&ext4_tmp, &req_id).await {
+        let _ = tokio::fs::remove_file(&ext4_tmp).await;
+        return Err(e);
+    }
 
     // Atomic rename into cache.
     tokio::fs::rename(&ext4_tmp, &ext4_path)
@@ -72,23 +107,209 @@ pub async fn convert_layer_to_rootfs(layer_path: &str) -> Result<String> {
     Ok(ext4_path)
 }
 
-/// Run `oci2rootfs` on an overlay2 layer directory.
-async fn run_oci2rootfs(layer_path: &str, output: &str) -> Result<()> {
-    if !Path::new(OCI2ROOTFS_BIN).exists() {
-        bail!("oci2rootfs not found at {OCI2ROOTFS_BIN}");
+/// Ensure the default busybox + vm-agent rootfs exists at `path` and is
+/// newer than its source binaries. Returns without touching the image when
+/// it is already up to date.
+pub async fn ensure_default_rootfs(path: &str) -> Result<()> {
+    let image = Path::new(path);
+    if is_default_rootfs_fresh(image) {
+        return Ok(());
     }
 
-    let result = Command::new(OCI2ROOTFS_BIN)
-        .args([layer_path, "--output", output])
+    if !Path::new(VM_AGENT_BIN).exists() {
+        bail!(
+            "vm-agent not found at {VM_AGENT_BIN}; it is staged by the host \
+             daemon next to arcbox-agent"
+        );
+    }
+
+    let applets = busybox_applets().await?;
+
+    let parent = image
+        .parent()
+        .with_context(|| format!("default rootfs path has no parent: {path}"))?;
+    tokio::fs::create_dir_all(parent)
+        .await
+        .context("failed to create default rootfs dir")?;
+
+    let tmp = parent.join(format!(".default-{}.ext4.tmp", Uuid::new_v4()));
+    let spec = DefaultRootfsSpec {
+        busybox: GUEST_BUSYBOX.into(),
+        vm_agent: VM_AGENT_BIN.into(),
+        applets,
+        size: DEFAULT_ROOTFS_SIZE,
+    };
+
+    tracing::info!(path, "building default sandbox rootfs");
+    {
+        let tmp = tmp.clone();
+        tokio::task::spawn_blocking(move || build_default_rootfs(&spec, &tmp))
+            .await
+            .context("default rootfs build task panicked")??;
+    }
+
+    tokio::fs::rename(&tmp, image)
+        .await
+        .context("failed to move default rootfs into place")?;
+    tracing::info!(path, "default sandbox rootfs ready");
+    Ok(())
+}
+
+/// True when the default rootfs image exists, looks like ext4, and is newer
+/// than both source binaries (busybox and vm-agent).
+fn is_default_rootfs_fresh(image: &Path) -> bool {
+    if !has_ext4_magic(image) {
+        return false;
+    }
+    let Ok(image_mtime) = image.metadata().and_then(|m| m.modified()) else {
+        return false;
+    };
+    for source in [GUEST_BUSYBOX, VM_AGENT_BIN] {
+        match std::fs::metadata(source).and_then(|m| m.modified()) {
+            Ok(mtime) if mtime <= image_mtime => {}
+            // Missing or newer source: rebuild (the build reports missing
+            // vm-agent with an actionable error).
+            _ => return false,
+        }
+    }
+    true
+}
+
+/// Inputs for [`build_default_rootfs`].
+struct DefaultRootfsSpec {
+    /// Static busybox binary copied to `/bin/busybox`.
+    busybox: std::path::PathBuf,
+    /// vm-agent binary copied to `/sbin/vm-agent` (the sandbox init).
+    vm_agent: std::path::PathBuf,
+    /// Applet names to symlink into `/bin` (from `busybox --list`).
+    applets: Vec<String>,
+    /// ext4 image capacity in bytes.
+    size: u64,
+}
+
+/// Write a minimal bootable rootfs: busybox + applet symlinks + vm-agent as
+/// `/sbin/vm-agent` (and `/sbin/init`), plus the standard directory skeleton.
+fn build_default_rootfs(spec: &DefaultRootfsSpec, out: &Path) -> Result<()> {
+    const DIR: u16 = file_mode::S_IFDIR | 0o755;
+    const EXE: u16 = file_mode::S_IFREG | 0o755;
+    const LNK: u16 = file_mode::S_IFLNK | 0o777;
+
+    let mut fmt = Formatter::with_options(out, FormatOptions::new(spec.size).label("arcbox-sbx"))
+        .context("failed to create ext4 formatter")?;
+
+    for dir in [
+        "/bin", "/sbin", "/dev", "/proc", "/sys", "/run", "/etc", "/root", "/var",
+    ] {
+        fmt.create(dir, DIR, None, None, None, None, None, None)
+            .with_context(|| format!("mkdir {dir}"))?;
+    }
+    // World-writable sticky /tmp.
+    fmt.create(
+        "/tmp",
+        file_mode::S_IFDIR | file_mode::S_ISVTX | 0o777,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+    )
+    .context("mkdir /tmp")?;
+
+    let mut busybox = std::fs::File::open(&spec.busybox)
+        .with_context(|| format!("failed to open {}", spec.busybox.display()))?;
+    fmt.create(
+        "/bin/busybox",
+        EXE,
+        None,
+        None,
+        Some(&mut busybox),
+        None,
+        None,
+        None,
+    )
+    .context("write /bin/busybox")?;
+
+    for applet in &spec.applets {
+        if applet == "busybox" || applet.contains('/') {
+            continue;
+        }
+        let path = format!("/bin/{applet}");
+        fmt.create(&path, LNK, Some("busybox"), None, None, None, None, None)
+            .with_context(|| format!("symlink {path}"))?;
+    }
+
+    let mut vm_agent = std::fs::File::open(&spec.vm_agent)
+        .with_context(|| format!("failed to open {}", spec.vm_agent.display()))?;
+    fmt.create(
+        "/sbin/vm-agent",
+        EXE,
+        None,
+        None,
+        Some(&mut vm_agent),
+        None,
+        None,
+        None,
+    )
+    .context("write /sbin/vm-agent")?;
+    // Fallback for boot args that omit init=: PID 1 is still vm-agent.
+    fmt.create(
+        "/sbin/init",
+        LNK,
+        Some("vm-agent"),
+        None,
+        None,
+        None,
+        None,
+        None,
+    )
+    .context("symlink /sbin/init")?;
+
+    let passwd = "root:x:0:0:root:/root:/bin/sh\n";
+    fmt.create(
+        "/etc/passwd",
+        file_mode::S_IFREG | 0o644,
+        None,
+        None,
+        Some(&mut passwd.as_bytes()),
+        None,
+        None,
+        None,
+    )
+    .context("write /etc/passwd")?;
+    let group = "root:x:0:\n";
+    fmt.create(
+        "/etc/group",
+        file_mode::S_IFREG | 0o644,
+        None,
+        None,
+        Some(&mut group.as_bytes()),
+        None,
+        None,
+        None,
+    )
+    .context("write /etc/group")?;
+
+    fmt.close().context("failed to finalize ext4 image")?;
+    Ok(())
+}
+
+/// List busybox applets via `busybox --list`.
+async fn busybox_applets() -> Result<Vec<String>> {
+    let output = Command::new(GUEST_BUSYBOX)
+        .arg("--list")
         .output()
         .await
-        .context("failed to spawn oci2rootfs")?;
-
-    if !result.status.success() {
-        let stderr = String::from_utf8_lossy(&result.stderr);
-        bail!("oci2rootfs failed: {stderr}");
+        .with_context(|| format!("failed to run {GUEST_BUSYBOX} --list"))?;
+    if !output.status.success() {
+        bail!("busybox --list failed with {}", output.status);
     }
-    Ok(())
+    Ok(String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .map(str::trim)
+        .filter(|l| !l.is_empty())
+        .map(str::to_owned)
+        .collect())
 }
 
 /// Inject vm-agent into an ext4 image via loop mount.
@@ -101,7 +322,7 @@ async fn inject_vm_agent(ext4_path: &str, req_id: &str) -> Result<()> {
     tokio::fs::create_dir_all(&mount_dir).await?;
 
     // Mount.
-    let status = Command::new("/bin/busybox")
+    let status = Command::new(GUEST_BUSYBOX)
         .args(["mount", "-o", "loop", ext4_path, &mount_dir])
         .status()
         .await
@@ -121,14 +342,14 @@ async fn inject_vm_agent(ext4_path: &str, req_id: &str) -> Result<()> {
 
     // chmod 755.
     if copy_result.is_ok() {
-        let _ = Command::new("/bin/busybox")
+        let _ = Command::new(GUEST_BUSYBOX)
             .args(["chmod", "755", &dest])
             .status()
             .await;
     }
 
     // Always unmount and cleanup, even on failure.
-    let _ = Command::new("/bin/busybox")
+    let _ = Command::new(GUEST_BUSYBOX)
         .args(["umount", &mount_dir])
         .status()
         .await;
@@ -168,5 +389,45 @@ mod tests {
         let a = path_hash("/var/lib/docker/overlay2/abc123");
         let b = path_hash("/var/lib/docker/overlay2/def456");
         assert_ne!(a, b);
+    }
+
+    #[test]
+    fn default_rootfs_builds_and_contains_init_chain() {
+        let dir = tempfile::tempdir().unwrap();
+        let busybox = dir.path().join("busybox");
+        let vm_agent = dir.path().join("vm-agent");
+        std::fs::write(&busybox, b"#!busybox-stub").unwrap();
+        std::fs::write(&vm_agent, b"#!vm-agent-stub").unwrap();
+
+        let out = dir.path().join("rootfs.ext4");
+        let spec = DefaultRootfsSpec {
+            busybox,
+            vm_agent,
+            applets: vec!["sh".into(), "ls".into(), "busybox".into()],
+            size: 8 * 1024 * 1024,
+        };
+        build_default_rootfs(&spec, &out).unwrap();
+
+        assert!(has_ext4_magic(&out));
+
+        let reader = arcbox_ext4::Reader::new(&out).unwrap();
+        for path in [
+            "/bin/busybox",
+            "/sbin/vm-agent",
+            "/sbin/init",
+            "/bin/sh",
+            "/etc/passwd",
+        ] {
+            assert!(
+                reader.tree().lookup(Path::new(path)).is_some(),
+                "missing {path}"
+            );
+        }
+        assert!(
+            reader
+                .tree()
+                .lookup(Path::new("/bin/nonexistent"))
+                .is_none()
+        );
     }
 }

--- a/guest/arcbox-agent/src/rootfs_builder.rs
+++ b/guest/arcbox-agent/src/rootfs_builder.rs
@@ -110,8 +110,46 @@ pub async fn convert_layer_to_rootfs(layer_path: &str) -> Result<String> {
 /// Ensure the default busybox + vm-agent rootfs exists at `path` and is
 /// newer than its source binaries. Returns without touching the image when
 /// it is already up to date.
+/// Serializes default-rootfs builds so concurrent `create` requests don't each
+/// rebuild the 512 MiB image. The atomic rename already prevents corruption;
+/// this only avoids the redundant work.
+fn build_lock() -> &'static tokio::sync::Mutex<()> {
+    static LOCK: std::sync::OnceLock<tokio::sync::Mutex<()>> = std::sync::OnceLock::new();
+    LOCK.get_or_init(|| tokio::sync::Mutex::new(()))
+}
+
+/// Remove leftover `*.ext4.tmp` build artifacts from the rootfs cache dir.
+///
+/// A rootfs build that crashed or panicked leaves a `.default-<uuid>.ext4.tmp`
+/// or `.rootfs-<id>.ext4.tmp` (each up to the image size) with no owner; sweep
+/// them at agent startup so repeated failures don't accrue disk usage.
+pub async fn sweep_stale_tmp() {
+    let Ok(mut entries) = tokio::fs::read_dir(ROOTFS_CACHE_DIR).await else {
+        return;
+    };
+    let mut removed = 0usize;
+    while let Ok(Some(entry)) = entries.next_entry().await {
+        if entry.file_name().to_string_lossy().ends_with(".ext4.tmp")
+            && tokio::fs::remove_file(entry.path()).await.is_ok()
+        {
+            removed += 1;
+        }
+    }
+    if removed > 0 {
+        tracing::info!(removed, "swept stale rootfs build artifacts");
+    }
+}
+
 pub async fn ensure_default_rootfs(path: &str) -> Result<()> {
     let image = Path::new(path);
+    if is_default_rootfs_fresh(image) {
+        return Ok(());
+    }
+
+    // Single-flight: a concurrent create for the same default image waits here,
+    // then the re-check lets it reuse the just-built image instead of
+    // redundantly rebuilding 512 MiB.
+    let _build = build_lock().lock().await;
     if is_default_rootfs_fresh(image) {
         return Ok(());
     }

--- a/guest/arcbox-agent/src/sandbox.rs
+++ b/guest/arcbox-agent/src/sandbox.rs
@@ -34,7 +34,9 @@ async fn drain_trailing_input<S: AsyncRead + Unpin>(stream: &mut S) {
     use tokio::time::{Duration, timeout};
     let _ = timeout(Duration::from_millis(100), async {
         if let Ok((msg_type, _, _)) = read_message(stream).await {
-            if msg_type != MessageType::SandboxExecInput {
+            if msg_type != MessageType::SandboxExecInput
+                && msg_type != MessageType::SandboxExecResize
+            {
                 tracing::warn!(?msg_type, "unexpected trailing message after exec");
             }
         }
@@ -372,6 +374,18 @@ impl SandboxService {
                                 ExecInputMsg::Eof
                             } else {
                                 ExecInputMsg::Stdin(data)
+                            };
+                            if in_tx.send(msg).await.is_err() {
+                                break;
+                            }
+                        }
+                        Ok((MessageType::SandboxExecResize, _, data)) => {
+                            let Ok(size) = sandbox_v1::TerminalSize::decode(data.as_slice()) else {
+                                break;
+                            };
+                            let msg = ExecInputMsg::Resize {
+                                width: u16::try_from(size.width).unwrap_or(u16::MAX),
+                                height: u16::try_from(size.height).unwrap_or(u16::MAX),
                             };
                             if in_tx.send(msg).await.is_err() {
                                 break;

--- a/guest/arcbox-agent/src/sandbox.rs
+++ b/guest/arcbox-agent/src/sandbox.rs
@@ -250,7 +250,7 @@ impl SandboxService {
                         // Encode an exit chunk carrying the error.
                         let done_msg = sandbox_v1::RunOutput {
                             stream: "exit".into(),
-                            data: Vec::new().into(),
+                            data: Vec::new(),
                             exit_code: 1,
                             done: true,
                         };
@@ -262,7 +262,7 @@ impl SandboxService {
                 let is_done = chunk.stream == "exit";
                 let msg = sandbox_v1::RunOutput {
                     stream: chunk.stream,
-                    data: chunk.data.into(),
+                    data: chunk.data,
                     exit_code: chunk.exit_code,
                     done: is_done,
                 };
@@ -374,7 +374,7 @@ impl SandboxService {
         let (in_tx, mut out_rx) = match self.exec(payload).await {
             Ok(pair) => pair,
             Err(e) => {
-                let err = ErrorResponse::new(e.status_code(), &e.to_string());
+                let err = ErrorResponse::new(e.status_code(), e.to_string());
                 write_message(stream, MessageType::Error, trace_id, &err.encode()).await?;
                 return Ok(());
             }
@@ -424,9 +424,8 @@ impl SandboxService {
             let trace_id_owned = trace_id.to_owned();
             let output_fut = async {
                 while let Some(encoded) = out_rx.recv().await {
-                    let done = sandbox_v1::ExecOutput::decode(encoded.as_slice())
-                        .map(|m| m.done)
-                        .unwrap_or(false);
+                    let done =
+                        sandbox_v1::ExecOutput::decode(encoded.as_slice()).is_ok_and(|m| m.done);
                     write_message(
                         &mut wh,
                         MessageType::SandboxExecOutput,
@@ -477,7 +476,7 @@ impl SandboxService {
         let mut rx = match self.run(payload).await {
             Ok(r) => r,
             Err(e) => {
-                let err = ErrorResponse::new(e.status_code(), &e.to_string());
+                let err = ErrorResponse::new(e.status_code(), e.to_string());
                 write_message(stream, MessageType::Error, trace_id, &err.encode()).await?;
                 return Ok(());
             }
@@ -503,7 +502,7 @@ impl SandboxService {
         let mut rx = match self.subscribe_events(payload) {
             Ok(r) => r,
             Err(e) => {
-                let err = ErrorResponse::new(e.status_code(), &e.to_string());
+                let err = ErrorResponse::new(e.status_code(), e.to_string());
                 write_message(stream, MessageType::Error, trace_id, &err.encode()).await?;
                 return Ok(());
             }
@@ -525,7 +524,7 @@ impl SandboxService {
         let req = sandbox_v1::SandboxEventsRequest::decode(payload)
             .map_err(|e| SandboxError::Decode(e.to_string()))?;
         let filter_id = req.id.clone();
-        let filter_action = req.action.clone();
+        let filter_action = req.action;
 
         let mut bcast_rx = self.manager.subscribe_events();
         let (tx, out_rx) = mpsc::unbounded_channel::<Vec<u8>>();
@@ -598,7 +597,7 @@ impl SandboxService {
         const CHUNK_SIZE: usize = 1024 * 1024;
         for chunk in data.chunks(CHUNK_SIZE) {
             let msg = sandbox_v1::FileChunk {
-                data: chunk.to_vec().into(),
+                data: chunk.to_vec(),
                 done: false,
             };
             write_message(
@@ -610,7 +609,7 @@ impl SandboxService {
             .await?;
         }
         let done = sandbox_v1::FileChunk {
-            data: Vec::new().into(),
+            data: Vec::new(),
             done: true,
         };
         write_message(
@@ -881,8 +880,8 @@ fn vm_info_to_proto(info: SandboxInfo) -> sandbox_v1::SandboxInfo {
         limits: Some(limits),
         network,
         created_at: info.created_at.timestamp(),
-        ready_at: info.ready_at.map(|t| t.timestamp()).unwrap_or(0),
-        last_exited_at: info.last_exited_at.map(|t| t.timestamp()).unwrap_or(0),
+        ready_at: info.ready_at.map_or(0, |t| t.timestamp()),
+        last_exited_at: info.last_exited_at.map_or(0, |t| t.timestamp()),
         last_exit_code: info.last_exit_code.unwrap_or(0),
         error: info.error.unwrap_or_default(),
     }

--- a/guest/arcbox-agent/src/sandbox.rs
+++ b/guest/arcbox-agent/src/sandbox.rs
@@ -46,6 +46,32 @@ async fn drain_trailing_input<S: AsyncRead + Unpin>(stream: &mut S) {
 // SandboxService
 // =============================================================================
 
+/// Verify the nested-virtualization prerequisite for sandboxes.
+///
+/// Firecracker needs `/dev/kvm`, which exists in this guest only when the
+/// host enabled nested virtualization (VZ backend on Apple Silicon M3+ with
+/// macOS 15+). Returns an actionable reason when the prerequisite is missing
+/// so `Create` can fail fast with `FAILED_PRECONDITION` instead of an opaque
+/// asynchronous boot failure.
+pub fn probe_kvm() -> Result<(), String> {
+    match std::fs::OpenOptions::new()
+        .read(true)
+        .write(true)
+        .open("/dev/kvm")
+    {
+        Ok(_) => Ok(()),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Err(
+            "sandboxes require nested virtualization (/dev/kvm is missing in the guest): \
+             use the VZ backend on Apple Silicon M3 or newer with macOS 15+; \
+             the HV backend and Intel/M1/M2 hosts cannot run sandboxes"
+                .into(),
+        ),
+        Err(e) => Err(format!(
+            "/dev/kvm exists but cannot be opened ({e}); sandboxes are unavailable"
+        )),
+    }
+}
+
 /// Thin wrapper around [`SandboxManager`] for use in the agent's RPC layer.
 pub struct SandboxService {
     manager: Arc<SandboxManager>,
@@ -101,7 +127,7 @@ impl SandboxService {
             .manager
             .create_sandbox(spec)
             .await
-            .map_err(|e| SandboxError::Internal(e.to_string()))?;
+            .map_err(SandboxError::from)?;
         register_sandbox_dns(&id, &ip_address);
         Ok(sandbox_v1::CreateSandboxResponse {
             id,
@@ -117,7 +143,7 @@ impl SandboxService {
         self.manager
             .stop_sandbox(&req.id, req.timeout_seconds)
             .await
-            .map_err(|e| SandboxError::Internal(e.to_string()))?;
+            .map_err(SandboxError::from)?;
         deregister_sandbox_dns(&req.id);
         Ok(())
     }
@@ -129,7 +155,7 @@ impl SandboxService {
         self.manager
             .remove_sandbox(&req.id, req.force)
             .await
-            .map_err(|e| SandboxError::Internal(e.to_string()))?;
+            .map_err(SandboxError::from)?;
         deregister_sandbox_dns(&req.id);
         Ok(())
     }
@@ -141,7 +167,7 @@ impl SandboxService {
         let info = self
             .manager
             .inspect_sandbox(&req.id)
-            .map_err(|e| SandboxError::Internal(e.to_string()))?;
+            .map_err(SandboxError::from)?;
         Ok(vm_info_to_proto(info))
     }
 
@@ -186,7 +212,7 @@ impl SandboxService {
                 req.timeout_seconds,
             )
             .await
-            .map_err(|e| SandboxError::Internal(e.to_string()))?;
+            .map_err(SandboxError::from)?;
 
         let (tx, out_rx) = mpsc::unbounded_channel::<Vec<u8>>();
         tokio::spawn(async move {
@@ -264,7 +290,7 @@ impl SandboxService {
                 req.timeout_seconds,
             )
             .await
-            .map_err(|e| SandboxError::Internal(e.to_string()))?;
+            .map_err(SandboxError::from)?;
 
         let (tx, out_stream_rx) = mpsc::unbounded_channel::<Vec<u8>>();
         tokio::spawn(async move {
@@ -509,7 +535,7 @@ impl SandboxService {
             .manager
             .checkpoint_sandbox(&req.sandbox_id, req.name)
             .await
-            .map_err(|e| SandboxError::Internal(e.to_string()))?;
+            .map_err(SandboxError::from)?;
         Ok(checkpoint_to_proto(info))
     }
 
@@ -535,7 +561,7 @@ impl SandboxService {
             .manager
             .restore_sandbox(spec)
             .await
-            .map_err(|e| SandboxError::Internal(e.to_string()))?;
+            .map_err(SandboxError::from)?;
         register_sandbox_dns(&id, &ip_address);
         Ok(sandbox_v1::RestoreResponse { id, ip_address })
     }
@@ -555,7 +581,7 @@ impl SandboxService {
         let summaries = self
             .manager
             .list_checkpoints(filter)
-            .map_err(|e| SandboxError::Internal(e.to_string()))?;
+            .map_err(SandboxError::from)?;
         Ok(sandbox_v1::ListSnapshotsResponse {
             snapshots: summaries
                 .into_iter()
@@ -569,7 +595,7 @@ impl SandboxService {
         let info = self
             .manager
             .inspect_sandbox(&sandbox_id.to_string())
-            .map_err(|e| SandboxError::Internal(e.to_string()))?;
+            .map_err(SandboxError::from)?;
         info.network
             .and_then(|n| n.ip_address.parse().ok())
             .ok_or_else(|| {
@@ -583,7 +609,7 @@ impl SandboxService {
             .map_err(|e| SandboxError::Decode(e.to_string()))?;
         self.manager
             .delete_checkpoint(&req.snapshot_id)
-            .map_err(|e| SandboxError::Internal(e.to_string()))
+            .map_err(SandboxError::from)
     }
 }
 

--- a/guest/arcbox-agent/src/sandbox.rs
+++ b/guest/arcbox-agent/src/sandbox.rs
@@ -49,14 +49,18 @@ async fn drain_trailing_input<S: AsyncRead + Unpin>(stream: &mut S) {
 /// Thin wrapper around [`SandboxManager`] for use in the agent's RPC layer.
 pub struct SandboxService {
     manager: Arc<SandboxManager>,
+    /// Default rootfs image path; auto-built on first use when missing.
+    default_rootfs: String,
 }
 
 impl SandboxService {
     /// Create a new [`SandboxService`] from the given config.
     pub fn new(config: VmmConfig) -> anyhow::Result<Self> {
+        let default_rootfs = config.defaults.rootfs.clone();
         let manager = SandboxManager::new(config).map_err(|e| anyhow::anyhow!("{e}"))?;
         Ok(Self {
             manager: Arc::new(manager),
+            default_rootfs,
         })
     }
 
@@ -67,8 +71,9 @@ impl SandboxService {
     /// Create a sandbox.
     ///
     /// When the rootfs path points to a directory (overlay2 layer), the agent
-    /// converts it to ext4 via `oci2rootfs` and injects `vm-agent` before
-    /// booting. Ext4 images are used directly.
+    /// converts it to ext4 via the `oci2rootfs` library and injects `vm-agent`
+    /// before booting. Ext4 images are used directly. An empty rootfs selects
+    /// the default busybox + vm-agent image, auto-built on first use.
     pub async fn create(
         &self,
         payload: &[u8],
@@ -77,8 +82,15 @@ impl SandboxService {
             .map_err(|e| SandboxError::Decode(e.to_string()))?;
         let mut spec = proto_to_spec(req);
 
-        // Auto-detect: directory → overlay2 layer needing conversion.
-        if !spec.rootfs.is_empty() && std::path::Path::new(&spec.rootfs).is_dir() {
+        if spec.rootfs.is_empty() {
+            // Default rootfs: build the busybox + vm-agent image on first use
+            // (rebuilt when the staged vm-agent is newer than the image).
+            crate::rootfs_builder::ensure_default_rootfs(&self.default_rootfs)
+                .await
+                .map_err(|e| SandboxError::Internal(format!("default rootfs: {e}")))?;
+            spec.rootfs.clone_from(&self.default_rootfs);
+        } else if std::path::Path::new(&spec.rootfs).is_dir() {
+            // Directory → overlay2 layer needing conversion.
             let ext4_path = crate::rootfs_builder::convert_layer_to_rootfs(&spec.rootfs)
                 .await
                 .map_err(|e| SandboxError::Internal(format!("rootfs build failed: {e}")))?;

--- a/guest/arcbox-agent/src/sandbox.rs
+++ b/guest/arcbox-agent/src/sandbox.rs
@@ -535,6 +535,153 @@ impl SandboxService {
     }
 
     // =========================================================================
+    // File I/O
+    // =========================================================================
+
+    /// Stream a file out of a sandbox as `SandboxFileData` frames.
+    ///
+    /// The final frame carries `done == true`. Errors (missing sandbox,
+    /// missing file, wrong state) are reported as a single `Error` frame.
+    pub async fn handle_read_file<S>(
+        &self,
+        stream: &mut S,
+        trace_id: &str,
+        payload: &[u8],
+    ) -> anyhow::Result<()>
+    where
+        S: AsyncWrite + Unpin,
+    {
+        let req = match sandbox_v1::ReadFileRequest::decode(payload) {
+            Ok(r) => r,
+            Err(e) => {
+                let err = ErrorResponse::new(400, format!("decode error: {e}"));
+                write_message(stream, MessageType::Error, trace_id, &err.encode()).await?;
+                return Ok(());
+            }
+        };
+
+        let data = match self.manager.read_sandbox_file(&req.id, &req.path).await {
+            Ok(d) => d,
+            Err(e) => {
+                let e = SandboxError::from(e);
+                let err = ErrorResponse::new(e.status_code(), e.to_string());
+                write_message(stream, MessageType::Error, trace_id, &err.encode()).await?;
+                return Ok(());
+            }
+        };
+
+        const CHUNK_SIZE: usize = 1024 * 1024;
+        for chunk in data.chunks(CHUNK_SIZE) {
+            let msg = sandbox_v1::FileChunk {
+                data: chunk.to_vec().into(),
+                done: false,
+            };
+            write_message(
+                stream,
+                MessageType::SandboxFileData,
+                trace_id,
+                &msg.encode_to_vec(),
+            )
+            .await?;
+        }
+        let done = sandbox_v1::FileChunk {
+            data: Vec::new().into(),
+            done: true,
+        };
+        write_message(
+            stream,
+            MessageType::SandboxFileData,
+            trace_id,
+            &done.encode_to_vec(),
+        )
+        .await?;
+        Ok(())
+    }
+
+    /// Receive a `SandboxFileChunk` stream and store it inside the sandbox.
+    ///
+    /// The open payload was already parsed by the dispatcher frame; chunk
+    /// frames follow on the same connection until `done == true`, then a
+    /// `SandboxFileWriteResponse` (or `Error`) frame answers.
+    pub async fn handle_write_file<S>(
+        &self,
+        stream: &mut S,
+        trace_id: &str,
+        payload: &[u8],
+    ) -> anyhow::Result<()>
+    where
+        S: AsyncRead + AsyncWrite + Unpin,
+    {
+        let open = match sandbox_v1::WriteFileOpen::decode(payload) {
+            Ok(o) => o,
+            Err(e) => {
+                let err = ErrorResponse::new(400, format!("decode error: {e}"));
+                write_message(stream, MessageType::Error, trace_id, &err.encode()).await?;
+                return Ok(());
+            }
+        };
+
+        let max = arcbox_vm::file_io::proto::MAX_FILE_SIZE;
+        let mut data = Vec::new();
+        loop {
+            match read_message(stream).await {
+                Ok((MessageType::SandboxFileChunk, _, frame)) => {
+                    let chunk = match sandbox_v1::FileChunk::decode(frame.as_slice()) {
+                        Ok(c) => c,
+                        Err(e) => {
+                            let err = ErrorResponse::new(400, format!("decode error: {e}"));
+                            write_message(stream, MessageType::Error, trace_id, &err.encode())
+                                .await?;
+                            return Ok(());
+                        }
+                    };
+                    if data.len() + chunk.data.len() > max {
+                        let err = ErrorResponse::new(
+                            400,
+                            format!("file exceeds the {max}-byte write limit"),
+                        );
+                        write_message(stream, MessageType::Error, trace_id, &err.encode()).await?;
+                        return Ok(());
+                    }
+                    data.extend_from_slice(&chunk.data);
+                    if chunk.done {
+                        break;
+                    }
+                }
+                Ok((other, _, _)) => {
+                    let err = ErrorResponse::new(
+                        400,
+                        format!("unexpected frame during write: {other:?}"),
+                    );
+                    write_message(stream, MessageType::Error, trace_id, &err.encode()).await?;
+                    return Ok(());
+                }
+                Err(e) => {
+                    tracing::warn!(error = %e, "write stream ended before done chunk");
+                    return Ok(());
+                }
+            }
+        }
+
+        let mode = if open.mode == 0 { 0o644 } else { open.mode };
+        match self
+            .manager
+            .write_sandbox_file(&open.id, &open.path, mode, &data)
+            .await
+        {
+            Ok(()) => {
+                write_message(stream, MessageType::SandboxFileWriteResponse, trace_id, &[]).await?;
+            }
+            Err(e) => {
+                let e = SandboxError::from(e);
+                let err = ErrorResponse::new(e.status_code(), e.to_string());
+                write_message(stream, MessageType::Error, trace_id, &err.encode()).await?;
+            }
+        }
+        Ok(())
+    }
+
+    // =========================================================================
     // Snapshots
     // =========================================================================
 

--- a/guest/arcbox-agent/src/sandbox.rs
+++ b/guest/arcbox-agent/src/sandbox.rs
@@ -110,6 +110,31 @@ impl SandboxService {
             .map_err(|e| SandboxError::Decode(e.to_string()))?;
         let mut spec = proto_to_spec(req);
 
+        // V1 contract: reject declared-but-unimplemented spec fields
+        // explicitly instead of silently ignoring them.
+        if !spec.mounts.is_empty() {
+            return Err(SandboxError::Unsupported(
+                "mounts are not supported in Sandbox V1; copy files in with \
+                 WriteFile (`arcbox sandbox cp`) instead"
+                    .into(),
+            ));
+        }
+        if spec.ssh_public_key.is_some() {
+            return Err(SandboxError::Unsupported(
+                "ssh_public_key is not supported in Sandbox V1; use Exec for \
+                 interactive access"
+                    .into(),
+            ));
+        }
+        if !spec.image.is_empty() {
+            return Err(SandboxError::Unsupported(
+                "registry image pull is not supported in Sandbox V1; build the \
+                 rootfs from a local Docker image with `arcbox sandbox create \
+                 --from-image` instead"
+                    .into(),
+            ));
+        }
+
         if spec.rootfs.is_empty() {
             // Default rootfs: build the busybox + vm-agent image on first use
             // (rebuilt when the staged vm-agent is newer than the image).

--- a/rpc/arcbox-grpc/build.rs
+++ b/rpc/arcbox-grpc/build.rs
@@ -20,8 +20,14 @@ fn main() {
         "../arcbox-protocol/proto/sandbox.proto",
     ];
 
+    let descriptor_path =
+        std::path::PathBuf::from(std::env::var("OUT_DIR").expect("OUT_DIR set by cargo"))
+            .join("arcbox_descriptor.bin");
+
     // Configure tonic-build
     tonic_build::configure()
+        // Emit the file descriptor set for gRPC server reflection.
+        .file_descriptor_set_path(&descriptor_path)
         // Map arcbox.v1 package to arcbox_protocol::v1 types
         .extern_path(".arcbox.v1", "::arcbox_protocol::v1")
         // Map sandbox.v1 package to arcbox_protocol::sandbox_v1 types

--- a/rpc/arcbox-grpc/src/lib.rs
+++ b/rpc/arcbox-grpc/src/lib.rs
@@ -37,6 +37,11 @@
 pub use arcbox_protocol;
 pub use tonic;
 
+/// Compiled file descriptor set of every ArcBox proto, for gRPC server
+/// reflection (`tonic-reflection`). Covers `arcbox.v1` and `sandbox.v1`.
+pub const FILE_DESCRIPTOR_SET: &[u8] =
+    include_bytes!(concat!(env!("OUT_DIR"), "/arcbox_descriptor.bin"));
+
 /// All gRPC services from the unified arcbox.v1 package.
 ///
 /// This module contains tonic-generated client and server code for:

--- a/rpc/arcbox-protocol/proto/sandbox.proto
+++ b/rpc/arcbox-protocol/proto/sandbox.proto
@@ -55,6 +55,16 @@ service SandboxService {
     // Emitted actions: "created" | "ready" | "running" | "idle" |
     //                  "stopping" | "stopped" | "failed" | "removed"
     rpc Events(SandboxEventsRequest) returns (stream SandboxEvent);
+
+    // Read a file from inside a sandbox as a stream of chunks.
+    // The final chunk has done == true. The sandbox must be alive
+    // (ready or running). Limited to 256 MiB per file.
+    rpc ReadFile(ReadFileRequest) returns (stream FileChunk);
+
+    // Write a file into a sandbox. The first message must carry `open`;
+    // subsequent messages stream `chunk` payloads, the last one with
+    // done == true. Limited to 256 MiB per file.
+    rpc WriteFile(stream WriteFileRequest) returns (Empty);
 }
 
 // =============================================================================
@@ -277,6 +287,46 @@ message ExecOutput {
     int32 exit_code = 3;
     // True on the last message of the stream.
     bool done = 4;
+}
+
+// =============================================================================
+// File I/O
+// =============================================================================
+
+// Request to read a file from a sandbox.
+message ReadFileRequest {
+    // Sandbox ID.
+    string id = 1;
+    // Absolute path inside the sandbox rootfs.
+    string path = 2;
+}
+
+// One chunk of file data in a ReadFile / WriteFile stream.
+message FileChunk {
+    // Raw bytes (may be empty on the final chunk).
+    bytes data = 1;
+    // True on the last chunk of the stream.
+    bool done = 2;
+}
+
+// Opens a WriteFile stream. Must be the first WriteFileRequest message.
+message WriteFileOpen {
+    // Sandbox ID.
+    string id = 1;
+    // Absolute destination path inside the sandbox rootfs.
+    string path = 2;
+    // Unix permission bits for the created file (0 = 0644).
+    uint32 mode = 3;
+}
+
+// A single client message in a WriteFile stream.
+message WriteFileRequest {
+    oneof payload {
+        // Stream header — sandbox, path, and mode.
+        WriteFileOpen open = 1;
+        // File content chunk; the last one has done == true.
+        FileChunk chunk = 2;
+    }
 }
 
 // =============================================================================

--- a/rpc/arcbox-protocol/proto/sandbox.proto
+++ b/rpc/arcbox-protocol/proto/sandbox.proto
@@ -563,6 +563,12 @@ message CheckpointResponse {
 }
 
 // Request to restore a sandbox from a snapshot.
+//
+// Direct-mode (non-jailer) limitation: the snapshot's vmstate records the
+// origin sandbox's absolute vsock socket path, so concurrent restores from
+// the same snapshot — or restoring while the origin sandbox is still
+// running — fail with FAILED_PRECONDITION on the vsock conflict. Jailer
+// mode restores into per-sandbox chroots and has no such constraint.
 message RestoreRequest {
     // Caller-supplied ID for the new sandbox (empty = auto-generated).
     string id = 1;

--- a/rpc/arcbox-protocol/proto/sandbox.proto
+++ b/rpc/arcbox-protocol/proto/sandbox.proto
@@ -168,8 +168,11 @@ message CreateSandboxRequest {
     ResourceLimits limits = 6;
 
     // --- Initial workload (optional) ---
-    // OCI image reference. When set, the agent pulls and runs this image
-    // inside the sandbox. Empty = use rootfs directly.
+    // OCI image reference. NOT supported in Sandbox V1: a non-empty value is
+    // rejected with FAILED_PRECONDITION. Build the rootfs from a local
+    // Docker image instead (CLI --from-image resolves the overlay2 layer and
+    // passes it as `rootfs`). Registry pull lands with a rustls-capable
+    // oci2rootfs release.
     string image = 7;
     // Initial command launched automatically after boot.
     // Empty = sandbox enters "ready" without running anything.
@@ -184,6 +187,8 @@ message CreateSandboxRequest {
     string user = 11;
 
     // --- Filesystem ---
+    // NOT supported in Sandbox V1: a non-empty list is rejected with
+    // FAILED_PRECONDITION. Copy files in with WriteFile / `sandbox cp`.
     repeated Mount mounts = 12;
 
     // --- Network ---
@@ -196,7 +201,8 @@ message CreateSandboxRequest {
     uint32 ttl_seconds = 14;
 
     // --- Provisioning ---
-    // SSH public key injected via MMDS (empty = no SSH).
+    // NOT supported in Sandbox V1: a set value is rejected with
+    // FAILED_PRECONDITION. Use Exec for interactive access.
     optional string ssh_public_key = 15;
 
     reserved 16;

--- a/rpc/arcbox-protocol/proto/sandbox.proto
+++ b/rpc/arcbox-protocol/proto/sandbox.proto
@@ -65,6 +65,15 @@ service SandboxService {
     // subsequent messages stream `chunk` payloads, the last one with
     // done == true. Limited to 256 MiB per file.
     rpc WriteFile(stream WriteFileRequest) returns (Empty);
+
+    // Expose a sandbox port on the host. The guest installs a DNAT rule from
+    // a reserved guest port (40000-49999) to the sandbox, and the daemon
+    // binds a host listener forwarding into the guest. Removed automatically
+    // on Stop/Remove.
+    rpc ExposePort(ExposePortRequest) returns (ExposePortResponse);
+
+    // Remove a previously exposed port mapping.
+    rpc UnexposePort(UnexposePortRequest) returns (Empty);
 }
 
 // =============================================================================
@@ -327,6 +336,68 @@ message WriteFileRequest {
         // File content chunk; the last one has done == true.
         FileChunk chunk = 2;
     }
+}
+
+// =============================================================================
+// Port exposure
+// =============================================================================
+
+// Request to expose a sandbox port on the host.
+message ExposePortRequest {
+    // Sandbox ID.
+    string id = 1;
+    // Port the workload listens on inside the sandbox.
+    uint32 sandbox_port = 2;
+    // Host port to bind (0 = reuse the allocated guest relay port).
+    uint32 host_port = 3;
+    // "tcp" (default) or "udp".
+    string protocol = 4;
+}
+
+// Response to ExposePort.
+message ExposePortResponse {
+    // Host port the service is reachable on (via loopback).
+    uint32 host_port = 1;
+    // Reserved-range guest port carrying the DNAT relay.
+    uint32 guest_port = 2;
+}
+
+// Request to remove an exposed port mapping.
+message UnexposePortRequest {
+    // Sandbox ID.
+    string id = 1;
+    // The sandbox port previously passed to ExposePort.
+    uint32 sandbox_port = 2;
+    // "tcp" (default) or "udp".
+    string protocol = 3;
+}
+
+// --- agent wire payloads (vsock, not served over gRPC) ---
+
+// Ask the guest agent to DNAT a reserved guest port to a sandbox port.
+message SandboxPortForwardRequest {
+    // Sandbox ID.
+    string id = 1;
+    // Destination port inside the sandbox.
+    uint32 sandbox_port = 2;
+    // "tcp" (default) or "udp".
+    string protocol = 3;
+}
+
+// Guest agent's answer: the allocated reserved-range guest port.
+message SandboxPortForwardResponse {
+    // Guest port now DNATed to the sandbox.
+    uint32 guest_port = 1;
+}
+
+// Ask the guest agent to remove a DNAT mapping.
+message SandboxPortForwardRemoveRequest {
+    // Sandbox ID.
+    string id = 1;
+    // The sandbox port previously forwarded.
+    uint32 sandbox_port = 2;
+    // "tcp" (default) or "udp".
+    string protocol = 3;
 }
 
 // =============================================================================

--- a/rpc/arcbox-protocol/src/generated/sandbox.v1.rs
+++ b/rpc/arcbox-protocol/src/generated/sandbox.v1.rs
@@ -255,6 +255,67 @@ pub struct ExecOutput {
     #[prost(bool, tag = "4")]
     pub done: bool,
 }
+/// Request to read a file from a sandbox.
+#[derive(serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ReadFileRequest {
+    /// Sandbox ID.
+    #[prost(string, tag = "1")]
+    pub id: ::prost::alloc::string::String,
+    /// Absolute path inside the sandbox rootfs.
+    #[prost(string, tag = "2")]
+    pub path: ::prost::alloc::string::String,
+}
+/// One chunk of file data in a ReadFile / WriteFile stream.
+#[derive(serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct FileChunk {
+    /// Raw bytes (may be empty on the final chunk).
+    #[prost(bytes = "vec", tag = "1")]
+    pub data: ::prost::alloc::vec::Vec<u8>,
+    /// True on the last chunk of the stream.
+    #[prost(bool, tag = "2")]
+    pub done: bool,
+}
+/// Opens a WriteFile stream. Must be the first WriteFileRequest message.
+#[derive(serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct WriteFileOpen {
+    /// Sandbox ID.
+    #[prost(string, tag = "1")]
+    pub id: ::prost::alloc::string::String,
+    /// Absolute destination path inside the sandbox rootfs.
+    #[prost(string, tag = "2")]
+    pub path: ::prost::alloc::string::String,
+    /// Unix permission bits for the created file (0 = 0644).
+    #[prost(uint32, tag = "3")]
+    pub mode: u32,
+}
+/// A single client message in a WriteFile stream.
+#[derive(serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct WriteFileRequest {
+    #[prost(oneof = "write_file_request::Payload", tags = "1, 2")]
+    pub payload: ::core::option::Option<write_file_request::Payload>,
+}
+/// Nested message and enum types in `WriteFileRequest`.
+pub mod write_file_request {
+    #[derive(serde::Serialize, serde::Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    #[derive(Clone, PartialEq, ::prost::Oneof)]
+    pub enum Payload {
+        /// Stream header — sandbox, path, and mode.
+        #[prost(message, tag = "1")]
+        Open(super::WriteFileOpen),
+        /// File content chunk; the last one has done == true.
+        #[prost(message, tag = "2")]
+        Chunk(super::FileChunk),
+    }
+}
 /// Request to stop a sandbox gracefully.
 #[derive(serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]

--- a/rpc/arcbox-protocol/src/generated/sandbox.v1.rs
+++ b/rpc/arcbox-protocol/src/generated/sandbox.v1.rs
@@ -316,6 +316,90 @@ pub mod write_file_request {
         Chunk(super::FileChunk),
     }
 }
+/// Request to expose a sandbox port on the host.
+#[derive(serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ExposePortRequest {
+    /// Sandbox ID.
+    #[prost(string, tag = "1")]
+    pub id: ::prost::alloc::string::String,
+    /// Port the workload listens on inside the sandbox.
+    #[prost(uint32, tag = "2")]
+    pub sandbox_port: u32,
+    /// Host port to bind (0 = reuse the allocated guest relay port).
+    #[prost(uint32, tag = "3")]
+    pub host_port: u32,
+    /// "tcp" (default) or "udp".
+    #[prost(string, tag = "4")]
+    pub protocol: ::prost::alloc::string::String,
+}
+/// Response to ExposePort.
+#[derive(serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[derive(Clone, Copy, PartialEq, ::prost::Message)]
+pub struct ExposePortResponse {
+    /// Host port the service is reachable on (via loopback).
+    #[prost(uint32, tag = "1")]
+    pub host_port: u32,
+    /// Reserved-range guest port carrying the DNAT relay.
+    #[prost(uint32, tag = "2")]
+    pub guest_port: u32,
+}
+/// Request to remove an exposed port mapping.
+#[derive(serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct UnexposePortRequest {
+    /// Sandbox ID.
+    #[prost(string, tag = "1")]
+    pub id: ::prost::alloc::string::String,
+    /// The sandbox port previously passed to ExposePort.
+    #[prost(uint32, tag = "2")]
+    pub sandbox_port: u32,
+    /// "tcp" (default) or "udp".
+    #[prost(string, tag = "3")]
+    pub protocol: ::prost::alloc::string::String,
+}
+/// Ask the guest agent to DNAT a reserved guest port to a sandbox port.
+#[derive(serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct SandboxPortForwardRequest {
+    /// Sandbox ID.
+    #[prost(string, tag = "1")]
+    pub id: ::prost::alloc::string::String,
+    /// Destination port inside the sandbox.
+    #[prost(uint32, tag = "2")]
+    pub sandbox_port: u32,
+    /// "tcp" (default) or "udp".
+    #[prost(string, tag = "3")]
+    pub protocol: ::prost::alloc::string::String,
+}
+/// Guest agent's answer: the allocated reserved-range guest port.
+#[derive(serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[derive(Clone, Copy, PartialEq, ::prost::Message)]
+pub struct SandboxPortForwardResponse {
+    /// Guest port now DNATed to the sandbox.
+    #[prost(uint32, tag = "1")]
+    pub guest_port: u32,
+}
+/// Ask the guest agent to remove a DNAT mapping.
+#[derive(serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct SandboxPortForwardRemoveRequest {
+    /// Sandbox ID.
+    #[prost(string, tag = "1")]
+    pub id: ::prost::alloc::string::String,
+    /// The sandbox port previously forwarded.
+    #[prost(uint32, tag = "2")]
+    pub sandbox_port: u32,
+    /// "tcp" (default) or "udp".
+    #[prost(string, tag = "3")]
+    pub protocol: ::prost::alloc::string::String,
+}
 /// Request to stop a sandbox gracefully.
 #[derive(serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]

--- a/rpc/arcbox-protocol/src/generated/sandbox.v1.rs
+++ b/rpc/arcbox-protocol/src/generated/sandbox.v1.rs
@@ -614,6 +614,12 @@ pub struct CheckpointResponse {
     pub created_at: ::prost::alloc::string::String,
 }
 /// Request to restore a sandbox from a snapshot.
+///
+/// Direct-mode (non-jailer) limitation: the snapshot's vmstate records the
+/// origin sandbox's absolute vsock socket path, so concurrent restores from
+/// the same snapshot — or restoring while the origin sandbox is still
+/// running — fail with FAILED_PRECONDITION on the vsock conflict. Jailer
+/// mode restores into per-sandbox chroots and has no such constraint.
 #[derive(serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
 #[derive(Clone, PartialEq, ::prost::Message)]

--- a/rpc/arcbox-protocol/src/generated/sandbox.v1.rs
+++ b/rpc/arcbox-protocol/src/generated/sandbox.v1.rs
@@ -79,8 +79,11 @@ pub struct CreateSandboxRequest {
     #[prost(message, optional, tag = "6")]
     pub limits: ::core::option::Option<ResourceLimits>,
     /// --- Initial workload (optional) ---
-    /// OCI image reference. When set, the agent pulls and runs this image
-    /// inside the sandbox. Empty = use rootfs directly.
+    /// OCI image reference. NOT supported in Sandbox V1: a non-empty value is
+    /// rejected with FAILED_PRECONDITION. Build the rootfs from a local
+    /// Docker image instead (CLI --from-image resolves the overlay2 layer and
+    /// passes it as `rootfs`). Registry pull lands with a rustls-capable
+    /// oci2rootfs release.
     #[prost(string, tag = "7")]
     pub image: ::prost::alloc::string::String,
     /// Initial command launched automatically after boot.
@@ -100,6 +103,8 @@ pub struct CreateSandboxRequest {
     #[prost(string, tag = "11")]
     pub user: ::prost::alloc::string::String,
     /// --- Filesystem ---
+    /// NOT supported in Sandbox V1: a non-empty list is rejected with
+    /// FAILED_PRECONDITION. Copy files in with WriteFile / `sandbox cp`.
     #[prost(message, repeated, tag = "12")]
     pub mounts: ::prost::alloc::vec::Vec<Mount>,
     /// --- Network ---
@@ -112,7 +117,8 @@ pub struct CreateSandboxRequest {
     #[prost(uint32, tag = "14")]
     pub ttl_seconds: u32,
     /// --- Provisioning ---
-    /// SSH public key injected via MMDS (empty = no SSH).
+    /// NOT supported in Sandbox V1: a set value is rejected with
+    /// FAILED_PRECONDITION. Use Exec for interactive access.
     #[prost(string, optional, tag = "15")]
     pub ssh_public_key: ::core::option::Option<::prost::alloc::string::String>,
 }

--- a/tests/e2e/Cargo.toml
+++ b/tests/e2e/Cargo.toml
@@ -20,6 +20,7 @@ serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 tempfile.workspace = true
 tokio.workspace = true
+tokio-stream.workspace = true
 toml_edit = "0.25.12"
 tonic.workspace = true
 tower.workspace = true

--- a/tests/e2e/src/bin/hv_e2e.rs
+++ b/tests/e2e/src/bin/hv_e2e.rs
@@ -440,7 +440,7 @@ fn ping_once(vmm: &Vmm, deadline: Duration) -> Result<(), String> {
     set_socket_timeout(fd, deadline).map_err(|e| format!("set_socket_timeout: {e}"))?;
 
     let mut client =
-        AgentClient::from_fd(GUEST_CID, fd).map_err(|e| format!("AgentClient::from_fd: {e}"))?;
+        AgentClient::from_fd_blocking(GUEST_CID, fd).map_err(|e| format!("AgentClient::from_fd_blocking: {e}"))?;
     client
         .ping_blocking()
         .map(|_| ())
@@ -491,7 +491,7 @@ fn dax_round_trip(vmm: &Vmm, fixture: &DaxFixture) -> Result<(), String> {
         .connect_vsock(AGENT_PORT)
         .map_err(|e| format!("connect_vsock: {e}"))?;
     let mut client =
-        AgentClient::from_fd(GUEST_CID, fd).map_err(|e| format!("AgentClient::from_fd: {e}"))?;
+        AgentClient::from_fd_blocking(GUEST_CID, fd).map_err(|e| format!("AgentClient::from_fd_blocking: {e}"))?;
     let resp = client
         .mmap_read_file_blocking(&fixture.guest_path, 0, fixture.length as u64)
         .map_err(|e| format!("mmap_read_file_blocking: {e}"))?;
@@ -608,7 +608,7 @@ fn get_system_info(vmm: &Vmm) -> Result<arcbox_protocol::SystemInfo, String> {
         .connect_vsock(AGENT_PORT)
         .map_err(|e| format!("connect_vsock: {e}"))?;
     let mut client =
-        AgentClient::from_fd(GUEST_CID, fd).map_err(|e| format!("AgentClient::from_fd: {e}"))?;
+        AgentClient::from_fd_blocking(GUEST_CID, fd).map_err(|e| format!("AgentClient::from_fd_blocking: {e}"))?;
     client
         .get_system_info_blocking()
         .map_err(|e| format!("get_system_info_blocking: {e}"))
@@ -652,7 +652,7 @@ fn kill_agent(vmm: &Vmm) -> Result<(), String> {
         .connect_vsock(AGENT_PORT)
         .map_err(|e| format!("connect_vsock: {e}"))?;
     let mut client =
-        AgentClient::from_fd(GUEST_CID, fd).map_err(|e| format!("AgentClient::from_fd: {e}"))?;
+        AgentClient::from_fd_blocking(GUEST_CID, fd).map_err(|e| format!("AgentClient::from_fd_blocking: {e}"))?;
     client
         .kill_agent_blocking()
         .map_err(|e| format!("kill_agent_blocking: {e}"))

--- a/tests/e2e/src/bin/hv_e2e.rs
+++ b/tests/e2e/src/bin/hv_e2e.rs
@@ -439,8 +439,8 @@ fn ping_once(vmm: &Vmm, deadline: Duration) -> Result<(), String> {
     // Bound connect attempts so a stuck guest doesn't hang the test indefinitely.
     set_socket_timeout(fd, deadline).map_err(|e| format!("set_socket_timeout: {e}"))?;
 
-    let mut client =
-        AgentClient::from_fd_blocking(GUEST_CID, fd).map_err(|e| format!("AgentClient::from_fd_blocking: {e}"))?;
+    let mut client = AgentClient::from_fd_blocking(GUEST_CID, fd)
+        .map_err(|e| format!("AgentClient::from_fd_blocking: {e}"))?;
     client
         .ping_blocking()
         .map(|_| ())
@@ -490,8 +490,8 @@ fn dax_round_trip(vmm: &Vmm, fixture: &DaxFixture) -> Result<(), String> {
     let fd = vmm
         .connect_vsock(AGENT_PORT)
         .map_err(|e| format!("connect_vsock: {e}"))?;
-    let mut client =
-        AgentClient::from_fd_blocking(GUEST_CID, fd).map_err(|e| format!("AgentClient::from_fd_blocking: {e}"))?;
+    let mut client = AgentClient::from_fd_blocking(GUEST_CID, fd)
+        .map_err(|e| format!("AgentClient::from_fd_blocking: {e}"))?;
     let resp = client
         .mmap_read_file_blocking(&fixture.guest_path, 0, fixture.length as u64)
         .map_err(|e| format!("mmap_read_file_blocking: {e}"))?;
@@ -607,8 +607,8 @@ fn get_system_info(vmm: &Vmm) -> Result<arcbox_protocol::SystemInfo, String> {
     let fd = vmm
         .connect_vsock(AGENT_PORT)
         .map_err(|e| format!("connect_vsock: {e}"))?;
-    let mut client =
-        AgentClient::from_fd_blocking(GUEST_CID, fd).map_err(|e| format!("AgentClient::from_fd_blocking: {e}"))?;
+    let mut client = AgentClient::from_fd_blocking(GUEST_CID, fd)
+        .map_err(|e| format!("AgentClient::from_fd_blocking: {e}"))?;
     client
         .get_system_info_blocking()
         .map_err(|e| format!("get_system_info_blocking: {e}"))
@@ -651,8 +651,8 @@ fn kill_agent(vmm: &Vmm) -> Result<(), String> {
     let fd = vmm
         .connect_vsock(AGENT_PORT)
         .map_err(|e| format!("connect_vsock: {e}"))?;
-    let mut client =
-        AgentClient::from_fd_blocking(GUEST_CID, fd).map_err(|e| format!("AgentClient::from_fd_blocking: {e}"))?;
+    let mut client = AgentClient::from_fd_blocking(GUEST_CID, fd)
+        .map_err(|e| format!("AgentClient::from_fd_blocking: {e}"))?;
     client
         .kill_agent_blocking()
         .map_err(|e| format!("kill_agent_blocking: {e}"))

--- a/tests/e2e/src/boot_assets.rs
+++ b/tests/e2e/src/boot_assets.rs
@@ -319,14 +319,44 @@ pub fn stage_dev_boot_assets(root: &Path, data_dir: &Path, version: &str) -> Res
     // the freshest agent found locally: the dev tree, a local
     // cross-compile, or the one an installed ArcBox app seeded — newest
     // mtime wins, since a stale agent fails the boot in confusing ways.
-    let agent_candidates = [
-        dev_boot_dir.join("arcbox-agent"),
-        root.join("target/aarch64-unknown-linux-musl/release/arcbox-agent"),
+    if !stage_freshest_binary(root, &dev_boot_dir, "arcbox-agent", &test_boot_dir)? {
+        warn!(
+            "no arcbox-agent found (looked in boot-assets/dev, musl target, ~/.arcbox/bin); \
+             the daemon will fail at runtime init"
+        );
+    }
+
+    // The sandbox service execs the microVM init at `/arcbox/bin/vm-agent`
+    // (= `<data_dir>/bin/vm-agent` through the VirtioFS data-dir mount), so
+    // stage it straight into the test data dir. Missing vm-agent degrades
+    // only sandbox scenarios, not the Docker lifecycle.
+    if !stage_freshest_binary(root, &dev_boot_dir, "vm-agent", &data_dir.join("bin"))? {
+        warn!("no vm-agent found; sandbox create will fail inside the guest");
+    }
+
+    info!(dev_boot_dir = %dev_boot_dir.display(), "using development boot assets");
+    Ok(())
+}
+
+/// Copy the newest-mtime copy of `name` (dev boot dir, musl target dir, or an
+/// installed ArcBox data dir) into `dest_dir`. Returns false when no
+/// candidate exists.
+fn stage_freshest_binary(
+    root: &Path,
+    dev_boot_dir: &Path,
+    name: &str,
+    dest_dir: &Path,
+) -> Result<bool> {
+    let candidates = [
+        dev_boot_dir.join(name),
+        root.join("target/aarch64-unknown-linux-musl/release")
+            .join(name),
         arcbox_constants::paths::ArcboxProfile::Production
             .default_data_dir()
-            .join("bin/arcbox-agent"),
+            .join("bin")
+            .join(name),
     ];
-    let freshest_agent = agent_candidates
+    let freshest = candidates
         .iter()
         .filter_map(|path| {
             let mtime = fs::metadata(path).ok()?.modified().ok()?;
@@ -334,19 +364,14 @@ pub fn stage_dev_boot_assets(root: &Path, data_dir: &Path, version: &str) -> Res
         })
         .max_by_key(|(_, mtime)| *mtime)
         .map(|(path, _)| path);
-    match freshest_agent {
-        Some(agent) => {
-            copy_file(agent, &test_boot_dir.join("arcbox-agent"))?;
-            info!(agent = %agent.display(), "staged guest agent");
+    match freshest {
+        Some(binary) => {
+            copy_file(binary, &dest_dir.join(name))?;
+            info!(binary = %binary.display(), name, "staged guest binary");
+            Ok(true)
         }
-        None => warn!(
-            "no arcbox-agent found (looked in boot-assets/dev, musl target, ~/.arcbox/bin); \
-             the daemon will fail at runtime init"
-        ),
+        None => Ok(false),
     }
-
-    info!(dev_boot_dir = %dev_boot_dir.display(), "using development boot assets");
-    Ok(())
 }
 
 fn copy_file(from: &Path, to: &Path) -> Result<()> {

--- a/tests/e2e/src/boot_assets.rs
+++ b/tests/e2e/src/boot_assets.rs
@@ -252,7 +252,7 @@ fn run_scenario(ctx: &mut TestContext, metrics: &mut RunMetrics) -> Result<()> {
     Ok(())
 }
 
-fn boot_version(lockfile: &Path) -> Result<String> {
+pub fn boot_version(lockfile: &Path) -> Result<String> {
     let text = fs::read_to_string(lockfile)
         .with_context(|| format!("reading asset lockfile {}", lockfile.display()))?;
     let doc = text

--- a/tests/e2e/src/daemon.rs
+++ b/tests/e2e/src/daemon.rs
@@ -299,7 +299,7 @@ fn assert_isolated(data_dir: &Path) -> Result<()> {
 }
 
 /// Connects a tonic channel over a Unix domain socket.
-async fn connect_unix(socket: &Path) -> Result<Channel> {
+pub async fn connect_unix(socket: &Path) -> Result<Channel> {
     // The URI is required by the HTTP/2 layer but unused: the connector
     // below ignores it and dials the Unix socket.
     let channel = Endpoint::from_static("http://[::]:50051")

--- a/tests/e2e/src/lib.rs
+++ b/tests/e2e/src/lib.rs
@@ -1,9 +1,9 @@
 use std::path::PathBuf;
 
 pub mod boot_assets;
-pub mod sandbox;
 pub mod daemon;
 pub mod metrics;
+pub mod sandbox;
 pub mod signing;
 
 pub fn repo_root() -> PathBuf {

--- a/tests/e2e/src/lib.rs
+++ b/tests/e2e/src/lib.rs
@@ -1,6 +1,7 @@
 use std::path::PathBuf;
 
 pub mod boot_assets;
+pub mod sandbox;
 pub mod daemon;
 pub mod metrics;
 pub mod signing;

--- a/tests/e2e/src/sandbox.rs
+++ b/tests/e2e/src/sandbox.rs
@@ -1,0 +1,450 @@
+//! Sandbox e2e smoke: the full stack over the real gRPC surface.
+//!
+//! Drives `CLI-equivalent` tonic clients against an isolated daemon:
+//! create (with an initial cmd) → ready → initial-cmd idle → Run →
+//! file round-trip (WriteFile/ReadFile) → Checkpoint → Restore
+//! (network_override) → Run in the restored sandbox → Stop/Remove.
+//!
+//! Requires nested virtualization (VZ backend on Apple Silicon M3+ with
+//! macOS 15+): without `/dev/kvm` in the guest, Create fails with
+//! FAILED_PRECONDITION and this scenario reports that reason.
+
+use std::env;
+use std::time::{Duration, Instant};
+
+use anyhow::{Context, Result, bail};
+use arcbox_grpc::sandbox_v1::sandbox_service_client::SandboxServiceClient;
+use arcbox_grpc::sandbox_v1::sandbox_snapshot_service_client::SandboxSnapshotServiceClient;
+use arcbox_protocol::sandbox_v1::{
+    CheckpointRequest, CreateSandboxRequest, FileChunk, InspectSandboxRequest,
+    ListSandboxesRequest, ReadFileRequest, RemoveSandboxRequest, ResourceLimits, RestoreRequest,
+    RunRequest, StopSandboxRequest, WriteFileOpen, WriteFileRequest, write_file_request,
+};
+use tonic::transport::Channel;
+use tracing::{info, warn};
+
+use crate::daemon::{DaemonConfig, DaemonHandle, connect_unix};
+use crate::metrics::RunMetrics;
+use crate::{env_flag, repo_root};
+
+/// Generous ceiling for daemon startup (asset staging + VM boot + agent).
+const READY_TIMEOUT: Duration = Duration::from_secs(180);
+/// Ceiling for a sandbox to reach `ready` (includes the first default
+/// rootfs build inside the guest).
+const SANDBOX_READY_TIMEOUT: Duration = Duration::from_secs(120);
+
+pub struct SandboxSmokeConfig {
+    pub skip_build: bool,
+    pub keep_test_dir: bool,
+    pub version: Option<String>,
+}
+
+impl SandboxSmokeConfig {
+    pub fn from_env() -> Self {
+        Self {
+            skip_build: env_flag("SKIP_BUILD"),
+            keep_test_dir: env_flag("KEEP_TEST_DIR"),
+            version: env::var("ARCBOX_BOOT_ASSET_VERSION").ok(),
+        }
+    }
+}
+
+/// Builds everything the smoke needs: host binaries + guest musl agents.
+///
+/// The `xtask e2e` prebuild recipe for the `sandbox` target must reproduce
+/// exactly these commands (packages AND profiles) — see `xtask/AGENTS.md`.
+pub fn build_binaries() -> Result<()> {
+    info!("building release binaries + musl guest agents");
+    let shell = xshell::Shell::new()?;
+    shell.change_dir(repo_root());
+    xshell::cmd!(shell, "cargo build --release -p arcbox-cli -p arcbox-daemon").run()?;
+    xshell::cmd!(
+        shell,
+        "cargo build --release -p arcbox-agent -p arcbox-vm --bins --target aarch64-unknown-linux-musl"
+    )
+    .run()?;
+    Ok(())
+}
+
+pub fn run(config: SandboxSmokeConfig) -> Result<()> {
+    info!("starting sandbox smoke");
+
+    if !config.skip_build {
+        build_binaries()?;
+    }
+
+    let root = repo_root();
+    let version = match config.version {
+        Some(v) => v,
+        None => crate::boot_assets::boot_version(&root.join("assets.lock"))?,
+    };
+
+    let temp_dir = tempfile::Builder::new()
+        .prefix("arcbox-sandbox-smoke-")
+        .tempdir()
+        .context("creating smoke test directory")?;
+    let data_dir = temp_dir.path().to_owned();
+
+    crate::boot_assets::stage_dev_boot_assets(&root, &data_dir, &version)?;
+
+    let mut metrics = RunMetrics::new("sandbox_smoke", Some("vz"));
+    let result = run_scenario(&root, &data_dir, &version, &mut metrics);
+    metrics.passed = result.is_ok();
+    match metrics.write(Some(&data_dir)) {
+        Ok(paths) => {
+            for path in paths {
+                info!(path = %path.display(), "run metrics written");
+            }
+        }
+        Err(error) => warn!("writing run metrics failed: {error:#}"),
+    }
+
+    if result.is_err() || config.keep_test_dir {
+        let path = temp_dir.keep();
+        warn!(path = %path.display(), "preserving test directory");
+    }
+    result
+}
+
+fn run_scenario(
+    root: &std::path::Path,
+    data_dir: &std::path::Path,
+    version: &str,
+    metrics: &mut RunMetrics,
+) -> Result<()> {
+    // VZ is the default backend; make it explicit for the metrics label.
+    let mut daemon = DaemonHandle::spawn(DaemonConfig {
+        binary: root.join("target/release/arcbox-daemon"),
+        data_dir: data_dir.to_owned(),
+        args: vec![],
+        env: vec![
+            ("ARCBOX_BOOT_ASSET_VERSION".to_owned(), version.to_owned()),
+            ("ARCBOX_VM_BACKEND".to_owned(), "vz".to_owned()),
+        ],
+    })?;
+
+    let ready_started = Instant::now();
+    daemon.wait_ready_blocking(READY_TIMEOUT)?;
+    metrics.record("daemon_ready", ready_started.elapsed().as_secs_f64());
+    info!(
+        elapsed_seconds = ready_started.elapsed().as_secs(),
+        "daemon ready"
+    );
+
+    let grpc_socket = daemon.grpc_socket();
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .context("building smoke runtime")?;
+
+    let scenario = rt.block_on(async {
+        let channel = connect_unix(&grpc_socket).await?;
+        drive_sandboxes(channel, metrics).await
+    });
+
+    // Always shut the daemon down; a teardown failure must not mask the
+    // scenario result.
+    match daemon.shutdown() {
+        Ok(status) => info!(%status, "daemon stopped"),
+        Err(error) => warn!("daemon shutdown failed: {error:#}"),
+    }
+
+    scenario
+}
+
+/// Attach the default `x-machine` routing header.
+fn with_machine<T>(msg: T) -> tonic::Request<T> {
+    let mut request = tonic::Request::new(msg);
+    request
+        .metadata_mut()
+        .insert("x-machine", tonic::metadata::MetadataValue::from_static("default"));
+    request
+}
+
+async fn drive_sandboxes(channel: Channel, metrics: &mut RunMetrics) -> Result<()> {
+    let mut sandboxes = SandboxServiceClient::new(channel.clone());
+    let mut snapshots = SandboxSnapshotServiceClient::new(channel);
+
+    // -- Create (with an initial cmd, exercising the auto-run path) --------
+    let create_started = Instant::now();
+    let created = sandboxes
+        .create(with_machine(CreateSandboxRequest {
+            id: "smoke1".into(),
+            limits: Some(ResourceLimits {
+                vcpus: 1,
+                memory_mib: 256,
+            }),
+            cmd: vec!["/bin/true".into()],
+            ..Default::default()
+        }))
+        .await
+        .context("Create failed")?
+        .into_inner();
+    metrics.record("sandbox_create", create_started.elapsed().as_secs_f64());
+    info!(id = %created.id, ip = %created.ip_address, state = %created.state, "sandbox created");
+    if created.state != "starting" {
+        bail!("unexpected create state {}", created.state);
+    }
+
+    // -- Wait for ready + the initial cmd's idle ---------------------------
+    let ready_started = Instant::now();
+    wait_for_state(&mut sandboxes, "smoke1", "ready", SANDBOX_READY_TIMEOUT).await?;
+    metrics.record("sandbox_ready", ready_started.elapsed().as_secs_f64());
+
+    let info = inspect(&mut sandboxes, "smoke1").await?;
+    if info.last_exited_at == 0 {
+        // The initial cmd may still be racing the readiness flip; give it a
+        // short grace period before asserting.
+        let deadline = Instant::now() + Duration::from_secs(30);
+        loop {
+            let info = inspect(&mut sandboxes, "smoke1").await?;
+            if info.last_exited_at > 0 {
+                break;
+            }
+            if Instant::now() > deadline {
+                bail!("initial cmd never ran (last_exited_at still 0)");
+            }
+            tokio::time::sleep(Duration::from_millis(500)).await;
+        }
+    }
+    let info = inspect(&mut sandboxes, "smoke1").await?;
+    if info.last_exit_code != 0 {
+        bail!("initial cmd exited with {}", info.last_exit_code);
+    }
+    info!("initial cmd ran and sandbox returned to ready");
+
+    // -- Run ----------------------------------------------------------------
+    let run_started = Instant::now();
+    let stdout =
+        run_and_collect(&mut sandboxes, "smoke1", &["/bin/echo", "hello-sandbox"]).await?;
+    if !stdout.contains("hello-sandbox") {
+        bail!("run output missing marker: {stdout:?}");
+    }
+    metrics.record("sandbox_run", run_started.elapsed().as_secs_f64());
+    wait_for_state(&mut sandboxes, "smoke1", "ready", Duration::from_secs(30)).await?;
+
+    // -- File round-trip ------------------------------------------------
+    let file_started = Instant::now();
+    let payload: Vec<u8> = (0..1024 * 1024).map(|i| (i % 251) as u8).collect();
+    write_file(&mut sandboxes, "smoke1", "/tmp/smoke.bin", &payload).await?;
+    let back = read_file(&mut sandboxes, "smoke1", "/tmp/smoke.bin").await?;
+    if back != payload {
+        bail!(
+            "file round-trip mismatch: sent {} bytes, got {}",
+            payload.len(),
+            back.len()
+        );
+    }
+    metrics.record("sandbox_file_io", file_started.elapsed().as_secs_f64());
+    info!("file round-trip verified");
+
+    // -- Checkpoint / Restore --------------------------------------------
+    let checkpoint_started = Instant::now();
+    let snapshot_id = snapshots
+        .checkpoint(with_machine(CheckpointRequest {
+            sandbox_id: "smoke1".into(),
+            name: "warm".into(),
+            ..Default::default()
+        }))
+        .await
+        .context("Checkpoint failed")?
+        .into_inner()
+        .snapshot_id;
+    metrics.record(
+        "sandbox_checkpoint",
+        checkpoint_started.elapsed().as_secs_f64(),
+    );
+    info!(%snapshot_id, "checkpoint taken");
+
+    let restore_started = Instant::now();
+    let restored = snapshots
+        .restore(with_machine(RestoreRequest {
+            id: "smoke2".into(),
+            snapshot_id: snapshot_id.clone(),
+            network_override: true,
+            ..Default::default()
+        }))
+        .await
+        .context("Restore failed")?
+        .into_inner();
+    info!(id = %restored.id, ip = %restored.ip_address, "sandbox restored");
+    let stdout =
+        run_and_collect(&mut sandboxes, "smoke2", &["/bin/echo", "hello-restore"]).await?;
+    if !stdout.contains("hello-restore") {
+        bail!("restored sandbox run output missing marker: {stdout:?}");
+    }
+    metrics.record("sandbox_restore", restore_started.elapsed().as_secs_f64());
+
+    // The file written before the checkpoint must exist in the restore.
+    let restored_file = read_file(&mut sandboxes, "smoke2", "/tmp/smoke.bin").await?;
+    if restored_file.len() != 1024 * 1024 {
+        bail!(
+            "restored sandbox lost the pre-checkpoint file ({} bytes)",
+            restored_file.len()
+        );
+    }
+
+    // -- Teardown -----------------------------------------------------------
+    let teardown_started = Instant::now();
+    sandboxes
+        .stop(with_machine(StopSandboxRequest {
+            id: "smoke1".into(),
+            timeout_seconds: 20,
+        }))
+        .await
+        .context("Stop failed")?;
+    for id in ["smoke1", "smoke2"] {
+        sandboxes
+            .remove(with_machine(RemoveSandboxRequest {
+                id: id.into(),
+                force: true,
+            }))
+            .await
+            .with_context(|| format!("Remove {id} failed"))?;
+    }
+    let remaining = sandboxes
+        .list(with_machine(ListSandboxesRequest::default()))
+        .await
+        .context("List failed")?
+        .into_inner();
+    if !remaining.sandboxes.is_empty() {
+        bail!(
+            "{} sandboxes left after teardown",
+            remaining.sandboxes.len()
+        );
+    }
+    metrics.record("sandbox_teardown", teardown_started.elapsed().as_secs_f64());
+
+    info!("sandbox smoke passed");
+    Ok(())
+}
+
+async fn inspect(
+    client: &mut SandboxServiceClient<Channel>,
+    id: &str,
+) -> Result<arcbox_protocol::sandbox_v1::SandboxInfo> {
+    Ok(client
+        .inspect(with_machine(InspectSandboxRequest { id: id.into() }))
+        .await
+        .context("Inspect failed")?
+        .into_inner())
+}
+
+/// Polls Inspect until the sandbox reaches `state`, failing fast on
+/// `failed` with the daemon-reported error.
+async fn wait_for_state(
+    client: &mut SandboxServiceClient<Channel>,
+    id: &str,
+    state: &str,
+    timeout: Duration,
+) -> Result<()> {
+    let deadline = Instant::now() + timeout;
+    loop {
+        let info = inspect(client, id).await?;
+        if info.state == state {
+            return Ok(());
+        }
+        if info.state == "failed" {
+            bail!("sandbox {id} failed: {}", info.error);
+        }
+        if Instant::now() > deadline {
+            bail!(
+                "sandbox {id} did not reach {state} within {timeout:?} (state: {})",
+                info.state
+            );
+        }
+        tokio::time::sleep(Duration::from_millis(500)).await;
+    }
+}
+
+/// Runs a command and returns concatenated stdout, asserting exit code 0.
+async fn run_and_collect(
+    client: &mut SandboxServiceClient<Channel>,
+    id: &str,
+    cmd: &[&str],
+) -> Result<String> {
+    let mut stream = client
+        .run(with_machine(RunRequest {
+            id: id.into(),
+            cmd: cmd.iter().map(|s| (*s).to_owned()).collect(),
+            ..Default::default()
+        }))
+        .await
+        .context("Run failed")?
+        .into_inner();
+
+    let mut stdout = String::new();
+    let mut exit_code = None;
+    while let Some(output) = stream.message().await.context("run stream error")? {
+        if output.stream == "stdout" {
+            stdout.push_str(&String::from_utf8_lossy(&output.data));
+        }
+        if output.done {
+            exit_code = Some(output.exit_code);
+            break;
+        }
+    }
+    match exit_code {
+        Some(0) => Ok(stdout),
+        Some(code) => bail!("command {cmd:?} exited with {code}: {stdout:?}"),
+        None => bail!("run stream ended without a done frame"),
+    }
+}
+
+async fn write_file(
+    client: &mut SandboxServiceClient<Channel>,
+    id: &str,
+    path: &str,
+    data: &[u8],
+) -> Result<()> {
+    let mut messages = vec![WriteFileRequest {
+        payload: Some(write_file_request::Payload::Open(WriteFileOpen {
+            id: id.into(),
+            path: path.into(),
+            mode: 0o644,
+        })),
+    }];
+    for chunk in data.chunks(256 * 1024) {
+        messages.push(WriteFileRequest {
+            payload: Some(write_file_request::Payload::Chunk(FileChunk {
+                data: chunk.to_vec(),
+                done: false,
+            })),
+        });
+    }
+    messages.push(WriteFileRequest {
+        payload: Some(write_file_request::Payload::Chunk(FileChunk {
+            data: Vec::new(),
+            done: true,
+        })),
+    });
+
+    client
+        .write_file(with_machine(tokio_stream::iter(messages)))
+        .await
+        .context("WriteFile failed")?;
+    Ok(())
+}
+
+async fn read_file(
+    client: &mut SandboxServiceClient<Channel>,
+    id: &str,
+    path: &str,
+) -> Result<Vec<u8>> {
+    let mut stream = client
+        .read_file(with_machine(ReadFileRequest {
+            id: id.into(),
+            path: path.into(),
+        }))
+        .await
+        .context("ReadFile failed")?
+        .into_inner();
+    let mut data = Vec::new();
+    while let Some(chunk) = stream.message().await.context("read stream error")? {
+        data.extend_from_slice(&chunk.data);
+        if chunk.done {
+            break;
+        }
+    }
+    Ok(data)
+}

--- a/tests/e2e/src/sandbox.rs
+++ b/tests/e2e/src/sandbox.rs
@@ -260,18 +260,32 @@ async fn drive_sandboxes(channel: Channel, metrics: &mut RunMetrics) -> Result<(
     );
     info!(%snapshot_id, "checkpoint taken");
 
+    // Stop the origin before restoring: with `network_override: false` the
+    // restored sandbox reuses the recorded NIC (the origin's TAP), so the
+    // origin must release it first. Fresh-network restore (a new TAP while
+    // the origin keeps running) relies on FC's `network_overrides`
+    // snapshot-load field, which the pinned Firecracker 1.10.1 predates —
+    // see docs/sandbox-api.md.
     let restore_started = Instant::now();
+    sandboxes
+        .stop(with_machine(StopSandboxRequest {
+            id: "smoke1".into(),
+            timeout_seconds: 20,
+        }))
+        .await
+        .context("Stop origin before restore failed")?;
+
     let restored = snapshots
         .restore(with_machine(RestoreRequest {
             id: "smoke2".into(),
             snapshot_id: snapshot_id.clone(),
-            network_override: true,
+            network_override: false,
             ..Default::default()
         }))
         .await
         .context("Restore failed")?
         .into_inner();
-    info!(id = %restored.id, ip = %restored.ip_address, "sandbox restored");
+    info!(id = %restored.id, "sandbox restored");
     let stdout = run_and_collect(&mut sandboxes, "smoke2", &["/bin/echo", "hello-restore"]).await?;
     if !stdout.contains("hello-restore") {
         bail!("restored sandbox run output missing marker: {stdout:?}");
@@ -289,13 +303,6 @@ async fn drive_sandboxes(channel: Channel, metrics: &mut RunMetrics) -> Result<(
 
     // -- Teardown -----------------------------------------------------------
     let teardown_started = Instant::now();
-    sandboxes
-        .stop(with_machine(StopSandboxRequest {
-            id: "smoke1".into(),
-            timeout_seconds: 20,
-        }))
-        .await
-        .context("Stop failed")?;
     for id in ["smoke1", "smoke2"] {
         sandboxes
             .remove(with_machine(RemoveSandboxRequest {

--- a/tests/e2e/src/sandbox.rs
+++ b/tests/e2e/src/sandbox.rs
@@ -57,7 +57,11 @@ pub fn build_binaries() -> Result<()> {
     info!("building release binaries + musl guest agents");
     let shell = xshell::Shell::new()?;
     shell.change_dir(repo_root());
-    xshell::cmd!(shell, "cargo build --release -p arcbox-cli -p arcbox-daemon").run()?;
+    xshell::cmd!(
+        shell,
+        "cargo build --release -p arcbox-cli -p arcbox-daemon"
+    )
+    .run()?;
     xshell::cmd!(
         shell,
         "cargo build --release -p arcbox-agent -p arcbox-vm --bins --target aarch64-unknown-linux-musl"
@@ -155,9 +159,10 @@ fn run_scenario(
 /// Attach the default `x-machine` routing header.
 fn with_machine<T>(msg: T) -> tonic::Request<T> {
     let mut request = tonic::Request::new(msg);
-    request
-        .metadata_mut()
-        .insert("x-machine", tonic::metadata::MetadataValue::from_static("default"));
+    request.metadata_mut().insert(
+        "x-machine",
+        tonic::metadata::MetadataValue::from_static("default"),
+    );
     request
 }
 
@@ -215,8 +220,7 @@ async fn drive_sandboxes(channel: Channel, metrics: &mut RunMetrics) -> Result<(
 
     // -- Run ----------------------------------------------------------------
     let run_started = Instant::now();
-    let stdout =
-        run_and_collect(&mut sandboxes, "smoke1", &["/bin/echo", "hello-sandbox"]).await?;
+    let stdout = run_and_collect(&mut sandboxes, "smoke1", &["/bin/echo", "hello-sandbox"]).await?;
     if !stdout.contains("hello-sandbox") {
         bail!("run output missing marker: {stdout:?}");
     }
@@ -268,8 +272,7 @@ async fn drive_sandboxes(channel: Channel, metrics: &mut RunMetrics) -> Result<(
         .context("Restore failed")?
         .into_inner();
     info!(id = %restored.id, ip = %restored.ip_address, "sandbox restored");
-    let stdout =
-        run_and_collect(&mut sandboxes, "smoke2", &["/bin/echo", "hello-restore"]).await?;
+    let stdout = run_and_collect(&mut sandboxes, "smoke2", &["/bin/echo", "hello-restore"]).await?;
     if !stdout.contains("hello-restore") {
         bail!("restored sandbox run output missing marker: {stdout:?}");
     }

--- a/tests/e2e/tests/sandbox.rs
+++ b/tests/e2e/tests/sandbox.rs
@@ -1,0 +1,24 @@
+//! Sandbox smoke test: full stack over the real gRPC surface.
+//!
+//! Requires nested virtualization (VZ backend, Apple Silicon M3+ with
+//! macOS 15+), staged boot assets, and a signable daemon binary. Run:
+//!
+//! ```console
+//! cargo test -p arcbox-e2e --test sandbox -- --ignored --nocapture
+//! ```
+
+use arcbox_e2e::sandbox::{SandboxSmokeConfig, run};
+
+#[test]
+#[ignore = "requires nested virtualization (VZ on M3+), boot assets, and a signed daemon"]
+fn sandbox_smoke() {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info")),
+        )
+        .with_test_writer()
+        .init();
+
+    run(SandboxSmokeConfig::from_env()).expect("sandbox smoke failed");
+}

--- a/virt/arcbox-vm/Cargo.toml
+++ b/virt/arcbox-vm/Cargo.toml
@@ -8,7 +8,7 @@ repository.workspace = true
 description       = "Guest-side Firecracker sandbox manager (frozen; see arcbox-vmm for host VMM)."
 
 [[bin]]
-name = "vmm-guest-agent"
+name = "vm-agent"
 path = "src/bin/vm-agent.rs"
 
 [dependencies]

--- a/virt/arcbox-vm/README.md
+++ b/virt/arcbox-vm/README.md
@@ -47,7 +47,7 @@ Exposes a `SandboxManager` API and optional gRPC service implementations
 
 | Crate | Type | Purpose |
 |-------|------|---------|
-| `arcbox-vm` | lib + bin | Sandbox orchestration, state, networking, snapshots; gRPC service implementations; ships the `vmm-guest-agent` binary |
+| `arcbox-vm` | lib + bin | Sandbox orchestration, state, networking, snapshots; gRPC service implementations; ships the `vm-agent` binary |
 
 There is no standalone daemon or CLI binary. The gRPC server and direct API usage are demonstrated via the examples described below.
 
@@ -439,8 +439,8 @@ and toolchain, then build:
 rustup target add x86_64-unknown-linux-musl
 brew install FiloSottile/musl-cross/musl-cross   # macOS
 
-cargo build -p arcbox-vm --bin vmm-guest-agent --target x86_64-unknown-linux-musl --release
-# output: target/x86_64-unknown-linux-musl/release/vmm-guest-agent
+cargo build -p arcbox-vm --bin vm-agent --target x86_64-unknown-linux-musl --release
+# output: target/x86_64-unknown-linux-musl/release/vm-agent
 ```
 
 ### Test

--- a/virt/arcbox-vm/src/bin/vm-agent.rs
+++ b/virt/arcbox-vm/src/bin/vm-agent.rs
@@ -87,8 +87,8 @@ mod agent {
         env: HashMap<String, String>,
         #[serde(default)]
         working_dir: String,
-        #[serde(default, rename = "user")]
-        _user: String,
+        #[serde(default)]
+        user: String,
         #[serde(default)]
         tty: bool,
         #[serde(default = "default_tty_width")]
@@ -405,14 +405,42 @@ mod agent {
     // Non-interactive execution (piped stdio)
     // -------------------------------------------------------------------------
 
-    fn handle_piped(conn: VsockStream, start: StartCommand) {
+    /// Resolve `StartCommand.user` against the rootfs passwd/group files.
+    fn resolve_start_user(
+        user: &str,
+    ) -> Result<Option<arcbox_vm::user_spec::ResolvedUser>, String> {
+        let passwd = std::fs::read_to_string("/etc/passwd").unwrap_or_default();
+        let group = std::fs::read_to_string("/etc/group").unwrap_or_default();
+        arcbox_vm::user_spec::resolve_user(user, &passwd, &group)
+    }
+
+    /// Report a start failure to the host as a stderr chunk plus an exit
+    /// frame, so clients see the reason instead of a bare stream EOF.
+    fn report_start_failure(conn: &mut VsockStream, exit_code: i32, message: &str) {
+        let _ = write_frame(conn, MSG_STDERR, message.as_bytes());
+        let _ = write_frame(conn, MSG_EXIT, &exit_code.to_le_bytes());
+    }
+
+    fn handle_piped(mut conn: VsockStream, start: StartCommand) {
+        use std::os::unix::process::CommandExt;
         use std::process::{Command, Stdio};
+
+        let user = match resolve_start_user(&start.user) {
+            Ok(u) => u,
+            Err(msg) => {
+                report_start_failure(&mut conn, 126, &msg);
+                return;
+            }
+        };
 
         let mut cmd = Command::new(start.cmd.first().expect("empty cmd"));
         cmd.args(start.cmd.get(1..).unwrap_or(&[]));
         cmd.envs(&start.env);
         if !start.working_dir.is_empty() {
             cmd.current_dir(&start.working_dir);
+        }
+        if let Some(u) = user {
+            cmd.uid(u.uid).gid(u.gid);
         }
         cmd.stdin(Stdio::piped())
             .stdout(Stdio::piped())
@@ -422,6 +450,7 @@ mod agent {
             Ok(c) => c,
             Err(e) => {
                 eprintln!("agent: spawn {:?}: {e}", start.cmd);
+                report_start_failure(&mut conn, 127, &format!("spawn {:?}: {e}", start.cmd));
                 return;
             }
         };
@@ -514,15 +543,25 @@ mod agent {
     // Interactive execution (pseudo-TTY)
     // -------------------------------------------------------------------------
 
-    fn handle_tty(conn: VsockStream, start: StartCommand) {
+    fn handle_tty(mut conn: VsockStream, start: StartCommand) {
         use nix::pty::OpenptyResult;
         use nix::unistd::{ForkResult, fork, setsid};
         use std::os::unix::io::{AsRawFd, FromRawFd, IntoRawFd};
+
+        // Resolve the user before forking so failures are reportable.
+        let user = match resolve_start_user(&start.user) {
+            Ok(u) => u,
+            Err(msg) => {
+                report_start_failure(&mut conn, 126, &msg);
+                return;
+            }
+        };
 
         let OpenptyResult { master, slave } = match nix::pty::openpty(None, None) {
             Ok(r) => r,
             Err(e) => {
                 eprintln!("agent: openpty: {e}");
+                report_start_failure(&mut conn, 126, &format!("openpty: {e}"));
                 return;
             }
         };
@@ -587,6 +626,23 @@ mod agent {
                 {
                     // SAFETY: cwd is a valid C string.
                     unsafe { libc::chdir(cwd.as_ptr()) };
+                }
+
+                if let Some(u) = user {
+                    // Drop privileges: supplementary groups, then gid, then
+                    // uid — the reverse order would lose the right to setgid.
+                    let gid = u.gid as libc::gid_t;
+                    // SAFETY: plain syscalls on the just-forked child; on any
+                    // failure we abort the exec with 126 rather than run the
+                    // workload with the wrong identity.
+                    unsafe {
+                        if libc::setgroups(1, &gid) != 0
+                            || libc::setgid(gid) != 0
+                            || libc::setuid(u.uid as libc::uid_t) != 0
+                        {
+                            libc::_exit(126);
+                        }
+                    }
                 }
 
                 // SAFETY: exec replaces the process image; argv is null-terminated.

--- a/virt/arcbox-vm/src/bin/vm-agent.rs
+++ b/virt/arcbox-vm/src/bin/vm-agent.rs
@@ -507,8 +507,28 @@ mod agent {
         if !start.working_dir.is_empty() {
             cmd.current_dir(&start.working_dir);
         }
-        if let Some(u) = user {
-            cmd.uid(u.uid).gid(u.gid);
+        // Run in a fresh session/process group and drop privileges in pre_exec,
+        // mirroring handle_tty: setsid so a timeout/disconnect kill can target
+        // the whole process group (descendants included), then supplementary
+        // groups → gid → uid, fail-closed. std's .uid()/.gid() skip setgroups,
+        // leaving the workload with root's supplementary group list.
+        let creds = user.map(|u| (u.uid as libc::uid_t, u.gid as libc::gid_t));
+        // SAFETY: the closure runs in the forked child before exec and calls
+        // only async-signal-safe syscalls.
+        unsafe {
+            cmd.pre_exec(move || {
+                if libc::setsid() < 0 {
+                    return Err(std::io::Error::last_os_error());
+                }
+                if let Some((uid, gid)) = creds
+                    && (libc::setgroups(1, &raw const gid) != 0
+                        || libc::setgid(gid) != 0
+                        || libc::setuid(uid) != 0)
+                {
+                    return Err(std::io::Error::last_os_error());
+                }
+                Ok(())
+            });
         }
         cmd.stdin(Stdio::piped())
             .stdout(Stdio::piped())
@@ -624,13 +644,18 @@ mod agent {
         });
     }
 
-    /// SIGKILL `pid` only if a signal-0 probe shows it is still alive, to avoid
-    /// killing a recycled pid. The reaper collects the terminated child.
+    /// SIGKILL the workload's process group if its leader is still alive.
+    ///
+    /// Both exec paths `setsid` the child, so its pgid equals its pid; killing
+    /// the group (`-pid`) takes down descendants a plain child-pid SIGKILL would
+    /// orphan. The signal-0 probe on the leader avoids killing a recycled pid.
+    /// The reaper collects the terminated children.
     fn kill_if_alive(pid: libc::pid_t) {
-        // SAFETY: kill with a valid pid; signal 0 only probes for existence.
+        // SAFETY: kill with a valid pid; signal 0 only probes for existence,
+        // and a negative pid targets the process group led by `pid`.
         unsafe {
             if libc::kill(pid, 0) == 0 {
-                let _ = libc::kill(pid, libc::SIGKILL);
+                let _ = libc::kill(-pid, libc::SIGKILL);
             }
         }
     }

--- a/virt/arcbox-vm/src/bin/vm-agent.rs
+++ b/virt/arcbox-vm/src/bin/vm-agent.rs
@@ -39,7 +39,7 @@ mod agent {
     use std::io::{Read, Write};
     use std::os::unix::io::RawFd;
     use std::sync::atomic::{AtomicUsize, Ordering};
-    use std::sync::{Arc, Mutex};
+    use std::sync::{Arc, Mutex, OnceLock, mpsc};
     use std::thread;
 
     use serde::Deserialize;
@@ -421,6 +421,70 @@ mod agent {
         let _ = write_frame(conn, MSG_EXIT, &exit_code.to_le_bytes());
     }
 
+    // -------------------------------------------------------------------------
+    // Child reaping (this agent is guest PID 1)
+    // -------------------------------------------------------------------------
+
+    /// Registry of workload children awaiting their exit status, keyed by pid.
+    ///
+    /// `vm-agent` runs as init, so every process in the guest is (eventually)
+    /// its child, including grandchildren reparented by double-forking daemons.
+    /// A single reaper thread owns *all* `waitpid` calls: workloads that exit
+    /// have their status routed back to the waiting handler via the registered
+    /// sender; reparented orphans are simply reaped and dropped. Handlers must
+    /// therefore never call `waitpid`/`Child::wait` themselves — that would race
+    /// the reaper and either lose an exit code or double-reap.
+    fn reap_registry() -> &'static Mutex<HashMap<libc::pid_t, mpsc::Sender<i32>>> {
+        static REGISTRY: OnceLock<Mutex<HashMap<libc::pid_t, mpsc::Sender<i32>>>> = OnceLock::new();
+        REGISTRY.get_or_init(|| Mutex::new(HashMap::new()))
+    }
+
+    /// Narrow a `std::process::Child::id()` (u32) to a `pid_t`. Linux pids are
+    /// bounded well below `i32::MAX`, so this never wraps.
+    #[allow(clippy::cast_possible_wrap, reason = "pids fit in pid_t")]
+    fn as_pid(id: u32) -> libc::pid_t {
+        id as libc::pid_t
+    }
+
+    /// Map a raw `wait` status to an exit code (128 + signal when killed).
+    fn wait_status_to_code(status: libc::c_int) -> Option<i32> {
+        if libc::WIFEXITED(status) {
+            Some(libc::WEXITSTATUS(status))
+        } else if libc::WIFSIGNALED(status) {
+            Some(128 + libc::WTERMSIG(status))
+        } else {
+            None // stopped / continued — not a termination
+        }
+    }
+
+    /// Start the single reaper thread. Reaps every child; routes the exit code
+    /// of registered workloads to their handler and discards orphan statuses.
+    fn start_reaper() {
+        thread::spawn(|| {
+            loop {
+                let mut status: libc::c_int = 0;
+                // SAFETY: waitpid with a valid status pointer; -1 waits on any child.
+                let pid = unsafe { libc::waitpid(-1, &raw mut status, 0) };
+                if pid <= 0 {
+                    // ECHILD (no children yet) or EINTR — back off briefly so we
+                    // don't spin while the guest is idle.
+                    thread::sleep(std::time::Duration::from_millis(50));
+                    continue;
+                }
+                let Some(code) = wait_status_to_code(status) else {
+                    continue;
+                };
+                // Drop the registry lock before sending so a handler's recv
+                // never contends with it.
+                let waiter = reap_registry().lock().unwrap().remove(&pid);
+                if let Some(tx) = waiter {
+                    let _ = tx.send(code);
+                }
+                // Otherwise a reparented orphan: reaped above, nothing to route.
+            }
+        });
+    }
+
     fn handle_piped(mut conn: VsockStream, start: StartCommand) {
         use std::os::unix::process::CommandExt;
         use std::process::{Command, Stdio};
@@ -433,7 +497,11 @@ mod agent {
             }
         };
 
-        let mut cmd = Command::new(start.cmd.first().expect("empty cmd"));
+        let Some(program) = start.cmd.first() else {
+            report_start_failure(&mut conn, 127, "empty command");
+            return;
+        };
+        let mut cmd = Command::new(program);
         cmd.args(start.cmd.get(1..).unwrap_or(&[]));
         cmd.envs(&start.env);
         if !start.working_dir.is_empty() {
@@ -446,14 +514,26 @@ mod agent {
             .stdout(Stdio::piped())
             .stderr(Stdio::piped());
 
-        let mut child = match cmd.spawn() {
-            Ok(c) => c,
-            Err(e) => {
-                eprintln!("agent: spawn {:?}: {e}", start.cmd);
-                report_start_failure(&mut conn, 127, &format!("spawn {:?}: {e}", start.cmd));
-                return;
+        // Spawn and register for reaping under one lock: if the child exits
+        // immediately, the reaper blocks on the registry lock until the insert
+        // below completes, so its exit code is never lost as an "orphan".
+        let (exit_tx, exit_rx) = mpsc::channel::<i32>();
+        let mut child = {
+            let mut registry = reap_registry().lock().unwrap();
+            match cmd.spawn() {
+                Ok(c) => {
+                    registry.insert(as_pid(c.id()), exit_tx);
+                    c
+                }
+                Err(e) => {
+                    drop(registry);
+                    eprintln!("agent: spawn {:?}: {e}", start.cmd);
+                    report_start_failure(&mut conn, 127, &format!("spawn {:?}: {e}", start.cmd));
+                    return;
+                }
             }
         };
+        let child_pid = as_pid(child.id());
 
         let mut child_stdin = child.stdin.take().unwrap();
         let child_stdout = child.stdout.take().unwrap();
@@ -491,29 +571,14 @@ mod agent {
         });
 
         if start.timeout_seconds > 0 {
-            let pid = child.id();
-            let timeout = start.timeout_seconds;
-            thread::spawn(move || {
-                // Sleep for the configured timeout, then check if the process still exists
-                // before attempting to send SIGKILL. This reduces the risk of killing a
-                // different process if the PID has been recycled.
-                thread::sleep(std::time::Duration::from_secs(timeout as u64));
-                unsafe {
-                    // Probe the process with signal 0. If this fails with ESRCH, the PID
-                    // is not currently in use and we must not send SIGKILL.
-                    #[allow(clippy::cast_possible_wrap)]
-                    let pid_i32 = pid as i32;
-                    if libc::kill(pid_i32, 0) == 0 {
-                        let _ = libc::kill(pid_i32, libc::SIGKILL);
-                    }
-                }
-            });
+            spawn_timeout_killer(child_pid, start.timeout_seconds);
         }
 
         // Read stdin frames from the host and forward to the child.
         // SAFETY: dup gives us a second fd for reading while the Arc owns the write fd.
         let read_fd = unsafe { libc::dup(writer.lock().unwrap().fd) };
         let mut reader = unsafe { VsockStream::from_raw_fd(read_fd) };
+        let mut host_disconnected = false;
         loop {
             match read_frame(&mut reader) {
                 Ok((MSG_STDIN, data)) => {
@@ -521,22 +586,53 @@ mod agent {
                         break;
                     }
                 }
-                Ok((MSG_EOF, _)) | Err(_) => {
+                Ok((MSG_EOF, _)) => {
+                    // Clean stdin EOF: stop forwarding but let the process run to
+                    // completion (its output still flows back).
                     drop(child_stdin);
+                    break;
+                }
+                Err(_) => {
+                    // Host connection gone: don't leave the workload running
+                    // headless — kill it and let the reaper collect it.
+                    host_disconnected = true;
                     break;
                 }
                 Ok(_) => {}
             }
         }
+        if host_disconnected {
+            kill_if_alive(child_pid);
+        }
 
         let _ = t_stdout.join();
         let _ = t_stderr.join();
-        let exit_code = child.wait().map_or(-1, |s| s.code().unwrap_or(-1));
+        // The reaper owns waitpid; block on the routed exit code.
+        let exit_code = exit_rx.recv().unwrap_or(-1);
         let _ = write_frame(
             &mut *writer.lock().unwrap(),
             MSG_EXIT,
             &exit_code.to_le_bytes(),
         );
+    }
+
+    /// SIGKILL `pid` after `timeout_seconds`, if it is still alive.
+    fn spawn_timeout_killer(pid: libc::pid_t, timeout_seconds: u32) {
+        thread::spawn(move || {
+            thread::sleep(std::time::Duration::from_secs(u64::from(timeout_seconds)));
+            kill_if_alive(pid);
+        });
+    }
+
+    /// SIGKILL `pid` only if a signal-0 probe shows it is still alive, to avoid
+    /// killing a recycled pid. The reaper collects the terminated child.
+    fn kill_if_alive(pid: libc::pid_t) {
+        // SAFETY: kill with a valid pid; signal 0 only probes for existence.
+        unsafe {
+            if libc::kill(pid, 0) == 0 {
+                let _ = libc::kill(pid, libc::SIGKILL);
+            }
+        }
     }
 
     // -------------------------------------------------------------------------
@@ -581,14 +677,22 @@ mod agent {
         let master_fd: RawFd = master.into_raw_fd();
         let slave_fd: RawFd = slave.as_raw_fd();
 
+        // Hold the reap registry lock across fork + register so the single
+        // reaper thread can't route (and discard) the child's exit status
+        // before it is registered below.
+        let (exit_tx, exit_rx) = mpsc::channel::<i32>();
+        let mut registry = reap_registry().lock().unwrap();
         match unsafe { fork() } {
             Err(e) => {
+                drop(registry);
                 // SAFETY: fork failed; close the unowned master fd to prevent leak.
                 unsafe { libc::close(master_fd) };
                 eprintln!("agent: fork: {e}");
             }
 
             Ok(ForkResult::Child) => {
+                // The child never touches `registry` (a COW guard copy); it
+                // execs or _exits below.
                 // SAFETY: close the inherited master fd in the child process.
                 unsafe { libc::close(master_fd) };
                 let _ = setsid();
@@ -651,6 +755,14 @@ mod agent {
             }
 
             Ok(ForkResult::Parent { child }) => {
+                let child_pid = child.as_raw();
+                registry.insert(child_pid, exit_tx);
+                drop(registry); // release before the (long-lived) session loop
+
+                if start.timeout_seconds > 0 {
+                    spawn_timeout_killer(child_pid, start.timeout_seconds);
+                }
+
                 drop(slave);
                 let writer: Arc<Mutex<VsockStream>> = Arc::new(Mutex::new(conn));
 
@@ -693,21 +805,21 @@ mod agent {
                             // SAFETY: master_fd is valid.
                             unsafe { libc::ioctl(master_fd, libc::TIOCSWINSZ, &winsize) };
                         }
-                        Ok((MSG_EOF, _)) | Err(_) => break,
+                        Ok((MSG_EOF, _)) => break,
+                        Err(_) => {
+                            // Host gone: kill the session's process group leader
+                            // rather than leave the interactive shell running.
+                            kill_if_alive(child_pid);
+                            break;
+                        }
                         Ok(_) => {}
                     }
                 }
 
                 let _ = t_pty.join();
 
-                let mut status: libc::c_int = 0;
-                // SAFETY: child.as_raw() is a valid pid returned from fork.
-                unsafe { libc::waitpid(child.as_raw(), &raw mut status, 0) };
-                let exit_code = if libc::WIFEXITED(status) {
-                    libc::WEXITSTATUS(status)
-                } else {
-                    -1
-                };
+                // The reaper owns waitpid; block on the routed exit code.
+                let exit_code = exit_rx.recv().unwrap_or(-1);
                 let _ = write_frame(
                     &mut *writer.lock().unwrap(),
                     MSG_EXIT,
@@ -853,6 +965,9 @@ mod agent {
     pub fn run() {
         mount_filesystems();
         setup_dns();
+        // This process is guest PID 1: start the reaper so exiting workloads and
+        // reparented double-fork orphans are collected instead of zombifying.
+        start_reaper();
         eprintln!("vm-agent: listening on vsock ports {AGENT_PORT} (exec), {FILE_PORT} (file I/O)");
         let exec_fd = create_vsock_listener(AGENT_PORT);
         let file_fd = create_vsock_listener(FILE_PORT);
@@ -923,6 +1038,32 @@ mod agent {
             assert!(
                 err.kind() == std::io::ErrorKind::Interrupted,
                 "accept: {err}"
+            );
+        }
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+
+        #[test]
+        fn normal_exit_decodes_to_its_code() {
+            // Linux wait status encodes a normal exit as `code << 8`.
+            assert_eq!(wait_status_to_code(0), Some(0));
+            assert_eq!(wait_status_to_code(42 << 8), Some(42));
+            assert_eq!(wait_status_to_code(127 << 8), Some(127));
+        }
+
+        #[test]
+        fn signal_death_maps_to_128_plus_signal() {
+            // A process killed by signal N has N in the low 7 status bits.
+            assert_eq!(
+                wait_status_to_code(libc::SIGKILL),
+                Some(128 + libc::SIGKILL)
+            );
+            assert_eq!(
+                wait_status_to_code(libc::SIGTERM),
+                Some(128 + libc::SIGTERM)
             );
         }
     }

--- a/virt/arcbox-vm/src/bin/vm-agent.rs
+++ b/virt/arcbox-vm/src/bin/vm-agent.rs
@@ -636,7 +636,7 @@ mod agent {
                     // failure we abort the exec with 126 rather than run the
                     // workload with the wrong identity.
                     unsafe {
-                        if libc::setgroups(1, &gid) != 0
+                        if libc::setgroups(1, &raw const gid) != 0
                             || libc::setgid(gid) != 0
                             || libc::setuid(u.uid as libc::uid_t) != 0
                         {

--- a/virt/arcbox-vm/src/bin/vm-agent.rs
+++ b/virt/arcbox-vm/src/bin/vm-agent.rs
@@ -1,4 +1,4 @@
-//! `vmm-guest-agent` — in-VM daemon that accepts exec/run sessions over vsock.
+//! `vm-agent` — in-VM daemon that accepts exec/run sessions over vsock.
 //!
 //! The agent listens on AF_VSOCK port 52.  For each connection it:
 //!
@@ -738,13 +738,13 @@ mod agent {
     /// sandboxes or custom rootfs with their own resolver config).
     fn setup_dns() {
         let Some(token) = cmdline_token("ip=") else {
-            eprintln!("vmm-guest-agent: no ip= parameter in cmdline, skipping DNS setup");
+            eprintln!("vm-agent: no ip= parameter in cmdline, skipping DNS setup");
             return;
         };
         let ip_param = match token.parse::<KernelIpParam>() {
             Ok(p) => p,
             Err(e) => {
-                eprintln!("vmm-guest-agent: invalid ip= parameter: {e}");
+                eprintln!("vm-agent: invalid ip= parameter: {e}");
                 return;
             }
         };
@@ -752,10 +752,10 @@ mod agent {
         let content = format!("nameserver {}\n", ip_param.gateway);
         match std::fs::write("/etc/resolv.conf", &content) {
             Ok(()) => eprintln!(
-                "vmm-guest-agent: wrote /etc/resolv.conf (nameserver {})",
+                "vm-agent: wrote /etc/resolv.conf (nameserver {})",
                 ip_param.gateway
             ),
-            Err(e) => eprintln!("vmm-guest-agent: failed to write /etc/resolv.conf: {e}"),
+            Err(e) => eprintln!("vm-agent: failed to write /etc/resolv.conf: {e}"),
         }
     }
 
@@ -797,9 +797,7 @@ mod agent {
     pub fn run() {
         mount_filesystems();
         setup_dns();
-        eprintln!(
-            "vmm-guest-agent: listening on vsock ports {AGENT_PORT} (exec), {FILE_PORT} (file I/O)"
-        );
+        eprintln!("vm-agent: listening on vsock ports {AGENT_PORT} (exec), {FILE_PORT} (file I/O)");
         let exec_fd = create_vsock_listener(AGENT_PORT);
         let file_fd = create_vsock_listener(FILE_PORT);
 
@@ -884,7 +882,7 @@ fn main() {
 
     #[cfg(not(target_os = "linux"))]
     {
-        eprintln!("vmm-guest-agent requires Linux (AF_VSOCK)");
+        eprintln!("vm-agent requires Linux (AF_VSOCK)");
         std::process::exit(1);
     }
 }

--- a/virt/arcbox-vm/src/boot_proto.rs
+++ b/virt/arcbox-vm/src/boot_proto.rs
@@ -1,5 +1,5 @@
 //! Boot protocol types shared between the host-side sandbox orchestrator
-//! and the guest-side `vmm-guest-agent`.
+//! and the guest-side `vm-agent`.
 //!
 //! These types define the contract passed through kernel boot parameters.
 //! Both sides import from this module so the encoding is defined once.
@@ -13,7 +13,7 @@ use std::str::FromStr;
 /// Format: `ip=<client>::<gateway>:<netmask>::eth0:off`
 ///
 /// Constructed by [`SandboxManager`](crate::SandboxManager) when building
-/// boot args, and parsed by `vmm-guest-agent` to derive the DNS nameserver
+/// boot args, and parsed by `vm-agent` to derive the DNS nameserver
 /// from the gateway.
 ///
 /// [`Display`] and [`FromStr`] round-trip through the same format so the

--- a/virt/arcbox-vm/src/lib.rs
+++ b/virt/arcbox-vm/src/lib.rs
@@ -39,6 +39,7 @@ pub mod snapshot;
 pub mod snapshot_cow;
 pub mod spawn;
 pub mod store;
+pub mod user_spec;
 pub mod vsock;
 
 // Keep the general VM manager available for internal tooling.

--- a/virt/arcbox-vm/src/sandbox.rs
+++ b/virt/arcbox-vm/src/sandbox.rs
@@ -58,6 +58,10 @@ pub struct SandboxManager {
     config: Arc<VmmConfig>,
     events_tx: broadcast::Sender<SandboxEvent>,
     cow_manager: Arc<CowManager>,
+    /// Flips to `true` once the startup orphan sweep has finished. Create and
+    /// restore gate on it so a re-created same-id sandbox can never race the
+    /// sweep (see [`SandboxManager::await_reconcile`]).
+    reconcile_done: tokio::sync::watch::Receiver<bool>,
 }
 
 impl SandboxManager {
@@ -84,16 +88,22 @@ impl SandboxManager {
         let config = Arc::new(config);
 
         // Sweep leftovers of a previous agent process (crash / respawn):
-        // orphaned Firecracker processes, TAPs, dm devices, chroots. Only
-        // meaningful inside a tokio runtime; sync constructions (unit tests)
-        // have no previous instance to reconcile.
+        // orphaned Firecracker processes, TAPs, dm devices, chroots. Create and
+        // restore wait for this to finish (await_reconcile) so a re-created
+        // same-id sandbox can't have its deterministically-named resources torn
+        // down mid-flight. Only meaningful inside a tokio runtime; sync
+        // constructions (unit tests) have no previous instance to reconcile.
+        let (reconcile_tx, reconcile_done) = tokio::sync::watch::channel(false);
         if tokio::runtime::Handle::try_current().is_ok() {
             let config = Arc::clone(&config);
             let network = Arc::clone(&network);
             let cow_manager = Arc::clone(&cow_manager);
             tokio::spawn(async move {
                 reconcile::sweep_orphans(&config, &network, &cow_manager).await;
+                let _ = reconcile_tx.send(true);
             });
+        } else {
+            let _ = reconcile_tx.send(true);
         }
 
         Ok(Self {
@@ -103,6 +113,123 @@ impl SandboxManager {
             config,
             events_tx,
             cow_manager,
+            reconcile_done,
         })
+    }
+
+    /// Wait until the startup orphan sweep has completed.
+    ///
+    /// The sweep tears down resources by deterministic per-id names
+    /// (`arcbox-snap-{id}`, the id's TAP, `arcbox-cow-{id}`) and adjusts the
+    /// shared template refcount. A create/restore that runs concurrently with
+    /// it — e.g. a client re-creating the same id right after an agent restart
+    /// — would have its live device destroyed or a live template detached.
+    /// Gating create/restore on the sweep removes that class entirely; it runs
+    /// once, so after completion this returns immediately.
+    pub(super) async fn await_reconcile(&self) {
+        let mut rx = self.reconcile_done.clone();
+        let _ = rx.wait_for(|&done| done).await;
+    }
+}
+
+/// Atomically reserve `id` in the instance map with a placeholder instance.
+///
+/// Create and restore both derive per-sandbox resources deterministically from
+/// the id (CoW file `arcbox-cow-{id}`, dm device `arcbox-snap-{id}`, TAP name).
+/// A check-then-insert with those resources set up in between is a TOCTOU: two
+/// concurrent restores to the same id both pass the check, then the second
+/// `create_sparse_file` truncates the file the first's loop device is backing,
+/// corrupting the winner's rootfs. Reserving the id up front (check + insert
+/// under one write lock) makes the loser fail fast with `AlreadyExists` before
+/// it touches any shared resource. The reservation is removed on drop unless
+/// [`IdReservation::commit`] is called, so every restore error path unwinds it.
+pub(super) fn reserve_id(
+    instances: &InstanceMap,
+    id: &SandboxId,
+    placeholder: SandboxInstance,
+) -> Result<IdReservation> {
+    let mut map = instances.write().unwrap();
+    if map.contains_key(id) {
+        return Err(VmmError::AlreadyExists(id.clone()));
+    }
+    map.insert(id.clone(), Arc::new(Mutex::new(placeholder)));
+    Ok(IdReservation {
+        instances: Arc::clone(instances),
+        id: id.clone(),
+        committed: false,
+    })
+}
+
+/// RAII reservation returned by [`reserve_id`]. Drops the placeholder from the
+/// instance map unless committed.
+pub(super) struct IdReservation {
+    instances: InstanceMap,
+    id: SandboxId,
+    committed: bool,
+}
+
+impl IdReservation {
+    /// The reserved instance `Arc`, for populating it in place on success.
+    pub(super) fn instance(&self) -> Arc<Mutex<SandboxInstance>> {
+        self.instances
+            .read()
+            .unwrap()
+            .get(&self.id)
+            .cloned()
+            .expect("reserved instance is present until commit/drop")
+    }
+
+    /// Keep the reservation: the instance is now fully initialized.
+    pub(super) fn commit(mut self) {
+        self.committed = true;
+    }
+}
+
+impl Drop for IdReservation {
+    fn drop(&mut self) {
+        if !self.committed {
+            self.instances.write().unwrap().remove(&self.id);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn placeholder(id: &str) -> SandboxInstance {
+        SandboxInstance::new(
+            id.to_owned(),
+            SandboxSpec::default(),
+            None,
+            PathBuf::from("/tmp/x"),
+        )
+    }
+
+    #[test]
+    fn reserve_id_rejects_a_concurrent_duplicate() {
+        let instances: InstanceMap = Arc::new(RwLock::new(HashMap::new()));
+        let first = reserve_id(&instances, &"dup".to_owned(), placeholder("dup")).unwrap();
+        // A second reservation of the same id must fail while the first is live.
+        assert!(matches!(
+            reserve_id(&instances, &"dup".to_owned(), placeholder("dup")),
+            Err(VmmError::AlreadyExists(_))
+        ));
+        first.commit();
+        assert!(instances.read().unwrap().contains_key("dup"));
+    }
+
+    #[test]
+    fn dropped_reservation_unwinds_the_placeholder() {
+        let instances: InstanceMap = Arc::new(RwLock::new(HashMap::new()));
+        {
+            let _r = reserve_id(&instances, &"tmp".to_owned(), placeholder("tmp")).unwrap();
+            assert!(instances.read().unwrap().contains_key("tmp"));
+            // no commit → dropped here
+        }
+        assert!(!instances.read().unwrap().contains_key("tmp"));
+        // The id is free to reserve again after an unwound restore.
+        let again = reserve_id(&instances, &"tmp".to_owned(), placeholder("tmp"));
+        assert!(again.is_ok());
     }
 }

--- a/virt/arcbox-vm/src/sandbox.rs
+++ b/virt/arcbox-vm/src/sandbox.rs
@@ -35,6 +35,7 @@ mod boot;
 mod checkpoint;
 mod cleanup;
 mod lifecycle;
+mod reconcile;
 mod types;
 mod workload;
 
@@ -45,6 +46,9 @@ pub use types::{
 };
 
 const EVENT_CHANNEL_CAPACITY: usize = 256;
+
+/// Shared registry of live sandbox instances.
+pub(crate) type InstanceMap = Arc<RwLock<HashMap<SandboxId, Arc<Mutex<SandboxInstance>>>>>;
 
 /// Manages the full lifecycle of multiple sandbox microVMs.
 pub struct SandboxManager {
@@ -77,11 +81,26 @@ impl SandboxManager {
             std::fs::create_dir_all(base).map_err(VmmError::Io)?;
         }
 
+        let config = Arc::new(config);
+
+        // Sweep leftovers of a previous agent process (crash / respawn):
+        // orphaned Firecracker processes, TAPs, dm devices, chroots. Only
+        // meaningful inside a tokio runtime; sync constructions (unit tests)
+        // have no previous instance to reconcile.
+        if tokio::runtime::Handle::try_current().is_ok() {
+            let config = Arc::clone(&config);
+            let network = Arc::clone(&network);
+            let cow_manager = Arc::clone(&cow_manager);
+            tokio::spawn(async move {
+                reconcile::sweep_orphans(&config, &network, &cow_manager).await;
+            });
+        }
+
         Ok(Self {
             instances: Arc::new(RwLock::new(HashMap::new())),
             network,
             snapshots,
-            config: Arc::new(config),
+            config,
             events_tx,
             cow_manager,
         })

--- a/virt/arcbox-vm/src/sandbox.rs
+++ b/virt/arcbox-vm/src/sandbox.rs
@@ -132,6 +132,27 @@ impl SandboxManager {
     }
 }
 
+/// Validate a caller-supplied sandbox or snapshot id.
+///
+/// Ids become filesystem path components, jailer `--id` values, and dm/TAP name
+/// fragments, so they are restricted to `[A-Za-z0-9_-]`. This rejects path
+/// traversal (`/`, `\`, `..`), NUL, whitespace, and anything the jailer would
+/// otherwise reject much later with an opaque boot failure.
+pub(super) fn validate_id(kind: &str, id: &str) -> Result<()> {
+    if id.is_empty() {
+        return Err(VmmError::Config(format!("{kind} must not be empty")));
+    }
+    if !id
+        .bytes()
+        .all(|b| b.is_ascii_alphanumeric() || b == b'-' || b == b'_')
+    {
+        return Err(VmmError::Config(format!(
+            "invalid {kind} {id:?}: only ASCII letters, digits, '-' and '_' are allowed"
+        )));
+    }
+    Ok(())
+}
+
 /// Atomically reserve `id` in the instance map with a placeholder instance.
 ///
 /// Create and restore both derive per-sandbox resources deterministically from
@@ -217,6 +238,19 @@ mod tests {
         ));
         first.commit();
         assert!(instances.read().unwrap().contains_key("dup"));
+    }
+
+    #[test]
+    fn validate_id_accepts_safe_ids_and_rejects_traversal() {
+        for ok in ["sandbox1", "a-b_c", "0f3e9d16-1234", "A_B-9"] {
+            assert!(validate_id("id", ok).is_ok(), "{ok} should be valid");
+        }
+        for bad in ["", "..", ".", "a/b", "a\\b", "a b", "a.b", "a\0b", "../etc"] {
+            assert!(
+                validate_id("id", bad).is_err(),
+                "{bad:?} should be rejected"
+            );
+        }
     }
 
     #[test]

--- a/virt/arcbox-vm/src/sandbox/boot.rs
+++ b/virt/arcbox-vm/src/sandbox/boot.rs
@@ -28,6 +28,22 @@ pub(super) async fn boot_sandbox(
         Ok((process, vm, vsock_uds_path, cow_handle)) => {
             let ready_at = Utc::now();
 
+            // Persist the crash-recovery record before handing resources to
+            // the instance, so an agent restart can reconcile them.
+            #[allow(
+                clippy::cast_possible_wrap,
+                reason = "Firecracker pid fits platform pid_t"
+            )]
+            let record = super::reconcile::SandboxStateRecord::new(
+                &id,
+                process.pid().map(|p| p as i32),
+                net_alloc.as_ref(),
+                cow_handle.as_ref(),
+                config.firecracker.jailer.is_some(),
+                None,
+            );
+            super::reconcile::write_state_record(&vm_dir, &record);
+
             let value = instances.read().unwrap().get(&id).cloned();
             if let Some(arc) = value {
                 let mut inst = arc.lock().unwrap();
@@ -81,7 +97,7 @@ async fn run_initial_cmd(
     id: &SandboxId,
     spec: SandboxSpec,
     vsock_uds_path: &Path,
-    instances: &Arc<RwLock<HashMap<SandboxId, Arc<Mutex<SandboxInstance>>>>>,
+    instances: &super::InstanceMap,
     events_tx: &broadcast::Sender<SandboxEvent>,
 ) {
     let start = StartCommand {

--- a/virt/arcbox-vm/src/sandbox/boot.rs
+++ b/virt/arcbox-vm/src/sandbox/boot.rs
@@ -38,13 +38,21 @@ pub(super) async fn boot_sandbox(
                 }
                 inst.process = Some(process);
                 inst.vm = Some(vm);
-                inst.vsock_uds_path = Some(vsock_uds_path);
+                inst.vsock_uds_path = Some(vsock_uds_path.clone());
                 inst.cow_handle = cow_handle;
                 inst.state = SandboxState::Ready;
                 inst.ready_at = Some(ready_at);
             }
             let _ = events_tx.send(SandboxEvent::new(&id, "ready"));
             info!(sandbox_id = %id, "sandbox booted and ready");
+
+            // Launch the initial workload, if the spec carries one. The
+            // sandbox stays alive when it exits (Running → Ready + "idle"),
+            // exactly like an explicit Run. A start failure is logged and
+            // leaves the sandbox Ready — the caller can still Run/Exec.
+            if !spec.cmd.is_empty() {
+                run_initial_cmd(&id, spec, &vsock_uds_path, &instances, &events_tx).await;
+            }
         }
         Err(e) => {
             let value = instances.read().unwrap().get(&id).cloned();
@@ -60,6 +68,40 @@ pub(super) async fn boot_sandbox(
             let _ =
                 events_tx.send(SandboxEvent::new(&id, "failed").with_attr("error", &e.to_string()));
             error!(sandbox_id = %id, error = %e, "sandbox boot failed");
+        }
+    }
+}
+
+/// Start the initial `cmd` from the creation spec and drain its output.
+///
+/// Uses the same workload path as `Run` (`start_run_workload`), so state
+/// transitions and events are identical; the output itself has no consumer
+/// and is discarded chunk by chunk to keep the exit handler flowing.
+async fn run_initial_cmd(
+    id: &SandboxId,
+    spec: SandboxSpec,
+    vsock_uds_path: &Path,
+    instances: &Arc<RwLock<HashMap<SandboxId, Arc<Mutex<SandboxInstance>>>>>,
+    events_tx: &broadcast::Sender<SandboxEvent>,
+) {
+    let start = StartCommand {
+        cmd: spec.cmd,
+        env: spec.env,
+        working_dir: spec.working_dir,
+        user: spec.user,
+        tty: false,
+        tty_width: 80,
+        tty_height: 24,
+        timeout_seconds: 0,
+    };
+    match super::workload::start_run_workload(id, vsock_uds_path, start, instances, events_tx).await
+    {
+        Ok(mut rx) => {
+            info!(sandbox_id = %id, "initial cmd started");
+            tokio::spawn(async move { while rx.recv().await.is_some() {} });
+        }
+        Err(e) => {
+            warn!(sandbox_id = %id, error = %e, "initial cmd failed to start; sandbox stays ready");
         }
     }
 }

--- a/virt/arcbox-vm/src/sandbox/boot.rs
+++ b/virt/arcbox-vm/src/sandbox/boot.rs
@@ -44,21 +44,44 @@ pub(super) async fn boot_sandbox(
             );
             super::reconcile::write_state_record(&vm_dir, &record);
 
-            let value = instances.read().unwrap().get(&id).cloned();
-            if let Some(arc) = value {
-                let mut inst = arc.lock().unwrap();
-                // If stop was requested while booting, do not transition to Ready.
-                if inst.state == SandboxState::Stopping || inst.state == SandboxState::Stopped {
-                    info!(sandbox_id = %id, "sandbox boot completed but stop was requested; staying stopped");
-                    return;
+            // Hand the booted resources to the instance while holding the map
+            // read guard, so a concurrent force-remove/TTL (which needs the
+            // write guard to drop the entry) cannot slip between the presence
+            // check and the handoff. If the instance is gone or already
+            // stopping, tear the resources down instead of dropping them — a
+            // dropped CowHandle leaks the dm device + loop + sparse COW file.
+            let mut process = Some(process);
+            let mut vm = Some(vm);
+            let mut cow_handle = cow_handle;
+            let accepted = {
+                let map = instances.read().unwrap();
+                match map.get(&id) {
+                    Some(arc) => {
+                        let mut inst = arc.lock().unwrap();
+                        if matches!(inst.state, SandboxState::Stopping | SandboxState::Stopped) {
+                            false
+                        } else {
+                            inst.process = process.take();
+                            inst.vm = vm.take();
+                            inst.vsock_uds_path = Some(vsock_uds_path.clone());
+                            inst.cow_handle = cow_handle.take();
+                            inst.state = SandboxState::Ready;
+                            inst.ready_at = Some(ready_at);
+                            true
+                        }
+                    }
+                    None => false,
                 }
-                inst.process = Some(process);
-                inst.vm = Some(vm);
-                inst.vsock_uds_path = Some(vsock_uds_path.clone());
-                inst.cow_handle = cow_handle;
-                inst.state = SandboxState::Ready;
-                inst.ready_at = Some(ready_at);
+            };
+
+            if !accepted {
+                info!(sandbox_id = %id, "sandbox removed/stopped during boot; tearing down booted resources");
+                if let Some(process) = process.take() {
+                    tear_down_orphaned_boot(process, cow_handle.take(), &cow_manager).await;
+                }
+                return;
             }
+
             let _ = events_tx.send(SandboxEvent::new(&id, "ready"));
             info!(sandbox_id = %id, "sandbox booted and ready");
 
@@ -291,6 +314,27 @@ pub(super) async fn kill_and_reap_fc(process: &mut fc_sdk::FirecrackerProcess) {
         );
     }
     let _ = tokio::time::timeout(std::time::Duration::from_secs(5), process.wait()).await;
+}
+
+/// Tear down the resources of a boot that finished after its sandbox was
+/// force-removed (or TTL-expired) mid-boot.
+///
+/// The instance entry is gone (or stopping), so these resources were never
+/// handed off. Without an explicit teardown the CoW dm device + loop + sparse
+/// COW file leak (`CowHandle` has no `Drop`) and Firecracker is left holding
+/// the block device. The TAP/IP and jailer chroot are owned by the racing
+/// remove/stop path and are intentionally not touched here.
+async fn tear_down_orphaned_boot(
+    mut process: fc_sdk::FirecrackerProcess,
+    cow_handle: Option<CowHandle>,
+    cow_manager: &CowManager,
+) {
+    // Kill + reap FC before the dm teardown so `dmsetup remove` doesn't hit
+    // EBUSY on the still-open block device.
+    kill_and_reap_fc(&mut process).await;
+    if let Some(handle) = cow_handle {
+        cow_manager.teardown(&handle).await;
+    }
 }
 
 /// Perform the actual Firecracker boot: spawn process, configure, start VM.

--- a/virt/arcbox-vm/src/sandbox/boot.rs
+++ b/virt/arcbox-vm/src/sandbox/boot.rs
@@ -241,19 +241,26 @@ pub(super) fn create_rootfs_symlink(vm_dir: &Path, dm_device: &str) -> Result<St
         .ok_or_else(|| VmmError::Config(format!("non-UTF-8 path: {}", link_path.display())))
 }
 
-/// Release dm-snapshot + recreated origin directory after a failed restore.
+/// Release the resources a partial restore has acquired: dm-snapshot CoW, the
+/// TAP/IP allocation, and the recreated origin directory.
 ///
-/// `CowHandle` has no Drop impl, so dropping it would leak the dm device,
-/// loop device, and sparse COW file.  This must be called on every error
-/// path between `cow_manager.setup` and the point where the handle is
-/// handed off to the SandboxInstance.
+/// None of these have a `Drop` that frees them (`CowHandle` and
+/// `NetworkAllocation` are plain records), so dropping them on a `?` would leak
+/// the dm device + loop + COW file and the TAP + IP. This must be called on
+/// every error path between resource acquisition and the point where they are
+/// handed off to the `SandboxInstance`.
 pub(super) async fn cleanup_pending_restore(
     cow_manager: &CowManager,
+    network: &NetworkManager,
     cow: Option<CowHandle>,
+    net_alloc: Option<&NetworkAllocation>,
     origin_dir: Option<&Path>,
 ) {
     if let Some(handle) = cow {
         cow_manager.teardown(&handle).await;
+    }
+    if let Some(net) = net_alloc {
+        network.release(net);
     }
     if let Some(dir) = origin_dir
         && let Err(e) = tokio::fs::remove_dir_all(dir).await

--- a/virt/arcbox-vm/src/sandbox/checkpoint.rs
+++ b/virt/arcbox-vm/src/sandbox/checkpoint.rs
@@ -13,6 +13,10 @@ async fn move_file(from: &Path, to: &Path) -> std::io::Result<()> {
     match tokio::fs::rename(from, to).await {
         Err(e) if e.kind() == std::io::ErrorKind::CrossesDevices => {
             tokio::fs::copy(from, to).await?;
+            // fsync the destination before removing the source: a crash between
+            // the copy and the remove must not leave a zero-length/partial
+            // snapshot file registered in the catalog.
+            tokio::fs::File::open(to).await?.sync_all().await?;
             tokio::fs::remove_file(from).await
         }
         other => other,
@@ -158,16 +162,11 @@ impl SandboxManager {
             .filter(|s| !s.is_empty())
             .unwrap_or_else(|| Uuid::new_v4().to_string());
 
-        if new_id.contains('/')
-            || new_id.contains('\\')
-            || new_id.contains('\0')
-            || new_id == "."
-            || new_id == ".."
-        {
-            return Err(VmmError::Config(format!(
-                "invalid sandbox ID: {new_id:?} (must not contain path separators)"
-            )));
-        }
+        super::validate_id("sandbox id", &new_id)?;
+        // The snapshot id is caller-supplied and flows into snapshot dir paths
+        // (create_dir_all / copy / remove_dir_all) — validate it too, or a
+        // `../` id would traverse out of the snapshots directory.
+        super::validate_id("snapshot id", &spec.snapshot_id)?;
 
         // Reserve the id atomically so a concurrent restore/create of the same
         // id fails fast with AlreadyExists instead of both proceeding to set up

--- a/virt/arcbox-vm/src/sandbox/checkpoint.rs
+++ b/virt/arcbox-vm/src/sandbox/checkpoint.rs
@@ -42,47 +42,57 @@ impl SandboxManager {
         };
 
         let vm = self.get_vm_handle(sandbox_id)?;
+        let snapshot_id = Uuid::new_v4().to_string();
 
         // Pause before snapshotting.
         vm.pause().await.map_err(VmmError::from)?;
 
-        let snapshot_id = Uuid::new_v4().to_string();
-
+        // Everything between pause and resume is fallible (chroot dir setup,
+        // chown, catalog dir prep, the snapshot RPC). Run it in a block whose
+        // result is handled only AFTER an unconditional resume — a bare `?`
+        // here previously left the guest paused forever, wedging every later
+        // RPC. Returns the chroot snapshot dir (jailer mode) to move afterward.
+        //
         // In jailer mode FC runs inside a chroot and can only write to paths
-        // within that chroot.  We create a temporary snapshot directory inside
-        // the chroot, pass the chroot-relative paths to FC, then move the
-        // resulting files to the standard catalog location on the host.
-        let (fc_vmstate_path, fc_mem_path, chroot_snap_dir_opt) =
-            if let Some(ref jc) = self.config.firecracker.jailer {
-                let base = jc.chroot_base_dir.as_deref().unwrap_or("/srv/jailer");
-                let cr = chroot_root(&self.config.firecracker.binary, base, sandbox_id);
-                let chroot_snap = cr.join("snapshots").join(&snapshot_id);
-                std::fs::create_dir_all(&chroot_snap).map_err(VmmError::Io)?;
-                // Firecracker runs as jc.uid/jc.gid; chown the directory so it
-                // can create the snapshot files.
-                let uid = nix::unistd::Uid::from_raw(jc.uid);
-                let gid = nix::unistd::Gid::from_raw(jc.gid);
-                nix::unistd::chown(&chroot_snap, Some(uid), Some(gid))
-                    .map_err(|e| VmmError::Process(format!("chown snapshot dir: {e}")))?;
-                // Paths as seen by Firecracker inside the chroot.
-                let fc_vmstate = format!("/snapshots/{snapshot_id}/vmstate");
-                let fc_mem = format!("/snapshots/{snapshot_id}/mem");
-                (fc_vmstate, fc_mem, Some(chroot_snap))
-            } else {
-                let snap_dir = self.snapshots.prepare_dir(sandbox_id, &snapshot_id)?;
-                (
-                    snap_dir.join("vmstate").to_str().unwrap().to_owned(),
-                    snap_dir.join("mem").to_str().unwrap().to_owned(),
-                    None,
-                )
-            };
+        // within it, so the snapshot is written to a chroot-local dir and moved
+        // to the catalog after resume.
+        let paused: Result<Option<PathBuf>> = async {
+            let (fc_vmstate_path, fc_mem_path, chroot_snap_dir_opt) =
+                if let Some(ref jc) = self.config.firecracker.jailer {
+                    let base = jc.chroot_base_dir.as_deref().unwrap_or("/srv/jailer");
+                    let cr = chroot_root(&self.config.firecracker.binary, base, sandbox_id);
+                    let chroot_snap = cr.join("snapshots").join(&snapshot_id);
+                    std::fs::create_dir_all(&chroot_snap).map_err(VmmError::Io)?;
+                    // Firecracker runs as jc.uid/jc.gid; chown the directory so
+                    // it can create the snapshot files.
+                    let uid = nix::unistd::Uid::from_raw(jc.uid);
+                    let gid = nix::unistd::Gid::from_raw(jc.gid);
+                    nix::unistd::chown(&chroot_snap, Some(uid), Some(gid))
+                        .map_err(|e| VmmError::Process(format!("chown snapshot dir: {e}")))?;
+                    // Paths as seen by Firecracker inside the chroot.
+                    let fc_vmstate = format!("/snapshots/{snapshot_id}/vmstate");
+                    let fc_mem = format!("/snapshots/{snapshot_id}/mem");
+                    (fc_vmstate, fc_mem, Some(chroot_snap))
+                } else {
+                    let snap_dir = self.snapshots.prepare_dir(sandbox_id, &snapshot_id)?;
+                    (
+                        snap_dir.join("vmstate").to_str().unwrap().to_owned(),
+                        snap_dir.join("mem").to_str().unwrap().to_owned(),
+                        None,
+                    )
+                };
 
-        let snap_result = vm.create_snapshot(&fc_vmstate_path, &fc_mem_path).await;
+            vm.create_snapshot(&fc_vmstate_path, &fc_mem_path)
+                .await
+                .map_err(VmmError::from)?;
+            Ok(chroot_snap_dir_opt)
+        }
+        .await;
 
-        // Always resume regardless of snapshot success.
+        // Always resume, regardless of how the paused section fared.
         let _ = vm.resume().await;
 
-        snap_result.map_err(VmmError::from)?;
+        let chroot_snap_dir_opt = paused?;
 
         // If jailer mode, move snapshot files from chroot to the catalog dir.
         let (vmstate_path, mem_path) = if let Some(chroot_snap) = chroot_snap_dir_opt {
@@ -156,13 +166,24 @@ impl SandboxManager {
             )));
         }
 
-        // Uniqueness check.
-        {
-            let instances = self.instances.read().unwrap();
-            if instances.contains_key(&new_id) {
-                return Err(VmmError::AlreadyExists(new_id.clone()));
-            }
-        }
+        // Reserve the id atomically so a concurrent restore/create of the same
+        // id fails fast with AlreadyExists instead of both proceeding to set up
+        // the deterministic per-id CoW/dm/TAP resources and corrupting each
+        // other (see reserve_id). Unwound on every error path via Drop.
+        let vm_dir = PathBuf::from(&self.config.firecracker.data_dir)
+            .join("sandboxes")
+            .join(&new_id);
+        let restore_spec = SandboxSpec {
+            id: Some(new_id.clone()),
+            labels: spec.labels.clone(),
+            ttl_seconds: spec.ttl_seconds,
+            ..Default::default()
+        };
+        let reservation = super::reserve_id(
+            &self.instances,
+            &new_id,
+            SandboxInstance::new(new_id.clone(), restore_spec, None, vm_dir.clone()),
+        )?;
 
         // Allocate network if requested.
         let net_alloc = if spec.network_override {
@@ -176,10 +197,7 @@ impl SandboxManager {
             .map(|n| n.ip_address.to_string())
             .unwrap_or_default();
 
-        // Create working directory.
-        let vm_dir = PathBuf::from(&self.config.firecracker.data_dir)
-            .join("sandboxes")
-            .join(&new_id);
+        // Create working directory (path reserved above).
         std::fs::create_dir_all(&vm_dir).map_err(VmmError::Io)?;
         let socket_path = vm_dir.join("firecracker.sock");
 
@@ -403,7 +421,9 @@ impl SandboxManager {
                 kill_and_reap_fc(&mut process).await;
                 cleanup_pending_restore(
                     &self.cow_manager,
+                    &self.network,
                     pending_cow,
+                    net_alloc.as_ref(),
                     pending_origin_dir.as_deref(),
                 )
                 .await;
@@ -441,7 +461,9 @@ impl SandboxManager {
                 kill_and_reap_fc(&mut process).await;
                 cleanup_pending_restore(
                     &self.cow_manager,
+                    &self.network,
                     pending_cow.take(),
+                    net_alloc.as_ref(),
                     pending_origin_dir.as_deref(),
                 )
                 .await;
@@ -468,48 +490,41 @@ impl SandboxManager {
             Ok(Ok(())) => {}
         }
 
-        // Build and register the new sandbox instance.
-        let restore_spec = SandboxSpec {
-            id: Some(new_id.clone()),
-            labels: spec.labels,
-            ttl_seconds: spec.ttl_seconds,
-            ..Default::default()
-        };
-        let mut instance =
-            SandboxInstance::new(new_id.clone(), restore_spec, net_alloc.clone(), vm_dir);
-        instance.process = Some(process);
-        instance.vm = Some(vm);
-        instance.vsock_uds_path = Some(actual_vsock_path);
-        // Hand off pending resources to the instance — they're now tracked
-        // for teardown via `remove_sandbox_impl` and won't leak.
-        instance.cow_handle = pending_cow.take();
-        instance.restore_origin_dir = pending_origin_dir.take();
-        instance.state = SandboxState::Ready;
-        instance.ready_at = Some(Utc::now());
-
-        // Persist the crash-recovery record for the restored sandbox.
-        #[allow(
-            clippy::cast_possible_wrap,
-            reason = "Firecracker pid fits platform pid_t"
-        )]
-        let record = super::reconcile::SandboxStateRecord::new(
-            &new_id,
-            instance
-                .process
-                .as_ref()
-                .and_then(|p| p.pid())
-                .map(|p| p as i32),
-            instance.network.as_ref(),
-            instance.cow_handle.as_ref(),
-            self.config.firecracker.jailer.is_some(),
-            instance.restore_origin_dir.as_deref(),
-        );
-        super::reconcile::write_state_record(&instance.vm_dir, &record);
-
+        // Populate the reserved instance in place, then commit the reservation
+        // so it survives (the placeholder inserted by reserve_id is otherwise
+        // removed on drop). All resources are now tracked on the instance and
+        // torn down via remove_sandbox_impl.
+        let arc = reservation.instance();
         {
-            let mut instances = self.instances.write().unwrap();
-            instances.insert(new_id.clone(), Arc::new(Mutex::new(instance)));
+            let mut inst = arc.lock().unwrap();
+            inst.network.clone_from(&net_alloc);
+            inst.process = Some(process);
+            inst.vm = Some(vm);
+            inst.vsock_uds_path = Some(actual_vsock_path);
+            inst.cow_handle = pending_cow.take();
+            inst.restore_origin_dir = pending_origin_dir.take();
+            inst.state = SandboxState::Ready;
+            inst.ready_at = Some(Utc::now());
+
+            // Persist the crash-recovery record for the restored sandbox.
+            #[allow(
+                clippy::cast_possible_wrap,
+                reason = "Firecracker pid fits platform pid_t"
+            )]
+            let record = super::reconcile::SandboxStateRecord::new(
+                &new_id,
+                inst.process
+                    .as_ref()
+                    .and_then(|p| p.pid())
+                    .map(|p| p as i32),
+                inst.network.as_ref(),
+                inst.cow_handle.as_ref(),
+                self.config.firecracker.jailer.is_some(),
+                inst.restore_origin_dir.as_deref(),
+            );
+            super::reconcile::write_state_record(&inst.vm_dir, &record);
         }
+        reservation.commit();
 
         let _ = self.events_tx.send(SandboxEvent::new(&new_id, "ready"));
 

--- a/virt/arcbox-vm/src/sandbox/checkpoint.rs
+++ b/virt/arcbox-vm/src/sandbox/checkpoint.rs
@@ -149,6 +149,10 @@ impl SandboxManager {
     ///
     /// Returns `(sandbox_id, ip_address)`.
     pub async fn restore_sandbox(&self, spec: RestoreSandboxSpec) -> Result<(SandboxId, String)> {
+        // Gate on the startup sweep before touching per-id resources (see
+        // create_sandbox / await_reconcile).
+        self.await_reconcile().await;
+
         let new_id = spec
             .id
             .clone()

--- a/virt/arcbox-vm/src/sandbox/checkpoint.rs
+++ b/virt/arcbox-vm/src/sandbox/checkpoint.rs
@@ -2,7 +2,6 @@ use super::boot::{
     chroot_root, cleanup_pending_restore, create_rootfs_symlink, kill_and_reap_fc,
     stage_kernel_for_jailer, stage_rootfs_copy_for_jailer, stage_rootfs_device_for_jailer,
 };
-use super::cleanup::remove_sandbox_impl;
 use super::*;
 
 /// Move a file even when source and destination sit on different mounts.
@@ -529,10 +528,12 @@ impl SandboxManager {
             super::reconcile::write_state_record(&inst.vm_dir, &record);
         }
         reservation.commit();
+        let ttl_armed_for = Arc::downgrade(&arc);
 
         let _ = self.events_tx.send(SandboxEvent::new(&new_id, "ready"));
 
-        // TTL expiry task.
+        // TTL expiry task — identity-guarded so a stale timer can't remove a
+        // same-id sandbox re-created after this one (see expire_sandbox).
         if spec.ttl_seconds > 0 {
             let instances = Arc::clone(&self.instances);
             let network = Arc::clone(&self.network);
@@ -541,10 +542,11 @@ impl SandboxManager {
             let cow2 = Arc::clone(&self.cow_manager);
             let id2 = new_id.clone();
             let ttl = spec.ttl_seconds;
+            let armed_for = ttl_armed_for;
             tokio::spawn(async move {
                 tokio::time::sleep(Duration::from_secs(ttl as u64)).await;
-                remove_sandbox_impl(
-                    &id2, true, &instances, &network, &events_tx, &config2, &cow2,
+                super::cleanup::expire_sandbox(
+                    &id2, &armed_for, &instances, &network, &events_tx, &config2, &cow2,
                 )
                 .await;
             });

--- a/virt/arcbox-vm/src/sandbox/checkpoint.rs
+++ b/virt/arcbox-vm/src/sandbox/checkpoint.rs
@@ -5,6 +5,21 @@ use super::boot::{
 use super::cleanup::remove_sandbox_impl;
 use super::*;
 
+/// Move a file even when source and destination sit on different mounts.
+///
+/// The jailer chroot is its own vfsmount (bind + pivot_root), so a plain
+/// `rename(2)` out of it fails with `EXDEV` regardless of the underlying
+/// filesystem; fall back to copy + remove in that case.
+async fn move_file(from: &Path, to: &Path) -> std::io::Result<()> {
+    match tokio::fs::rename(from, to).await {
+        Err(e) if e.kind() == std::io::ErrorKind::CrossesDevices => {
+            tokio::fs::copy(from, to).await?;
+            tokio::fs::remove_file(from).await
+        }
+        other => other,
+    }
+}
+
 impl SandboxManager {
     pub async fn checkpoint_sandbox(
         &self,
@@ -74,11 +89,11 @@ impl SandboxManager {
             let catalog_dir = self.snapshots.prepare_dir(sandbox_id, &snapshot_id)?;
             let dst_vmstate = catalog_dir.join("vmstate");
             let dst_mem = catalog_dir.join("mem");
-            tokio::fs::rename(chroot_snap.join("vmstate"), &dst_vmstate)
+            move_file(&chroot_snap.join("vmstate"), &dst_vmstate)
                 .await
                 .map_err(VmmError::Io)?;
             if chroot_snap.join("mem").exists() {
-                tokio::fs::rename(chroot_snap.join("mem"), &dst_mem)
+                move_file(&chroot_snap.join("mem"), &dst_mem)
                     .await
                     .map_err(VmmError::Io)?;
             }

--- a/virt/arcbox-vm/src/sandbox/checkpoint.rs
+++ b/virt/arcbox-vm/src/sandbox/checkpoint.rs
@@ -472,6 +472,25 @@ impl SandboxManager {
         instance.state = SandboxState::Ready;
         instance.ready_at = Some(Utc::now());
 
+        // Persist the crash-recovery record for the restored sandbox.
+        #[allow(
+            clippy::cast_possible_wrap,
+            reason = "Firecracker pid fits platform pid_t"
+        )]
+        let record = super::reconcile::SandboxStateRecord::new(
+            &new_id,
+            instance
+                .process
+                .as_ref()
+                .and_then(|p| p.pid())
+                .map(|p| p as i32),
+            instance.network.as_ref(),
+            instance.cow_handle.as_ref(),
+            self.config.firecracker.jailer.is_some(),
+            instance.restore_origin_dir.as_deref(),
+        );
+        super::reconcile::write_state_record(&instance.vm_dir, &record);
+
         {
             let mut instances = self.instances.write().unwrap();
             instances.insert(new_id.clone(), Arc::new(Mutex::new(instance)));

--- a/virt/arcbox-vm/src/sandbox/cleanup.rs
+++ b/virt/arcbox-vm/src/sandbox/cleanup.rs
@@ -19,9 +19,49 @@ pub(super) async fn remove_sandbox_impl(
         return;
     };
 
-    // Kill the Firecracker process and wait for it to exit before releasing
-    // network resources. TAP destruction (ioctl TUNSETPERSIST clear / ip link
-    // delete fallback) fails if the TAP fd is still held by a running process.
+    release_runtime_resources(id, &arc, network, config, cow_manager).await;
+
+    // Remove the sandbox working directory (sockets, logs, etc.).
+    let vm_dir = PathBuf::from(&config.firecracker.data_dir)
+        .join("sandboxes")
+        .join(id);
+    if let Err(e) = tokio::fs::remove_dir_all(&vm_dir).await
+        && e.kind() != std::io::ErrorKind::NotFound
+    {
+        warn!(sandbox_id = %id, err = %e, "failed to remove sandbox dir");
+    }
+
+    // For restored sandboxes: also remove the original sandbox's vm_dir,
+    // which we recreated during restore to host the vmstate-recorded
+    // `rootfs.link` symlink and FC vsock socket.  Without this every
+    // restore-and-remove cycle would leak one orphaned directory.
+    let origin_dir = arc.lock().unwrap().restore_origin_dir.clone();
+    if let Some(dir) = origin_dir
+        && let Err(e) = tokio::fs::remove_dir_all(&dir).await
+        && e.kind() != std::io::ErrorKind::NotFound
+    {
+        warn!(sandbox_id = %id, err = %e, "failed to remove restore origin dir");
+    }
+
+    instances.write().unwrap().remove(id);
+    let _ = events_tx.send(SandboxEvent::new(id, "removed"));
+}
+
+/// Free every runtime resource a sandbox holds: the Firecracker process
+/// (SIGKILL + bounded reap), the dm-snapshot CoW device, the TAP + IP
+/// allocation, and the jailer chroot. Idempotent — every resource is
+/// `take()`n, so calling this from both Stop and Remove is safe.
+///
+/// The ordering is load-bearing: FC must be dead before the CoW teardown
+/// (`dmsetup remove` returns EBUSY while the block device is open) and
+/// before TAP destruction (the ioctl fails while the fd is held).
+pub(super) async fn release_runtime_resources(
+    id: &str,
+    arc: &Arc<Mutex<SandboxInstance>>,
+    network: &Arc<NetworkManager>,
+    config: &Arc<VmmConfig>,
+    cow_manager: &Arc<CowManager>,
+) {
     let mut fc_process = {
         let mut inst = arc.lock().unwrap();
         if let Some(ref mut proc) = inst.process
@@ -56,9 +96,9 @@ pub(super) async fn remove_sandbox_impl(
 
     // Release network resources (destroys TAP via ioctl).
     {
-        let inst = arc.lock().unwrap();
-        if let Some(ref net) = inst.network {
-            network.release(net);
+        let mut inst = arc.lock().unwrap();
+        if let Some(net) = inst.network.take() {
+            network.release(&net);
         }
     }
 
@@ -69,35 +109,11 @@ pub(super) async fn remove_sandbox_impl(
         // Remove {base}/{exec_name}/{id}/ (parent of "root/").
         if let Some(parent) = chroot_dir.parent()
             && let Err(e) = tokio::fs::remove_dir_all(parent).await
+            && e.kind() != std::io::ErrorKind::NotFound
         {
             warn!(sandbox_id = %id, err = %e, "failed to remove jailer chroot dir");
         }
     }
-
-    // Remove the sandbox working directory (sockets, logs, etc.).
-    let vm_dir = PathBuf::from(&config.firecracker.data_dir)
-        .join("sandboxes")
-        .join(id);
-    if let Err(e) = tokio::fs::remove_dir_all(&vm_dir).await
-        && e.kind() != std::io::ErrorKind::NotFound
-    {
-        warn!(sandbox_id = %id, err = %e, "failed to remove sandbox dir");
-    }
-
-    // For restored sandboxes: also remove the original sandbox's vm_dir,
-    // which we recreated during restore to host the vmstate-recorded
-    // `rootfs.link` symlink and FC vsock socket.  Without this every
-    // restore-and-remove cycle would leak one orphaned directory.
-    let origin_dir = arc.lock().unwrap().restore_origin_dir.clone();
-    if let Some(dir) = origin_dir
-        && let Err(e) = tokio::fs::remove_dir_all(&dir).await
-        && e.kind() != std::io::ErrorKind::NotFound
-    {
-        warn!(sandbox_id = %id, err = %e, "failed to remove restore origin dir");
-    }
-
-    instances.write().unwrap().remove(id);
-    let _ = events_tx.send(SandboxEvent::new(id, "removed"));
 }
 
 pub(super) fn inst_to_info(inst: &SandboxInstance) -> SandboxInfo {

--- a/virt/arcbox-vm/src/sandbox/cleanup.rs
+++ b/virt/arcbox-vm/src/sandbox/cleanup.rs
@@ -43,8 +43,55 @@ pub(super) async fn remove_sandbox_impl(
         warn!(sandbox_id = %id, err = %e, "failed to remove restore origin dir");
     }
 
-    instances.write().unwrap().remove(id);
+    // Only drop the map entry if it is still the instance we tore down. A
+    // concurrent re-create under the same id installs a different Arc that this
+    // removal must not evict.
+    {
+        let mut map = instances.write().unwrap();
+        if map.get(id).is_some_and(|cur| Arc::ptr_eq(cur, &arc)) {
+            map.remove(id);
+        }
+    }
     let _ = events_tx.send(SandboxEvent::new(id, "removed"));
+}
+
+/// True when `armed_for` still refers to the instance currently registered
+/// under the id. Used to decide whether a fired TTL timer applies.
+fn is_armed_instance(
+    armed_for: &std::sync::Weak<Mutex<SandboxInstance>>,
+    current: Option<&Arc<Mutex<SandboxInstance>>>,
+) -> bool {
+    match (armed_for.upgrade(), current) {
+        (Some(mine), Some(cur)) => Arc::ptr_eq(&mine, cur),
+        _ => false,
+    }
+}
+
+/// TTL expiry: force-remove `id`, but only if the instance registered under it
+/// is still the one this timer was armed for.
+///
+/// A sandbox that was removed and re-created under the same id (deterministic
+/// caller-supplied ids make this common) installs a fresh `Arc`. The captured
+/// `Weak` then points at a different — or dropped — instance, so the stale
+/// timer becomes a no-op instead of force-removing the unrelated new sandbox.
+#[allow(
+    clippy::type_complexity,
+    reason = "manager storage type is shared here"
+)]
+pub(super) async fn expire_sandbox(
+    id: &str,
+    armed_for: &std::sync::Weak<Mutex<SandboxInstance>>,
+    instances: &Arc<RwLock<HashMap<SandboxId, Arc<Mutex<SandboxInstance>>>>>,
+    network: &Arc<NetworkManager>,
+    events_tx: &broadcast::Sender<SandboxEvent>,
+    config: &Arc<VmmConfig>,
+    cow_manager: &Arc<CowManager>,
+) {
+    let current = instances.read().unwrap().get(id).cloned();
+    if !is_armed_instance(armed_for, current.as_ref()) {
+        return;
+    }
+    remove_sandbox_impl(id, true, instances, network, events_tx, config, cow_manager).await;
 }
 
 /// Free every runtime resource a sandbox holds: the Firecracker process
@@ -113,6 +160,42 @@ pub(super) async fn release_runtime_resources(
         {
             warn!(sandbox_id = %id, err = %e, "failed to remove jailer chroot dir");
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn instance(id: &str) -> Arc<Mutex<SandboxInstance>> {
+        Arc::new(Mutex::new(SandboxInstance::new(
+            id.to_owned(),
+            SandboxSpec::default(),
+            None,
+            PathBuf::from("/tmp/x"),
+        )))
+    }
+
+    #[test]
+    fn ttl_applies_only_to_the_armed_generation() {
+        let original = instance("job");
+        let armed_for = Arc::downgrade(&original);
+
+        // Same instance still registered → timer applies.
+        assert!(is_armed_instance(&armed_for, Some(&original)));
+
+        // Removed and re-created under the same id → a different Arc; the stale
+        // timer must NOT match the new generation.
+        let recreated = instance("job");
+        assert!(!is_armed_instance(&armed_for, Some(&recreated)));
+
+        // Removed with nothing re-created → no match.
+        assert!(!is_armed_instance(&armed_for, None));
+
+        // Original fully dropped → the Weak is dead, no match even if some
+        // other instance is present.
+        drop(original);
+        assert!(!is_armed_instance(&armed_for, Some(&recreated)));
     }
 }
 

--- a/virt/arcbox-vm/src/sandbox/cleanup.rs
+++ b/virt/arcbox-vm/src/sandbox/cleanup.rs
@@ -163,6 +163,26 @@ pub(super) async fn release_runtime_resources(
     }
 }
 
+pub(super) fn inst_to_info(inst: &SandboxInstance) -> SandboxInfo {
+    SandboxInfo {
+        id: inst.id.clone(),
+        state: inst.state,
+        labels: inst.labels.clone(),
+        vcpus: inst.spec.vcpus,
+        memory_mib: inst.spec.memory_mib,
+        network: inst.network.as_ref().map(|n| SandboxNetworkInfo {
+            ip_address: n.ip_address.to_string(),
+            gateway: n.gateway.to_string(),
+            tap_name: n.tap_name.clone(),
+        }),
+        created_at: inst.created_at,
+        ready_at: inst.ready_at,
+        last_exited_at: inst.last_exited_at,
+        last_exit_code: inst.last_exit_code,
+        error: inst.error.clone(),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -196,25 +216,5 @@ mod tests {
         // other instance is present.
         drop(original);
         assert!(!is_armed_instance(&armed_for, Some(&recreated)));
-    }
-}
-
-pub(super) fn inst_to_info(inst: &SandboxInstance) -> SandboxInfo {
-    SandboxInfo {
-        id: inst.id.clone(),
-        state: inst.state,
-        labels: inst.labels.clone(),
-        vcpus: inst.spec.vcpus,
-        memory_mib: inst.spec.memory_mib,
-        network: inst.network.as_ref().map(|n| SandboxNetworkInfo {
-            ip_address: n.ip_address.to_string(),
-            gateway: n.gateway.to_string(),
-            tap_name: n.tap_name.clone(),
-        }),
-        created_at: inst.created_at,
-        ready_at: inst.ready_at,
-        last_exited_at: inst.last_exited_at,
-        last_exit_code: inst.last_exit_code,
-        error: inst.error.clone(),
     }
 }

--- a/virt/arcbox-vm/src/sandbox/lifecycle.rs
+++ b/virt/arcbox-vm/src/sandbox/lifecycle.rs
@@ -126,10 +126,21 @@ impl SandboxManager {
 
     /// Stop a sandbox gracefully.
     ///
-    /// Sends Ctrl+Alt+Del to the guest and waits up to `timeout_seconds`
-    /// (default 30 s) for the VM to shut down.
+    /// Waits up to `timeout_seconds` (default 30 s) for an active workload
+    /// to exit, asks the guest to shut down (Ctrl+Alt+Del reboots the guest,
+    /// which exits Firecracker), and SIGKILLs Firecracker only if it
+    /// outlives the remaining budget. All runtime resources (TAP + IP,
+    /// dm-snapshot CoW, jailer chroot) are released on `Stopped`; only the
+    /// inspectable record and the log directory survive until `Remove`.
     pub async fn stop_sandbox(&self, id: &SandboxId, timeout_seconds: u32) -> Result<()> {
-        let vm_handle = {
+        let budget = Duration::from_secs(u64::from(if timeout_seconds > 0 {
+            timeout_seconds
+        } else {
+            30
+        }));
+        let deadline = tokio::time::Instant::now() + budget;
+
+        let (was_running, vm_handle) = {
             let instance = self.get_instance(id)?;
             let mut inst = instance.lock().unwrap();
             match inst.state {
@@ -142,42 +153,62 @@ impl SandboxManager {
                     });
                 }
             }
+            let was_running = inst.state == SandboxState::Running;
             inst.state = SandboxState::Stopping;
-            inst.vm.as_ref().map(Arc::clone)
+            (was_running, inst.vm.as_ref().map(Arc::clone))
         };
 
         let _ = self.events_tx.send(SandboxEvent::new(id, "stopping"));
 
-        if let Some(vm) = vm_handle {
-            let timeout = if timeout_seconds > 0 {
-                timeout_seconds
-            } else {
-                30
-            };
-            // Ignore errors — VM may have already exited.
-            let _ =
-                tokio::time::timeout(Duration::from_secs(timeout as u64), vm.send_ctrl_alt_del())
-                    .await;
+        // Drain: give an active workload the budget to finish. The run/exec
+        // watcher flips the state to Ready (over our Stopping) when the exit
+        // chunk arrives, so poll for that transition.
+        if was_running {
+            while tokio::time::Instant::now() < deadline {
+                let state = self.get_instance(id)?.lock().unwrap().state;
+                if state != SandboxState::Stopping {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(100)).await;
+            }
+            // Re-assert Stopping for observers regardless of drain outcome.
+            self.get_instance(id)?.lock().unwrap().state = SandboxState::Stopping;
         }
 
-        // Force-kill the Firecracker process if it is still alive.
+        // Ask the guest to shut down. Ctrl+Alt+Del triggers a guest reboot,
+        // which Firecracker turns into a VM exit. Errors are ignored — the
+        // VM may already be gone.
+        if let Some(vm) = vm_handle {
+            let _ = tokio::time::timeout(Duration::from_secs(5), vm.send_ctrl_alt_del()).await;
+        }
+
+        // Wait for Firecracker to exit within the remaining budget; SIGKILL
+        // as a fallback, then reap.
+        let fc_process = self.get_instance(id)?.lock().unwrap().process.take();
+        if let Some(mut proc) = fc_process {
+            let remaining = deadline
+                .checked_duration_since(tokio::time::Instant::now())
+                .unwrap_or(Duration::from_secs(1))
+                .max(Duration::from_secs(1));
+            if tokio::time::timeout(remaining, proc.wait()).await.is_err() {
+                warn!(sandbox_id = %id, "guest did not shut down in time; killing firecracker");
+                super::boot::kill_and_reap_fc(&mut proc).await;
+            }
+        }
+
+        // Release TAP/IP, CoW device, and chroot now that FC is gone; the
+        // record itself stays inspectable until Remove.
         {
             let instance = self.get_instance(id)?;
-            let mut inst = instance.lock().unwrap();
-            if let Some(ref mut proc) = inst.process
-                && let Some(pid) = proc.pid()
-                && pid > 0
-            {
-                let _ = nix::sys::signal::kill(
-                    #[allow(
-                        clippy::cast_possible_wrap,
-                        reason = "Firecracker pid fits platform pid_t"
-                    )]
-                    nix::unistd::Pid::from_raw(pid as i32),
-                    nix::sys::signal::Signal::SIGKILL,
-                );
-            }
-            inst.state = SandboxState::Stopped;
+            super::cleanup::release_runtime_resources(
+                id,
+                &instance,
+                &self.network,
+                &self.config,
+                &self.cow_manager,
+            )
+            .await;
+            instance.lock().unwrap().state = SandboxState::Stopped;
         }
 
         let _ = self.events_tx.send(SandboxEvent::new(id, "stopped"));

--- a/virt/arcbox-vm/src/sandbox/lifecycle.rs
+++ b/virt/arcbox-vm/src/sandbox/lifecycle.rs
@@ -35,13 +35,9 @@ impl SandboxManager {
             .filter(|s| !s.is_empty())
             .unwrap_or_else(|| Uuid::new_v4().to_string());
 
-        // Sanitize caller-supplied IDs: reject path separators and other
-        // dangerous characters to prevent directory traversal.
-        if id.contains('/') || id.contains('\\') || id.contains('\0') || id == "." || id == ".." {
-            return Err(VmmError::Config(format!(
-                "invalid sandbox ID: {id:?} (must not contain path separators)"
-            )));
-        }
+        // Restrict caller-supplied ids to a safe charset (path components,
+        // jailer --id, dm/TAP names). Auto-generated UUIDs pass unchanged.
+        super::validate_id("sandbox id", &id)?;
 
         // Uniqueness check.
         {
@@ -270,10 +266,14 @@ impl SandboxManager {
         state_filter: Option<&str>,
         label_filter: &HashMap<String, String>,
     ) -> Vec<SandboxSummary> {
-        self.instances
-            .read()
-            .unwrap()
-            .values()
+        // Snapshot the Arcs under the map read guard, then release it before
+        // locking any instance. The manager's discipline is "never hold the
+        // instances map lock while holding an instance lock"; taking both here
+        // (as before) is the one place that could deadlock a future writer that
+        // locks in the opposite order.
+        let instances: Vec<_> = self.instances.read().unwrap().values().cloned().collect();
+        instances
+            .iter()
             .filter_map(|arc| {
                 let inst = arc.lock().unwrap();
                 // State filter.

--- a/virt/arcbox-vm/src/sandbox/lifecycle.rs
+++ b/virt/arcbox-vm/src/sandbox/lifecycle.rs
@@ -39,15 +39,23 @@ impl SandboxManager {
         // jailer --id, dm/TAP names). Auto-generated UUIDs pass unchanged.
         super::validate_id("sandbox id", &id)?;
 
-        // Uniqueness check.
-        {
-            let instances = self.instances.read().unwrap();
-            if instances.contains_key(&id) {
-                return Err(VmmError::AlreadyExists(id));
-            }
-        }
+        let vm_dir = PathBuf::from(&self.config.firecracker.data_dir)
+            .join("sandboxes")
+            .join(&id);
 
-        // Allocate network resources (point-to-point TAP).
+        // Reserve the id atomically BEFORE allocating any per-id resource, so
+        // two concurrent creates of the same id can't both pass a uniqueness
+        // check and race — the loser fails with AlreadyExists instead of
+        // overwriting the map entry and leaking the winner's TAP/instance
+        // (mirrors restore; unwound on any early return via Drop).
+        let reservation = super::reserve_id(
+            &self.instances,
+            &id,
+            SandboxInstance::new(id.clone(), spec.clone(), None, vm_dir.clone()),
+        )?;
+
+        // Allocate network resources (point-to-point TAP). The id is claimed,
+        // so a concurrent create already failed at reserve_id above.
         let net_alloc = if spec.network.mode == "none" {
             None
         } else {
@@ -59,22 +67,21 @@ impl SandboxManager {
             .map(|n| n.ip_address.to_string())
             .unwrap_or_default();
 
-        // Create the VM working directory.
-        let vm_dir = PathBuf::from(&self.config.firecracker.data_dir)
-            .join("sandboxes")
-            .join(&id);
-        std::fs::create_dir_all(&vm_dir).map_err(VmmError::Io)?;
-
-        // Insert instance in Starting state. Keep a Weak to identify this exact
-        // generation when its TTL timer fires (see expire_sandbox).
-        let instance =
-            SandboxInstance::new(id.clone(), spec.clone(), net_alloc.clone(), vm_dir.clone());
-        let arc = Arc::new(Mutex::new(instance));
-        let ttl_armed_for = Arc::downgrade(&arc);
-        {
-            let mut instances = self.instances.write().unwrap();
-            instances.insert(id.clone(), arc);
+        // Create the VM working directory; release the TAP if this fails (the
+        // reservation itself unwinds the placeholder on the early return).
+        if let Err(e) = std::fs::create_dir_all(&vm_dir) {
+            if let Some(net) = &net_alloc {
+                self.network.release(net);
+            }
+            return Err(VmmError::Io(e));
         }
+
+        // Populate the reserved instance and commit it. Keep a Weak to identify
+        // this exact generation when its TTL timer fires (see expire_sandbox).
+        let arc = reservation.instance();
+        arc.lock().unwrap().network.clone_from(&net_alloc);
+        let ttl_armed_for = Arc::downgrade(&arc);
+        reservation.commit();
 
         // Broadcast "created" event.
         let _ = self.events_tx.send(SandboxEvent::new(&id, "created"));

--- a/virt/arcbox-vm/src/sandbox/lifecycle.rs
+++ b/virt/arcbox-vm/src/sandbox/lifecycle.rs
@@ -69,12 +69,15 @@ impl SandboxManager {
             .join(&id);
         std::fs::create_dir_all(&vm_dir).map_err(VmmError::Io)?;
 
-        // Insert instance in Starting state.
+        // Insert instance in Starting state. Keep a Weak to identify this exact
+        // generation when its TTL timer fires (see expire_sandbox).
         let instance =
             SandboxInstance::new(id.clone(), spec.clone(), net_alloc.clone(), vm_dir.clone());
+        let arc = Arc::new(Mutex::new(instance));
+        let ttl_armed_for = Arc::downgrade(&arc);
         {
             let mut instances = self.instances.write().unwrap();
-            instances.insert(id.clone(), Arc::new(Mutex::new(instance)));
+            instances.insert(id.clone(), arc);
         }
 
         // Broadcast "created" event.
@@ -115,10 +118,11 @@ impl SandboxManager {
             let cow2 = Arc::clone(&self.cow_manager);
             let id2 = id.clone();
             let ttl = spec.ttl_seconds;
+            let armed_for = ttl_armed_for;
             tokio::spawn(async move {
                 tokio::time::sleep(Duration::from_secs(ttl as u64)).await;
-                remove_sandbox_impl(
-                    &id2, true, &instances, &network, &events_tx, &config2, &cow2,
+                super::cleanup::expire_sandbox(
+                    &id2, &armed_for, &instances, &network, &events_tx, &config2, &cow2,
                 )
                 .await;
             });

--- a/virt/arcbox-vm/src/sandbox/lifecycle.rs
+++ b/virt/arcbox-vm/src/sandbox/lifecycle.rs
@@ -326,6 +326,45 @@ impl SandboxManager {
             .ok_or_else(|| VmmError::Vsock(format!("sandbox {id} has no vsock configured")))
     }
 
+    /// Verify the sandbox is alive (Ready or Running) and return its vsock
+    /// UDS path. Unlike [`Self::require_ready_vsock`], an in-flight workload
+    /// does not block the operation — file I/O works alongside Run/Exec.
+    pub(super) fn require_alive_vsock(&self, id: &SandboxId) -> Result<PathBuf> {
+        let instance = self.get_instance(id)?;
+        let inst = instance.lock().unwrap();
+        match inst.state {
+            SandboxState::Ready | SandboxState::Running => {}
+            s => {
+                return Err(VmmError::WrongState {
+                    id: id.clone(),
+                    expected: "Ready or Running".into(),
+                    actual: s.to_string(),
+                });
+            }
+        }
+        inst.vsock_uds_path
+            .clone()
+            .ok_or_else(|| VmmError::Vsock(format!("sandbox {id} has no vsock configured")))
+    }
+
+    /// Read a file from inside an alive sandbox over the vsock file channel.
+    pub async fn read_sandbox_file(&self, id: &SandboxId, path: &str) -> Result<Vec<u8>> {
+        let uds = self.require_alive_vsock(id)?;
+        crate::file_io::read_file(&uds, path).await
+    }
+
+    /// Write a file into an alive sandbox over the vsock file channel.
+    pub async fn write_sandbox_file(
+        &self,
+        id: &SandboxId,
+        path: &str,
+        mode: u32,
+        data: &[u8],
+    ) -> Result<()> {
+        let uds = self.require_alive_vsock(id)?;
+        crate::file_io::write_file(&uds, path, mode, data).await
+    }
+
     pub(super) fn get_vm_handle(&self, id: &SandboxId) -> Result<Arc<fc_sdk::Vm>> {
         let instance = self.get_instance(id)?;
         let inst = instance.lock().unwrap();

--- a/virt/arcbox-vm/src/sandbox/lifecycle.rs
+++ b/virt/arcbox-vm/src/sandbox/lifecycle.rs
@@ -4,6 +4,10 @@ use super::*;
 
 impl SandboxManager {
     pub async fn create_sandbox(&self, mut spec: SandboxSpec) -> Result<(SandboxId, String)> {
+        // Do not allocate any per-id resources until the startup orphan sweep
+        // has run — otherwise a re-created same-id sandbox races it.
+        self.await_reconcile().await;
+
         // Apply daemon defaults for fields not supplied by the caller.
         let defaults = &self.config.defaults;
         if spec.kernel.is_empty() {

--- a/virt/arcbox-vm/src/sandbox/lifecycle.rs
+++ b/virt/arcbox-vm/src/sandbox/lifecycle.rs
@@ -208,7 +208,10 @@ impl SandboxManager {
                 &self.cow_manager,
             )
             .await;
-            instance.lock().unwrap().state = SandboxState::Stopped;
+            let mut inst = instance.lock().unwrap();
+            inst.state = SandboxState::Stopped;
+            // Every reconcilable resource is gone; drop the crash record.
+            super::reconcile::clear_state_record(&inst.vm_dir);
         }
 
         let _ = self.events_tx.send(SandboxEvent::new(id, "stopped"));

--- a/virt/arcbox-vm/src/sandbox/reconcile.rs
+++ b/virt/arcbox-vm/src/sandbox/reconcile.rs
@@ -58,19 +58,30 @@ impl CowRecord {
 }
 
 /// Crash-recovery record of one live sandbox.
+///
+/// Every field except `id` is `#[serde(default)]`, and new fields must keep
+/// that convention: it lets a newer agent read an older record (missing fields
+/// default) and an older agent read a newer one (unknown fields are ignored),
+/// so a schema change never silently disables reconciliation of a pre-upgrade
+/// sandbox — which would leak its resources.
 #[derive(Debug, Serialize, Deserialize)]
 pub(super) struct SandboxStateRecord {
     /// Sandbox ID (also the directory name).
     pub id: String,
     /// Firecracker PID at boot time.
+    #[serde(default)]
     pub pid: Option<i32>,
     /// Network allocation to release (TAP + IP).
+    #[serde(default)]
     pub network: Option<NetworkAllocation>,
     /// dm-snapshot CoW resources to tear down.
+    #[serde(default)]
     cow: Option<CowRecord>,
     /// Whether a jailer chroot was created for this sandbox.
+    #[serde(default)]
     pub jailer: bool,
     /// For restored sandboxes: the recreated origin directory to remove.
+    #[serde(default)]
     pub restore_origin_dir: Option<PathBuf>,
 }
 

--- a/virt/arcbox-vm/src/sandbox/reconcile.rs
+++ b/virt/arcbox-vm/src/sandbox/reconcile.rs
@@ -1,0 +1,260 @@
+//! Crash-recovery reconciliation for sandbox runtime state.
+//!
+//! `SandboxManager` state is in-memory; if the agent restarts (crash,
+//! supervision respawn) the Firecracker processes, TAP devices, dm-snapshot
+//! devices, and jailer chroots of running sandboxes leak, and fresh IP
+//! allocations can collide with orphaned TAPs. To recover, every successful
+//! boot/restore persists a small `state.json` next to the sandbox's runtime
+//! files, and a new manager sweeps those records: orphaned Firecracker
+//! processes are killed and every held resource is torn down. Sandboxes are
+//! ephemeral by design, so reconciliation destroys rather than re-adopts.
+
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+use tracing::{info, warn};
+
+use crate::config::VmmConfig;
+use crate::network::{NetworkAllocation, NetworkManager};
+use crate::snapshot_cow::{CowHandle, CowManager};
+
+/// File name of the per-sandbox crash-recovery record.
+const STATE_FILE: &str = "state.json";
+
+/// Plain serializable mirror of [`CowHandle`].
+///
+/// `CowHandle` itself is deliberately `!Clone`/`!Serialize` (it owns a
+/// template refcount); this record carries just enough to rebuild a handle
+/// for teardown after a restart.
+#[derive(Debug, Serialize, Deserialize)]
+struct CowRecord {
+    dm_name: String,
+    dm_device: String,
+    cow_loop: String,
+    cow_file: PathBuf,
+    template_path: PathBuf,
+}
+
+impl CowRecord {
+    fn from_handle(handle: &CowHandle) -> Self {
+        Self {
+            dm_name: handle.dm_name.clone(),
+            dm_device: handle.dm_device.clone(),
+            cow_loop: handle.cow_loop.clone(),
+            cow_file: handle.cow_file.clone(),
+            template_path: handle.template_path.clone(),
+        }
+    }
+
+    fn into_handle(self) -> CowHandle {
+        CowHandle {
+            dm_name: self.dm_name,
+            dm_device: self.dm_device,
+            cow_loop: self.cow_loop,
+            cow_file: self.cow_file,
+            template_path: self.template_path,
+        }
+    }
+}
+
+/// Crash-recovery record of one live sandbox.
+#[derive(Debug, Serialize, Deserialize)]
+pub(super) struct SandboxStateRecord {
+    /// Sandbox ID (also the directory name).
+    pub id: String,
+    /// Firecracker PID at boot time.
+    pub pid: Option<i32>,
+    /// Network allocation to release (TAP + IP).
+    pub network: Option<NetworkAllocation>,
+    /// dm-snapshot CoW resources to tear down.
+    cow: Option<CowRecord>,
+    /// Whether a jailer chroot was created for this sandbox.
+    pub jailer: bool,
+    /// For restored sandboxes: the recreated origin directory to remove.
+    pub restore_origin_dir: Option<PathBuf>,
+}
+
+impl SandboxStateRecord {
+    /// Assemble a record from boot/restore results.
+    pub fn new(
+        id: &str,
+        pid: Option<i32>,
+        network: Option<&NetworkAllocation>,
+        cow: Option<&CowHandle>,
+        jailer: bool,
+        restore_origin_dir: Option<&Path>,
+    ) -> Self {
+        Self {
+            id: id.to_owned(),
+            pid,
+            network: network.cloned(),
+            cow: cow.map(CowRecord::from_handle),
+            jailer,
+            restore_origin_dir: restore_origin_dir.map(Path::to_path_buf),
+        }
+    }
+}
+
+/// Persist the crash-recovery record into the sandbox's runtime directory.
+///
+/// Best-effort: a failed write only degrades crash recovery, never a boot.
+pub(super) fn write_state_record(vm_dir: &Path, record: &SandboxStateRecord) {
+    let path = vm_dir.join(STATE_FILE);
+    match serde_json::to_vec_pretty(record) {
+        Ok(bytes) => {
+            if let Err(e) = std::fs::write(&path, bytes) {
+                warn!(sandbox_id = %record.id, error = %e, "failed to persist sandbox state");
+            }
+        }
+        Err(e) => warn!(sandbox_id = %record.id, error = %e, "failed to encode sandbox state"),
+    }
+}
+
+/// Remove the crash-recovery record (resources have been released).
+pub(super) fn clear_state_record(vm_dir: &Path) {
+    let _ = std::fs::remove_file(vm_dir.join(STATE_FILE));
+}
+
+/// Sweep `<data_dir>/sandboxes/*/state.json` and tear down every leftover.
+///
+/// Runs once per manager construction, in the background. Ordering per
+/// sandbox mirrors live teardown: kill Firecracker → wait for exit → dm
+/// teardown → TAP release → chroot + directory removal.
+pub(super) async fn sweep_orphans(
+    config: &VmmConfig,
+    network: &NetworkManager,
+    cow_manager: &CowManager,
+) {
+    let sandboxes_dir = PathBuf::from(&config.firecracker.data_dir).join("sandboxes");
+    let Ok(entries) = std::fs::read_dir(&sandboxes_dir) else {
+        return;
+    };
+
+    for entry in entries.flatten() {
+        let dir = entry.path();
+        let state_path = dir.join(STATE_FILE);
+        let record: SandboxStateRecord = match std::fs::read(&state_path) {
+            Ok(bytes) => match serde_json::from_slice(&bytes) {
+                Ok(r) => r,
+                Err(e) => {
+                    warn!(path = %state_path.display(), error = %e, "unreadable sandbox record");
+                    continue;
+                }
+            },
+            // No record: either never booted or cleanly stopped.
+            Err(_) => continue,
+        };
+
+        info!(sandbox_id = %record.id, "reconciling orphaned sandbox");
+
+        if let Some(pid) = record.pid {
+            kill_orphaned_firecracker(pid).await;
+        }
+
+        if let Some(cow) = record.cow {
+            cow_manager.teardown(&cow.into_handle()).await;
+        }
+
+        if let Some(alloc) = &record.network {
+            network.release(alloc);
+        }
+
+        if record.jailer
+            && let Some(ref jc) = config.firecracker.jailer
+        {
+            let base = jc.chroot_base_dir.as_deref().unwrap_or("/srv/jailer");
+            let chroot = super::boot::chroot_root(&config.firecracker.binary, base, &record.id);
+            if let Some(parent) = chroot.parent() {
+                let _ = tokio::fs::remove_dir_all(parent).await;
+            }
+        }
+
+        if let Some(origin) = &record.restore_origin_dir {
+            let _ = tokio::fs::remove_dir_all(origin).await;
+        }
+
+        if let Err(e) = tokio::fs::remove_dir_all(&dir).await {
+            warn!(sandbox_id = %record.id, error = %e, "failed to remove orphaned sandbox dir");
+        }
+    }
+}
+
+/// SIGKILL an orphaned Firecracker process and wait for it to disappear.
+///
+/// The PID may have been recycled since the record was written, so the
+/// process is killed only when its command name still looks like
+/// Firecracker (Linux `/proc/<pid>/comm`; on other targets the check
+/// degrades to "process exists").
+async fn kill_orphaned_firecracker(pid: i32) {
+    if !process_is_firecracker(pid) {
+        return;
+    }
+    let _ = nix::sys::signal::kill(
+        nix::unistd::Pid::from_raw(pid),
+        nix::sys::signal::Signal::SIGKILL,
+    );
+    // The orphan was reparented to init, which reaps it; poll until the PID
+    // vanishes so dm teardown doesn't hit EBUSY on the open block device.
+    for _ in 0..50 {
+        if nix::sys::signal::kill(nix::unistd::Pid::from_raw(pid), None).is_err() {
+            return;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    }
+    warn!(pid, "orphaned firecracker did not exit after SIGKILL");
+}
+
+/// True when `pid` is alive and (on Linux) named like a Firecracker binary.
+fn process_is_firecracker(pid: i32) -> bool {
+    if nix::sys::signal::kill(nix::unistd::Pid::from_raw(pid), None).is_err() {
+        return false;
+    }
+    #[cfg(target_os = "linux")]
+    {
+        match std::fs::read_to_string(format!("/proc/{pid}/comm")) {
+            Ok(comm) => comm.trim_end().starts_with("firecracker"),
+            Err(_) => false,
+        }
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        true
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn state_record_roundtrips_through_json() {
+        let record = SandboxStateRecord {
+            id: "sb-1".into(),
+            pid: Some(42),
+            network: None,
+            cow: Some(CowRecord {
+                dm_name: "arcbox-snap-sb-1".into(),
+                dm_device: "/dev/mapper/arcbox-snap-sb-1".into(),
+                cow_loop: "/dev/loop7".into(),
+                cow_file: "/var/lib/arcbox/cow/sb-1".into(),
+                template_path: "/var/lib/arcbox/sandbox/rootfs.ext4".into(),
+            }),
+            jailer: true,
+            restore_origin_dir: None,
+        };
+        let bytes = serde_json::to_vec(&record).unwrap();
+        let parsed: SandboxStateRecord = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(parsed.id, "sb-1");
+        assert_eq!(parsed.pid, Some(42));
+        assert!(parsed.jailer);
+        let handle = parsed.cow.unwrap().into_handle();
+        assert_eq!(handle.dm_name, "arcbox-snap-sb-1");
+    }
+
+    #[test]
+    fn dead_pid_is_not_firecracker() {
+        // PID 0 targets "the calling process group" for kill(2); use an
+        // implausibly high PID instead.
+        assert!(!process_is_firecracker(i32::MAX - 1));
+    }
+}

--- a/virt/arcbox-vm/src/sandbox/types.rs
+++ b/virt/arcbox-vm/src/sandbox/types.rs
@@ -53,10 +53,11 @@ pub struct SandboxMountSpec {
 
 /// Full sandbox creation parameters.
 ///
-/// Fields related to workload execution (`cmd`, `env`, `working_dir`, `user`,
-/// `mounts`) are **not consumed by `create_sandbox`**.  They are stored in the
-/// spec for later use by `run_in_sandbox` / `exec_in_sandbox` or passed through
-/// the gRPC layer.  `image` and `ssh_public_key` are reserved for future use.
+/// The initial workload fields (`cmd`, `env`, `working_dir`, `user`) are
+/// consumed by the boot task: a non-empty `cmd` is launched automatically
+/// once the sandbox is ready, through the same path as `Run`.
+/// `mounts`, `image`, and `ssh_public_key` are validated at the service
+/// boundary (see the guest agent's `SandboxService::create`).
 #[derive(Debug, Clone, Default)]
 pub struct SandboxSpec {
     /// Caller-supplied ID; auto-generated (UUID) when `None` or empty.

--- a/virt/arcbox-vm/src/sandbox/workload.rs
+++ b/virt/arcbox-vm/src/sandbox/workload.rs
@@ -1,13 +1,116 @@
 use super::*;
 
+/// Guarded `Ready → Running` transition.
+///
+/// This is the sandbox's single-workload claim. It is taken **before** any
+/// command is dispatched into the guest, so a caller that loses a concurrent
+/// race (or arrives after a `stop` set `Stopping`) is rejected with
+/// `WrongState` *without* having launched a process. A blind assignment here
+/// was the original defect: two concurrent `Run`s would both dispatch, then
+/// one would be told it lost — after its command was already executing.
+fn claim_running(id: &SandboxId, instances: &InstanceMap) -> Result<()> {
+    let arc = instances
+        .read()
+        .unwrap()
+        .get(id)
+        .cloned()
+        .ok_or_else(|| VmmError::NotFound(id.clone()))?;
+    let mut inst = arc.lock().unwrap();
+    if inst.state != SandboxState::Ready {
+        return Err(VmmError::WrongState {
+            id: id.clone(),
+            expected: "Ready".into(),
+            actual: inst.state.to_string(),
+        });
+    }
+    inst.state = SandboxState::Running;
+    Ok(())
+}
+
+/// Roll a claim back to `Ready` after a failed dispatch.
+///
+/// Only downgrades when the sandbox is still `Running` (i.e. this claim still
+/// owns it). If a concurrent `stop` moved it to `Stopping`, that transition is
+/// left intact — stop owns the teardown from there.
+fn release_running(id: &SandboxId, instances: &InstanceMap) {
+    if let Some(arc) = instances.read().unwrap().get(id).cloned() {
+        let mut inst = arc.lock().unwrap();
+        if inst.state == SandboxState::Running {
+            inst.state = SandboxState::Ready;
+        }
+    }
+}
+
+/// Record a workload's exit and return the sandbox to `Ready`.
+///
+/// Runs when the `exit` chunk is observed. The `Ready` flip happens only from
+/// an active state (`Running` during a normal workload, `Stopping` while a
+/// `stop` drains — where the flip is the drain's completion signal); a sandbox
+/// already driven to `Stopped` is never resurrected.
+fn finish_workload(
+    id: &SandboxId,
+    exit_code: i32,
+    instances: &InstanceMap,
+    events_tx: &broadcast::Sender<SandboxEvent>,
+) {
+    if let Some(arc) = instances.read().unwrap().get(id).cloned() {
+        let mut inst = arc.lock().unwrap();
+        inst.last_exit_code = Some(exit_code);
+        inst.last_exited_at = Some(Utc::now());
+        if matches!(inst.state, SandboxState::Running | SandboxState::Stopping) {
+            inst.state = SandboxState::Ready;
+        }
+    }
+    let _ = events_tx
+        .send(SandboxEvent::new(id, "idle").with_attr("exit_code", &exit_code.to_string()));
+}
+
+/// Spawn the watcher that mirrors a workload's output to the caller and drives
+/// the exit-side state machine.
+///
+/// The watcher **always drains `inner_rx` to completion** so the `exit` chunk
+/// is processed even after the caller drops its receiver. Coupling the state
+/// update to a successful forward was the original defect: a consumer that
+/// disconnected mid-workload broke the loop before the exit frame, stranding
+/// the sandbox in `Running` forever. Now a gone consumer only stops the
+/// forwarding; the drain (and the `Running → Ready` flip) continues.
+fn spawn_exit_watcher(
+    id: &SandboxId,
+    inner_rx: tokio::sync::mpsc::Receiver<Result<OutputChunk>>,
+    instances: &InstanceMap,
+    events_tx: &broadcast::Sender<SandboxEvent>,
+) -> tokio::sync::mpsc::Receiver<Result<OutputChunk>> {
+    let (wrapped_tx, wrapped_rx) = tokio::sync::mpsc::channel(64);
+    let instances = Arc::clone(instances);
+    let events_tx = events_tx.clone();
+    let sandbox_id = id.clone();
+    tokio::spawn(async move {
+        let mut inner_rx = inner_rx;
+        let mut consumer_gone = false;
+        while let Some(result) = inner_rx.recv().await {
+            // Handle the exit chunk regardless of the consumer's presence.
+            if let Ok(chunk) = &result
+                && chunk.stream == "exit"
+            {
+                finish_workload(&sandbox_id, chunk.exit_code, &instances, &events_tx);
+            }
+            // Forward until the consumer goes away, then keep draining so the
+            // exit chunk above is still reached.
+            if !consumer_gone && wrapped_tx.send(result).await.is_err() {
+                consumer_gone = true;
+            }
+        }
+    });
+    wrapped_rx
+}
+
 /// Start a non-interactive workload over the sandbox's vsock and wire up the
 /// `Running → Ready` state machine.
 ///
-/// Shared by `Run` and the initial `cmd` launched right after boot: connects
-/// to the in-VM agent (retrying while it is still starting), flips the
-/// sandbox to `Running` once the session is established, and spawns a
-/// watcher that intercepts the exit chunk to restore `Ready`, record the
-/// exit code, and broadcast an `idle` event.
+/// Shared by `Run` and the initial `cmd` launched right after boot: claims the
+/// sandbox (`Ready → Running`) **before** connecting so a losing racer never
+/// dispatches a command, launches the session, then spawns the exit watcher.
+/// A launch failure rolls the claim back to `Ready`.
 pub(super) async fn start_run_workload(
     id: &SandboxId,
     uds_path: &Path,
@@ -15,73 +118,18 @@ pub(super) async fn start_run_workload(
     instances: &super::InstanceMap,
     events_tx: &broadcast::Sender<SandboxEvent>,
 ) -> Result<tokio::sync::mpsc::Receiver<Result<OutputChunk>>> {
-    let inner_rx = vsock::run(uds_path, start).await?;
+    claim_running(id, instances)?;
 
-    // Claim the sandbox with a guarded Ready → Running transition. A `stop`
-    // that raced this workload (e.g. arriving during the boot → initial-cmd
-    // window) sets `Stopping` under the same lock; if it won, abort here
-    // instead of clobbering its state and running on released resources.
-    // `stop` then sees either `Running` (drains us) or its own `Stopping`
-    // (we bailed) — never a lost update.
-    {
-        let arc = instances
-            .read()
-            .unwrap()
-            .get(id)
-            .cloned()
-            .ok_or_else(|| VmmError::NotFound(id.clone()))?;
-        let mut inst = arc.lock().unwrap();
-        if inst.state != SandboxState::Ready {
-            return Err(VmmError::WrongState {
-                id: id.clone(),
-                expected: "Ready".into(),
-                actual: inst.state.to_string(),
-            });
+    let inner_rx = match vsock::run(uds_path, start).await {
+        Ok(rx) => rx,
+        Err(e) => {
+            release_running(id, instances);
+            return Err(e);
         }
-        inst.state = SandboxState::Running;
-    }
+    };
     let _ = events_tx.send(SandboxEvent::new(id, "running"));
 
-    // Wrap the receiver to intercept MSG_EXIT and update state.
-    let (wrapped_tx, wrapped_rx) = tokio::sync::mpsc::channel(64);
-    let instances = Arc::clone(instances);
-    let events_tx = events_tx.clone();
-    let sandbox_id = id.clone();
-    tokio::spawn(async move {
-        let mut inner_rx = inner_rx;
-        while let Some(result) = inner_rx.recv().await {
-            let send_result = match &result {
-                Ok(chunk) if chunk.stream == "exit" => {
-                    let exit_code = chunk.exit_code;
-                    let value = instances.read().unwrap().get(&sandbox_id).cloned();
-                    if let Some(arc) = value {
-                        let mut inst = arc.lock().unwrap();
-                        inst.last_exit_code = Some(exit_code);
-                        inst.last_exited_at = Some(Utc::now());
-                        // Return to Ready only from an active state. During a
-                        // stop's drain the state is Stopping — flipping to
-                        // Ready is the drain's completion signal — but never
-                        // resurrect a sandbox stop has already driven to
-                        // Stopped (its resources are gone).
-                        if matches!(inst.state, SandboxState::Running | SandboxState::Stopping) {
-                            inst.state = SandboxState::Ready;
-                        }
-                    }
-                    let _ = events_tx.send(
-                        SandboxEvent::new(&sandbox_id, "idle")
-                            .with_attr("exit_code", &exit_code.to_string()),
-                    );
-                    wrapped_tx.send(result).await
-                }
-                _ => wrapped_tx.send(result).await,
-            };
-            if send_result.is_err() {
-                break;
-            }
-        }
-    });
-
-    Ok(wrapped_rx)
+    Ok(spawn_exit_watcher(id, inner_rx, instances, events_tx))
 }
 
 impl SandboxManager {
@@ -152,61 +200,166 @@ impl SandboxManager {
             timeout_seconds,
         };
 
-        let (in_tx, inner_rx) = vsock::exec(&uds_path, start).await?;
+        // Claim BEFORE opening the session (see start_run_workload): a losing
+        // racer must not launch an interactive process in the guest.
+        claim_running(id, &self.instances)?;
 
-        // Guarded Ready → Running transition (see start_run_workload): abort
-        // if a stop raced this exec session rather than clobber its state.
-        {
-            let inst = self.get_instance(id)?;
-            let mut guard = inst.lock().unwrap();
-            if guard.state != SandboxState::Ready {
-                return Err(VmmError::WrongState {
-                    id: id.clone(),
-                    expected: "Ready".into(),
-                    actual: guard.state.to_string(),
-                });
+        let (in_tx, inner_rx) = match vsock::exec(&uds_path, start).await {
+            Ok(pair) => pair,
+            Err(e) => {
+                release_running(id, &self.instances);
+                return Err(e);
             }
-            guard.state = SandboxState::Running;
-        }
+        };
         let _ = self.events_tx.send(SandboxEvent::new(id, "running"));
 
-        // Wrap the output receiver to intercept MSG_EXIT and update state.
-        let (wrapped_tx, wrapped_rx) = tokio::sync::mpsc::channel(64);
-        let instances = Arc::clone(&self.instances);
-        let events_tx = self.events_tx.clone();
-        let sandbox_id = id.clone();
-        tokio::spawn(async move {
-            let mut inner_rx = inner_rx;
-            while let Some(result) = inner_rx.recv().await {
-                let send_result = match &result {
-                    Ok(chunk) if chunk.stream == "exit" => {
-                        let exit_code = chunk.exit_code;
-                        let value = instances.read().unwrap().get(&sandbox_id).cloned();
-                        if let Some(arc) = value {
-                            let mut inst = arc.lock().unwrap();
-                            inst.last_exit_code = Some(exit_code);
-                            inst.last_exited_at = Some(Utc::now());
-                            // See start_run_workload: only return to Ready from
-                            // an active state; never resurrect a Stopped sandbox.
-                            if matches!(inst.state, SandboxState::Running | SandboxState::Stopping)
-                            {
-                                inst.state = SandboxState::Ready;
-                            }
-                        }
-                        let _ = events_tx.send(
-                            SandboxEvent::new(&sandbox_id, "idle")
-                                .with_attr("exit_code", &exit_code.to_string()),
-                        );
-                        wrapped_tx.send(result).await
-                    }
-                    _ => wrapped_tx.send(result).await,
-                };
-                if send_result.is_err() {
-                    break;
-                }
-            }
-        });
-
+        let wrapped_rx = spawn_exit_watcher(id, inner_rx, &self.instances, &self.events_tx);
         Ok((in_tx, wrapped_rx))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Build a one-instance map in the given state for state-machine tests.
+    fn instance_map(id: &str, state: SandboxState) -> InstanceMap {
+        let mut inst = SandboxInstance::new(
+            id.to_owned(),
+            SandboxSpec::default(),
+            None,
+            PathBuf::from("/tmp/does-not-matter"),
+        );
+        inst.state = state;
+        let map = HashMap::from([(id.to_owned(), Arc::new(Mutex::new(inst)))]);
+        Arc::new(RwLock::new(map))
+    }
+
+    fn state_of(id: &str, instances: &InstanceMap) -> SandboxState {
+        instances.read().unwrap()[id].lock().unwrap().state
+    }
+
+    #[test]
+    fn claim_running_transitions_from_ready_only() {
+        let instances = instance_map("s", SandboxState::Ready);
+        claim_running(&"s".to_owned(), &instances).unwrap();
+        assert_eq!(state_of("s", &instances), SandboxState::Running);
+
+        // A second claim on the now-Running sandbox must be rejected — this is
+        // the guard that stops a concurrent workload from being dispatched.
+        let err = claim_running(&"s".to_owned(), &instances).unwrap_err();
+        assert!(matches!(err, VmmError::WrongState { .. }));
+        assert_eq!(state_of("s", &instances), SandboxState::Running);
+    }
+
+    #[test]
+    fn claim_running_rejects_missing_and_stopping() {
+        let instances = instance_map("s", SandboxState::Stopping);
+        assert!(matches!(
+            claim_running(&"s".to_owned(), &instances).unwrap_err(),
+            VmmError::WrongState { .. }
+        ));
+        assert!(matches!(
+            claim_running(&"missing".to_owned(), &instances).unwrap_err(),
+            VmmError::NotFound(_)
+        ));
+    }
+
+    #[test]
+    fn release_running_only_downgrades_running() {
+        let instances = instance_map("s", SandboxState::Running);
+        release_running(&"s".to_owned(), &instances);
+        assert_eq!(state_of("s", &instances), SandboxState::Ready);
+
+        // A stop that won the race left Stopping; rollback must not clobber it.
+        instances.read().unwrap()["s"].lock().unwrap().state = SandboxState::Stopping;
+        release_running(&"s".to_owned(), &instances);
+        assert_eq!(state_of("s", &instances), SandboxState::Stopping);
+    }
+
+    #[tokio::test]
+    async fn watcher_restores_ready_even_when_consumer_disconnects() {
+        // Regression for the strand-in-Running bug: drop the consumer before
+        // the exit chunk; the watcher must still process the exit and flip
+        // Running → Ready.
+        let instances = instance_map("s", SandboxState::Running);
+        let (events_tx, _events_rx) = broadcast::channel(16);
+        let (inner_tx, inner_rx) = tokio::sync::mpsc::channel(8);
+
+        let wrapped_rx = spawn_exit_watcher(&"s".to_owned(), inner_rx, &instances, &events_tx);
+        drop(wrapped_rx); // consumer gone immediately
+
+        inner_tx
+            .send(Ok(OutputChunk {
+                stream: "stdout".into(),
+                data: b"noise".to_vec(),
+                exit_code: 0,
+            }))
+            .await
+            .unwrap();
+        inner_tx
+            .send(Ok(OutputChunk {
+                stream: "exit".into(),
+                data: vec![],
+                exit_code: 7,
+            }))
+            .await
+            .unwrap();
+        drop(inner_tx); // guest side closes after exit
+
+        // Give the detached watcher a moment to drain and update state.
+        for _ in 0..50 {
+            if state_of("s", &instances) == SandboxState::Ready {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+        assert_eq!(state_of("s", &instances), SandboxState::Ready);
+        let last_exit_code = {
+            let guard = instances.read().unwrap();
+            let code = guard["s"].lock().unwrap().last_exit_code;
+            code
+        };
+        assert_eq!(last_exit_code, Some(7));
+    }
+
+    #[tokio::test]
+    async fn watcher_forwards_then_finishes_for_a_live_consumer() {
+        let instances = instance_map("s", SandboxState::Running);
+        let (events_tx, mut events_rx) = broadcast::channel(16);
+        let (inner_tx, inner_rx) = tokio::sync::mpsc::channel(8);
+
+        let mut wrapped_rx = spawn_exit_watcher(&"s".to_owned(), inner_rx, &instances, &events_tx);
+
+        inner_tx
+            .send(Ok(OutputChunk {
+                stream: "stdout".into(),
+                data: b"hello".to_vec(),
+                exit_code: 0,
+            }))
+            .await
+            .unwrap();
+        let first = wrapped_rx.recv().await.unwrap().unwrap();
+        assert_eq!(first.data, b"hello");
+
+        inner_tx
+            .send(Ok(OutputChunk {
+                stream: "exit".into(),
+                data: vec![],
+                exit_code: 0,
+            }))
+            .await
+            .unwrap();
+        drop(inner_tx);
+
+        // The forwarded exit chunk arrives, then the channel closes.
+        let exit = wrapped_rx.recv().await.unwrap().unwrap();
+        assert_eq!(exit.stream, "exit");
+        assert!(wrapped_rx.recv().await.is_none());
+        assert_eq!(state_of("s", &instances), SandboxState::Ready);
+
+        // An "idle" event was broadcast on exit.
+        let ev = events_rx.recv().await.unwrap();
+        assert_eq!(ev.action, "idle");
     }
 }

--- a/virt/arcbox-vm/src/sandbox/workload.rs
+++ b/virt/arcbox-vm/src/sandbox/workload.rs
@@ -12,13 +12,14 @@ pub(super) async fn start_run_workload(
     id: &SandboxId,
     uds_path: &Path,
     start: StartCommand,
-    instances: &Arc<RwLock<HashMap<SandboxId, Arc<Mutex<SandboxInstance>>>>>,
+    instances: &super::InstanceMap,
     events_tx: &broadcast::Sender<SandboxEvent>,
 ) -> Result<tokio::sync::mpsc::Receiver<Result<OutputChunk>>> {
     let inner_rx = vsock::run(uds_path, start).await?;
 
     // Transition to Running only after the vsock session is established.
-    if let Some(arc) = instances.read().unwrap().get(id).cloned() {
+    let entry = instances.read().unwrap().get(id).cloned();
+    if let Some(arc) = entry {
         arc.lock().unwrap().state = SandboxState::Running;
     }
     let _ = events_tx.send(SandboxEvent::new(id, "running"));

--- a/virt/arcbox-vm/src/sandbox/workload.rs
+++ b/virt/arcbox-vm/src/sandbox/workload.rs
@@ -33,7 +33,9 @@ fn claim_running(id: &SandboxId, instances: &InstanceMap) -> Result<()> {
 /// owns it). If a concurrent `stop` moved it to `Stopping`, that transition is
 /// left intact — stop owns the teardown from there.
 fn release_running(id: &SandboxId, instances: &InstanceMap) {
-    if let Some(arc) = instances.read().unwrap().get(id).cloned() {
+    // Drop the map read guard before taking the instance lock.
+    let arc = instances.read().unwrap().get(id).cloned();
+    if let Some(arc) = arc {
         let mut inst = arc.lock().unwrap();
         if inst.state == SandboxState::Running {
             inst.state = SandboxState::Ready;
@@ -53,7 +55,9 @@ fn finish_workload(
     instances: &InstanceMap,
     events_tx: &broadcast::Sender<SandboxEvent>,
 ) {
-    if let Some(arc) = instances.read().unwrap().get(id).cloned() {
+    // Drop the map read guard before taking the instance lock.
+    let arc = instances.read().unwrap().get(id).cloned();
+    if let Some(arc) = arc {
         let mut inst = arc.lock().unwrap();
         inst.last_exit_code = Some(exit_code);
         inst.last_exited_at = Some(Utc::now());

--- a/virt/arcbox-vm/src/sandbox/workload.rs
+++ b/virt/arcbox-vm/src/sandbox/workload.rs
@@ -1,5 +1,63 @@
 use super::*;
 
+/// Start a non-interactive workload over the sandbox's vsock and wire up the
+/// `Running → Ready` state machine.
+///
+/// Shared by `Run` and the initial `cmd` launched right after boot: connects
+/// to the in-VM agent (retrying while it is still starting), flips the
+/// sandbox to `Running` once the session is established, and spawns a
+/// watcher that intercepts the exit chunk to restore `Ready`, record the
+/// exit code, and broadcast an `idle` event.
+pub(super) async fn start_run_workload(
+    id: &SandboxId,
+    uds_path: &Path,
+    start: StartCommand,
+    instances: &Arc<RwLock<HashMap<SandboxId, Arc<Mutex<SandboxInstance>>>>>,
+    events_tx: &broadcast::Sender<SandboxEvent>,
+) -> Result<tokio::sync::mpsc::Receiver<Result<OutputChunk>>> {
+    let inner_rx = vsock::run(uds_path, start).await?;
+
+    // Transition to Running only after the vsock session is established.
+    if let Some(arc) = instances.read().unwrap().get(id).cloned() {
+        arc.lock().unwrap().state = SandboxState::Running;
+    }
+    let _ = events_tx.send(SandboxEvent::new(id, "running"));
+
+    // Wrap the receiver to intercept MSG_EXIT and update state.
+    let (wrapped_tx, wrapped_rx) = tokio::sync::mpsc::channel(64);
+    let instances = Arc::clone(instances);
+    let events_tx = events_tx.clone();
+    let sandbox_id = id.clone();
+    tokio::spawn(async move {
+        let mut inner_rx = inner_rx;
+        while let Some(result) = inner_rx.recv().await {
+            let send_result = match &result {
+                Ok(chunk) if chunk.stream == "exit" => {
+                    let exit_code = chunk.exit_code;
+                    let value = instances.read().unwrap().get(&sandbox_id).cloned();
+                    if let Some(arc) = value {
+                        let mut inst = arc.lock().unwrap();
+                        inst.state = SandboxState::Ready;
+                        inst.last_exit_code = Some(exit_code);
+                        inst.last_exited_at = Some(Utc::now());
+                    }
+                    let _ = events_tx.send(
+                        SandboxEvent::new(&sandbox_id, "idle")
+                            .with_attr("exit_code", &exit_code.to_string()),
+                    );
+                    wrapped_tx.send(result).await
+                }
+                _ => wrapped_tx.send(result).await,
+            };
+            if send_result.is_err() {
+                break;
+            }
+        }
+    });
+
+    Ok(wrapped_rx)
+}
+
 impl SandboxManager {
     #[allow(
         clippy::too_many_arguments,
@@ -29,48 +87,7 @@ impl SandboxManager {
             timeout_seconds,
         };
 
-        let inner_rx = vsock::run(&uds_path, start).await?;
-
-        // Transition to Running only after vsock session is established.
-        {
-            let inst = self.get_instance(id)?;
-            inst.lock().unwrap().state = SandboxState::Running;
-        }
-        let _ = self.events_tx.send(SandboxEvent::new(id, "running"));
-
-        // Wrap the receiver to intercept MSG_EXIT and update state.
-        let (wrapped_tx, wrapped_rx) = tokio::sync::mpsc::channel(64);
-        let instances = Arc::clone(&self.instances);
-        let events_tx = self.events_tx.clone();
-        let sandbox_id = id.clone();
-        tokio::spawn(async move {
-            let mut inner_rx = inner_rx;
-            while let Some(result) = inner_rx.recv().await {
-                let send_result = match &result {
-                    Ok(chunk) if chunk.stream == "exit" => {
-                        let exit_code = chunk.exit_code;
-                        let value = instances.read().unwrap().get(&sandbox_id).cloned();
-                        if let Some(arc) = value {
-                            let mut inst = arc.lock().unwrap();
-                            inst.state = SandboxState::Ready;
-                            inst.last_exit_code = Some(exit_code);
-                            inst.last_exited_at = Some(Utc::now());
-                        }
-                        let _ = events_tx.send(
-                            SandboxEvent::new(&sandbox_id, "idle")
-                                .with_attr("exit_code", &exit_code.to_string()),
-                        );
-                        wrapped_tx.send(result).await
-                    }
-                    _ => wrapped_tx.send(result).await,
-                };
-                if send_result.is_err() {
-                    break;
-                }
-            }
-        });
-
-        Ok(wrapped_rx)
+        start_run_workload(id, &uds_path, start, &self.instances, &self.events_tx).await
     }
 
     /// Start an interactive exec session inside a ready sandbox.

--- a/virt/arcbox-vm/src/sandbox/workload.rs
+++ b/virt/arcbox-vm/src/sandbox/workload.rs
@@ -17,10 +17,28 @@ pub(super) async fn start_run_workload(
 ) -> Result<tokio::sync::mpsc::Receiver<Result<OutputChunk>>> {
     let inner_rx = vsock::run(uds_path, start).await?;
 
-    // Transition to Running only after the vsock session is established.
-    let entry = instances.read().unwrap().get(id).cloned();
-    if let Some(arc) = entry {
-        arc.lock().unwrap().state = SandboxState::Running;
+    // Claim the sandbox with a guarded Ready → Running transition. A `stop`
+    // that raced this workload (e.g. arriving during the boot → initial-cmd
+    // window) sets `Stopping` under the same lock; if it won, abort here
+    // instead of clobbering its state and running on released resources.
+    // `stop` then sees either `Running` (drains us) or its own `Stopping`
+    // (we bailed) — never a lost update.
+    {
+        let arc = instances
+            .read()
+            .unwrap()
+            .get(id)
+            .cloned()
+            .ok_or_else(|| VmmError::NotFound(id.clone()))?;
+        let mut inst = arc.lock().unwrap();
+        if inst.state != SandboxState::Ready {
+            return Err(VmmError::WrongState {
+                id: id.clone(),
+                expected: "Ready".into(),
+                actual: inst.state.to_string(),
+            });
+        }
+        inst.state = SandboxState::Running;
     }
     let _ = events_tx.send(SandboxEvent::new(id, "running"));
 
@@ -38,9 +56,16 @@ pub(super) async fn start_run_workload(
                     let value = instances.read().unwrap().get(&sandbox_id).cloned();
                     if let Some(arc) = value {
                         let mut inst = arc.lock().unwrap();
-                        inst.state = SandboxState::Ready;
                         inst.last_exit_code = Some(exit_code);
                         inst.last_exited_at = Some(Utc::now());
+                        // Return to Ready only from an active state. During a
+                        // stop's drain the state is Stopping — flipping to
+                        // Ready is the drain's completion signal — but never
+                        // resurrect a sandbox stop has already driven to
+                        // Stopped (its resources are gone).
+                        if matches!(inst.state, SandboxState::Running | SandboxState::Stopping) {
+                            inst.state = SandboxState::Ready;
+                        }
                     }
                     let _ = events_tx.send(
                         SandboxEvent::new(&sandbox_id, "idle")
@@ -129,10 +154,19 @@ impl SandboxManager {
 
         let (in_tx, inner_rx) = vsock::exec(&uds_path, start).await?;
 
-        // Transition to Running only after vsock session is established.
+        // Guarded Ready → Running transition (see start_run_workload): abort
+        // if a stop raced this exec session rather than clobber its state.
         {
             let inst = self.get_instance(id)?;
-            inst.lock().unwrap().state = SandboxState::Running;
+            let mut guard = inst.lock().unwrap();
+            if guard.state != SandboxState::Ready {
+                return Err(VmmError::WrongState {
+                    id: id.clone(),
+                    expected: "Ready".into(),
+                    actual: guard.state.to_string(),
+                });
+            }
+            guard.state = SandboxState::Running;
         }
         let _ = self.events_tx.send(SandboxEvent::new(id, "running"));
 
@@ -150,9 +184,14 @@ impl SandboxManager {
                         let value = instances.read().unwrap().get(&sandbox_id).cloned();
                         if let Some(arc) = value {
                             let mut inst = arc.lock().unwrap();
-                            inst.state = SandboxState::Ready;
                             inst.last_exit_code = Some(exit_code);
                             inst.last_exited_at = Some(Utc::now());
+                            // See start_run_workload: only return to Ready from
+                            // an active state; never resurrect a Stopped sandbox.
+                            if matches!(inst.state, SandboxState::Running | SandboxState::Stopping)
+                            {
+                                inst.state = SandboxState::Ready;
+                            }
                         }
                         let _ = events_tx.send(
                             SandboxEvent::new(&sandbox_id, "idle")

--- a/virt/arcbox-vm/src/user_spec.rs
+++ b/virt/arcbox-vm/src/user_spec.rs
@@ -1,0 +1,159 @@
+//! Docker-style `user` specification parsing for sandbox workloads.
+//!
+//! Resolves `"uid"`, `"uid:gid"`, `"name"`, and `"name:group"` against the
+//! *sandbox rootfs*'s `/etc/passwd` and `/etc/group` contents (passed in as
+//! strings so the logic stays pure and host-testable). Semantics follow
+//! `docker run --user`: a numeric uid that has no passwd entry falls back to
+//! gid 0, a named user must exist, and an explicit group part wins.
+
+/// A resolved uid/gid pair for workload execution.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ResolvedUser {
+    /// Numeric user ID to run as.
+    pub uid: u32,
+    /// Numeric group ID to run as.
+    pub gid: u32,
+}
+
+/// Resolve a Docker-style user spec against passwd/group file contents.
+///
+/// Returns `Ok(None)` for an empty spec (run as the agent's own user, i.e.
+/// root inside the microVM). Fails with an actionable message when a named
+/// user or group does not exist in the sandbox rootfs.
+pub fn resolve_user(spec: &str, passwd: &str, group: &str) -> Result<Option<ResolvedUser>, String> {
+    let spec = spec.trim();
+    if spec.is_empty() {
+        return Ok(None);
+    }
+
+    let (user_part, group_part) = match spec.split_once(':') {
+        Some((u, g)) => (u, Some(g)),
+        None => (spec, None),
+    };
+
+    let (uid, passwd_gid) = if let Ok(uid) = user_part.parse::<u32>() {
+        // Numeric uid: passwd entry is optional; without one Docker runs the
+        // process with gid 0.
+        (uid, passwd_entry_by_uid(passwd, uid).map(|(_, gid)| gid))
+    } else {
+        let (uid, gid) = passwd_entry_by_name(passwd, user_part)
+            .ok_or_else(|| format!("user '{user_part}' not found in the sandbox /etc/passwd"))?;
+        (uid, Some(gid))
+    };
+
+    let gid = match group_part {
+        None => passwd_gid.unwrap_or(0),
+        Some(g) => {
+            if let Ok(gid) = g.parse::<u32>() {
+                gid
+            } else {
+                group_entry_by_name(group, g)
+                    .ok_or_else(|| format!("group '{g}' not found in the sandbox /etc/group"))?
+            }
+        }
+    };
+
+    Ok(Some(ResolvedUser { uid, gid }))
+}
+
+/// Find `(uid, gid)` for a passwd entry by user name.
+fn passwd_entry_by_name(passwd: &str, name: &str) -> Option<(u32, u32)> {
+    passwd_entries(passwd)
+        .find_map(|(entry_name, uid, gid)| (entry_name == name).then_some((uid, gid)))
+}
+
+/// Find `(name-ignored, gid)` for a passwd entry by uid.
+fn passwd_entry_by_uid(passwd: &str, uid: u32) -> Option<(u32, u32)> {
+    passwd_entries(passwd).find_map(|(_, entry_uid, gid)| (entry_uid == uid).then_some((uid, gid)))
+}
+
+/// Iterate `name:pw:uid:gid` prefixes of well-formed passwd lines.
+fn passwd_entries(passwd: &str) -> impl Iterator<Item = (&str, u32, u32)> {
+    passwd.lines().filter_map(|line| {
+        let mut fields = line.split(':');
+        let name = fields.next()?;
+        let _pw = fields.next()?;
+        let uid = fields.next()?.parse().ok()?;
+        let gid = fields.next()?.parse().ok()?;
+        Some((name, uid, gid))
+    })
+}
+
+/// Find a gid for a group entry (`name:pw:gid:members`) by group name.
+fn group_entry_by_name(group: &str, name: &str) -> Option<u32> {
+    group.lines().find_map(|line| {
+        let mut fields = line.split(':');
+        let entry_name = fields.next()?;
+        let _pw = fields.next()?;
+        let gid = fields.next()?.parse().ok()?;
+        (entry_name == name).then_some(gid)
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const PASSWD: &str = "root:x:0:0:root:/root:/bin/sh\nweb:x:1000:1001:web:/home/web:/bin/sh\n";
+    const GROUP: &str = "root:x:0:\nstaff:x:2000:web\n";
+
+    #[test]
+    fn empty_spec_is_none() {
+        assert_eq!(resolve_user("", PASSWD, GROUP).unwrap(), None);
+        assert_eq!(resolve_user("  ", PASSWD, GROUP).unwrap(), None);
+    }
+
+    #[test]
+    fn numeric_uid_uses_passwd_gid() {
+        let u = resolve_user("1000", PASSWD, GROUP).unwrap().unwrap();
+        assert_eq!(
+            u,
+            ResolvedUser {
+                uid: 1000,
+                gid: 1001
+            }
+        );
+    }
+
+    #[test]
+    fn numeric_uid_without_passwd_entry_falls_back_to_gid_zero() {
+        let u = resolve_user("4242", PASSWD, GROUP).unwrap().unwrap();
+        assert_eq!(u, ResolvedUser { uid: 4242, gid: 0 });
+    }
+
+    #[test]
+    fn numeric_uid_gid_pair() {
+        let u = resolve_user("7:9", PASSWD, GROUP).unwrap().unwrap();
+        assert_eq!(u, ResolvedUser { uid: 7, gid: 9 });
+    }
+
+    #[test]
+    fn named_user_resolves_both_ids() {
+        let u = resolve_user("web", PASSWD, GROUP).unwrap().unwrap();
+        assert_eq!(
+            u,
+            ResolvedUser {
+                uid: 1000,
+                gid: 1001
+            }
+        );
+    }
+
+    #[test]
+    fn named_user_with_named_group() {
+        let u = resolve_user("web:staff", PASSWD, GROUP).unwrap().unwrap();
+        assert_eq!(
+            u,
+            ResolvedUser {
+                uid: 1000,
+                gid: 2000
+            }
+        );
+    }
+
+    #[test]
+    fn unknown_named_user_errors() {
+        assert!(resolve_user("ghost", PASSWD, GROUP).is_err());
+        assert!(resolve_user("web:ghosts", PASSWD, GROUP).is_err());
+    }
+}

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -9,6 +9,7 @@ authors.workspace = true
 
 [dependencies]
 anyhow.workspace = true
+arcbox-constants = { version = "0.4.16", path = "../common/arcbox-constants", features = ["std"] }
 clap = { workspace = true, features = ["derive", "env"] }
 dirs.workspace = true
 flate2 = "1.1.9"

--- a/xtask/src/commands/dev.rs
+++ b/xtask/src/commands/dev.rs
@@ -69,15 +69,9 @@ fn boot_version(lockfile: &std::path::Path) -> Result<String> {
 }
 
 fn default_data_dir() -> PathBuf {
-    if cfg!(target_os = "macos") {
-        dirs::home_dir()
-            .expect("home directory is required for default macOS data dir")
-            .join("Library/Application Support/arcbox")
-    } else {
-        dirs::data_dir()
-            .expect("data directory is required for default Linux data dir")
-            .join("arcbox")
-    }
+    // Same resolution as the daemon/CLI (~/.arcbox), not the old
+    // Application Support location.
+    arcbox_constants::paths::ArcboxProfile::Production.default_data_dir()
 }
 
 fn dev_assets_match(dev_boot_dir: &std::path::Path, version: &str) -> Result<bool> {

--- a/xtask/src/commands/e2e.rs
+++ b/xtask/src/commands/e2e.rs
@@ -142,6 +142,21 @@ fn prebuild(root: &std::path::Path, test: &str) -> Result<bool> {
             xshell::cmd!(shell, "cargo build --release -p arcbox-e2e --bin hv_e2e").run()?;
             Ok(true)
         }
+        // Must match tests/e2e/src/sandbox.rs::build_binaries exactly
+        // (packages AND profiles), or SKIP_BUILD runs stale binaries.
+        "sandbox" => {
+            xshell::cmd!(
+                shell,
+                "cargo build --release -p arcbox-cli -p arcbox-daemon"
+            )
+            .run()?;
+            xshell::cmd!(
+                shell,
+                "cargo build --release -p arcbox-agent -p arcbox-vm --bins --target aarch64-unknown-linux-musl"
+            )
+            .run()?;
+            Ok(true)
+        }
         other => {
             println!("[e2e] no prebuild recipe for test '{other}'; every run builds for itself");
             Ok(false)


### PR DESCRIPTION
Delivers the **SandBox V1** Linear project: turns the sandbox primitives from "code exists but nothing works out of the box" into a usable, E2B-style local sandbox stack, validated end-to-end on a real VZ daemon.

The full stack now passes a sandbox e2e smoke on this hardware (Apple M5 Max, VZ backend): create (with initial cmd) → ready → initial-cmd idle → Run → 1 MiB file round-trip → Checkpoint → Stop → Restore → Run in restored sandbox with the pre-checkpoint file intact → Remove.

## What landed (per CORE issue)

- **CORE-5 asset pipeline** — guest defaults point at the real VirtioFS layout (`/arcbox/runtime/{bin,kernel}`); overlay2→ext4 uses the `oci2rootfs` library (no missing external binary); an empty `rootfs` auto-builds a busybox + vm-agent image via `arcbox-ext4`; the `vm-agent` bin target is staged by the e2e harness and seeded from the app bundle. `docs/data-directories.md` corrected.
- **CORE-13 capability gating** — the agent probes `/dev/kvm` and rejects sandbox RPCs with `FAILED_PRECONDITION` when nested virt is unavailable; agent wire error codes now map onto real gRPC statuses (`CoreError::Agent`).
- **CORE-6 initial workload** — `CreateSandboxRequest.cmd` runs automatically after boot through the shared `Run` path.
- **CORE-9 graceful stop** — Stop drains the workload, waits for FC exit within the budget, SIGKILLs only as fallback, and releases TAP/CoW/chroot on `Stopped`.
- **CORE-8 exec plumbing** — TTY resize wired end-to-end (new `SandboxExecResize` frame); vm-agent honors Docker-style `user` (`arcbox_vm::user_spec`).
- **CORE-7 file I/O** — `ReadFile`/`WriteFile` gRPC (chunked, 256 MiB cap) over new wire frames; `arcbox sandbox cp`.
- **CORE-2 port exposure** — `ExposePort`/`UnexposePort`: guest `PortForwardManager` (iptables DNAT, reserved 40000-49999, event-driven cleanup) composed with the host inbound relay; `arcbox sandbox expose/unexpose`.
- **CORE-14 reconcile** — per-sandbox `state.json`; a fresh manager sweeps orphaned FC/TAP/dm/chroot after an agent restart.
- **CORE-11 / CORE-12** — `mounts` / `image` / `ssh_public_key` are rejected explicitly with actionable messages instead of silently ignored.
- **CORE-15 / CORE-4** — gRPC server reflection (v1 + v1alpha) + `docs/sandbox-api.md` integration reference.
- **CORE-10** — `tests/e2e --test sandbox` smoke + `xtask e2e` prebuild recipe.

Incidental correctness fixes found by the smoke: the agent transport is now chosen by VM backend rather than the fd's socket domain (VZ was mis-routed onto the blocking transport, breaking every streaming sandbox RPC); jailer checkpoint collection tolerates `EXDEV`; `xtask dev boot-assets` resolves the user cache at `~/.arcbox`.

## Known follow-ups (documented, not blockers)

- Fresh-network restore (`network_override: true`) needs Firecracker's `network_overrides` snapshot-load field; the pinned FC 1.10.1 predates it. Restore reusing the recorded NIC works today. Tracked for the FC upgrade in boot-assets.
- CORE-1 (guest-side file I/O + clock sync) shipped earlier via #35 and can be closed.

## Validation

- `cargo fmt --check --all`, `cargo clippy --workspace --exclude arcbox-agent` (+ agent clippy for the touched files on the musl target), `cargo test --workspace --exclude arcbox-agent` — all green.
- `buf breaking` against origin/master — passes (all proto changes additive).
- Guest agent + vm-agent cross-compiled for `aarch64-unknown-linux-musl`.
- Sandbox e2e smoke — passes on VZ.

Generated proto is regenerated and committed.

---

## Post-review hardening (P0/P1/P2, 13 commits)

A three-agent deep review (guest agent / SandboxManager core / host chain) found 2 P0 + 10 P1 + a batch of P2. All contained findings are fixed, unit-tested, and re-validated by the VZ smoke; each is one focused commit.

**P0 / P1 — correctness & isolation**
- Claim the workload slot *before* dispatching into the guest, so a losing racer never runs a phantom command; the exit watcher drains to the exit chunk even if the consumer disconnected (no more stranded `Running`).
- Gate create/restore on the crash-recovery sweep, so a re-created same-id sandbox can't have its deterministically-named dm/TAP/CoW torn down mid-flight; tear the CoW down on a boot-vs-remove race instead of leaking it.
- Guarantee checkpoint always resumes the guest; reserve the restore id up front to close a CoW-truncation TOCTOU; release the TAP on restore failure.
- Identity-guard TTL expiry so a stale timer can't remove a re-created same-id sandbox.
- vm-agent (guest PID 1) now reaps reparented orphans via a single routing reaper, enforces `timeout_seconds` on the TTY path, and kills the workload's process group on host disconnect.
- Tag sandbox DNAT rules and flush orphans at agent startup (no cross-restart leak/misroute).
- Expose binds `127.0.0.1` (not `0.0.0.0`); a client RST mid-upload aborts the write instead of committing a truncated file.

**P2 — robustness & fidelity**
- Preserve agent error codes (bad input → 400, streaming errors keep their code instead of `INTERNAL`).
- Bounded streaming channels + stop draining dropped consumers (removes an unbounded-memory vector from a spewing sandbox).
- Expose fails loudly when no port could be bound; strict id charset `[A-Za-z0-9_-]` for sandbox and snapshot ids (closes a snapshot_id path traversal); EXDEV move fsync; `serde(default)` on the crash-recovery record; `list_sandboxes` lock-ordering; vm-agent `setgroups` in the piped path; single-flight rootfs builds + tmp sweep; `run_dir` `0700`.

Deferred (tracked, needs new infra, not a contained fix): host-side port/DNS cleanup on TTL/daemon-restart → CORE-20 (blocked by the daemon sandbox-event watcher, CORE-19).
