### PR TITLE
fix(hv): platform correctness + guest-initiated reboot (ABX-402..405)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -452,12 +452,15 @@ name = "arcbox-e2e"
 version = "0.4.16"
 dependencies = [
  "anyhow",
+ "arcbox-constants",
  "arcbox-core",
  "arcbox-grpc",
  "arcbox-protocol",
  "arcbox-vmm",
  "hyper-util",
  "libc",
+ "serde",
+ "serde_json",
  "tempfile",
  "tokio",
  "toml_edit 0.25.12+spec-1.1.0",
@@ -2048,8 +2051,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8cb01cd46b0cf372153850f4c6c272d9cbea2da513e07538405148f95bd789f3"
 dependencies = [
  "atomic",
+ "parking_lot",
  "pear",
  "serde",
+ "tempfile",
  "toml 0.8.23",
  "uncased",
  "version_check",

--- a/app/arcbox-core/src/machine.rs
+++ b/app/arcbox-core/src/machine.rs
@@ -725,6 +725,39 @@ impl MachineManager {
         Ok(())
     }
 
+    /// Reports whether a machine's VM stopped on its own (guest-driven), and if
+    /// so whether it was a reboot request. See [`VmManager::vm_self_stopped`].
+    #[must_use]
+    pub fn vm_self_stopped(&self, name: &str) -> Option<bool> {
+        let machines = self.machines.read().ok()?;
+        let vm_id = machines.get(name)?.vm_id.clone();
+        drop(machines);
+        self.vm_manager.vm_self_stopped(&vm_id)
+    }
+
+    /// Reboots a machine's VM in place (guest PSCI SYSTEM_RESET): a full
+    /// teardown then a fresh boot, leaving the machine record Running. The
+    /// caller re-establishes agent readiness afterward.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the machine is unknown or the reboot fails.
+    pub fn reboot(&self, name: &str) -> Result<()> {
+        let vm_id = {
+            let machines = self.machines.read().map_err(|_| CoreError::LockPoisoned)?;
+            machines
+                .get(name)
+                .ok_or_else(|| CoreError::not_found(name.to_string()))?
+                .vm_id
+                .clone()
+        };
+        // Reboot is a slow teardown+reboot; do it without holding the registry
+        // lock so concurrent reads stay responsive.
+        self.vm_manager.reboot(&vm_id)?;
+        tracing::info!("Rebooted machine '{}'", name);
+        Ok(())
+    }
+
     /// Switches a stopped machine's hypervisor backend.
     ///
     /// Updates the lazily-built VM config and the in-memory and persisted

--- a/app/arcbox-core/src/vm.rs
+++ b/app/arcbox-core/src/vm.rs
@@ -281,6 +281,46 @@ impl VmManager {
         Ok(())
     }
 
+    /// Reports whether a VM stopped on its own — i.e. its VMM is still owned by
+    /// the entry (no `stop()` cleared it) but is no longer running.
+    ///
+    /// `None` = still running, or no VMM/entry. `Some(true)` = stopped via a
+    /// guest PSCI SYSTEM_RESET (reboot request); `Some(false)` = stopped some
+    /// other way (guest halt / crash).
+    #[must_use]
+    pub fn vm_self_stopped(&self, id: &VmId) -> Option<bool> {
+        let vms = self.vms.read().ok()?;
+        let vmm = vms.get(id)?.vmm.as_ref()?;
+        if vmm.is_running() {
+            None
+        } else {
+            Some(vmm.reset_requested())
+        }
+    }
+
+    /// Reboots a VM in place: full teardown + fresh boot in the same process,
+    /// keeping the entry (unlike `stop`, which drops the VMM). Used when the
+    /// guest issued PSCI SYSTEM_RESET.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the entry is missing, has no VMM, or the reboot
+    /// (teardown + re-initialization) fails.
+    pub fn reboot(&self, id: &VmId) -> Result<()> {
+        let mut vms = self.vms.write().map_err(|_| CoreError::LockPoisoned)?;
+        let entry = vms
+            .get_mut(id)
+            .ok_or_else(|| CoreError::not_found(id.to_string()))?;
+        let vmm = entry
+            .vmm
+            .as_mut()
+            .ok_or_else(|| CoreError::invalid_state(format!("VM {id} has no VMM to reboot")))?;
+        vmm.reboot()?;
+        entry.info.state = MachineState::Running;
+        tracing::info!("Rebooted VM {}", id);
+        Ok(())
+    }
+
     /// Attempts graceful VM shutdown via vsock shutdown RPC.
     ///
     /// Sends a shutdown command to the guest agent, then waits for the VM to

--- a/app/arcbox-core/src/vm_lifecycle/actor.rs
+++ b/app/arcbox-core/src/vm_lifecycle/actor.rs
@@ -283,6 +283,13 @@ impl LifecycleActor {
         let mut idle_ticker = tokio::time::interval(Duration::from_secs(BALLOON_SHRINK_DELAY_SECS));
         idle_ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
 
+        // Poll for a guest-initiated stop (PSCI SYSTEM_RESET) so a guest reboot
+        // becomes an in-place VMM reboot. Coarse interval: reboot isn't
+        // latency-critical and an idle daemon shouldn't wake often.
+        const VM_LIVENESS_POLL_SECS: u64 = 2;
+        let mut liveness_ticker = tokio::time::interval(Duration::from_secs(VM_LIVENESS_POLL_SECS));
+        liveness_ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+
         loop {
             // Split-borrow the receivers away from `self` so the dispatch
             // helpers can borrow `self` mutably inside the match arms.
@@ -296,6 +303,9 @@ impl LifecycleActor {
                 }
                 _ = idle_ticker.tick() => {
                     self.on_idle_tick(&mut machine);
+                }
+                _ = liveness_ticker.tick() => {
+                    self.on_liveness_tick(&mut machine);
                 }
             }
         }
@@ -356,6 +366,15 @@ impl LifecycleActor {
                 let events = self.events_tx.clone();
                 self.inflight = Some(tokio::spawn(async move {
                     shared.run_stop(epoch, &events).await;
+                }));
+            }
+            Effect::SpawnReboot { timeout_ms } => {
+                let epoch = self.abort_inflight();
+                let shared = Arc::clone(&self.shared);
+                let events = self.events_tx.clone();
+                let timeout = Duration::from_millis(timeout_ms);
+                self.inflight = Some(tokio::spawn(async move {
+                    shared.run_reboot(timeout, epoch, &events).await;
                 }));
             }
             Effect::AbortInflight => {
@@ -594,6 +613,29 @@ impl LifecycleActor {
                 self.shared.idle_seconds()
             );
             self.dispatch(machine, VmEvent::IdleTimeout);
+        }
+    }
+
+    /// Detects a guest-initiated VM stop and, when it was a PSCI SYSTEM_RESET,
+    /// reboots the VM in place. Only meaningful while we believe the VM is up;
+    /// a guest halt/crash (`Some(false)`) is left as-is for now.
+    fn on_liveness_tick(&mut self, machine: &mut Machine) {
+        if !matches!(
+            self.public(),
+            VmLifecycleState::Running | VmLifecycleState::Idle
+        ) {
+            return;
+        }
+        if self
+            .shared
+            .machine_manager
+            .vm_self_stopped(&self.shared.machine_name)
+            == Some(true)
+        {
+            tracing::info!("guest requested reboot (SYSTEM_RESET); rebooting VM in place");
+            let timeout_ms =
+                u64::try_from(self.shared.config.startup_timeout.as_millis()).unwrap_or(u64::MAX);
+            self.dispatch(machine, VmEvent::GuestReset { timeout_ms });
         }
     }
 

--- a/app/arcbox-core/src/vm_lifecycle/boot.rs
+++ b/app/arcbox-core/src/vm_lifecycle/boot.rs
@@ -121,6 +121,10 @@ impl LifecycleShared {
         tokio::task::spawn_blocking(move || mm.reboot(&name))
             .await
             .map_err(|e| CoreError::Vm(format!("reboot task panicked: {e}")))??;
+        // The teardown dropped the bridge along with the VMM; the fresh boot
+        // created a new one, so the host container-subnet route must be
+        // reinstalled exactly like after a normal start.
+        self.spawn_route_reconciler();
         self.wait_for_agent(timeout).await?;
         self.sync_guest_clock().await;
         Ok(())

--- a/app/arcbox-core/src/vm_lifecycle/boot.rs
+++ b/app/arcbox-core/src/vm_lifecycle/boot.rs
@@ -93,6 +93,39 @@ impl LifecycleShared {
         let _ = events.send(Completion { epoch, outcome });
     }
 
+    /// Reboots the VM in place (guest PSCI SYSTEM_RESET), then waits for the
+    /// agent, reporting the outcome tagged with this sub-task's epoch. Mirrors
+    /// [`run_boot`](Self::run_boot) so the actor treats a reboot exactly like a
+    /// boot (AgentReady promotes back to running; BootFailed lands in failed).
+    pub(super) async fn run_reboot(
+        self: Arc<Self>,
+        timeout: Duration,
+        epoch: u64,
+        events: &mpsc::UnboundedSender<Completion>,
+    ) {
+        let outcome = match self.reboot(timeout).await {
+            Ok(()) => InternalEvent::AgentReady,
+            Err(e) => InternalEvent::BootFailed(e.to_string()),
+        };
+        let _ = events.send(Completion { epoch, outcome });
+    }
+
+    /// Reboot body: a full teardown + fresh boot of the VMM (blocking), then
+    /// agent readiness + clock sync — the tail of `boot` without the
+    /// create/drift step, since the machine record and disks are unchanged.
+    async fn reboot(&self, timeout: Duration) -> Result<()> {
+        let mm = Arc::clone(&self.machine_manager);
+        let name = self.machine_name.clone();
+        // `reboot` is a synchronous stop + re-init + start; keep it off the
+        // async workers.
+        tokio::task::spawn_blocking(move || mm.reboot(&name))
+            .await
+            .map_err(|e| CoreError::Vm(format!("reboot task panicked: {e}")))??;
+        self.wait_for_agent(timeout).await?;
+        self.sync_guest_clock().await;
+        Ok(())
+    }
+
     /// The boot body: drift check, optional (re)create, start loop with
     /// recovery retries, then agent readiness.
     async fn boot(&self, create_hint: bool, timeout: Duration) -> Result<()> {

--- a/app/arcbox-core/src/vm_lifecycle/machine.rs
+++ b/app/arcbox-core/src/vm_lifecycle/machine.rs
@@ -60,6 +60,12 @@ pub(super) enum VmEvent {
     Stopped,
     /// Force-stop request (preempts any in-flight boot/stop).
     ForceStop,
+    /// The VM stopped on its own because the guest issued PSCI SYSTEM_RESET
+    /// (reboot). Detected by the liveness tick; triggers an in-place reboot.
+    GuestReset {
+        /// Startup budget (ms) for the post-reboot agent-readiness wait.
+        timeout_ms: u64,
+    },
 }
 
 /// Balloon target requested by a transition; the actor applies it idempotently.
@@ -98,6 +104,12 @@ pub(super) enum Effect {
     },
     /// Spawn the graceful-stop sub-task.
     SpawnStop,
+    /// Spawn the reboot sub-task: reboot the VMM in place, then wait for the
+    /// agent, reporting AgentReady / BootFailed like a boot.
+    SpawnReboot {
+        /// Startup budget in milliseconds.
+        timeout_ms: u64,
+    },
     /// Abort the in-flight boot/stop sub-task (force path).
     AbortInflight,
     /// Remove the machine record (force path).
@@ -246,6 +258,16 @@ impl VmLifecycle {
                 context.emit(Effect::SpawnStop);
                 Transition(State::stopping())
             }
+            VmEvent::GuestReset { timeout_ms } => {
+                // Guest rebooted itself (PSCI SYSTEM_RESET). Bump the
+                // incarnation so the Docker proxy drops cached readiness, then
+                // reboot the VMM in place and boot back to running.
+                context.emit(Effect::BumpGeneration);
+                context.emit(Effect::SpawnReboot {
+                    timeout_ms: *timeout_ms,
+                });
+                Transition(State::starting())
+            }
             _ => Super,
         }
     }
@@ -383,6 +405,43 @@ mod machine_tests {
         let (state, effects) = step(&mut sm, &mut fx, VmEvent::Failure);
         assert_eq!(state, VmLifecycleState::Failed);
         assert!(effects.is_empty());
+    }
+
+    #[test]
+    fn guest_reset_reboots_from_running() {
+        let mut fx = Effects::default();
+        let mut sm = running_machine(&mut fx);
+
+        let (state, effects) = step(&mut sm, &mut fx, VmEvent::GuestReset { timeout_ms: T });
+        assert_eq!(state, VmLifecycleState::Starting);
+        assert_eq!(
+            effects,
+            vec![
+                Effect::BumpGeneration,
+                Effect::SpawnReboot { timeout_ms: T }
+            ]
+        );
+
+        // The reboot sub-task reports agent readiness -> back to running.
+        let (state, _) = step(&mut sm, &mut fx, VmEvent::AgentReady);
+        assert_eq!(state, VmLifecycleState::Running);
+    }
+
+    #[test]
+    fn guest_reset_from_idle_also_reboots() {
+        let mut fx = Effects::default();
+        let mut sm = running_machine(&mut fx);
+        step(&mut sm, &mut fx, VmEvent::IdleTimeout); // -> Idle
+
+        let (state, effects) = step(&mut sm, &mut fx, VmEvent::GuestReset { timeout_ms: T });
+        assert_eq!(state, VmLifecycleState::Starting);
+        assert_eq!(
+            effects,
+            vec![
+                Effect::BumpGeneration,
+                Effect::SpawnReboot { timeout_ms: T }
+            ]
+        );
     }
 
     #[test]

--- a/app/arcbox-docker/src/proxy/state.rs
+++ b/app/arcbox-docker/src/proxy/state.rs
@@ -178,21 +178,32 @@ impl EndpointReadiness {
                 continue;
             }
 
+            // This future owns the `Verifying` slot from here on, and it can
+            // be dropped at any await point: hyper cancels the request future
+            // when the client disconnects (e.g. the docker CLI times out its
+            // `_ping` while the System VM reboots). The claim's Drop rolls the
+            // state back to `Unverified` and wakes a parked request to take
+            // over — without it, a cancelled verifier leaves `Verifying`
+            // behind forever and every later request parks behind a
+            // verification nobody is running.
+            let claim = VerifyingClaim {
+                readiness: Some(self),
+            };
             let result = async {
                 prepare_runtime.await?;
                 verify_endpoint().await
             }
             .await;
-
-            let mut state = self.state.lock().unwrap_or_else(|e| e.into_inner());
-            *state = if result.is_ok() {
-                EndpointReadinessState::Verified
-            } else {
-                EndpointReadinessState::Unverified
-            };
-            self.changed.notify_waiters();
+            claim.complete(result.is_ok());
             return result;
         }
+    }
+
+    /// Sets the terminal state of a verification and wakes parked requests.
+    fn finish(&self, next: EndpointReadinessState) {
+        let mut state = self.state.lock().unwrap_or_else(|e| e.into_inner());
+        *state = next;
+        self.changed.notify_waiters();
     }
 
     fn invalidate(&self) {
@@ -206,6 +217,36 @@ impl EndpointReadiness {
     #[cfg(test)]
     fn state(&self) -> EndpointReadinessState {
         *self.state.lock().unwrap_or_else(|e| e.into_inner())
+    }
+}
+
+/// RAII claim on the `Verifying` slot of [`EndpointReadiness`].
+///
+/// Dropped without [`Self::complete`] — the verifier future was cancelled
+/// mid-verification — it rolls the state back to `Unverified` and notifies,
+/// so a parked request re-runs the verification instead of parking forever.
+struct VerifyingClaim<'a> {
+    readiness: Option<&'a EndpointReadiness>,
+}
+
+impl VerifyingClaim<'_> {
+    fn complete(mut self, verified: bool) {
+        if let Some(readiness) = self.readiness.take() {
+            readiness.finish(if verified {
+                EndpointReadinessState::Verified
+            } else {
+                EndpointReadinessState::Unverified
+            });
+        }
+    }
+}
+
+impl Drop for VerifyingClaim<'_> {
+    fn drop(&mut self) {
+        if let Some(readiness) = self.readiness.take() {
+            tracing::debug!("endpoint verification cancelled; rolling back to unverified");
+            readiness.finish(EndpointReadinessState::Unverified);
+        }
     }
 }
 
@@ -333,6 +374,83 @@ mod tests {
 
         assert_eq!(verified.load(Ordering::Relaxed), 2);
         assert_eq!(readiness.state(), EndpointReadinessState::Unverified);
+    }
+
+    #[tokio::test]
+    async fn cancelled_verifier_rolls_back_to_unverified() {
+        let readiness = Arc::new(EndpointReadiness::new());
+
+        // A verifier stuck in prepare_runtime (e.g. parked across a System VM
+        // reboot) whose client disconnects: hyper drops the request future.
+        let stuck_readiness = Arc::clone(&readiness);
+        let stuck = tokio::spawn(async move {
+            stuck_readiness
+                .ensure_verified(std::future::pending::<Result<()>>(), || async {
+                    Ok::<(), DockerError>(())
+                })
+                .await
+        });
+        while readiness.state() != EndpointReadinessState::Verifying {
+            sleep(Duration::from_millis(1)).await;
+        }
+
+        stuck.abort();
+        let _ = stuck.await;
+
+        assert_eq!(readiness.state(), EndpointReadinessState::Unverified);
+
+        // The next request verifies instead of parking forever.
+        let verified = Arc::new(AtomicUsize::new(0));
+        let verified_current = Arc::clone(&verified);
+        readiness
+            .ensure_verified(async { Ok::<(), DockerError>(()) }, || async move {
+                verified_current.fetch_add(1, Ordering::Relaxed);
+                Ok::<(), DockerError>(())
+            })
+            .await
+            .unwrap();
+        assert_eq!(readiness.state(), EndpointReadinessState::Verified);
+        assert_eq!(verified.load(Ordering::Relaxed), 1);
+    }
+
+    #[tokio::test]
+    async fn cancelled_verifier_hands_over_to_parked_request() {
+        let readiness = Arc::new(EndpointReadiness::new());
+
+        let stuck_readiness = Arc::clone(&readiness);
+        let stuck = tokio::spawn(async move {
+            stuck_readiness
+                .ensure_verified(std::future::pending::<Result<()>>(), || async {
+                    Ok::<(), DockerError>(())
+                })
+                .await
+        });
+        while readiness.state() != EndpointReadinessState::Verifying {
+            sleep(Duration::from_millis(1)).await;
+        }
+
+        // A second request parks behind the stuck verification.
+        let parked_readiness = Arc::clone(&readiness);
+        let parked_verified = Arc::new(AtomicUsize::new(0));
+        let parked_counter = Arc::clone(&parked_verified);
+        let parked = tokio::spawn(async move {
+            parked_readiness
+                .ensure_verified(async { Ok::<(), DockerError>(()) }, || async move {
+                    parked_counter.fetch_add(1, Ordering::Relaxed);
+                    Ok::<(), DockerError>(())
+                })
+                .await
+        });
+        // Let it register on the notify before the cancellation fires.
+        sleep(Duration::from_millis(10)).await;
+
+        stuck.abort();
+        let _ = stuck.await;
+
+        // The parked request must wake, take over, and verify.
+        parked.await.unwrap().unwrap();
+        assert_eq!(readiness.state(), EndpointReadinessState::Verified);
+        assert_eq!(parked_verified.load(Ordering::Relaxed), 1);
     }
 
     /// Connector stub for ProxyState tests — never actually dialed, since the

--- a/tests/e2e/src/boot_assets.rs
+++ b/tests/e2e/src/boot_assets.rs
@@ -2,12 +2,12 @@ use std::{
     env,
     fs::{self},
     path::{Path, PathBuf},
-    process::{Command, Stdio},
+    process::Command,
     thread,
     time::{Duration, Instant},
 };
 
-use anyhow::{Context, Result, anyhow, bail};
+use anyhow::{Context, Result, bail};
 use tempfile::TempDir;
 use toml_edit::DocumentMut;
 use tracing::{info, warn};
@@ -104,37 +104,15 @@ impl TestContext {
     }
 
     fn docker_host(&self) -> String {
-        // Default HostLayout: the Docker socket lives under <data_dir>/run.
-        format!("unix://{}", self.test_dir.join("run/docker.sock").display())
+        crate::docker::docker_host(&self.test_dir)
     }
 
     fn docker_output(&self, args: &[&str], timeout: Duration) -> Result<String> {
-        let output = run_with_timeout(
-            Command::new("docker")
-                .env("DOCKER_HOST", self.docker_host())
-                .args(args),
-            timeout,
-        )?;
-        let stdout = String::from_utf8_lossy(&output.stdout);
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        if output.status.success() {
-            Ok(format!("{stdout}{stderr}"))
-        } else {
-            bail!(
-                "docker {} failed with {}\n{}{}",
-                args.join(" "),
-                output.status,
-                stdout,
-                stderr
-            );
-        }
+        crate::docker::docker_output(&self.test_dir, args, timeout)
     }
 
     fn docker_ignore(&self, args: &[String]) {
-        let _ = Command::new("docker")
-            .env("DOCKER_HOST", self.docker_host())
-            .args(args)
-            .status();
+        crate::docker::docker_ignore(&self.test_dir, args);
     }
 }
 
@@ -589,26 +567,6 @@ fn test_stop_rm(ctx: &TestContext) -> Result<()> {
 
 fn remove_container(ctx: &TestContext, cid: &str) {
     ctx.docker_ignore(&["rm".to_owned(), "-f".to_owned(), cid.to_owned()]);
-}
-
-fn run_with_timeout(command: &mut Command, timeout: Duration) -> Result<std::process::Output> {
-    let mut child = command
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()?;
-    let start = Instant::now();
-    while start.elapsed() < timeout {
-        if child.try_wait()?.is_some() {
-            return child
-                .wait_with_output()
-                .context("collecting command output");
-        }
-        thread::sleep(Duration::from_millis(100));
-    }
-
-    let _ = child.kill();
-    let _ = child.wait();
-    Err(anyhow!("command timed out after {}s", timeout.as_secs()))
 }
 
 fn cid_prefix(cid: &str) -> &str {

--- a/tests/e2e/src/docker.rs
+++ b/tests/e2e/src/docker.rs
@@ -1,0 +1,73 @@
+//! Docker CLI helpers for daemon-level scenarios.
+//!
+//! Every daemon under test exposes its own Docker socket under
+//! `<data_dir>/run/docker.sock`. These helpers always target that socket
+//! via `DOCKER_HOST`, so the developer's Docker context and any host
+//! daemon stay untouched (see tests/e2e/README.md on isolation).
+
+use std::path::Path;
+use std::process::{Command, Stdio};
+use std::thread;
+use std::time::{Duration, Instant};
+
+use anyhow::{Context, Result, anyhow, bail};
+
+/// `DOCKER_HOST` value addressing the daemon's per-data-dir socket.
+#[must_use]
+pub fn docker_host(data_dir: &Path) -> String {
+    // Default HostLayout: the Docker socket lives under <data_dir>/run.
+    format!("unix://{}", data_dir.join("run/docker.sock").display())
+}
+
+/// Runs `docker <args>` against the daemon under `data_dir`, returning
+/// combined stdout+stderr. Fails on non-zero exit or after `timeout`.
+pub fn docker_output(data_dir: &Path, args: &[&str], timeout: Duration) -> Result<String> {
+    let output = run_with_timeout(
+        Command::new("docker")
+            .env("DOCKER_HOST", docker_host(data_dir))
+            .args(args),
+        timeout,
+    )?;
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    if output.status.success() {
+        Ok(format!("{stdout}{stderr}"))
+    } else {
+        bail!(
+            "docker {} failed with {}\n{}{}",
+            args.join(" "),
+            output.status,
+            stdout,
+            stderr
+        );
+    }
+}
+
+/// Best-effort `docker <args>` for cleanup paths; failures are ignored.
+pub fn docker_ignore(data_dir: &Path, args: &[String]) {
+    let _ = Command::new("docker")
+        .env("DOCKER_HOST", docker_host(data_dir))
+        .args(args)
+        .status();
+}
+
+/// Runs a command, killing it once `timeout` passes.
+pub fn run_with_timeout(command: &mut Command, timeout: Duration) -> Result<std::process::Output> {
+    let mut child = command
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()?;
+    let start = Instant::now();
+    while start.elapsed() < timeout {
+        if child.try_wait()?.is_some() {
+            return child
+                .wait_with_output()
+                .context("collecting command output");
+        }
+        thread::sleep(Duration::from_millis(100));
+    }
+
+    let _ = child.kill();
+    let _ = child.wait();
+    Err(anyhow!("command timed out after {}s", timeout.as_secs()))
+}

--- a/tests/e2e/src/lib.rs
+++ b/tests/e2e/src/lib.rs
@@ -2,6 +2,7 @@ use std::path::PathBuf;
 
 pub mod boot_assets;
 pub mod daemon;
+pub mod docker;
 pub mod metrics;
 pub mod signing;
 

--- a/tests/e2e/tests/hv_reboot.rs
+++ b/tests/e2e/tests/hv_reboot.rs
@@ -1,0 +1,225 @@
+//! End-to-end guest-initiated reboot on the HV backend (ABX-402).
+//!
+//! Boots the System VM through a real daemon on the custom-HV backend and
+//! issues `reboot -f` inside the guest. The daemon's lifecycle actor must
+//! observe the PSCI SYSTEM_RESET verdict (2s liveness poll) and reboot the
+//! VM in place: the guest comes back with a new kernel `boot_id`, the
+//! agent reconnects, and the Docker path recovers — all within one daemon
+//! process. A final `poweroff -f` guards the opposite verdict: SYSTEM_OFF
+//! must stop the VM without triggering a reboot.
+//!
+//! Both the trigger and the observation ride the Docker path, so no guest
+//! shell is needed (the debug-console rcS shell exists only on newer
+//! rootfs generations): `/proc/sys/kernel/random/boot_id` is kernel-global
+//! (not namespaced), so a container reads the guest's boot identity, and a
+//! `--privileged --pid=host` container's `reboot(2)` reboots the guest
+//! kernel — `--pid=host` is load-bearing, since in a non-initial PID
+//! namespace `reboot(2)` merely kills that namespace's init.
+
+use std::path::Path;
+use std::sync::Once;
+use std::time::{Duration, Instant};
+
+use anyhow::{Context, Result, bail};
+use arcbox_e2e::boot_assets::{resolve_boot_version, stage_dev_boot_assets};
+use arcbox_e2e::daemon::{DaemonConfig, DaemonHandle};
+use arcbox_e2e::docker::docker_output;
+use arcbox_e2e::metrics::RunMetrics;
+use tracing_subscriber::EnvFilter;
+
+static TRACING: Once = Once::new();
+
+const READY_TIMEOUT: Duration = Duration::from_secs(180);
+/// Budget for the full round trip after `reboot -f`: ≤2s liveness-poll
+/// detection + in-place VMM teardown + fresh HV boot + agent reconnect +
+/// runtime restart + Docker proxy reconciliation.
+const REBOOT_TIMEOUT: Duration = Duration::from_secs(180);
+/// Watch window after `poweroff -f` during which no new boot identity may
+/// appear. Sized well above the observed reboot round trip, so a misread
+/// SYSTEM_OFF would surface within it.
+const POWEROFF_QUIET: Duration = Duration::from_secs(90);
+/// Ceiling for one docker CLI invocation.
+const DOCKER_ATTEMPT: Duration = Duration::from_secs(30);
+
+#[test]
+#[ignore = "boots an HV System VM through a real daemon and reboots it from inside"]
+fn guest_reboot_is_detected_and_rebooted_in_place() -> Result<()> {
+    init_tracing();
+
+    let root = arcbox_e2e::repo_root();
+    if !arcbox_e2e::env_flag("SKIP_BUILD") {
+        let shell = xshell::Shell::new()?;
+        shell.change_dir(&root);
+        xshell::cmd!(shell, "cargo build --release -p arcbox-daemon").run()?;
+    }
+
+    let version = resolve_boot_version(&root)?;
+    let data_dir = tempfile::Builder::new()
+        .prefix("arcbox-hv-reboot-")
+        .tempdir()?;
+    stage_dev_boot_assets(&root, data_dir.path(), &version)?;
+
+    let mut daemon = DaemonHandle::spawn(DaemonConfig {
+        binary: root.join("target/release/arcbox-daemon"),
+        data_dir: data_dir.path().to_owned(),
+        args: vec![],
+        env: vec![
+            ("ARCBOX_BOOT_ASSET_VERSION".to_owned(), version),
+            ("ARCBOX_VM_BACKEND".to_owned(), "hv".to_owned()),
+        ],
+    })?;
+
+    let mut metrics = RunMetrics::new("hv_reboot", Some("hv"));
+    let result = scenario(&mut daemon, data_dir.path(), &mut metrics);
+    metrics.passed = result.is_ok();
+    if let Err(error) = metrics.write(Some(data_dir.path())) {
+        tracing::warn!("writing run metrics failed: {error:#}");
+    }
+    if result.is_err() {
+        match daemon.dump_virtio_debug() {
+            Ok(path) => tracing::warn!(path = %path.display(), "virtio debug snapshot captured"),
+            Err(error) => tracing::warn!("virtio debug dump failed: {error:#}"),
+        }
+        let kept = data_dir.keep();
+        tracing::warn!(path = %kept.display(), "preserving test directory");
+    }
+    result
+}
+
+fn scenario(daemon: &mut DaemonHandle, data_dir: &Path, metrics: &mut RunMetrics) -> Result<()> {
+    metrics.time("daemon_ready", || daemon.wait_ready_blocking(READY_TIMEOUT))?;
+
+    let image = std::env::var("ARCBOX_E2E_IMAGE").unwrap_or_else(|_| "alpine:latest".to_owned());
+
+    metrics.time("docker_baseline", || {
+        docker_output(data_dir, &["pull", &image], Duration::from_secs(90)).context("docker pull")
+    })?;
+
+    let first = metrics.time("first_boot_id", || {
+        guest_boot_id(data_dir, &image).context("capturing the pre-reboot boot identity")
+    })?;
+    tracing::info!(boot_id = %first, "guest boot identity captured");
+
+    // The trigger. The docker call dies with the guest (the container never
+    // exits normally), so its error is expected and only logged.
+    let trigger = docker_output(
+        data_dir,
+        &[
+            "run",
+            "--rm",
+            "--privileged",
+            "--pid=host",
+            &image,
+            "reboot",
+            "-f",
+        ],
+        DOCKER_ATTEMPT,
+    );
+    tracing::info!(outcome = ?trigger.map(|o| o.trim().to_owned()), "issued reboot -f inside the guest");
+
+    let second = metrics.time("reboot_roundtrip", || {
+        wait_for_new_boot_id(data_dir, &image, &first, REBOOT_TIMEOUT)
+    })?;
+    tracing::info!(boot_id = %second, "guest rebooted in place and the docker path recovered");
+
+    // Guard the opposite verdict: SYSTEM_OFF must never read as a reboot.
+    metrics.time("poweroff_guard", || -> Result<()> {
+        let trigger = docker_output(
+            data_dir,
+            &["run", "--rm", "--privileged", "--pid=host", &image, "poweroff", "-f"],
+            DOCKER_ATTEMPT,
+        );
+        tracing::info!(outcome = ?trigger.map(|o| o.trim().to_owned()), "issued poweroff -f inside the guest");
+
+        let quiet_until = Instant::now() + POWEROFF_QUIET;
+        while Instant::now() < quiet_until {
+            match guest_boot_id(data_dir, &image) {
+                Ok(id) if id != second => {
+                    bail!("SYSTEM_OFF was answered by a reboot (boot_id {id})")
+                }
+                Ok(_) => {} // still going down
+                Err(error) => tracing::debug!("guest unreachable (expected): {error:#}"),
+            }
+            std::thread::sleep(Duration::from_secs(3));
+        }
+        // After the window the guest must actually be down.
+        match guest_boot_id(data_dir, &image) {
+            Ok(id) if id == second => {
+                bail!("guest still running {POWEROFF_QUIET:?} after poweroff -f")
+            }
+            Ok(id) => bail!("SYSTEM_OFF was answered by a reboot (boot_id {id})"),
+            Err(_) => {
+                tracing::info!("SYSTEM_OFF honored: guest stayed down");
+                Ok(())
+            }
+        }
+    })?;
+
+    // The daemon itself must have survived the whole dance.
+    let snapshot = daemon
+        .dump_virtio_debug()
+        .context("daemon gRPC no longer answering after the poweroff guard")?;
+    tracing::info!(path = %snapshot.display(), "daemon alive; final virtio snapshot written");
+    Ok(())
+}
+
+/// Reads the guest kernel's boot identity through the Docker path.
+fn guest_boot_id(data_dir: &Path, image: &str) -> Result<String> {
+    let out = docker_output(
+        data_dir,
+        &[
+            "run",
+            "--rm",
+            image,
+            "cat",
+            "/proc/sys/kernel/random/boot_id",
+        ],
+        DOCKER_ATTEMPT,
+    )?;
+    out.lines()
+        .map(str::trim)
+        .find(|line| is_boot_id(line))
+        .map(str::to_owned)
+        .with_context(|| format!("no boot_id in docker output: {out}"))
+}
+
+/// A kernel boot_id: a lowercase hyphenated UUID.
+fn is_boot_id(s: &str) -> bool {
+    s.len() == 36
+        && s.bytes()
+            .all(|b| matches!(b, b'0'..=b'9' | b'a'..=b'f' | b'-'))
+}
+
+/// Polls the guest's boot identity until it differs from `previous`,
+/// tolerating the unreachable window while the VM reboots in place and
+/// the runtime recovers.
+fn wait_for_new_boot_id(
+    data_dir: &Path,
+    image: &str,
+    previous: &str,
+    timeout: Duration,
+) -> Result<String> {
+    let deadline = Instant::now() + timeout;
+    loop {
+        match guest_boot_id(data_dir, image) {
+            Ok(id) if id != previous => return Ok(id),
+            Ok(_) => tracing::debug!("guest still reports the old boot identity"),
+            Err(error) => tracing::debug!("docker path not recovered yet: {error:#}"),
+        }
+        if Instant::now() >= deadline {
+            bail!("guest did not come back with a new boot identity within {timeout:?}");
+        }
+        std::thread::sleep(Duration::from_secs(3));
+    }
+}
+
+fn init_tracing() {
+    TRACING.call_once(|| {
+        let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info"));
+        tracing_subscriber::fmt()
+            .with_env_filter(filter)
+            .with_target(false)
+            .compact()
+            .init();
+    });
+}

--- a/virt/arcbox-hv/src/exit.rs
+++ b/virt/arcbox-hv/src/exit.rs
@@ -74,6 +74,13 @@ pub enum ExceptionClass {
 pub struct MmioInfo {
     /// Guest physical address that was accessed.
     pub address: u64,
+    /// Whether the instruction syndrome is valid (ESR ISS[24] = ISV). When
+    /// `false`, `access_size` / `register` / `sign_extend` / `sixty_four` are
+    /// architecturally UNKNOWN and the access **cannot** be serviced from this
+    /// syndrome alone — it came from an instruction the hardware does not
+    /// syndrome-decode (LDP/STP, atomics, some writeback-addressing forms).
+    /// Only `is_write` (WnR) and `address` are meaningful in that case.
+    pub isv: bool,
     /// `true` if the guest was writing, `false` if reading.
     pub is_write: bool,
     /// Width of the access: 1, 2, 4, or 8 bytes.
@@ -85,8 +92,12 @@ pub struct MmioInfo {
     /// the guest intended to write. For reads, the VMM writes the emulated
     /// value back via `HvVcpu::set_reg(self.register, value)`.
     pub value: u64,
-    /// Whether the loaded value should be sign-extended.
+    /// Whether the loaded value should be sign-extended (ESR ISS[21] = SSE).
     pub sign_extend: bool,
+    /// Transfer register width (ESR ISS[15] = SF): `true` = 64-bit (Xt),
+    /// `false` = 32-bit (Wt). Only meaningful for a sign-extended load, which
+    /// must extend to this width.
+    pub sixty_four: bool,
 }
 
 /// Parse a raw [`ffi::HvVcpuExitInfo`] into a typed [`VcpuExit`].
@@ -109,19 +120,32 @@ fn parse_exception(syndrome: u64, exc: &ffi::HvVcpuExitException) -> ExceptionCl
 
     match ec {
         EC_DATA_ABORT_LOWER | EC_DATA_ABORT_SAME => {
+            // ESR_EL2 Data Abort ISS (ARM DDI 0487, D17.2.40):
+            //   ISS[24]    ISV — Instruction Syndrome Valid. When 0, SAS/SSE/SRT/SF
+            //              are UNKNOWN (LDP/STP, atomics, some writeback forms); the
+            //              access cannot be decoded from the syndrome alone.
+            //   ISS[23:22] SAS — access size (0=B,1=H,2=W,3=D)   [valid iff ISV]
+            //   ISS[21]    SSE — sign-extend the loaded value     [valid iff ISV]
+            //   ISS[20:16] SRT — transfer register Xt             [valid iff ISV]
+            //   ISS[15]    SF  — 64-bit register width            [valid iff ISV]
+            //   ISS[6]     WnR — write-not-read                   [always valid]
+            let isv = ((syndrome >> 24) & 1) != 0;
             let is_write = ((syndrome >> 6) & 1) != 0;
             let sas = ((syndrome >> 22) & 3) as u8;
             let access_size = 1u8 << sas;
             let register = ((syndrome >> 16) & 0x1f) as u8;
             let sign_extend = ((syndrome >> 21) & 1) != 0;
+            let sixty_four = ((syndrome >> 15) & 1) != 0;
 
             ExceptionClass::DataAbort(MmioInfo {
                 address: exc.physical_address,
+                isv,
                 is_write,
                 access_size,
                 register,
                 value: 0,
                 sign_extend,
+                sixty_four,
             })
         }
         EC_INSN_ABORT_LOWER | EC_INSN_ABORT_SAME => ExceptionClass::InstructionAbort {
@@ -177,9 +201,12 @@ mod tests {
     use super::*;
 
     /// Build a syndrome value for a data abort with the given parameters.
+    /// Sets ISV=1 (a hardware-decoded single-register access, as Linux's
+    /// virtio-mmio driver always produces).
     fn data_abort_syndrome(ec: u8, sas: u8, is_write: bool, reg: u8, sext: bool) -> u64 {
         let mut s: u64 = 0;
         s |= u64::from(ec) << 26;
+        s |= 1 << 24; // ISV
         s |= u64::from(sas) << 22;
         if sext {
             s |= 1 << 21;
@@ -246,6 +273,7 @@ mod tests {
                 class: ExceptionClass::DataAbort(mmio),
                 ..
             } => {
+                assert!(mmio.isv);
                 assert!(mmio.is_write);
                 assert_eq!(mmio.access_size, 4);
                 assert_eq!(mmio.register, 5);
@@ -253,6 +281,57 @@ mod tests {
                 assert!(!mmio.sign_extend);
             }
             other => panic!("expected DataAbort, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_data_abort_isv_clear() {
+        // A data abort from an instruction the hardware does not syndrome-decode
+        // (LDP/STP, atomics, ...): ISS[24]=0. The transfer-register / size fields
+        // must not be trusted; only ISV=false and WnR are meaningful.
+        let mut syndrome = data_abort_syndrome(EC_DATA_ABORT_LOWER, 3, false, 7, false);
+        syndrome &= !(1 << 24); // clear ISV
+        let info = ffi::HvVcpuExitInfo {
+            reason: ffi::HV_EXIT_REASON_EXCEPTION,
+            exception: ffi::HvVcpuExitException {
+                syndrome,
+                virtual_address: 0,
+                physical_address: 0x0900_0000,
+            },
+        };
+        match parse_exit(&info) {
+            VcpuExit::Exception {
+                class: ExceptionClass::DataAbort(mmio),
+                ..
+            } => assert!(!mmio.isv),
+            other => panic!("expected DataAbort, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_data_abort_sf_bit() {
+        // SF (ISS[15]) selects the 64-bit register width for the transfer.
+        let base = data_abort_syndrome(EC_DATA_ABORT_LOWER, 2, false, 3, true);
+        for (sf, expect_64) in [(0u64, false), (1u64, true)] {
+            let syndrome = base | (sf << 15);
+            let info = ffi::HvVcpuExitInfo {
+                reason: ffi::HV_EXIT_REASON_EXCEPTION,
+                exception: ffi::HvVcpuExitException {
+                    syndrome,
+                    virtual_address: 0,
+                    physical_address: 0x0900_0000,
+                },
+            };
+            match parse_exit(&info) {
+                VcpuExit::Exception {
+                    class: ExceptionClass::DataAbort(mmio),
+                    ..
+                } => {
+                    assert_eq!(mmio.sixty_four, expect_64, "SF={sf}");
+                    assert!(mmio.sign_extend);
+                }
+                other => panic!("expected DataAbort for SF={sf}, got {other:?}"),
+            }
         }
     }
 

--- a/virt/arcbox-vmm/src/vmm/darwin_hv/lifecycle.rs
+++ b/virt/arcbox-vmm/src/vmm/darwin_hv/lifecycle.rs
@@ -234,6 +234,7 @@ impl Vmm {
 
         let running = self.running.clone();
         let paused = self.hv_paused.clone();
+        let reset_requested = self.hv_reset_requested.clone();
         // Ensure a fresh start always begins unpaused, even if a prior
         // session was stopped while paused.
         paused.store(false, std::sync::atomic::Ordering::SeqCst);
@@ -278,6 +279,7 @@ impl Vmm {
 
                 let r = running.clone();
                 let p = paused.clone();
+                let rr = reset_requested.clone();
                 let dm = device_manager.clone();
                 let th = vcpu_thread_handles.clone();
                 let ids = hv_vcpu_ids.clone();
@@ -301,6 +303,7 @@ impl Vmm {
                                 VcpuContext {
                                     device_manager: dm,
                                     running: r,
+                                    reset_requested: rr,
                                     paused: p,
                                     pl011: uart,
                                     cpu_on_senders: Some(senders_for_thread),
@@ -340,6 +343,7 @@ impl Vmm {
                         VcpuContext {
                             device_manager,
                             running,
+                            reset_requested,
                             paused,
                             pl011,
                             cpu_on_senders,

--- a/virt/arcbox-vmm/src/vmm/darwin_hv/lifecycle.rs
+++ b/virt/arcbox-vmm/src/vmm/darwin_hv/lifecycle.rs
@@ -256,13 +256,25 @@ impl Vmm {
         self.hv_vcpu_stats.clone_from(&vcpu_stats);
 
         // --- Set up PSCI CPU_ON channels for secondary vCPUs ---
+        // The registry is shared with *every* vCPU thread — the BSP and each
+        // secondary — so a CPU_ON issued from any CPU can reach any target.
+        // Linux may bring a secondary online from a CPU other than the BSP
+        // (CPU hotplug, some resume paths); handing the secondaries `None`
+        // here made every such call return NOT_SUPPORTED.
         let cpu_on_senders: Option<CpuOnSenders> = if vcpu_count > 1 {
-            let mut senders_vec: Vec<Option<mpsc::Sender<CpuOnRequest>>> = Vec::new();
-            senders_vec.push(None); // Slot 0 = BSP
+            let senders: CpuOnSenders =
+                Arc::new(Mutex::new(Vec::with_capacity(vcpu_count as usize)));
+            senders
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .push(None); // Slot 0 = BSP
 
             for i in 1..vcpu_count {
                 let (tx, rx) = mpsc::channel::<CpuOnRequest>();
-                senders_vec.push(Some(tx));
+                senders
+                    .lock()
+                    .unwrap_or_else(std::sync::PoisonError::into_inner)
+                    .push(Some(tx));
 
                 let r = running.clone();
                 let p = paused.clone();
@@ -272,7 +284,7 @@ impl Vmm {
                 let uart = pl011.clone();
                 let hvc_fds_clone = self.hvc_blk_fds.clone();
                 let stats = vcpu_stats[i as usize].clone();
-                let senders_placeholder: Option<CpuOnSenders> = None;
+                let senders_for_thread = senders.clone();
 
                 let t = std::thread::Builder::new()
                     .name(format!("hv-vcpu-{i}"))
@@ -291,7 +303,7 @@ impl Vmm {
                                     running: r,
                                     paused: p,
                                     pl011: uart,
-                                    cpu_on_senders: senders_placeholder,
+                                    cpu_on_senders: Some(senders_for_thread),
                                     vcpu_thread_handles: th,
                                     hv_vcpu_ids: ids,
                                     hvc_blk_fds: hvc_fds_clone,
@@ -307,7 +319,6 @@ impl Vmm {
                 self.hv_vcpu_threads.push(t);
             }
 
-            let senders = Arc::new(Mutex::new(senders_vec));
             self.hv_cpu_on_senders = Some(senders.clone());
             Some(senders)
         } else {

--- a/virt/arcbox-vmm/src/vmm/darwin_hv/mod.rs
+++ b/virt/arcbox-vmm/src/vmm/darwin_hv/mod.rs
@@ -310,8 +310,12 @@ mod tests {
     #[test]
     fn test_pl011_read_flags() {
         let uart = Pl011::new();
-        // Flag register should always return 0 (TX FIFO not full).
-        assert_eq!(uart.read(PL011_BASE + PL011_FR, 4), 0);
+        // Idle flag register: RXFE (bit 4) and TXFE (bit 7) set, TXFF (bit 5)
+        // clear — the line is empty and ready, with no phantom RX data.
+        let fr = uart.read(PL011_BASE + PL011_FR, 4);
+        assert_eq!(fr & (1 << 4), 1 << 4, "RXFE must be set");
+        assert_eq!(fr & (1 << 7), 1 << 7, "TXFE must be set");
+        assert_eq!(fr & (1 << 5), 0, "TXFF must be clear");
     }
 
     #[test]

--- a/virt/arcbox-vmm/src/vmm/darwin_hv/pl011.rs
+++ b/virt/arcbox-vmm/src/vmm/darwin_hv/pl011.rs
@@ -16,6 +16,14 @@ pub const PL011_DR: u64 = 0x000;
 /// Flag Register offset.
 pub const PL011_FR: u64 = 0x018;
 
+// UARTFR (flag register) bits. This emulator is TX-only with an always-
+// drainable transmit path and no receive FIFO, so the idle state is:
+// receive FIFO empty, transmit FIFO empty, transmit FIFO not full.
+/// Receive FIFO empty (bit 4) — always set: we deliver no RX data.
+const FR_RXFE: u64 = 1 << 4;
+/// Transmit FIFO empty (bit 7) — always set: writes drain immediately.
+const FR_TXFE: u64 = 1 << 7;
+
 /// Minimal PL011 UART emulator for early boot console output.
 pub struct Pl011 {
     /// Accumulated output buffer (line buffered).
@@ -37,8 +45,10 @@ impl Pl011 {
     pub fn read(&self, addr: u64, _size: usize) -> u64 {
         let offset = addr - PL011_BASE;
         match offset {
-            // Flag Register: TX FIFO never full, RX FIFO always empty.
-            PL011_FR => 0,
+            // Flag Register: RX FIFO empty + TX FIFO empty (TXFF stays clear),
+            // so a driver polling RXFE won't read phantom input and one waiting
+            // on TXFE before writing sees the line ready.
+            PL011_FR => FR_RXFE | FR_TXFE,
             _ => 0,
         }
     }

--- a/virt/arcbox-vmm/src/vmm/darwin_hv/psci.rs
+++ b/virt/arcbox-vmm/src/vmm/darwin_hv/psci.rs
@@ -166,12 +166,16 @@ fn cpu_on_snapshot(cpu_on_senders: Option<&CpuOnSenders>) -> Vec<bool> {
 }
 
 /// Reads registers X1–X3, resolves the PSCI call, applies its effect (shutdown
-/// flag or CPU_ON dispatch), and writes the return value into X0.
+/// or reboot flag, CPU_ON dispatch), and writes the return value into X0.
+///
+/// SYSTEM_RESET sets `reset_requested` in addition to clearing `running`, so
+/// the lifecycle driver reboots the guest rather than powering the machine off.
 pub fn handle_psci(
     vcpu_id: u32,
     func_id: u64,
     vcpu: &arcbox_hv::HvVcpu,
     running: &Arc<AtomicBool>,
+    reset_requested: &Arc<AtomicBool>,
     cpu_on_senders: Option<&CpuOnSenders>,
 ) {
     let x1 = vcpu.get_reg(X1).unwrap_or(0);
@@ -193,6 +197,7 @@ pub fn handle_psci(
         }
         PsciEffect::SystemReset => {
             tracing::info!("vCPU {vcpu_id}: PSCI SYSTEM_RESET");
+            reset_requested.store(true, Ordering::SeqCst);
             running.store(false, Ordering::SeqCst);
         }
         PsciEffect::CpuOn {

--- a/virt/arcbox-vmm/src/vmm/darwin_hv/psci.rs
+++ b/virt/arcbox-vmm/src/vmm/darwin_hv/psci.rs
@@ -1,34 +1,58 @@
 //! PSCI (Power State Coordination Interface) handling.
 //!
-//! Implements the subset of PSCI needed by Linux guests: VERSION, SYSTEM_OFF,
-//! SYSTEM_RESET, and CPU_ON. Called from the vCPU run loop on HVC exits
-//! whose immediate number matches the SMCCC PSCI function ID range.
+//! Implements the subset of PSCI a Linux guest exercises: VERSION, FEATURES,
+//! SYSTEM_OFF, SYSTEM_RESET, CPU_ON, AFFINITY_INFO, and MIGRATE_INFO_TYPE.
+//! Called from the vCPU run loop on HVC/SMC exits whose function ID is in the
+//! SMCCC PSCI range.
+//!
+//! The decision logic lives in the pure [`resolve_psci`] so it can be unit
+//! tested without a live vCPU or the channel registry; [`handle_psci`] applies
+//! the resulting effect (write X0, request shutdown, dispatch CPU_ON).
 
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex, PoisonError, mpsc};
 
 use arcbox_hv::reg::{HV_REG_X0 as X0, HV_REG_X1 as X1, HV_REG_X2 as X2, HV_REG_X3 as X3};
 
+/// PSCI PSCI_VERSION: return the implemented PSCI version.
+const PSCI_VERSION: u64 = 0x8400_0000;
 /// PSCI CPU_ON (64-bit): power up a secondary CPU.
 const PSCI_CPU_ON_64: u64 = 0xC400_0003;
-
+/// PSCI AFFINITY_INFO (64-bit): query a CPU's power state.
+const PSCI_AFFINITY_INFO_64: u64 = 0xC400_0004;
+/// PSCI AFFINITY_INFO (32-bit alias).
+const PSCI_AFFINITY_INFO_32: u64 = 0x8400_0004;
+/// PSCI MIGRATE_INFO_TYPE: describe Trusted-OS migration requirements.
+const PSCI_MIGRATE_INFO_TYPE: u64 = 0x8400_0006;
 /// PSCI SYSTEM_OFF: shut the system down.
 const PSCI_SYSTEM_OFF: u64 = 0x8400_0008;
-
 /// PSCI SYSTEM_RESET: reset the system.
 const PSCI_SYSTEM_RESET: u64 = 0x8400_0009;
-
-/// PSCI PSCI_VERSION: return PSCI version.
-const PSCI_VERSION: u64 = 0x8400_0000;
+/// PSCI PSCI_FEATURES: query whether a given PSCI function is implemented.
+const PSCI_FEATURES: u64 = 0x8400_000A;
 
 /// PSCI return code: success.
 const PSCI_SUCCESS: u64 = 0;
-
-/// PSCI return code: the target CPU is already on (-4 in two's complement).
+/// PSCI return code: function not supported (-1).
+const PSCI_NOT_SUPPORTED: u64 = (-1_i64) as u64;
+/// PSCI return code: invalid parameters (-2).
+const PSCI_INVALID_PARAMS: u64 = (-2_i64) as u64;
+/// PSCI return code: the target CPU is already on (-4).
 const PSCI_ALREADY_ON: u64 = (-4_i64) as u64;
 
+/// AFFINITY_INFO state: the affinity instance is ON.
+const AFFINITY_INFO_ON: u64 = 0;
+/// AFFINITY_INFO state: the affinity instance is OFF.
+const AFFINITY_INFO_OFF: u64 = 1;
+
+/// MIGRATE_INFO_TYPE: Trusted-OS not present / migration not required.
+const MIGRATE_TYPE_NOT_REQUIRED: u64 = 2;
+
+/// PSCI v1.0 (major=1, minor=0).
+const PSCI_VERSION_1_0: u64 = 1 << 16;
+
 /// Request to power on a secondary vCPU via PSCI CPU_ON.
-/// Fields are written by the BSP and read by the secondary vCPU thread.
+/// Fields are written by the originating vCPU and read by the target's thread.
 pub struct CpuOnRequest {
     /// Target MPIDR (CPU affinity identifier). Logged for diagnostics;
     /// the actual target is determined by channel routing in start_darwin_hv.
@@ -41,14 +65,108 @@ pub struct CpuOnRequest {
 
 /// Shared state for secondary vCPU wake-up channels.
 ///
-/// Index `i` corresponds to vCPU `i` (0-based). The BSP (vCPU 0) does not
-/// have an entry. Each `Option<Sender>` is `take()`-n exactly once when the
-/// guest calls PSCI CPU_ON for that vCPU, preventing double-start.
+/// Index `i` corresponds to vCPU `i` (0-based). Slot 0 (BSP) is always `None`.
+/// Each secondary's `Option<Sender>` is `take()`-n exactly once when the guest
+/// calls PSCI CPU_ON for that vCPU, so a taken (`None`) slot means the CPU is
+/// on, and a present (`Some`) slot means it is still off.
 pub type CpuOnSenders = Arc<Mutex<Vec<Option<mpsc::Sender<CpuOnRequest>>>>>;
 
-/// Reads registers X1–X3 as needed and writes the return value into X0.
-/// For SYSTEM_OFF / SYSTEM_RESET, sets `running` to `false` so the caller
-/// can break out of its run loop.
+/// The side effect a resolved PSCI call asks the caller to perform. Kept
+/// separate from the X0 return value so the decision logic stays pure.
+#[derive(Debug, PartialEq, Eq)]
+enum PsciEffect {
+    /// No effect beyond writing the return value.
+    None,
+    /// Power the whole system off.
+    SystemOff,
+    /// Reset (reboot) the whole system.
+    SystemReset,
+    /// Bring a secondary CPU online at `entry_point` with `context_id` in X0.
+    CpuOn {
+        target: usize,
+        entry_point: u64,
+        context_id: u64,
+    },
+}
+
+/// Whether PSCI_FEATURES should report a function as implemented.
+fn psci_feature_supported(func_id: u64) -> bool {
+    matches!(
+        func_id,
+        PSCI_VERSION
+            | PSCI_FEATURES
+            | PSCI_CPU_ON_64
+            | PSCI_AFFINITY_INFO_64
+            | PSCI_AFFINITY_INFO_32
+            | PSCI_MIGRATE_INFO_TYPE
+            | PSCI_SYSTEM_OFF
+            | PSCI_SYSTEM_RESET
+    )
+}
+
+/// Resolves a PSCI call to an `(X0 return value, effect)` pair without touching
+/// the vCPU or the channel registry. `cpu_on` gives each CPU's power state
+/// (index = CPU, `true` = on) so CPU_ON / AFFINITY_INFO can be decided and
+/// tested in isolation. The CPU_ON result is optimistic: the caller resolves
+/// the take-once race with a concurrent CPU_ON when applying the effect.
+fn resolve_psci(func_id: u64, x1: u64, x2: u64, x3: u64, cpu_on: &[bool]) -> (u64, PsciEffect) {
+    match func_id {
+        PSCI_VERSION => (PSCI_VERSION_1_0, PsciEffect::None),
+        PSCI_FEATURES => {
+            let ret = if psci_feature_supported(x1) {
+                PSCI_SUCCESS
+            } else {
+                PSCI_NOT_SUPPORTED
+            };
+            (ret, PsciEffect::None)
+        }
+        PSCI_SYSTEM_OFF => (PSCI_SUCCESS, PsciEffect::SystemOff),
+        PSCI_SYSTEM_RESET => (PSCI_SUCCESS, PsciEffect::SystemReset),
+        PSCI_MIGRATE_INFO_TYPE => (MIGRATE_TYPE_NOT_REQUIRED, PsciEffect::None),
+        PSCI_CPU_ON_64 => {
+            let target = (x1 & 0xFF) as usize;
+            match cpu_on.get(target).copied() {
+                None => (PSCI_INVALID_PARAMS, PsciEffect::None),
+                Some(true) => (PSCI_ALREADY_ON, PsciEffect::None),
+                Some(false) => (
+                    PSCI_SUCCESS,
+                    PsciEffect::CpuOn {
+                        target,
+                        entry_point: x2,
+                        context_id: x3,
+                    },
+                ),
+            }
+        }
+        PSCI_AFFINITY_INFO_64 | PSCI_AFFINITY_INFO_32 => {
+            let target = (x1 & 0xFF) as usize;
+            match cpu_on.get(target).copied() {
+                None => (PSCI_INVALID_PARAMS, PsciEffect::None),
+                Some(true) => (AFFINITY_INFO_ON, PsciEffect::None),
+                Some(false) => (AFFINITY_INFO_OFF, PsciEffect::None),
+            }
+        }
+        _ => (PSCI_NOT_SUPPORTED, PsciEffect::None),
+    }
+}
+
+/// Snapshots each CPU's power state from the channel registry: a present
+/// (`Some`) sender means the CPU has not been started (off), a taken (`None`)
+/// slot means it is on. A single-vCPU VM has just CPU 0, always on.
+fn cpu_on_snapshot(cpu_on_senders: Option<&CpuOnSenders>) -> Vec<bool> {
+    match cpu_on_senders {
+        Some(senders) => senders
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner)
+            .iter()
+            .map(Option::is_none)
+            .collect(),
+        None => vec![true],
+    }
+}
+
+/// Reads registers X1–X3, resolves the PSCI call, applies its effect (shutdown
+/// flag or CPU_ON dispatch), and writes the return value into X0.
 pub fn handle_psci(
     vcpu_id: u32,
     func_id: u64,
@@ -56,76 +174,180 @@ pub fn handle_psci(
     running: &Arc<AtomicBool>,
     cpu_on_senders: Option<&CpuOnSenders>,
 ) {
-    match func_id {
-        PSCI_VERSION => {
-            // Return PSCI v1.0 (major=1, minor=0).
-            let _ = vcpu.set_reg(X0, 1 << 16);
-        }
+    let x1 = vcpu.get_reg(X1).unwrap_or(0);
+    let x2 = vcpu.get_reg(X2).unwrap_or(0);
+    let x3 = vcpu.get_reg(X3).unwrap_or(0);
 
-        PSCI_SYSTEM_OFF => {
+    let cpu_on = cpu_on_snapshot(cpu_on_senders);
+    let (mut ret, effect) = resolve_psci(func_id, x1, x2, x3, &cpu_on);
+
+    match effect {
+        PsciEffect::None => {
+            if ret == PSCI_NOT_SUPPORTED {
+                tracing::debug!("vCPU {vcpu_id}: unhandled PSCI func {func_id:#x}");
+            }
+        }
+        PsciEffect::SystemOff => {
             tracing::info!("vCPU {vcpu_id}: PSCI SYSTEM_OFF");
             running.store(false, Ordering::SeqCst);
         }
-
-        PSCI_SYSTEM_RESET => {
+        PsciEffect::SystemReset => {
             tracing::info!("vCPU {vcpu_id}: PSCI SYSTEM_RESET");
             running.store(false, Ordering::SeqCst);
         }
-
-        PSCI_CPU_ON_64 => {
-            let target_mpidr = vcpu.get_reg(X1).unwrap_or(0);
-            let entry_point = vcpu.get_reg(X2).unwrap_or(0);
-            let context_id = vcpu.get_reg(X3).unwrap_or(0);
-
-            // Extract CPU index from MPIDR Aff0 field (simple linear topology).
-            let target_cpu = (target_mpidr & 0xFF) as usize;
-
-            if let Some(senders) = cpu_on_senders {
-                let mut senders_guard = senders.lock().unwrap_or_else(PoisonError::into_inner);
-
-                // Take the sender so it can only be used once (CPU_ON is
-                // idempotent in the PSCI spec — a second call for the same
-                // target returns ALREADY_ON).
-                if let Some(sender) = senders_guard.get_mut(target_cpu).and_then(|s| s.take()) {
-                    match sender.send(CpuOnRequest {
-                        _target_cpu: target_mpidr,
-                        entry_point,
-                        context_id,
-                    }) {
-                        Ok(()) => {
-                            tracing::info!(
-                                "vCPU {vcpu_id}: PSCI CPU_ON target={target_cpu} \
-                                 entry={entry_point:#x} ctx={context_id:#x}"
-                            );
-                            let _ = vcpu.set_reg(X0, PSCI_SUCCESS);
-                        }
-                        Err(_) => {
-                            // Receiver gone — secondary thread exited before
-                            // we could send. Treat as ALREADY_ON.
-                            tracing::warn!(
-                                "vCPU {vcpu_id}: PSCI CPU_ON target={target_cpu} \
-                                 channel closed"
-                            );
-                            let _ = vcpu.set_reg(X0, PSCI_ALREADY_ON);
-                        }
+        PsciEffect::CpuOn {
+            target,
+            entry_point,
+            context_id,
+        } => {
+            // The decision above was optimistic (target seen as off). Take the
+            // sender under the lock to resolve the race with a concurrent
+            // CPU_ON for the same target: a taken slot means someone already
+            // started it, so report ALREADY_ON.
+            let sender = cpu_on_senders.and_then(|s| {
+                s.lock()
+                    .unwrap_or_else(PoisonError::into_inner)
+                    .get_mut(target)
+                    .and_then(Option::take)
+            });
+            match sender {
+                Some(tx) => match tx.send(CpuOnRequest {
+                    _target_cpu: x1,
+                    entry_point,
+                    context_id,
+                }) {
+                    Ok(()) => {
+                        tracing::info!(
+                            "vCPU {vcpu_id}: PSCI CPU_ON target={target} \
+                             entry={entry_point:#x} ctx={context_id:#x}"
+                        );
+                        ret = PSCI_SUCCESS;
                     }
-                } else {
-                    // No sender for this CPU — either already started or
-                    // invalid target.
-                    tracing::debug!("vCPU {vcpu_id}: PSCI CPU_ON target={target_cpu} already on");
-                    let _ = vcpu.set_reg(X0, PSCI_ALREADY_ON);
+                    Err(_) => {
+                        // Receiver gone — the target thread exited before we
+                        // could send. Treat as already on.
+                        tracing::warn!(
+                            "vCPU {vcpu_id}: PSCI CPU_ON target={target} channel closed"
+                        );
+                        ret = PSCI_ALREADY_ON;
+                    }
+                },
+                None => {
+                    tracing::debug!("vCPU {vcpu_id}: PSCI CPU_ON target={target} already on");
+                    ret = PSCI_ALREADY_ON;
                 }
-            } else {
-                // Single-vCPU VM — CPU_ON is not supported.
-                tracing::debug!("vCPU {vcpu_id}: PSCI CPU_ON ignored (single-vCPU VM)");
-                let _ = vcpu.set_reg(X0, u64::MAX); // NOT_SUPPORTED
             }
         }
+    }
 
-        _ => {
-            tracing::debug!("vCPU {vcpu_id}: unhandled PSCI func {func_id:#x}");
-            // Return NOT_SUPPORTED (-1) in X0.
-            let _ = vcpu.set_reg(X0, u64::MAX);
+    let _ = vcpu.set_reg(X0, ret);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn version_reports_1_0() {
+        let (ret, eff) = resolve_psci(PSCI_VERSION, 0, 0, 0, &[true]);
+        assert_eq!(ret, PSCI_VERSION_1_0);
+        assert_eq!(eff, PsciEffect::None);
+    }
+
+    #[test]
+    fn features_reports_supported_and_unsupported() {
+        for f in [
+            PSCI_CPU_ON_64,
+            PSCI_AFFINITY_INFO_64,
+            PSCI_SYSTEM_OFF,
+            PSCI_SYSTEM_RESET,
+            PSCI_MIGRATE_INFO_TYPE,
+            PSCI_VERSION,
+            PSCI_FEATURES,
+        ] {
+            assert_eq!(
+                resolve_psci(PSCI_FEATURES, f, 0, 0, &[true]).0,
+                PSCI_SUCCESS
+            );
         }
+        // CPU_SUSPEND (0xC400_0001) is not implemented.
+        assert_eq!(
+            resolve_psci(PSCI_FEATURES, 0xC400_0001, 0, 0, &[true]).0,
+            PSCI_NOT_SUPPORTED
+        );
+    }
+
+    #[test]
+    fn system_off_and_reset_effects() {
+        assert_eq!(
+            resolve_psci(PSCI_SYSTEM_OFF, 0, 0, 0, &[true]).1,
+            PsciEffect::SystemOff
+        );
+        assert_eq!(
+            resolve_psci(PSCI_SYSTEM_RESET, 0, 0, 0, &[true]).1,
+            PsciEffect::SystemReset
+        );
+    }
+
+    #[test]
+    fn migrate_info_type_not_required() {
+        assert_eq!(
+            resolve_psci(PSCI_MIGRATE_INFO_TYPE, 0, 0, 0, &[true]),
+            (MIGRATE_TYPE_NOT_REQUIRED, PsciEffect::None)
+        );
+    }
+
+    #[test]
+    fn cpu_on_off_target_yields_dispatch() {
+        // CPU 0 on (BSP), CPU 1 off.
+        let (ret, eff) = resolve_psci(PSCI_CPU_ON_64, 1, 0x4020_0000, 0x1234, &[true, false]);
+        assert_eq!(ret, PSCI_SUCCESS);
+        assert_eq!(
+            eff,
+            PsciEffect::CpuOn {
+                target: 1,
+                entry_point: 0x4020_0000,
+                context_id: 0x1234,
+            }
+        );
+    }
+
+    #[test]
+    fn cpu_on_already_on_and_invalid() {
+        // Target already on.
+        assert_eq!(
+            resolve_psci(PSCI_CPU_ON_64, 0, 0, 0, &[true, false]).0,
+            PSCI_ALREADY_ON
+        );
+        // Target out of range.
+        assert_eq!(
+            resolve_psci(PSCI_CPU_ON_64, 5, 0, 0, &[true, false]).0,
+            PSCI_INVALID_PARAMS
+        );
+    }
+
+    #[test]
+    fn affinity_info_reports_state() {
+        assert_eq!(
+            resolve_psci(PSCI_AFFINITY_INFO_64, 0, 0, 0, &[true, false]).0,
+            AFFINITY_INFO_ON
+        );
+        assert_eq!(
+            resolve_psci(PSCI_AFFINITY_INFO_64, 1, 0, 0, &[true, false]).0,
+            AFFINITY_INFO_OFF
+        );
+        assert_eq!(
+            resolve_psci(PSCI_AFFINITY_INFO_32, 9, 0, 0, &[true, false]).0,
+            PSCI_INVALID_PARAMS
+        );
+    }
+
+    #[test]
+    fn unknown_function_not_supported() {
+        // CPU_OFF (0x8400_0002) is not implemented yet.
+        assert_eq!(
+            resolve_psci(0x8400_0002, 0, 0, 0, &[true]),
+            (PSCI_NOT_SUPPORTED, PsciEffect::None)
+        );
     }
 }

--- a/virt/arcbox-vmm/src/vmm/darwin_hv/setup.rs
+++ b/virt/arcbox-vmm/src/vmm/darwin_hv/setup.rs
@@ -15,6 +15,17 @@ use crate::vmm::darwin_hv::pl011::{PL011_BASE, PL011_SIZE};
 
 use super::*;
 
+/// Fills `buf` with fresh entropy from the host CSPRNG for the FDT boot seeds
+/// (`rng-seed`, `kaslr-seed`). Fails fast: a weak or absent boot seed is a real
+/// security regression, so we propagate the error rather than seed with a
+/// predictable value.
+fn read_boot_entropy(buf: &mut [u8]) -> Result<()> {
+    use std::io::Read;
+    std::fs::File::open("/dev/urandom")
+        .and_then(|mut f| f.read_exact(buf))
+        .map_err(|e| VmmError::Memory(format!("FDT seed: reading /dev/urandom failed: {e}")))
+}
+
 impl Vmm {
     /// Custom VMM initialization using Hypervisor.framework (manual execution).
     ///
@@ -559,6 +570,17 @@ impl Vmm {
                 fdt.property_u64("linux,initrd-end", initrd_start + initrd_size)
                     .map_err(fdt_err)?;
             }
+            // Seed the guest's entropy pool and KASLR from the host CSPRNG.
+            // Without rng-seed the guest CRNG initializes late (it otherwise
+            // blocks until virtio-rng feeds it); without kaslr-seed the kernel
+            // gets no early KASLR entropy. VZ's bootloader supplies both.
+            let mut rng_seed = [0u8; 64];
+            read_boot_entropy(&mut rng_seed)?;
+            fdt.property("rng-seed", &rng_seed).map_err(fdt_err)?;
+            let mut kaslr = [0u8; 8];
+            read_boot_entropy(&mut kaslr)?;
+            fdt.property_u64("kaslr-seed", u64::from_le_bytes(kaslr))
+                .map_err(fdt_err)?;
             fdt.end_node(chosen).map_err(fdt_err)?;
 
             // Memory node

--- a/virt/arcbox-vmm/src/vmm/darwin_hv/vcpu_loop.rs
+++ b/virt/arcbox-vmm/src/vmm/darwin_hv/vcpu_loop.rs
@@ -196,6 +196,39 @@ pub(super) fn vcpu_run_loop(vcpu_id: u32, entry_addr: u64, x0_value: u64, ctx: V
         tracing::warn!("vCPU {vcpu_id}: set SCTLR_EL1 failed: {e}");
     }
 
+    // Set MPIDR_EL1 for this vCPU (Aff0 = vcpu_id, other affinity fields 0).
+    // GIC affinity routing and the FDT `reg` values both depend on it, so the
+    // write must stick: if MPIDR is silently non-writable on some macOS version
+    // every vCPU reports Aff0 = 0 and interrupts misroute in a subtle,
+    // hard-to-debug way. Verify the readback and abort the boot rather than run
+    // with corrupted affinity. Done *before* the registry pushes below so a
+    // failure early-returns without leaving a stale vCPU id / thread handle
+    // (ABX-367). The readback only distinguishes a rejected write on
+    // secondaries — the BSP's Aff0 is 0 whether or not the write took.
+    let mpidr = u64::from(vcpu_id) & 0xFF;
+    if let Err(e) = vcpu.set_sys_reg(arcbox_hv::sys_reg::HV_SYS_REG_MPIDR_EL1, mpidr) {
+        tracing::error!("vCPU {vcpu_id}: set MPIDR_EL1 failed: {e}; aborting boot");
+        running.store(false, Ordering::SeqCst);
+        return;
+    }
+    match vcpu.get_sys_reg(arcbox_hv::sys_reg::HV_SYS_REG_MPIDR_EL1) {
+        Ok(v) if v & 0xFF == u64::from(vcpu_id) => {}
+        Ok(v) => {
+            tracing::error!(
+                "vCPU {vcpu_id}: MPIDR_EL1 Aff0 readback {:#x} != {vcpu_id}; aborting boot \
+                 (GIC affinity would be wrong)",
+                v & 0xFF,
+            );
+            running.store(false, Ordering::SeqCst);
+            return;
+        }
+        Err(e) => {
+            tracing::error!("vCPU {vcpu_id}: MPIDR_EL1 readback failed: {e}; aborting boot");
+            running.store(false, Ordering::SeqCst);
+            return;
+        }
+    }
+
     // Register this vCPU's framework ID and this thread's handle after all
     // register-setup calls succeed. If any setup call fails above, the
     // early return drops `HvVcpu` (triggering `hv_vcpu_destroy`) and the
@@ -215,13 +248,6 @@ pub(super) fn vcpu_run_loop(vcpu_id: u32, entry_addr: u64, x0_value: u64, ctx: V
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
         handles.push(std::thread::current());
-    }
-
-    // Set MPIDR_EL1 for this vCPU (used by GIC affinity routing).
-    // Simple layout: Aff0 = vcpu_id, all other affinity fields 0.
-    let mpidr = u64::from(vcpu_id) & 0xFF;
-    if let Err(e) = vcpu.set_sys_reg(arcbox_hv::sys_reg::HV_SYS_REG_MPIDR_EL1, mpidr) {
-        tracing::warn!("vCPU {vcpu_id}: set MPIDR failed (may not be writable): {e}");
     }
 
     tracing::info!(

--- a/virt/arcbox-vmm/src/vmm/darwin_hv/vcpu_loop.rs
+++ b/virt/arcbox-vmm/src/vmm/darwin_hv/vcpu_loop.rs
@@ -9,7 +9,7 @@
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 
-use arcbox_hv::{ExceptionClass, HvVcpu, VcpuExit};
+use arcbox_hv::{ExceptionClass, HvVcpu, MmioInfo, VcpuExit};
 
 use super::hvc_blk::{
     ARCBOX_HVC_BLK_FLUSH, ARCBOX_HVC_BLK_READ, ARCBOX_HVC_BLK_WRITE, ARCBOX_HVC_PROBE,
@@ -84,6 +84,53 @@ fn read_mmio_write_reg(vcpu: &HvVcpu, vcpu_id: u32, register: u8) -> Option<u64>
             tracing::error!("vCPU {vcpu_id}: get_reg(X{register}) failed: {e}");
             None
         }
+    }
+}
+
+/// Sign-extends an MMIO load result from `access_size` bytes to the transfer
+/// register width. `sixty_four` selects the AArch64 target: `true` → 64-bit Xt
+/// (`LDRSB/H/W` into X), `false` → 32-bit Wt (`LDRSB/H` into W, whose write
+/// zero-extends into the 64-bit register). Zero-extending loads never set
+/// `sign_extend`, so they never reach this.
+fn sign_extend_mmio(value: u64, access_size: u8, sixty_four: bool) -> u64 {
+    let bits = u32::from(access_size) * 8;
+    // Nothing to extend once the loaded width already fills the register.
+    if bits == 0 || bits >= 64 {
+        return value;
+    }
+    if sixty_four {
+        let shift = 64 - bits;
+        #[allow(clippy::cast_possible_wrap)]
+        let signed = (value << shift) as i64 >> shift;
+        signed as u64
+    } else if bits >= 32 {
+        // 32-bit target loading 32 bits: no extension, zero-extend to 64.
+        u64::from(value as u32)
+    } else {
+        // Sign-extend within 32 bits, then zero-extend the W-register write.
+        let shift = 32 - bits;
+        #[allow(clippy::cast_possible_wrap, clippy::cast_possible_truncation)]
+        let signed = ((value as u32) << shift) as i32 >> shift;
+        u64::from(signed as u32)
+    }
+}
+
+/// Completes an MMIO read: applies sign-extension when the faulting load
+/// requested it, honors the `Rt == 31` zero-register discard, and writes the
+/// result into the guest's transfer register.
+fn complete_mmio_read(vcpu: &HvVcpu, vcpu_id: u32, mmio: &MmioInfo, raw: u64) {
+    // Rt == 31 in a load is the zero register (XZR/WZR): the result is
+    // discarded. `set_reg(31, _)` would instead clobber SP.
+    if mmio.register == 31 {
+        return;
+    }
+    let value = if mmio.sign_extend {
+        sign_extend_mmio(raw, mmio.access_size, mmio.sixty_four)
+    } else {
+        raw
+    };
+    if let Err(e) = vcpu.set_reg(u32::from(mmio.register), value) {
+        tracing::error!("vCPU {vcpu_id}: set_reg(X{}) failed: {e}", mmio.register);
     }
 }
 
@@ -245,6 +292,26 @@ pub(super) fn vcpu_run_loop(vcpu_id: u32, entry_addr: u64, x0_value: u64, ctx: V
                 } else {
                     &stats.mmio_reads
                 });
+
+                // ISV=0: the syndrome carries no valid transfer register or
+                // access size (LDP/STP, atomics, some writeback-addressing
+                // forms). We cannot service the access correctly and must not
+                // fabricate a decode — that silently corrupts guest registers
+                // or MMIO state. Refuse loudly and skip the instruction rather
+                // than act on garbage. Linux's virtio-mmio driver only issues
+                // single-register `readl`/`writel` (ISV=1), so this is a
+                // defensive path; correct handling would single-step re-execute.
+                if !mmio.isv {
+                    tracing::error!(
+                        "vCPU {vcpu_id}: undecodable MMIO {} at {:#x} (ESR ISV=0) — skipping instruction",
+                        if mmio.is_write { "write" } else { "read" },
+                        mmio.address,
+                    );
+                    let pc = vcpu.get_reg(reg::PC).unwrap_or(0);
+                    let _ = vcpu.set_reg(reg::PC, pc.wrapping_add(4));
+                    continue;
+                }
+
                 // Check PL011 UART region first, then fall through to DeviceManager.
                 let handled_by_pl011 = {
                     let uart_match = {
@@ -265,12 +332,7 @@ pub(super) fn vcpu_run_loop(vcpu_id: u32, entry_addr: u64, x0_value: u64, ctx: V
                                 .lock()
                                 .unwrap()
                                 .read(mmio.address, mmio.access_size as usize);
-                            if let Err(e) = vcpu.set_reg(u32::from(mmio.register), value) {
-                                tracing::error!(
-                                    "vCPU {vcpu_id}: set_reg(X{}) failed: {e}",
-                                    mmio.register
-                                );
-                            }
+                            complete_mmio_read(&vcpu, vcpu_id, mmio, value);
                         }
                         true
                     } else {
@@ -319,12 +381,7 @@ pub(super) fn vcpu_run_loop(vcpu_id: u32, entry_addr: u64, x0_value: u64, ctx: V
                                 0 // Return 0 for unknown reads.
                             }
                         };
-                        if let Err(e) = vcpu.set_reg(u32::from(mmio.register), value) {
-                            tracing::error!(
-                                "vCPU {vcpu_id}: set_reg(X{}) failed: {e}",
-                                mmio.register
-                            );
-                        }
+                        complete_mmio_read(&vcpu, vcpu_id, mmio, value);
                     }
                 }
 
@@ -494,4 +551,57 @@ pub(super) fn vcpu_run_loop(vcpu_id: u32, entry_addr: u64, x0_value: u64, ctx: V
     pl011.lock().unwrap().flush();
 
     tracing::info!("vCPU {vcpu_id}: exited");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::sign_extend_mmio;
+
+    #[test]
+    fn ldrsb_to_x_sign_extends_to_64() {
+        // LDRSB Xt, [..]: 1 byte, 64-bit target. 0x80 -> -128 in all 64 bits.
+        assert_eq!(sign_extend_mmio(0x80, 1, true), 0xFFFF_FFFF_FFFF_FF80);
+        assert_eq!(sign_extend_mmio(0x7F, 1, true), 0x7F);
+    }
+
+    #[test]
+    fn ldrsb_to_w_sign_extends_within_32_then_zero_extends() {
+        // LDRSB Wt, [..]: 1 byte, 32-bit target. 0x80 -> 0xFFFF_FF80, and the
+        // W-register write zero-extends the upper 32 bits.
+        assert_eq!(sign_extend_mmio(0x80, 1, false), 0x0000_0000_FFFF_FF80);
+        assert_eq!(sign_extend_mmio(0x7F, 1, false), 0x7F);
+    }
+
+    #[test]
+    fn ldrsh_sign_extends_halfword() {
+        assert_eq!(sign_extend_mmio(0x8000, 2, true), 0xFFFF_FFFF_FFFF_8000);
+        assert_eq!(sign_extend_mmio(0x8000, 2, false), 0x0000_0000_FFFF_8000);
+        assert_eq!(sign_extend_mmio(0x1234, 2, true), 0x1234);
+    }
+
+    #[test]
+    fn ldrsw_sign_extends_word_to_64() {
+        // LDRSW is always 32-bit source into a 64-bit register.
+        assert_eq!(
+            sign_extend_mmio(0x8000_0000, 4, true),
+            0xFFFF_FFFF_8000_0000
+        );
+        assert_eq!(sign_extend_mmio(0x0000_0001, 4, true), 0x1);
+    }
+
+    #[test]
+    fn full_and_wide_widths_are_passthrough() {
+        // 8-byte load: nothing above bit 63 to extend into.
+        assert_eq!(
+            sign_extend_mmio(0xFFFF_FFFF_FFFF_FF80, 8, true),
+            0xFFFF_FFFF_FFFF_FF80
+        );
+        // 4-byte load into a 32-bit register is not sign-extended (no SSE):
+        // this helper only runs when sign_extend is set, but the width-fills-
+        // register branch must still zero-extend cleanly.
+        assert_eq!(
+            sign_extend_mmio(0x8000_0000, 4, false),
+            0x0000_0000_8000_0000
+        );
+    }
 }

--- a/virt/arcbox-vmm/src/vmm/darwin_hv/vcpu_loop.rs
+++ b/virt/arcbox-vmm/src/vmm/darwin_hv/vcpu_loop.rs
@@ -46,6 +46,9 @@ pub(super) struct VcpuContext {
     pub device_manager: Arc<crate::device::DeviceManager>,
     /// Shared flag; the loop exits when this is set to `false`.
     pub running: Arc<AtomicBool>,
+    /// Set (with `running=false`) when the guest issues PSCI SYSTEM_RESET, so
+    /// the lifecycle driver reboots the guest instead of powering it off.
+    pub reset_requested: Arc<AtomicBool>,
     /// Cooperative pause flag. When `true`, the vCPU parks itself after its
     /// next `vcpu.run()` return instead of re-entering guest execution.
     /// Cleared by `resume`, which also unparks the thread.
@@ -153,6 +156,7 @@ pub(super) fn vcpu_run_loop(vcpu_id: u32, entry_addr: u64, x0_value: u64, ctx: V
     let VcpuContext {
         device_manager,
         running,
+        reset_requested,
         paused,
         pl011,
         cpu_on_senders,
@@ -476,7 +480,14 @@ pub(super) fn vcpu_run_loop(vcpu_id: u32, entry_addr: u64, x0_value: u64, ctx: V
                     }
                     _ => {
                         // PSCI and other standard calls.
-                        handle_psci(vcpu_id, func_id, &vcpu, &running, cpu_on_senders.as_ref());
+                        handle_psci(
+                            vcpu_id,
+                            func_id,
+                            &vcpu,
+                            &running,
+                            &reset_requested,
+                            cpu_on_senders.as_ref(),
+                        );
                         if !running.load(Ordering::Relaxed) {
                             break;
                         }
@@ -494,7 +505,14 @@ pub(super) fn vcpu_run_loop(vcpu_id: u32, entry_addr: u64, x0_value: u64, ctx: V
                     Ok(v) => v,
                     Err(_) => continue,
                 };
-                handle_psci(vcpu_id, func_id, &vcpu, &running, cpu_on_senders.as_ref());
+                handle_psci(
+                    vcpu_id,
+                    func_id,
+                    &vcpu,
+                    &running,
+                    &reset_requested,
+                    cpu_on_senders.as_ref(),
+                );
                 if !running.load(Ordering::Relaxed) {
                     break;
                 }

--- a/virt/arcbox-vmm/src/vmm/mod.rs
+++ b/virt/arcbox-vmm/src/vmm/mod.rs
@@ -245,6 +245,12 @@ pub struct Vmm {
     /// (which is a terminal stop signal).
     #[cfg(target_os = "macos")]
     hv_paused: Arc<AtomicBool>,
+    /// Set by a guest PSCI SYSTEM_RESET (as opposed to SYSTEM_OFF): the vCPU
+    /// loop stops the VM and flags this so the lifecycle driver reboots the
+    /// guest via [`Vmm::reboot`] instead of tearing the machine down. Cleared
+    /// by `reboot`.
+    #[cfg(target_os = "macos")]
+    hv_reset_requested: Arc<AtomicBool>,
 }
 
 impl Vmm {
@@ -355,6 +361,8 @@ impl Vmm {
             hv_balloon: None,
             #[cfg(target_os = "macos")]
             hv_paused: Arc::new(AtomicBool::new(false)),
+            #[cfg(target_os = "macos")]
+            hv_reset_requested: Arc::new(AtomicBool::new(false)),
         })
     }
 
@@ -588,6 +596,36 @@ impl Vmm {
         self.state = VmmState::Stopped;
         tracing::info!("VMM stopped");
         Ok(())
+    }
+
+    /// Returns whether the guest requested a reboot (PSCI SYSTEM_RESET) rather
+    /// than a power-off. The lifecycle driver polls this after the VM stops to
+    /// choose between tearing the machine down and rebooting it via
+    /// [`Vmm::reboot`].
+    #[cfg(target_os = "macos")]
+    #[must_use]
+    pub fn reset_requested(&self) -> bool {
+        self.hv_reset_requested.load(Ordering::SeqCst)
+    }
+
+    /// Reboots the guest in the same process: full teardown followed by a fresh
+    /// boot, re-creating the `HvVm` and reloading the kernel/FDT. Clears the
+    /// reset-requested flag. Used by the lifecycle driver when the guest issued
+    /// PSCI SYSTEM_RESET.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if teardown or re-initialization fails.
+    #[cfg(target_os = "macos")]
+    pub fn reboot(&mut self) -> Result<()> {
+        tracing::info!("Rebooting VM (guest SYSTEM_RESET): full teardown + fresh boot");
+        self.hv_reset_requested.store(false, Ordering::SeqCst);
+        self.stop()?;
+        // `initialize()` requires the Created state; `stop()` left us Stopped
+        // with every HV resource released (HvVm, guest RAM, devices). Reset the
+        // state so `start()` re-runs initialization from a clean slate.
+        self.state = VmmState::Created;
+        self.start()
     }
 
     /// Returns the configured memory size for this VM.

--- a/virt/arcbox-vmm/src/vmm/mod.rs
+++ b/virt/arcbox-vmm/src/vmm/mod.rs
@@ -601,29 +601,36 @@ impl Vmm {
     /// Returns whether the guest requested a reboot (PSCI SYSTEM_RESET) rather
     /// than a power-off. The lifecycle driver polls this after the VM stops to
     /// choose between tearing the machine down and rebooting it via
-    /// [`Vmm::reboot`].
-    #[cfg(target_os = "macos")]
+    /// [`Vmm::reboot`]. Always `false` on non-macOS backends (only the HV path
+    /// tracks the flag).
     #[must_use]
     pub fn reset_requested(&self) -> bool {
-        self.hv_reset_requested.load(Ordering::SeqCst)
+        #[cfg(target_os = "macos")]
+        {
+            self.hv_reset_requested.load(Ordering::SeqCst)
+        }
+        #[cfg(not(target_os = "macos"))]
+        {
+            false
+        }
     }
 
     /// Reboots the guest in the same process: full teardown followed by a fresh
-    /// boot, re-creating the `HvVm` and reloading the kernel/FDT. Clears the
-    /// reset-requested flag. Used by the lifecycle driver when the guest issued
-    /// PSCI SYSTEM_RESET.
+    /// boot, re-creating the hypervisor VM and reloading the kernel/FDT. Clears
+    /// the reset-requested flag. Used by the lifecycle driver when the guest
+    /// issued PSCI SYSTEM_RESET.
     ///
     /// # Errors
     ///
     /// Returns an error if teardown or re-initialization fails.
-    #[cfg(target_os = "macos")]
     pub fn reboot(&mut self) -> Result<()> {
-        tracing::info!("Rebooting VM (guest SYSTEM_RESET): full teardown + fresh boot");
+        tracing::info!("Rebooting VM: full teardown + fresh boot");
+        #[cfg(target_os = "macos")]
         self.hv_reset_requested.store(false, Ordering::SeqCst);
         self.stop()?;
         // `initialize()` requires the Created state; `stop()` left us Stopped
-        // with every HV resource released (HvVm, guest RAM, devices). Reset the
-        // state so `start()` re-runs initialization from a clean slate.
+        // with every resource released. Reset the state so `start()` re-runs
+        // initialization from a clean slate (re-creating the HvVm on HV).
         self.state = VmmState::Created;
         self.start()
     }


### PR DESCRIPTION
## Summary

HV-backend platform-correctness fixes from the Linear **HV Backend** project, capped by end-to-end guest-initiated reboot support, hardware-validated on Apple Silicon.

### HV platform correctness
- **ABX-404** — MMIO Data Aborts: apply sign-extension (SSE/SF), refuse ISV=0 faults instead of misdecoding, discard loads targeting XZR (`6c50b78e`)
- **ABX-405** — seed FDT `rng-seed`/`kaslr-seed` from host entropy; implement the PL011 flag register (`64187e26`)
- **ABX-403** (partial) — fail fast on MPIDR writes, fix CPU_ON issued from a secondary vCPU (`f1beb070`); implement PSCI `FEATURES` / `AFFINITY_INFO` / `MIGRATE_INFO_TYPE` (`6a1c1ae9`). CPU_OFF re-online is deferred (needs a vcpu_run_loop lifecycle refactor).

### Guest-initiated reboot, end to end (ABX-402)
- `Vmm::reboot()` + `reset_requested` plumbing: PSCI `SYSTEM_RESET` records a reset verdict distinct from `SYSTEM_OFF` (`ade8c6e9`)
- `VmManager::reboot` / `vm_self_stopped` — in-place teardown + fresh boot that keeps the VM entry (`53d6a0fa`)
- Lifecycle actor: 2s liveness poll detects the guest-initiated stop, the statig HSM handles `GuestReset` by bumping `restart_generation` and rebooting in place; the reboot reports `AgentReady`/`BootFailed` exactly like a boot (`eb102a8d`)

### Docker proxy fix found during validation
- **`d5a99f12`** — hyper drops a request future when its client disconnects; if that request owned the `EndpointReadiness::Verifying` slot (docker CLI times out `_ping` during the reboot window), the slot leaked forever and every later request parked behind a verification nobody was running — the whole Docker API wedged permanently. Fixed with an RAII `VerifyingClaim` whose `Drop` rolls back to `Unverified` and hands over to a parked request. Not reboot-specific: any client disconnect during a slow verification (e.g. a backend switch) hit the same wedge.

### New e2e coverage
- **`a30c10d2`** — `tests/e2e/tests/hv_reboot.rs`: boots the System VM on HV through a real daemon, triggers `reboot -f` from a `--privileged --pid=host` container, asserts new kernel `boot_id` + agent reconnect + Docker recovery, then guards the opposite verdict (`poweroff -f` / SYSTEM_OFF must stay down) and daemon survival. Docker CLI helpers extracted into a shared `arcbox_e2e::docker` module.

## Validation

- Hardware run (M-series, HV): SYSTEM_RESET → liveness detection **262ms**; trigger → new `boot_id` + docker functional **3.7s**; poweroff guard honored; daemon alive throughout.
- `cargo test -p arcbox-e2e --test hv_reboot -- --ignored` → **ok** (196.85s, includes the deliberate 90s poweroff window)
- `cargo test -p arcbox-core --lib` (76) / `-p arcbox-docker --lib` (103, incl. 2 new cancellation regressions) / `-p arcbox-vmm` unit tests
- `cargo clippy --workspace --exclude arcbox-agent --all-targets -- -D warnings` + `cargo fmt --all --check` clean

## Notes

- The staged dev rootfs (0.6.1) predates the busybox-init/rcS redesign, so the debug-console socket has no guest shell — the e2e test drives everything through the Docker path instead.
- Follow-ups tracked in Linear: guest poweroff detection + slow SIGTERM on a self-stopped guest (ABX-414 family), ABX-403 CPU_OFF re-online, `panic=1` auto-reboot verification.