### PR TITLE
feat(hv): PL031 RTC, PSCI CPU_OFF, and guest-halt teardown fixes (ABX-416, ABX-403, ABX-415)

### DIFF
--- a/virt/arcbox-net-inject/src/irq.rs
+++ b/virt/arcbox-net-inject/src/irq.rs
@@ -25,6 +25,14 @@ impl IrqHandle {
     /// Fires the interrupt: set MMIO interrupt_status + GIC SPI + exit vCPUs.
     pub fn trigger(&self) {
         let _ = (self.callback)(self.irq, true);
-        (self.exit_vcpus)();
+        // ABX-397 experiment: skip the all-vCPU force exit when
+        // ARCBOX_NET_NO_EXIT_VCPUS is set, to measure whether the in-kernel
+        // GICv3 already interrupts running vCPUs (making the broadcast pure
+        // overhead). TEMPORARY — remove before merge.
+        static SKIP_EXIT: std::sync::LazyLock<bool> =
+            std::sync::LazyLock::new(|| std::env::var_os("ARCBOX_NET_NO_EXIT_VCPUS").is_some());
+        if !*SKIP_EXIT {
+            (self.exit_vcpus)();
+        }
     }
 }

--- a/virt/arcbox-net-inject/src/irq.rs
+++ b/virt/arcbox-net-inject/src/irq.rs
@@ -25,14 +25,6 @@ impl IrqHandle {
     /// Fires the interrupt: set MMIO interrupt_status + GIC SPI + exit vCPUs.
     pub fn trigger(&self) {
         let _ = (self.callback)(self.irq, true);
-        // ABX-397 experiment: skip the all-vCPU force exit when
-        // ARCBOX_NET_NO_EXIT_VCPUS is set, to measure whether the in-kernel
-        // GICv3 already interrupts running vCPUs (making the broadcast pure
-        // overhead). TEMPORARY — remove before merge.
-        static SKIP_EXIT: std::sync::LazyLock<bool> =
-            std::sync::LazyLock::new(|| std::env::var_os("ARCBOX_NET_NO_EXIT_VCPUS").is_some());
-        if !*SKIP_EXIT {
-            (self.exit_vcpus)();
-        }
+        (self.exit_vcpus)();
     }
 }

--- a/virt/arcbox-vmm/src/vmm/darwin_hv/lifecycle.rs
+++ b/virt/arcbox-vmm/src/vmm/darwin_hv/lifecycle.rs
@@ -5,7 +5,7 @@ use crate::error::{Result, VmmError};
 use super::pl011::Pl011;
 use super::pl031::Pl031;
 use super::psci::{CpuOnRequest, CpuPower, CpuPowerRegistry};
-use super::vcpu_loop::{VcpuContext, VcpuLoopExit, vcpu_run_loop};
+use super::vcpu_loop::{VcpuBoot, VcpuContext, vcpu_run_loop};
 use super::*;
 
 impl Vmm {
@@ -289,41 +289,31 @@ impl Vmm {
                 let stats = vcpu_stats[i as usize].clone();
                 let registry_for_thread = registry.clone();
 
-                // The thread parks on its receiver until CPU_ON, runs the
-                // vCPU, and — when the guest offlines it via CPU_OFF —
-                // parks again for the next CPU_ON. It exits when the
-                // registry is closed (stop) or the VM shuts down.
+                // The thread creates its HvVcpu once, parks on its receiver
+                // until CPU_ON, and — when the guest offlines it via
+                // CPU_OFF — parks again for the next CPU_ON without
+                // destroying the vCPU (see vcpu_run_loop). It exits when
+                // the registry is closed (stop) or the VM shuts down.
                 let t = std::thread::Builder::new()
                     .name(format!("hv-vcpu-{i}"))
                     .spawn(move || {
-                        while let Ok(req) = rx.recv() {
-                            tracing::info!(
-                                "vCPU {i}: received CPU_ON, starting at {:#x}",
-                                req.entry_point
-                            );
-                            let exit = vcpu_run_loop(
-                                i,
-                                req.entry_point,
-                                req.context_id,
-                                VcpuContext {
-                                    device_manager: dm.clone(),
-                                    running: r.clone(),
-                                    reset_requested: rr.clone(),
-                                    paused: p.clone(),
-                                    pl011: uart.clone(),
-                                    pl031: rtc.clone(),
-                                    cpu_power: Some(registry_for_thread.clone()),
-                                    vcpu_thread_handles: th.clone(),
-                                    hv_vcpu_ids: ids.clone(),
-                                    hvc_blk_fds: hvc_fds_clone.clone(),
-                                    stats: stats.clone(),
-                                },
-                            );
-                            if exit != VcpuLoopExit::CpuOff {
-                                return;
-                            }
-                        }
-                        tracing::debug!("vCPU {i}: channel closed, exiting");
+                        vcpu_run_loop(
+                            i,
+                            VcpuBoot::AwaitCpuOn(rx),
+                            VcpuContext {
+                                device_manager: dm,
+                                running: r,
+                                reset_requested: rr,
+                                paused: p,
+                                pl011: uart,
+                                pl031: rtc,
+                                cpu_power: Some(registry_for_thread),
+                                vcpu_thread_handles: th,
+                                hv_vcpu_ids: ids,
+                                hvc_blk_fds: hvc_fds_clone,
+                                stats,
+                            },
+                        );
                     })
                     .map_err(|e| VmmError::Vcpu(format!("spawn vcpu-{i}: {e}")))?;
                 self.hv_vcpu_threads.push(t);
@@ -345,8 +335,10 @@ impl Vmm {
                 .spawn(move || {
                     vcpu_run_loop(
                         0,
-                        kernel_entry,
-                        fdt_addr,
+                        VcpuBoot::Immediate {
+                            entry: kernel_entry,
+                            x0: fdt_addr,
+                        },
                         VcpuContext {
                             device_manager,
                             running,

--- a/virt/arcbox-vmm/src/vmm/darwin_hv/lifecycle.rs
+++ b/virt/arcbox-vmm/src/vmm/darwin_hv/lifecycle.rs
@@ -1,11 +1,11 @@
-use std::sync::{Arc, Mutex, mpsc};
+use std::sync::{Arc, mpsc};
 
 use crate::error::{Result, VmmError};
 
 use super::pl011::Pl011;
 use super::pl031::Pl031;
-use super::psci::{CpuOnRequest, CpuOnSenders};
-use super::vcpu_loop::{VcpuContext, vcpu_run_loop};
+use super::psci::{CpuOnRequest, CpuPower, CpuPowerRegistry};
+use super::vcpu_loop::{VcpuContext, VcpuLoopExit, vcpu_run_loop};
 use super::*;
 
 impl Vmm {
@@ -258,27 +258,25 @@ impl Vmm {
             .collect();
         self.hv_vcpu_stats.clone_from(&vcpu_stats);
 
-        // --- Set up PSCI CPU_ON channels for secondary vCPUs ---
+        // --- Set up the PSCI power registry for secondary vCPUs ---
         // The registry is shared with *every* vCPU thread — the BSP and each
         // secondary — so a CPU_ON issued from any CPU can reach any target.
         // Linux may bring a secondary online from a CPU other than the BSP
         // (CPU hotplug, some resume paths); handing the secondaries `None`
         // here made every such call return NOT_SUPPORTED.
-        let cpu_on_senders: Option<CpuOnSenders> = if vcpu_count > 1 {
-            let senders: CpuOnSenders =
-                Arc::new(Mutex::new(Vec::with_capacity(vcpu_count as usize)));
-            senders
-                .lock()
-                .unwrap_or_else(std::sync::PoisonError::into_inner)
-                .push(None); // Slot 0 = BSP
-
-            for i in 1..vcpu_count {
+        let cpu_power: Option<CpuPower> = if vcpu_count > 1 {
+            let mut senders: Vec<Option<mpsc::Sender<CpuOnRequest>>> =
+                Vec::with_capacity(vcpu_count as usize);
+            senders.push(None); // Slot 0 = BSP
+            let mut receivers = Vec::with_capacity(vcpu_count as usize - 1);
+            for _ in 1..vcpu_count {
                 let (tx, rx) = mpsc::channel::<CpuOnRequest>();
-                senders
-                    .lock()
-                    .unwrap_or_else(std::sync::PoisonError::into_inner)
-                    .push(Some(tx));
+                senders.push(Some(tx));
+                receivers.push(rx);
+            }
+            let registry = CpuPowerRegistry::from_senders(senders);
 
+            for (i, rx) in (1..vcpu_count).zip(receivers) {
                 let r = running.clone();
                 let p = paused.clone();
                 let rr = reset_requested.clone();
@@ -289,45 +287,50 @@ impl Vmm {
                 let rtc = pl031.clone();
                 let hvc_fds_clone = self.hvc_blk_fds.clone();
                 let stats = vcpu_stats[i as usize].clone();
-                let senders_for_thread = senders.clone();
+                let registry_for_thread = registry.clone();
 
+                // The thread parks on its receiver until CPU_ON, runs the
+                // vCPU, and — when the guest offlines it via CPU_OFF —
+                // parks again for the next CPU_ON. It exits when the
+                // registry is closed (stop) or the VM shuts down.
                 let t = std::thread::Builder::new()
                     .name(format!("hv-vcpu-{i}"))
-                    .spawn(move || match rx.recv() {
-                        Ok(req) => {
+                    .spawn(move || {
+                        while let Ok(req) = rx.recv() {
                             tracing::info!(
                                 "vCPU {i}: received CPU_ON, starting at {:#x}",
                                 req.entry_point
                             );
-                            vcpu_run_loop(
+                            let exit = vcpu_run_loop(
                                 i,
                                 req.entry_point,
                                 req.context_id,
                                 VcpuContext {
-                                    device_manager: dm,
-                                    running: r,
-                                    reset_requested: rr,
-                                    paused: p,
-                                    pl011: uart,
-                                    pl031: rtc,
-                                    cpu_on_senders: Some(senders_for_thread),
-                                    vcpu_thread_handles: th,
-                                    hv_vcpu_ids: ids,
-                                    hvc_blk_fds: hvc_fds_clone,
-                                    stats,
+                                    device_manager: dm.clone(),
+                                    running: r.clone(),
+                                    reset_requested: rr.clone(),
+                                    paused: p.clone(),
+                                    pl011: uart.clone(),
+                                    pl031: rtc.clone(),
+                                    cpu_power: Some(registry_for_thread.clone()),
+                                    vcpu_thread_handles: th.clone(),
+                                    hv_vcpu_ids: ids.clone(),
+                                    hvc_blk_fds: hvc_fds_clone.clone(),
+                                    stats: stats.clone(),
                                 },
                             );
+                            if exit != VcpuLoopExit::CpuOff {
+                                return;
+                            }
                         }
-                        Err(_) => {
-                            tracing::debug!("vCPU {i}: channel closed, never started");
-                        }
+                        tracing::debug!("vCPU {i}: channel closed, exiting");
                     })
                     .map_err(|e| VmmError::Vcpu(format!("spawn vcpu-{i}: {e}")))?;
                 self.hv_vcpu_threads.push(t);
             }
 
-            self.hv_cpu_on_senders = Some(senders.clone());
-            Some(senders)
+            self.hv_cpu_power = Some(registry.clone());
+            Some(registry)
         } else {
             None
         };
@@ -351,7 +354,7 @@ impl Vmm {
                             paused,
                             pl011,
                             pl031,
-                            cpu_on_senders,
+                            cpu_power,
                             vcpu_thread_handles,
                             hv_vcpu_ids: bsp_hv_vcpu_ids,
                             hvc_blk_fds,
@@ -378,14 +381,17 @@ impl Vmm {
         self.running
             .store(false, std::sync::atomic::Ordering::SeqCst);
 
-        // Drop the PSCI CPU_ON channel senders. Secondary vCPU threads
-        // spawn with `rx.recv()` waiting for a CPU_ON request; when the
-        // guest only brought up the BSP they stay parked indefinitely.
-        // Dropping the senders makes their `recv()` return `Err(RecvError)`
-        // so they exit the recv and hit the `running=false` check. See
-        // ABX-364 — before this drop the secondary vCPU join could take
-        // 20+ seconds.
-        self.hv_cpu_on_senders.take();
+        // Close the PSCI power registry. Secondary vCPU threads park on
+        // `rx.recv()` while off (never CPU_ON'd, or offlined via CPU_OFF);
+        // closing drops every sender under the registry lock so their
+        // `recv()` returns `Err(RecvError)` and the threads exit. See
+        // ABX-364 — before this the secondary vCPU join could take 20+
+        // seconds. `close()` (not just dropping our handle) is required
+        // because every vCPU thread holds its own registry Arc, which
+        // keeps the senders alive.
+        if let Some(registry) = self.hv_cpu_power.take() {
+            registry.close();
+        }
 
         // Drop block-I/O worker senders so `rx.recv()` in
         // `blk_io_worker_loop` returns `Err(RecvError)` and the workers

--- a/virt/arcbox-vmm/src/vmm/darwin_hv/lifecycle.rs
+++ b/virt/arcbox-vmm/src/vmm/darwin_hv/lifecycle.rs
@@ -3,6 +3,7 @@ use std::sync::{Arc, Mutex, mpsc};
 use crate::error::{Result, VmmError};
 
 use super::pl011::Pl011;
+use super::pl031::Pl031;
 use super::psci::{CpuOnRequest, CpuOnSenders};
 use super::vcpu_loop::{VcpuContext, vcpu_run_loop};
 use super::*;
@@ -240,6 +241,7 @@ impl Vmm {
         paused.store(false, std::sync::atomic::Ordering::SeqCst);
         let vcpu_count = self.config.vcpu_count;
         let pl011 = Arc::new(std::sync::Mutex::new(Pl011::new()));
+        let pl031 = Arc::new(std::sync::Mutex::new(Pl031::new()));
 
         let vcpu_thread_handles = self
             .hv_vcpu_thread_handles
@@ -284,6 +286,7 @@ impl Vmm {
                 let th = vcpu_thread_handles.clone();
                 let ids = hv_vcpu_ids.clone();
                 let uart = pl011.clone();
+                let rtc = pl031.clone();
                 let hvc_fds_clone = self.hvc_blk_fds.clone();
                 let stats = vcpu_stats[i as usize].clone();
                 let senders_for_thread = senders.clone();
@@ -306,6 +309,7 @@ impl Vmm {
                                     reset_requested: rr,
                                     paused: p,
                                     pl011: uart,
+                                    pl031: rtc,
                                     cpu_on_senders: Some(senders_for_thread),
                                     vcpu_thread_handles: th,
                                     hv_vcpu_ids: ids,
@@ -346,6 +350,7 @@ impl Vmm {
                             reset_requested,
                             paused,
                             pl011,
+                            pl031,
                             cpu_on_senders,
                             vcpu_thread_handles,
                             hv_vcpu_ids: bsp_hv_vcpu_ids,

--- a/virt/arcbox-vmm/src/vmm/darwin_hv/mod.rs
+++ b/virt/arcbox-vmm/src/vmm/darwin_hv/mod.rs
@@ -78,6 +78,14 @@ const VIRTIO_MMIO_SIZE: u64 = 0x200;
 /// Maximum number of VirtIO MMIO devices.
 const VIRTIO_MMIO_MAX_DEVICES: u64 = 32;
 
+/// The PL031 alarm SPI must stay past a fully populated VirtIO device
+/// table: the allocator hands out INTIDs 32.. (FDT SPI 0..), one per
+/// device, so any SPI below the device cap can alias a live device line.
+const _: () = assert!(
+    pl031::PL031_FDT_SPI as u64 >= VIRTIO_MMIO_MAX_DEVICES,
+    "PL031 alarm SPI aliases the VirtIO IRQ range"
+);
+
 /// First SPI interrupt number for VirtIO devices (GIC SPI numbering).
 #[cfg(test)]
 const VIRTIO_IRQ_BASE: u32 = 48;

--- a/virt/arcbox-vmm/src/vmm/darwin_hv/mod.rs
+++ b/virt/arcbox-vmm/src/vmm/darwin_hv/mod.rs
@@ -36,6 +36,7 @@ mod inline_sink;
 mod lifecycle;
 mod network;
 pub(super) mod pl011;
+pub(super) mod pl031;
 mod psci;
 mod setup;
 mod vcpu_loop;
@@ -44,6 +45,7 @@ mod vsock;
 pub(super) use pl011::Pl011;
 #[cfg(test)]
 use pl011::{PL011_BASE, PL011_DR, PL011_FR, PL011_SIZE};
+pub(super) use pl031::Pl031;
 pub use psci::CpuOnRequest;
 
 /// Shared registry of vCPU thread handles for WFI unparking.
@@ -417,5 +419,20 @@ mod tests {
                 || PL011_BASE + PL011_SIZE <= virtio_start,
             "PL011 and VirtIO MMIO regions overlap"
         );
+        // PL031 sits in its own page between PL011 and the VirtIO region.
+        const {
+            assert!(
+                pl031::PL031_BASE >= PL011_BASE + PL011_SIZE,
+                "PL031 overlaps PL011"
+            );
+            assert!(
+                pl031::PL031_BASE + pl031::PL031_SIZE <= VIRTIO_MMIO_BASE,
+                "PL031 overlaps VirtIO MMIO region"
+            );
+            assert!(
+                pl031::PL031_BASE + pl031::PL031_SIZE <= RAM_BASE_IPA,
+                "PL031 must be below guest RAM"
+            );
+        };
     }
 }

--- a/virt/arcbox-vmm/src/vmm/darwin_hv/mod.rs
+++ b/virt/arcbox-vmm/src/vmm/darwin_hv/mod.rs
@@ -46,7 +46,7 @@ pub(super) use pl011::Pl011;
 #[cfg(test)]
 use pl011::{PL011_BASE, PL011_DR, PL011_FR, PL011_SIZE};
 pub(super) use pl031::Pl031;
-pub use psci::CpuOnRequest;
+pub use psci::CpuPower;
 
 /// Shared registry of vCPU thread handles for WFI unparking.
 ///

--- a/virt/arcbox-vmm/src/vmm/darwin_hv/pl031.rs
+++ b/virt/arcbox-vmm/src/vmm/darwin_hv/pl031.rs
@@ -16,10 +16,11 @@
 pub const PL031_BASE: u64 = 0x0B00_1000;
 /// PL031 MMIO region size.
 pub const PL031_SIZE: u64 = 0x1000;
-/// FDT SPI number for the (never asserted) alarm interrupt. Kept far above
-/// the VirtIO allocator's range (INTIDs from 32 == FDT SPI 0 upward) so the
-/// node's `interrupts` property never aliases a live device line.
-pub const PL031_FDT_SPI: u32 = 31;
+/// FDT SPI number for the (never asserted) alarm interrupt. The VirtIO
+/// allocator hands out INTIDs 32..(32 + VIRTIO_MMIO_MAX_DEVICES), i.e. FDT
+/// SPIs 0..=31, so SPI 32 (INTID 64) sits just past a fully populated
+/// device table and can never alias a live device line.
+pub const PL031_FDT_SPI: u32 = 32;
 
 // PL031 register offsets (ARM DDI 0224C).
 /// Data register: current time in seconds (read-only).

--- a/virt/arcbox-vmm/src/vmm/darwin_hv/pl031.rs
+++ b/virt/arcbox-vmm/src/vmm/darwin_hv/pl031.rs
@@ -1,0 +1,182 @@
+//! Minimal PL031 RTC emulator backed by the host wall clock.
+//!
+//! Gives the guest kernel a real-time clock so it can set CLOCK_REALTIME
+//! itself at boot (`CONFIG_RTC_HCTOSYS`) and after resume, instead of
+//! sitting at the kernel default epoch until the post-readiness agent ping
+//! pushes the time (ABX-416).
+//!
+//! Emulated surface: the time-of-day registers plus the AMBA PrimeCell
+//! identification registers — Linux binds `rtc-pl031` through the AMBA bus,
+//! which probes the PeriphID/PCellID words before any driver code runs.
+//! The match/alarm interrupt is accepted but never raised (RTC_RIS stays 0),
+//! so RTC alarms are inert; nothing in the guest stack uses them.
+
+/// PL031 MMIO base address. One page above the PL011 UART (0x0B00_0000),
+/// below the VirtIO MMIO region (0x0C00_0000).
+pub const PL031_BASE: u64 = 0x0B00_1000;
+/// PL031 MMIO region size.
+pub const PL031_SIZE: u64 = 0x1000;
+/// FDT SPI number for the (never asserted) alarm interrupt. Kept far above
+/// the VirtIO allocator's range (INTIDs from 32 == FDT SPI 0 upward) so the
+/// node's `interrupts` property never aliases a live device line.
+pub const PL031_FDT_SPI: u32 = 31;
+
+// PL031 register offsets (ARM DDI 0224C).
+/// Data register: current time in seconds (read-only).
+const RTC_DR: u64 = 0x000;
+/// Match register: alarm compare value.
+const RTC_MR: u64 = 0x004;
+/// Load register: writing sets the current time.
+const RTC_LR: u64 = 0x008;
+/// Control register: bit 0 = RTC enable.
+const RTC_CR: u64 = 0x00C;
+/// Interrupt mask set/clear.
+const RTC_IMSC: u64 = 0x010;
+/// Raw interrupt status (read-only).
+const RTC_RIS: u64 = 0x014;
+/// Masked interrupt status (read-only).
+const RTC_MIS: u64 = 0x018;
+/// Interrupt clear (write-only).
+const RTC_ICR: u64 = 0x01C;
+
+/// AMBA PrimeCell identification words, one byte per word, read at
+/// 0xFE0..=0xFFC. PeriphID identifies the part as a PL031 r1; PCellID is
+/// the fixed PrimeCell signature. The AMBA bus core validates these before
+/// binding a driver.
+const AMBA_ID_BASE: u64 = 0xFE0;
+const AMBA_IDS: [u8; 8] = [0x31, 0x10, 0x14, 0x00, 0x0D, 0xF0, 0x05, 0xB1];
+
+/// Minimal PL031 RTC emulator.
+pub struct Pl031 {
+    /// Guest-visible time = host wall clock + this offset (wrapping u32
+    /// seconds). Zero until the guest writes RTC_LR, so reads report the
+    /// host's own epoch seconds.
+    tick_offset: u32,
+    /// Last value written to RTC_LR (readable per the TRM).
+    lr: u32,
+    /// Match register value; stored but never compared (no alarm delivery).
+    mr: u32,
+    /// Interrupt mask bit 0; stored so the guest reads back what it wrote.
+    imsc: u32,
+}
+
+impl Pl031 {
+    /// Creates a PL031 reporting the host wall clock.
+    pub fn new() -> Self {
+        Self {
+            tick_offset: 0,
+            lr: 0,
+            mr: 0,
+            imsc: 0,
+        }
+    }
+
+    /// Returns `true` if `addr` falls within the PL031 MMIO range.
+    pub fn contains(&self, addr: u64) -> bool {
+        (PL031_BASE..PL031_BASE + PL031_SIZE).contains(&addr)
+    }
+
+    /// Host wall clock as wrapping u32 seconds since the Unix epoch (the
+    /// PL031 counter width; wraps in 2106).
+    fn host_secs() -> u32 {
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map_or(0, |d| d.as_secs() as u32)
+    }
+
+    /// Handles an MMIO read from the PL031 region.
+    pub fn read(&self, addr: u64, _size: usize) -> u64 {
+        let offset = addr - PL031_BASE;
+        let value = match offset {
+            RTC_DR => Self::host_secs().wrapping_add(self.tick_offset),
+            RTC_MR => self.mr,
+            RTC_LR => self.lr,
+            // The RTC is always running; the enable bit reads as set.
+            RTC_CR => 1,
+            RTC_IMSC => self.imsc,
+            // No alarm is ever raised.
+            RTC_RIS | RTC_MIS => 0,
+            _ if (AMBA_ID_BASE..AMBA_ID_BASE + 0x20).contains(&offset) => {
+                u32::from(AMBA_IDS[((offset - AMBA_ID_BASE) >> 2) as usize])
+            }
+            _ => 0,
+        };
+        u64::from(value)
+    }
+
+    /// Handles an MMIO write to the PL031 region.
+    pub fn write(&mut self, addr: u64, _size: usize, value: u64) {
+        let offset = addr - PL031_BASE;
+        let value = value as u32;
+        match offset {
+            RTC_LR => {
+                // Guest sets the time: remember it as an offset from the
+                // host clock so the RTC keeps ticking from the new value.
+                self.tick_offset = value.wrapping_sub(Self::host_secs());
+                self.lr = value;
+            }
+            RTC_MR => self.mr = value,
+            RTC_IMSC => self.imsc = value & 1,
+            // CR (enable bit) and ICR (interrupt clear) are ignored: the
+            // RTC always runs and no interrupt is ever pending.
+            RTC_CR | RTC_ICR => {}
+            _ => {}
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn read32(rtc: &Pl031, offset: u64) -> u32 {
+        rtc.read(PL031_BASE + offset, 4) as u32
+    }
+
+    #[test]
+    fn dr_reports_host_wall_clock() {
+        let rtc = Pl031::new();
+        let before = Pl031::host_secs();
+        let dr = read32(&rtc, RTC_DR);
+        let after = Pl031::host_secs();
+        assert!(
+            (before..=after).contains(&dr),
+            "DR {dr} not in [{before}, {after}]"
+        );
+    }
+
+    #[test]
+    fn lr_write_offsets_dr_and_reads_back() {
+        let mut rtc = Pl031::new();
+        let target = 0x1000_0000u32;
+        rtc.write(PL031_BASE + RTC_LR, 4, u64::from(target));
+        assert_eq!(read32(&rtc, RTC_LR), target);
+        let dr = read32(&rtc, RTC_DR);
+        // DR should now tick from the loaded value (allow a 2s test margin).
+        assert!(
+            dr.wrapping_sub(target) <= 2,
+            "DR {dr} not near loaded {target}"
+        );
+    }
+
+    #[test]
+    fn control_and_interrupt_registers() {
+        let mut rtc = Pl031::new();
+        assert_eq!(read32(&rtc, RTC_CR), 1, "RTC reads as enabled");
+        rtc.write(PL031_BASE + RTC_CR, 4, 0); // ignored
+        assert_eq!(read32(&rtc, RTC_CR), 1);
+        rtc.write(PL031_BASE + RTC_IMSC, 4, 1);
+        assert_eq!(read32(&rtc, RTC_IMSC), 1);
+        assert_eq!(read32(&rtc, RTC_RIS), 0);
+        assert_eq!(read32(&rtc, RTC_MIS), 0);
+        rtc.write(PL031_BASE + RTC_MR, 4, 42);
+        assert_eq!(read32(&rtc, RTC_MR), 42);
+    }
+
+    #[test]
+    fn amba_primecell_ids_match_pl031() {
+        let rtc = Pl031::new();
+        let ids: Vec<u32> = (0..8).map(|i| read32(&rtc, AMBA_ID_BASE + i * 4)).collect();
+        assert_eq!(ids, vec![0x31, 0x10, 0x14, 0x00, 0x0D, 0xF0, 0x05, 0xB1]);
+    }
+}

--- a/virt/arcbox-vmm/src/vmm/darwin_hv/psci.rs
+++ b/virt/arcbox-vmm/src/vmm/darwin_hv/psci.rs
@@ -1,13 +1,14 @@
 //! PSCI (Power State Coordination Interface) handling.
 //!
 //! Implements the subset of PSCI a Linux guest exercises: VERSION, FEATURES,
-//! SYSTEM_OFF, SYSTEM_RESET, CPU_ON, AFFINITY_INFO, and MIGRATE_INFO_TYPE.
-//! Called from the vCPU run loop on HVC/SMC exits whose function ID is in the
-//! SMCCC PSCI range.
+//! SYSTEM_OFF, SYSTEM_RESET, CPU_ON, CPU_OFF, AFFINITY_INFO, and
+//! MIGRATE_INFO_TYPE. Called from the vCPU run loop on HVC/SMC exits whose
+//! function ID is in the SMCCC PSCI range.
 //!
 //! The decision logic lives in the pure [`resolve_psci`] so it can be unit
-//! tested without a live vCPU or the channel registry; [`handle_psci`] applies
-//! the resulting effect (write X0, request shutdown, dispatch CPU_ON).
+//! tested without a live vCPU or the power registry; [`handle_psci`] applies
+//! the resulting effect (write X0, request shutdown, dispatch CPU_ON, mark
+//! the calling CPU off).
 
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex, PoisonError, mpsc};
@@ -16,6 +17,8 @@ use arcbox_hv::reg::{HV_REG_X0 as X0, HV_REG_X1 as X1, HV_REG_X2 as X2, HV_REG_X
 
 /// PSCI PSCI_VERSION: return the implemented PSCI version.
 const PSCI_VERSION: u64 = 0x8400_0000;
+/// PSCI CPU_OFF: power down the calling CPU.
+const PSCI_CPU_OFF: u64 = 0x8400_0002;
 /// PSCI CPU_ON (64-bit): power up a secondary CPU.
 const PSCI_CPU_ON_64: u64 = 0xC400_0003;
 /// PSCI AFFINITY_INFO (64-bit): query a CPU's power state.
@@ -37,6 +40,8 @@ const PSCI_SUCCESS: u64 = 0;
 const PSCI_NOT_SUPPORTED: u64 = (-1_i64) as u64;
 /// PSCI return code: invalid parameters (-2).
 const PSCI_INVALID_PARAMS: u64 = (-2_i64) as u64;
+/// PSCI return code: the request is denied (-3). CPU_OFF on the BSP.
+const PSCI_DENIED: u64 = (-3_i64) as u64;
 /// PSCI return code: the target CPU is already on (-4).
 const PSCI_ALREADY_ON: u64 = (-4_i64) as u64;
 
@@ -63,13 +68,101 @@ pub struct CpuOnRequest {
     pub context_id: u64,
 }
 
-/// Shared state for secondary vCPU wake-up channels.
+/// Per-vCPU power slot in the [`CpuPowerRegistry`].
+struct CpuSlot {
+    /// Whether the CPU is currently powered on.
+    on: bool,
+    /// Wake-up channel to the vCPU's (re-armable) thread. `None` for the
+    /// BSP, which boots directly and can never be powered off (CPU_OFF on
+    /// it is DENIED).
+    tx: Option<mpsc::Sender<CpuOnRequest>>,
+}
+
+/// Power state + wake-up channels for every vCPU, indexed by vCPU id.
 ///
-/// Index `i` corresponds to vCPU `i` (0-based). Slot 0 (BSP) is always `None`.
-/// Each secondary's `Option<Sender>` is `take()`-n exactly once when the guest
-/// calls PSCI CPU_ON for that vCPU, so a taken (`None`) slot means the CPU is
-/// on, and a present (`Some`) slot means it is still off.
-pub type CpuOnSenders = Arc<Mutex<Vec<Option<mpsc::Sender<CpuOnRequest>>>>>;
+/// Each secondary's sender is persistent: CPU_ON sends a [`CpuOnRequest`]
+/// and marks the slot on; CPU_OFF marks it off and the vCPU thread parks
+/// back on its receiver, ready for the next CPU_ON. The registry is shared
+/// with every vCPU thread so any CPU can power any other CPU on.
+pub struct CpuPowerRegistry {
+    slots: Mutex<Vec<CpuSlot>>,
+}
+
+/// Shared handle to the power registry.
+pub type CpuPower = Arc<CpuPowerRegistry>;
+
+impl CpuPowerRegistry {
+    /// Builds a registry from per-vCPU senders (index = vCPU id). Slot 0
+    /// (BSP, `None`) starts on; every slot with a sender starts off.
+    pub fn from_senders(senders: Vec<Option<mpsc::Sender<CpuOnRequest>>>) -> CpuPower {
+        Arc::new(Self {
+            slots: Mutex::new(
+                senders
+                    .into_iter()
+                    .map(|tx| CpuSlot {
+                        on: tx.is_none(),
+                        tx,
+                    })
+                    .collect(),
+            ),
+        })
+    }
+
+    fn lock(&self) -> std::sync::MutexGuard<'_, Vec<CpuSlot>> {
+        self.slots.lock().unwrap_or_else(PoisonError::into_inner)
+    }
+
+    /// Snapshots each CPU's power state (index = vCPU id).
+    fn snapshot(&self) -> Vec<bool> {
+        self.lock().iter().map(|slot| slot.on).collect()
+    }
+
+    /// Powers `target` on: marks the slot on and wakes its thread. Resolves
+    /// the race with a concurrent CPU_ON for the same target under the lock.
+    /// Returns the PSCI return code for X0.
+    fn cpu_on(&self, target: usize, request: CpuOnRequest) -> u64 {
+        let mut slots = self.lock();
+        let Some(slot) = slots.get_mut(target) else {
+            return PSCI_INVALID_PARAMS;
+        };
+        if slot.on {
+            return PSCI_ALREADY_ON;
+        }
+        let Some(tx) = slot.tx.as_ref() else {
+            // Off but no wake channel — only reachable for the BSP, which
+            // never turns off; treat defensively as already on.
+            return PSCI_ALREADY_ON;
+        };
+        match tx.send(request) {
+            Ok(()) => {
+                slot.on = true;
+                PSCI_SUCCESS
+            }
+            // Receiver gone — the target thread exited (shutdown teardown).
+            Err(_) => PSCI_ALREADY_ON,
+        }
+    }
+
+    /// Marks the calling CPU off (CPU_OFF). The caller's thread must then
+    /// leave the run loop and park on its receiver. A CPU_ON arriving
+    /// between this mark and the park simply queues on the channel.
+    fn mark_off(&self, vcpu_id: usize) {
+        if let Some(slot) = self.lock().get_mut(vcpu_id) {
+            slot.on = false;
+        }
+    }
+
+    /// Drops every wake-up sender so parked vCPU threads see their `recv()`
+    /// fail and exit. Called from the stop path; works no matter how many
+    /// registry handles the vCPU threads themselves still hold (each thread
+    /// keeps one, so merely dropping the VMM's `Arc` would never close the
+    /// channels — ABX-364).
+    pub fn close(&self) {
+        for slot in self.lock().iter_mut() {
+            slot.tx = None;
+        }
+    }
+}
 
 /// The side effect a resolved PSCI call asks the caller to perform. Kept
 /// separate from the X0 return value so the decision logic stays pure.
@@ -87,6 +180,18 @@ enum PsciEffect {
         entry_point: u64,
         context_id: u64,
     },
+    /// Power the calling CPU off: mark it off and leave the run loop.
+    CpuOff,
+}
+
+/// What the vCPU run loop must do after a PSCI call.
+#[derive(Debug, PartialEq, Eq)]
+pub(in crate::vmm) enum PsciExit {
+    /// Keep running the guest.
+    Continue,
+    /// The calling CPU powered itself off: leave the run loop and park
+    /// awaiting the next CPU_ON (secondaries only).
+    CpuOff,
 }
 
 /// Whether PSCI_FEATURES should report a function as implemented.
@@ -95,6 +200,7 @@ fn psci_feature_supported(func_id: u64) -> bool {
         func_id,
         PSCI_VERSION
             | PSCI_FEATURES
+            | PSCI_CPU_OFF
             | PSCI_CPU_ON_64
             | PSCI_AFFINITY_INFO_64
             | PSCI_AFFINITY_INFO_32
@@ -105,11 +211,19 @@ fn psci_feature_supported(func_id: u64) -> bool {
 }
 
 /// Resolves a PSCI call to an `(X0 return value, effect)` pair without touching
-/// the vCPU or the channel registry. `cpu_on` gives each CPU's power state
-/// (index = CPU, `true` = on) so CPU_ON / AFFINITY_INFO can be decided and
-/// tested in isolation. The CPU_ON result is optimistic: the caller resolves
-/// the take-once race with a concurrent CPU_ON when applying the effect.
-fn resolve_psci(func_id: u64, x1: u64, x2: u64, x3: u64, cpu_on: &[bool]) -> (u64, PsciEffect) {
+/// the vCPU or the power registry. `caller` is the calling vCPU (CPU_OFF
+/// applies to it); `cpu_on` gives each CPU's power state (index = CPU,
+/// `true` = on) so CPU_ON / AFFINITY_INFO can be decided and tested in
+/// isolation. The CPU_ON result is optimistic: the caller resolves the race
+/// with a concurrent CPU_ON when applying the effect.
+fn resolve_psci(
+    caller: usize,
+    func_id: u64,
+    x1: u64,
+    x2: u64,
+    x3: u64,
+    cpu_on: &[bool],
+) -> (u64, PsciEffect) {
     match func_id {
         PSCI_VERSION => (PSCI_VERSION_1_0, PsciEffect::None),
         PSCI_FEATURES => {
@@ -123,6 +237,16 @@ fn resolve_psci(func_id: u64, x1: u64, x2: u64, x3: u64, cpu_on: &[bool]) -> (u6
         PSCI_SYSTEM_OFF => (PSCI_SUCCESS, PsciEffect::SystemOff),
         PSCI_SYSTEM_RESET => (PSCI_SUCCESS, PsciEffect::SystemReset),
         PSCI_MIGRATE_INFO_TYPE => (MIGRATE_TYPE_NOT_REQUIRED, PsciEffect::None),
+        PSCI_CPU_OFF => {
+            // The BSP boots the machine and has no re-arm channel; denying
+            // its CPU_OFF matches what Linux expects for a non-offlinable
+            // boot CPU. Secondaries power off and can be CPU_ON'd again.
+            if caller == 0 {
+                (PSCI_DENIED, PsciEffect::None)
+            } else {
+                (PSCI_SUCCESS, PsciEffect::CpuOff)
+            }
+        }
         PSCI_CPU_ON_64 => {
             let target = (x1 & 0xFF) as usize;
             match cpu_on.get(target).copied() {
@@ -150,40 +274,36 @@ fn resolve_psci(func_id: u64, x1: u64, x2: u64, x3: u64, cpu_on: &[bool]) -> (u6
     }
 }
 
-/// Snapshots each CPU's power state from the channel registry: a present
-/// (`Some`) sender means the CPU has not been started (off), a taken (`None`)
-/// slot means it is on. A single-vCPU VM has just CPU 0, always on.
-fn cpu_on_snapshot(cpu_on_senders: Option<&CpuOnSenders>) -> Vec<bool> {
-    match cpu_on_senders {
-        Some(senders) => senders
-            .lock()
-            .unwrap_or_else(PoisonError::into_inner)
-            .iter()
-            .map(Option::is_none)
-            .collect(),
+/// Snapshots each CPU's power state from the registry. A single-vCPU VM has
+/// no registry — just CPU 0, always on.
+fn cpu_on_snapshot(cpu_power: Option<&CpuPower>) -> Vec<bool> {
+    match cpu_power {
+        Some(registry) => registry.snapshot(),
         None => vec![true],
     }
 }
 
 /// Reads registers X1–X3, resolves the PSCI call, applies its effect (shutdown
-/// or reboot flag, CPU_ON dispatch), and writes the return value into X0.
+/// or reboot flag, CPU_ON dispatch, CPU_OFF mark), and writes the return value
+/// into X0. Returns whether the calling vCPU must leave its run loop.
 ///
 /// SYSTEM_RESET sets `reset_requested` in addition to clearing `running`, so
 /// the lifecycle driver reboots the guest rather than powering the machine off.
-pub fn handle_psci(
+pub(in crate::vmm) fn handle_psci(
     vcpu_id: u32,
     func_id: u64,
     vcpu: &arcbox_hv::HvVcpu,
     running: &Arc<AtomicBool>,
     reset_requested: &Arc<AtomicBool>,
-    cpu_on_senders: Option<&CpuOnSenders>,
-) {
+    cpu_power: Option<&CpuPower>,
+) -> PsciExit {
     let x1 = vcpu.get_reg(X1).unwrap_or(0);
     let x2 = vcpu.get_reg(X2).unwrap_or(0);
     let x3 = vcpu.get_reg(X3).unwrap_or(0);
 
-    let cpu_on = cpu_on_snapshot(cpu_on_senders);
-    let (mut ret, effect) = resolve_psci(func_id, x1, x2, x3, &cpu_on);
+    let cpu_on = cpu_on_snapshot(cpu_power);
+    let (mut ret, effect) = resolve_psci(vcpu_id as usize, func_id, x1, x2, x3, &cpu_on);
+    let mut exit = PsciExit::Continue;
 
     match effect {
         PsciEffect::None => {
@@ -205,47 +325,45 @@ pub fn handle_psci(
             entry_point,
             context_id,
         } => {
-            // The decision above was optimistic (target seen as off). Take the
-            // sender under the lock to resolve the race with a concurrent
-            // CPU_ON for the same target: a taken slot means someone already
-            // started it, so report ALREADY_ON.
-            let sender = cpu_on_senders.and_then(|s| {
-                s.lock()
-                    .unwrap_or_else(PoisonError::into_inner)
-                    .get_mut(target)
-                    .and_then(Option::take)
-            });
-            match sender {
-                Some(tx) => match tx.send(CpuOnRequest {
-                    _target_cpu: x1,
-                    entry_point,
-                    context_id,
-                }) {
-                    Ok(()) => {
-                        tracing::info!(
-                            "vCPU {vcpu_id}: PSCI CPU_ON target={target} \
-                             entry={entry_point:#x} ctx={context_id:#x}"
-                        );
-                        ret = PSCI_SUCCESS;
-                    }
-                    Err(_) => {
-                        // Receiver gone — the target thread exited before we
-                        // could send. Treat as already on.
-                        tracing::warn!(
-                            "vCPU {vcpu_id}: PSCI CPU_ON target={target} channel closed"
-                        );
-                        ret = PSCI_ALREADY_ON;
-                    }
-                },
-                None => {
-                    tracing::debug!("vCPU {vcpu_id}: PSCI CPU_ON target={target} already on");
-                    ret = PSCI_ALREADY_ON;
-                }
+            // The decision above was optimistic (target seen as off). The
+            // registry re-checks and marks the slot under its lock, so a
+            // concurrent CPU_ON for the same target reports ALREADY_ON.
+            ret = match cpu_power {
+                Some(registry) => registry.cpu_on(
+                    target,
+                    CpuOnRequest {
+                        _target_cpu: x1,
+                        entry_point,
+                        context_id,
+                    },
+                ),
+                // Unreachable: a CpuOn effect requires an off CPU, and the
+                // registry-less single-vCPU snapshot has none.
+                None => PSCI_INVALID_PARAMS,
+            };
+            if ret == PSCI_SUCCESS {
+                tracing::info!(
+                    "vCPU {vcpu_id}: PSCI CPU_ON target={target} \
+                     entry={entry_point:#x} ctx={context_id:#x}"
+                );
+            } else {
+                tracing::debug!("vCPU {vcpu_id}: PSCI CPU_ON target={target} ret={:#x}", ret);
             }
+        }
+        PsciEffect::CpuOff => {
+            // Mark the slot off before leaving the run loop: a CPU_ON that
+            // races in right after simply queues on the channel and the
+            // parked thread picks it up.
+            if let Some(registry) = cpu_power {
+                registry.mark_off(vcpu_id as usize);
+            }
+            tracing::info!("vCPU {vcpu_id}: PSCI CPU_OFF");
+            exit = PsciExit::CpuOff;
         }
     }
 
     let _ = vcpu.set_reg(X0, ret);
+    exit
 }
 
 #[cfg(test)]
@@ -254,7 +372,7 @@ mod tests {
 
     #[test]
     fn version_reports_1_0() {
-        let (ret, eff) = resolve_psci(PSCI_VERSION, 0, 0, 0, &[true]);
+        let (ret, eff) = resolve_psci(0, PSCI_VERSION, 0, 0, 0, &[true]);
         assert_eq!(ret, PSCI_VERSION_1_0);
         assert_eq!(eff, PsciEffect::None);
     }
@@ -262,6 +380,7 @@ mod tests {
     #[test]
     fn features_reports_supported_and_unsupported() {
         for f in [
+            PSCI_CPU_OFF,
             PSCI_CPU_ON_64,
             PSCI_AFFINITY_INFO_64,
             PSCI_SYSTEM_OFF,
@@ -271,13 +390,13 @@ mod tests {
             PSCI_FEATURES,
         ] {
             assert_eq!(
-                resolve_psci(PSCI_FEATURES, f, 0, 0, &[true]).0,
+                resolve_psci(0, PSCI_FEATURES, f, 0, 0, &[true]).0,
                 PSCI_SUCCESS
             );
         }
         // CPU_SUSPEND (0xC400_0001) is not implemented.
         assert_eq!(
-            resolve_psci(PSCI_FEATURES, 0xC400_0001, 0, 0, &[true]).0,
+            resolve_psci(0, PSCI_FEATURES, 0xC400_0001, 0, 0, &[true]).0,
             PSCI_NOT_SUPPORTED
         );
     }
@@ -285,11 +404,11 @@ mod tests {
     #[test]
     fn system_off_and_reset_effects() {
         assert_eq!(
-            resolve_psci(PSCI_SYSTEM_OFF, 0, 0, 0, &[true]).1,
+            resolve_psci(0, PSCI_SYSTEM_OFF, 0, 0, 0, &[true]).1,
             PsciEffect::SystemOff
         );
         assert_eq!(
-            resolve_psci(PSCI_SYSTEM_RESET, 0, 0, 0, &[true]).1,
+            resolve_psci(0, PSCI_SYSTEM_RESET, 0, 0, 0, &[true]).1,
             PsciEffect::SystemReset
         );
     }
@@ -297,7 +416,7 @@ mod tests {
     #[test]
     fn migrate_info_type_not_required() {
         assert_eq!(
-            resolve_psci(PSCI_MIGRATE_INFO_TYPE, 0, 0, 0, &[true]),
+            resolve_psci(0, PSCI_MIGRATE_INFO_TYPE, 0, 0, 0, &[true]),
             (MIGRATE_TYPE_NOT_REQUIRED, PsciEffect::None)
         );
     }
@@ -305,7 +424,7 @@ mod tests {
     #[test]
     fn cpu_on_off_target_yields_dispatch() {
         // CPU 0 on (BSP), CPU 1 off.
-        let (ret, eff) = resolve_psci(PSCI_CPU_ON_64, 1, 0x4020_0000, 0x1234, &[true, false]);
+        let (ret, eff) = resolve_psci(0, PSCI_CPU_ON_64, 1, 0x4020_0000, 0x1234, &[true, false]);
         assert_eq!(ret, PSCI_SUCCESS);
         assert_eq!(
             eff,
@@ -321,12 +440,12 @@ mod tests {
     fn cpu_on_already_on_and_invalid() {
         // Target already on.
         assert_eq!(
-            resolve_psci(PSCI_CPU_ON_64, 0, 0, 0, &[true, false]).0,
+            resolve_psci(0, PSCI_CPU_ON_64, 0, 0, 0, &[true, false]).0,
             PSCI_ALREADY_ON
         );
         // Target out of range.
         assert_eq!(
-            resolve_psci(PSCI_CPU_ON_64, 5, 0, 0, &[true, false]).0,
+            resolve_psci(0, PSCI_CPU_ON_64, 5, 0, 0, &[true, false]).0,
             PSCI_INVALID_PARAMS
         );
     }
@@ -334,25 +453,81 @@ mod tests {
     #[test]
     fn affinity_info_reports_state() {
         assert_eq!(
-            resolve_psci(PSCI_AFFINITY_INFO_64, 0, 0, 0, &[true, false]).0,
+            resolve_psci(0, PSCI_AFFINITY_INFO_64, 0, 0, 0, &[true, false]).0,
             AFFINITY_INFO_ON
         );
         assert_eq!(
-            resolve_psci(PSCI_AFFINITY_INFO_64, 1, 0, 0, &[true, false]).0,
+            resolve_psci(0, PSCI_AFFINITY_INFO_64, 1, 0, 0, &[true, false]).0,
             AFFINITY_INFO_OFF
         );
         assert_eq!(
-            resolve_psci(PSCI_AFFINITY_INFO_32, 9, 0, 0, &[true, false]).0,
+            resolve_psci(0, PSCI_AFFINITY_INFO_32, 9, 0, 0, &[true, false]).0,
             PSCI_INVALID_PARAMS
         );
     }
 
     #[test]
-    fn unknown_function_not_supported() {
-        // CPU_OFF (0x8400_0002) is not implemented yet.
+    fn cpu_off_denied_for_bsp_allowed_for_secondary() {
         assert_eq!(
-            resolve_psci(0x8400_0002, 0, 0, 0, &[true]),
+            resolve_psci(0, PSCI_CPU_OFF, 0, 0, 0, &[true, true]),
+            (PSCI_DENIED, PsciEffect::None)
+        );
+        assert_eq!(
+            resolve_psci(1, PSCI_CPU_OFF, 0, 0, 0, &[true, true]),
+            (PSCI_SUCCESS, PsciEffect::CpuOff)
+        );
+    }
+
+    #[test]
+    fn unknown_function_not_supported() {
+        // SYSTEM_RESET2 (0xC400_0012) is not implemented.
+        assert_eq!(
+            resolve_psci(0, 0xC400_0012, 0, 0, 0, &[true]),
             (PSCI_NOT_SUPPORTED, PsciEffect::None)
         );
+    }
+
+    /// A secondary can be onlined, offlined, and re-onlined; the registry
+    /// state and the wake channel stay consistent across the cycle.
+    #[test]
+    fn registry_online_offline_reonline_roundtrip() {
+        let (tx, rx) = mpsc::channel::<CpuOnRequest>();
+        let registry = CpuPowerRegistry::from_senders(vec![None, Some(tx)]);
+        assert_eq!(registry.snapshot(), vec![true, false]);
+
+        let req = |entry| CpuOnRequest {
+            _target_cpu: 1,
+            entry_point: entry,
+            context_id: 0,
+        };
+        assert_eq!(registry.cpu_on(1, req(0x1000)), PSCI_SUCCESS);
+        assert_eq!(rx.try_recv().unwrap().entry_point, 0x1000);
+        assert_eq!(registry.snapshot(), vec![true, true]);
+        assert_eq!(registry.cpu_on(1, req(0x1000)), PSCI_ALREADY_ON);
+
+        registry.mark_off(1);
+        assert_eq!(registry.snapshot(), vec![true, false]);
+
+        assert_eq!(registry.cpu_on(1, req(0x2000)), PSCI_SUCCESS);
+        assert_eq!(rx.try_recv().unwrap().entry_point, 0x2000);
+        assert_eq!(registry.snapshot(), vec![true, true]);
+
+        // Out-of-range target and the BSP slot (no channel).
+        assert_eq!(registry.cpu_on(9, req(0)), PSCI_INVALID_PARAMS);
+        registry.mark_off(0); // BSP has no channel: off but not wakeable
+        assert_eq!(registry.cpu_on(0, req(0)), PSCI_ALREADY_ON);
+    }
+
+    /// `close()` drops the senders even while other registry handles are
+    /// alive, so a parked `recv()` fails and the thread can exit (the
+    /// stop-path contract; ABX-364).
+    #[test]
+    fn registry_close_disconnects_parked_receivers() {
+        let (tx, rx) = mpsc::channel::<CpuOnRequest>();
+        let registry = CpuPowerRegistry::from_senders(vec![None, Some(tx)]);
+        let thread_handle = registry.clone(); // simulates a vCPU thread's Arc
+        registry.close();
+        assert!(rx.recv().is_err());
+        drop(thread_handle);
     }
 }

--- a/virt/arcbox-vmm/src/vmm/darwin_hv/setup.rs
+++ b/virt/arcbox-vmm/src/vmm/darwin_hv/setup.rs
@@ -12,6 +12,10 @@ use crate::irq::IrqChip;
 #[cfg(feature = "gic")]
 use crate::irq::{Gsi, IrqTriggerCallback};
 use crate::vmm::darwin_hv::pl011::{PL011_BASE, PL011_SIZE};
+use crate::vmm::darwin_hv::pl031::{PL031_BASE, PL031_FDT_SPI, PL031_SIZE};
+
+/// FDT phandle for the fixed APB clock node (the GIC owns phandle 1).
+const APB_PCLK_PHANDLE: u32 = 2;
 
 use super::*;
 
@@ -667,6 +671,43 @@ impl Vmm {
             fdt.property_u32("clock-frequency", 24_000_000)
                 .map_err(fdt_err)?;
             fdt.end_node(uart).map_err(fdt_err)?;
+
+            // Fixed APB clock for AMBA PrimeCell peripherals. The AMBA bus
+            // core refuses to bind a driver (rtc-pl031) without an
+            // "apb_pclk" clock reference, so the PL031 node below needs
+            // this even though the emulated RTC has no real clock input.
+            let apb_pclk = fdt.begin_node("apb-pclk").map_err(fdt_err)?;
+            fdt.property_string("compatible", "fixed-clock")
+                .map_err(fdt_err)?;
+            fdt.property_u32("#clock-cells", 0).map_err(fdt_err)?;
+            fdt.property_u32("clock-frequency", 24_000_000)
+                .map_err(fdt_err)?;
+            fdt.property_phandle(APB_PCLK_PHANDLE).map_err(fdt_err)?;
+            fdt.end_node(apb_pclk).map_err(fdt_err)?;
+
+            // PL031 RTC: lets the guest kernel set CLOCK_REALTIME from the
+            // host wall clock at boot (CONFIG_RTC_HCTOSYS) instead of
+            // waiting for the post-readiness agent ping (ABX-416).
+            let rtc = fdt
+                .begin_node(&format!("pl031@{PL031_BASE:x}"))
+                .map_err(fdt_err)?;
+            fdt.property_string_list(
+                "compatible",
+                vec!["arm,pl031".into(), "arm,primecell".into()],
+            )
+            .map_err(fdt_err)?;
+            let mut rtc_reg = Vec::new();
+            rtc_reg.extend_from_slice(&PL031_BASE.to_be_bytes());
+            rtc_reg.extend_from_slice(&PL031_SIZE.to_be_bytes());
+            fdt.property("reg", &rtc_reg).map_err(fdt_err)?;
+            // Alarm interrupt line; the emulator never asserts it.
+            fdt.property_array_u32("interrupts", &[0, PL031_FDT_SPI, 4])
+                .map_err(fdt_err)?;
+            fdt.property_u32("clocks", APB_PCLK_PHANDLE)
+                .map_err(fdt_err)?;
+            fdt.property_string("clock-names", "apb_pclk")
+                .map_err(fdt_err)?;
+            fdt.end_node(rtc).map_err(fdt_err)?;
 
             // VirtIO MMIO devices from DeviceManager
             for entry in &fdt_entries {

--- a/virt/arcbox-vmm/src/vmm/darwin_hv/vcpu_loop.rs
+++ b/virt/arcbox-vmm/src/vmm/darwin_hv/vcpu_loop.rs
@@ -15,7 +15,7 @@ use super::hvc_blk::{
     ARCBOX_HVC_BLK_FLUSH, ARCBOX_HVC_BLK_READ, ARCBOX_HVC_BLK_WRITE, ARCBOX_HVC_PROBE,
     handle_hvc_blk_flush, handle_hvc_blk_io,
 };
-use super::psci::{CpuOnSenders, handle_psci};
+use super::psci::{CpuPower, PsciExit, handle_psci};
 use super::{HvVcpuIds, Pl011, Pl031, VcpuThreadHandles};
 
 /// ARM64 register IDs re-exported from arcbox-hv.
@@ -57,9 +57,9 @@ pub(super) struct VcpuContext {
     pub pl011: Arc<std::sync::Mutex<Pl011>>,
     /// Shared PL031 RTC emulator backed by the host wall clock.
     pub pl031: Arc<std::sync::Mutex<Pl031>>,
-    /// Channel senders for waking secondary vCPUs via PSCI CPU_ON.
+    /// Per-vCPU power registry (states + CPU_ON wake channels).
     /// `None` when the VM has only one vCPU.
-    pub cpu_on_senders: Option<CpuOnSenders>,
+    pub cpu_power: Option<CpuPower>,
     /// Registry of vCPU thread handles used by the IRQ callback to
     /// unpark WFI-blocked threads.
     pub vcpu_thread_handles: VcpuThreadHandles,
@@ -139,6 +139,17 @@ fn complete_mmio_read(vcpu: &HvVcpu, vcpu_id: u32, mmio: &MmioInfo, raw: u64) {
     }
 }
 
+/// Why [`vcpu_run_loop`] returned.
+#[derive(Debug, PartialEq, Eq)]
+pub(super) enum VcpuLoopExit {
+    /// VM shutdown or an unrecoverable setup failure: the thread must exit.
+    Shutdown,
+    /// The guest powered this CPU off via PSCI CPU_OFF. The thread should
+    /// park on its CPU_ON receiver and call [`vcpu_run_loop`] again when a
+    /// new request arrives (secondaries only; the BSP is never offlined).
+    CpuOff,
+}
+
 /// Runs a single vCPU in a loop, dispatching MMIO traps to the device manager.
 ///
 /// This function is intended to be called from a dedicated thread per vCPU.
@@ -154,7 +165,12 @@ fn complete_mmio_read(vcpu: &HvVcpu, vcpu_id: u32, mmio: &MmioInfo, raw: u64) {
 /// * `x0_value` — Initial value of X0. For the BSP this is the FDT address;
 ///   for a secondary vCPU it is the context_id from PSCI CPU_ON.
 /// * `ctx` — Shared resources for the vCPU (device manager, IRQ state, etc.).
-pub(super) fn vcpu_run_loop(vcpu_id: u32, entry_addr: u64, x0_value: u64, ctx: VcpuContext) {
+pub(super) fn vcpu_run_loop(
+    vcpu_id: u32,
+    entry_addr: u64,
+    x0_value: u64,
+    ctx: VcpuContext,
+) -> VcpuLoopExit {
     let VcpuContext {
         device_manager,
         running,
@@ -162,7 +178,7 @@ pub(super) fn vcpu_run_loop(vcpu_id: u32, entry_addr: u64, x0_value: u64, ctx: V
         paused,
         pl011,
         pl031,
-        cpu_on_senders,
+        cpu_power,
         vcpu_thread_handles,
         hv_vcpu_ids,
         hvc_blk_fds,
@@ -173,7 +189,7 @@ pub(super) fn vcpu_run_loop(vcpu_id: u32, entry_addr: u64, x0_value: u64, ctx: V
         Ok(v) => v,
         Err(e) => {
             tracing::error!("vCPU {vcpu_id}: creation failed: {e}");
-            return;
+            return VcpuLoopExit::Shutdown;
         }
     };
 
@@ -184,18 +200,18 @@ pub(super) fn vcpu_run_loop(vcpu_id: u32, entry_addr: u64, x0_value: u64, ctx: V
     //   CPSR = EL1h, DAIF masked
     if let Err(e) = vcpu.set_reg(reg::PC, entry_addr) {
         tracing::error!("vCPU {vcpu_id}: set PC failed: {e}");
-        return;
+        return VcpuLoopExit::Shutdown;
     }
     if let Err(e) = vcpu.set_reg(reg::X0, x0_value) {
         tracing::error!("vCPU {vcpu_id}: set X0 failed: {e}");
-        return;
+        return VcpuLoopExit::Shutdown;
     }
     let _ = vcpu.set_reg(reg::X1, 0);
     let _ = vcpu.set_reg(reg::X2, 0);
     let _ = vcpu.set_reg(reg::X3, 0);
     if let Err(e) = vcpu.set_reg(reg::CPSR, CPSR_EL1H) {
         tracing::error!("vCPU {vcpu_id}: set CPSR failed: {e}");
-        return;
+        return VcpuLoopExit::Shutdown;
     }
 
     // ARM64 boot protocol: MMU must be off, caches can be on or off.
@@ -216,7 +232,7 @@ pub(super) fn vcpu_run_loop(vcpu_id: u32, entry_addr: u64, x0_value: u64, ctx: V
     if let Err(e) = vcpu.set_sys_reg(arcbox_hv::sys_reg::HV_SYS_REG_MPIDR_EL1, mpidr) {
         tracing::error!("vCPU {vcpu_id}: set MPIDR_EL1 failed: {e}; aborting boot");
         running.store(false, Ordering::SeqCst);
-        return;
+        return VcpuLoopExit::Shutdown;
     }
     match vcpu.get_sys_reg(arcbox_hv::sys_reg::HV_SYS_REG_MPIDR_EL1) {
         Ok(v) if v & 0xFF == u64::from(vcpu_id) => {}
@@ -227,12 +243,12 @@ pub(super) fn vcpu_run_loop(vcpu_id: u32, entry_addr: u64, x0_value: u64, ctx: V
                 v & 0xFF,
             );
             running.store(false, Ordering::SeqCst);
-            return;
+            return VcpuLoopExit::Shutdown;
         }
         Err(e) => {
             tracing::error!("vCPU {vcpu_id}: MPIDR_EL1 readback failed: {e}; aborting boot");
             running.store(false, Ordering::SeqCst);
-            return;
+            return VcpuLoopExit::Shutdown;
         }
     }
 
@@ -264,6 +280,7 @@ pub(super) fn vcpu_run_loop(vcpu_id: u32, entry_addr: u64, x0_value: u64, ctx: V
         SCTLR_EL1_RESET,
     );
 
+    let mut loop_exit = VcpuLoopExit::Shutdown;
     loop {
         if !running.load(Ordering::Relaxed) {
             tracing::info!("vCPU {vcpu_id}: shutdown requested");
@@ -510,15 +527,19 @@ pub(super) fn vcpu_run_loop(vcpu_id: u32, entry_addr: u64, x0_value: u64, ctx: V
                     }
                     _ => {
                         // PSCI and other standard calls.
-                        handle_psci(
+                        let psci_exit = handle_psci(
                             vcpu_id,
                             func_id,
                             &vcpu,
                             &running,
                             &reset_requested,
-                            cpu_on_senders.as_ref(),
+                            cpu_power.as_ref(),
                         );
                         if !running.load(Ordering::Relaxed) {
+                            break;
+                        }
+                        if psci_exit == PsciExit::CpuOff {
+                            loop_exit = VcpuLoopExit::CpuOff;
                             break;
                         }
                     }
@@ -535,15 +556,19 @@ pub(super) fn vcpu_run_loop(vcpu_id: u32, entry_addr: u64, x0_value: u64, ctx: V
                     Ok(v) => v,
                     Err(_) => continue,
                 };
-                handle_psci(
+                let psci_exit = handle_psci(
                     vcpu_id,
                     func_id,
                     &vcpu,
                     &running,
                     &reset_requested,
-                    cpu_on_senders.as_ref(),
+                    cpu_power.as_ref(),
                 );
                 if !running.load(Ordering::Relaxed) {
+                    break;
+                }
+                if psci_exit == PsciExit::CpuOff {
+                    loop_exit = VcpuLoopExit::CpuOff;
                     break;
                 }
             }
@@ -624,7 +649,27 @@ pub(super) fn vcpu_run_loop(vcpu_id: u32, entry_addr: u64, x0_value: u64, ctx: V
     // Flush any remaining UART output.
     pl011.lock().unwrap().flush();
 
-    tracing::info!("vCPU {vcpu_id}: exited");
+    if loop_exit == VcpuLoopExit::CpuOff {
+        // Unregister before dropping the HvVcpu: a stale raw handle in the
+        // ID registry would make the next `hv_vcpus_exit` pass a dangling
+        // handle to Apple's framework (UB per its contract, ABX-367), and a
+        // stale thread handle would take unparks meant for live vCPUs. The
+        // re-onlined loop re-registers both after setup succeeds.
+        let raw = vcpu.raw_handle();
+        hv_vcpu_ids
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .retain(|&id| id != raw);
+        let self_id = std::thread::current().id();
+        vcpu_thread_handles
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .retain(|t| t.id() != self_id);
+        tracing::info!("vCPU {vcpu_id}: offline (CPU_OFF), awaiting CPU_ON");
+    } else {
+        tracing::info!("vCPU {vcpu_id}: exited");
+    }
+    loop_exit
 }
 
 #[cfg(test)]

--- a/virt/arcbox-vmm/src/vmm/darwin_hv/vcpu_loop.rs
+++ b/virt/arcbox-vmm/src/vmm/darwin_hv/vcpu_loop.rs
@@ -139,38 +139,46 @@ fn complete_mmio_read(vcpu: &HvVcpu, vcpu_id: u32, mmio: &MmioInfo, raw: u64) {
     }
 }
 
-/// Why [`vcpu_run_loop`] returned.
+/// Why the inner exit-dispatch loop ended one power-on cycle.
 #[derive(Debug, PartialEq, Eq)]
-pub(super) enum VcpuLoopExit {
+enum VcpuLoopExit {
     /// VM shutdown or an unrecoverable setup failure: the thread must exit.
     Shutdown,
-    /// The guest powered this CPU off via PSCI CPU_OFF. The thread should
-    /// park on its CPU_ON receiver and call [`vcpu_run_loop`] again when a
-    /// new request arrives (secondaries only; the BSP is never offlined).
+    /// The guest powered this CPU off via PSCI CPU_OFF: park on the CPU_ON
+    /// receiver and boot again when the next request arrives.
     CpuOff,
 }
 
-/// Runs a single vCPU in a loop, dispatching MMIO traps to the device manager.
+/// How a vCPU thread begins executing.
+pub(super) enum VcpuBoot {
+    /// Boot immediately at `entry` with `x0` (the BSP: kernel entry + FDT).
+    Immediate { entry: u64, x0: u64 },
+    /// Powered off: wait for the first PSCI CPU_ON on this receiver, and
+    /// park on it again after every CPU_OFF (secondaries). The thread exits
+    /// when the power registry closes the sender (VM stop).
+    AwaitCpuOn(std::sync::mpsc::Receiver<super::psci::CpuOnRequest>),
+}
+
+/// Runs a single vCPU for the lifetime of the VM, dispatching MMIO traps to
+/// the device manager and handling PSCI power cycles.
 ///
 /// This function is intended to be called from a dedicated thread per vCPU.
 /// `HvVcpu` is `!Send`, so it must be created inside this function on the
-/// thread that will run it.
+/// thread that will run it. The `HvVcpu` is created exactly ONCE and reused
+/// across CPU_OFF/CPU_ON cycles: `hv_vcpu_create` takes a framework-global
+/// lock that a vCPU sitting inside `hv_vcpu_run` can starve indefinitely, so
+/// re-creating the vCPU on re-online deadlocks against the still-running
+/// CPUs (observed on real hotplug: re-online wedged mid-sequence in
+/// `os_unfair_lock` inside `hv_vcpu_create`). Reuse also keeps the GIC
+/// redistributor ↔ vCPU binding stable.
 ///
 /// # Arguments
 ///
 /// * `vcpu_id` — Logical vCPU index (0-based, for logging).
-/// * `entry_addr` — Guest IPA where execution begins. For the BSP this is
-///   the kernel entry point; for a secondary vCPU it is the address passed
-///   in PSCI CPU_ON.
-/// * `x0_value` — Initial value of X0. For the BSP this is the FDT address;
-///   for a secondary vCPU it is the context_id from PSCI CPU_ON.
+/// * `boot` — Immediate entry point (BSP) or the CPU_ON receiver to park on
+///   (secondaries).
 /// * `ctx` — Shared resources for the vCPU (device manager, IRQ state, etc.).
-pub(super) fn vcpu_run_loop(
-    vcpu_id: u32,
-    entry_addr: u64,
-    x0_value: u64,
-    ctx: VcpuContext,
-) -> VcpuLoopExit {
+pub(super) fn vcpu_run_loop(vcpu_id: u32, boot: VcpuBoot, ctx: VcpuContext) {
     let VcpuContext {
         device_manager,
         running,
@@ -189,35 +197,9 @@ pub(super) fn vcpu_run_loop(
         Ok(v) => v,
         Err(e) => {
             tracing::error!("vCPU {vcpu_id}: creation failed: {e}");
-            return VcpuLoopExit::Shutdown;
+            return;
         }
     };
-
-    // Set initial register state for ARM64 Linux boot protocol:
-    //   PC   = entry address (kernel entry for BSP, PSCI entry for secondary)
-    //   X0   = parameter (FDT address for BSP, context_id for secondary)
-    //   X1-X3 = 0 (reserved per ARM64 boot protocol)
-    //   CPSR = EL1h, DAIF masked
-    if let Err(e) = vcpu.set_reg(reg::PC, entry_addr) {
-        tracing::error!("vCPU {vcpu_id}: set PC failed: {e}");
-        return VcpuLoopExit::Shutdown;
-    }
-    if let Err(e) = vcpu.set_reg(reg::X0, x0_value) {
-        tracing::error!("vCPU {vcpu_id}: set X0 failed: {e}");
-        return VcpuLoopExit::Shutdown;
-    }
-    let _ = vcpu.set_reg(reg::X1, 0);
-    let _ = vcpu.set_reg(reg::X2, 0);
-    let _ = vcpu.set_reg(reg::X3, 0);
-    if let Err(e) = vcpu.set_reg(reg::CPSR, CPSR_EL1H) {
-        tracing::error!("vCPU {vcpu_id}: set CPSR failed: {e}");
-        return VcpuLoopExit::Shutdown;
-    }
-
-    // ARM64 boot protocol: MMU must be off, caches can be on or off.
-    if let Err(e) = vcpu.set_sys_reg(arcbox_hv::sys_reg::HV_SYS_REG_SCTLR_EL1, SCTLR_EL1_RESET) {
-        tracing::warn!("vCPU {vcpu_id}: set SCTLR_EL1 failed: {e}");
-    }
 
     // Set MPIDR_EL1 for this vCPU (Aff0 = vcpu_id, other affinity fields 0).
     // GIC affinity routing and the FDT `reg` values both depend on it, so the
@@ -232,7 +214,7 @@ pub(super) fn vcpu_run_loop(
     if let Err(e) = vcpu.set_sys_reg(arcbox_hv::sys_reg::HV_SYS_REG_MPIDR_EL1, mpidr) {
         tracing::error!("vCPU {vcpu_id}: set MPIDR_EL1 failed: {e}; aborting boot");
         running.store(false, Ordering::SeqCst);
-        return VcpuLoopExit::Shutdown;
+        return;
     }
     match vcpu.get_sys_reg(arcbox_hv::sys_reg::HV_SYS_REG_MPIDR_EL1) {
         Ok(v) if v & 0xFF == u64::from(vcpu_id) => {}
@@ -243,23 +225,25 @@ pub(super) fn vcpu_run_loop(
                 v & 0xFF,
             );
             running.store(false, Ordering::SeqCst);
-            return VcpuLoopExit::Shutdown;
+            return;
         }
         Err(e) => {
             tracing::error!("vCPU {vcpu_id}: MPIDR_EL1 readback failed: {e}; aborting boot");
             running.store(false, Ordering::SeqCst);
-            return VcpuLoopExit::Shutdown;
+            return;
         }
     }
 
     // Register this vCPU's framework ID and this thread's handle after all
-    // register-setup calls succeed. If any setup call fails above, the
-    // early return drops `HvVcpu` (triggering `hv_vcpu_destroy`) and the
-    // thread exits without leaving either a stale ID or a dead `Thread`
-    // in the shared registries. A stale ID would make `hv_vcpus_exit`
-    // pass a dangling handle to Apple's framework (UB per its contract,
-    // ABX-367); a dead thread handle would grow the registry unboundedly
-    // across failed boots.
+    // one-time setup succeeds. If setup fails above, the early return drops
+    // `HvVcpu` (triggering `hv_vcpu_destroy`) and the thread exits without
+    // leaving either a stale ID or a dead `Thread` in the shared registries.
+    // A stale ID would make `hv_vcpus_exit` pass a dangling handle to
+    // Apple's framework (UB per its contract, ABX-367); a dead thread handle
+    // would grow the registry unboundedly across failed boots. The entries
+    // stay valid across CPU_OFF cycles because the `HvVcpu` is never
+    // destroyed: `hv_vcpus_exit` on a powered-off (not-running) vCPU is a
+    // harmless no-op, and a stray unpark does not disturb `recv()`.
     {
         let mut ids = hv_vcpu_ids
             .lock()
@@ -273,403 +257,467 @@ pub(super) fn vcpu_run_loop(
         handles.push(std::thread::current());
     }
 
-    tracing::info!(
-        "vCPU {vcpu_id}: starting at PC={:#x}, X0={:#x}, SCTLR={:#x}",
-        entry_addr,
-        x0_value,
-        SCTLR_EL1_RESET,
-    );
-
-    let mut loop_exit = VcpuLoopExit::Shutdown;
-    loop {
-        if !running.load(Ordering::Relaxed) {
-            tracing::info!("vCPU {vcpu_id}: shutdown requested");
-            break;
-        }
-
-        // Cooperative pause: if the host has requested a pause, park here
-        // until resume clears the flag. Check after each `vcpu.run()` return
-        // so the vCPU never re-enters guest execution while paused. The
-        // host calls `hv_vcpus_exit` to kick us out of `vcpu.run()`, we
-        // observe `paused`, and park. `resume` unparks every registered
-        // vCPU thread via `vcpu_thread_handles`.
-        while paused.load(Ordering::Acquire) && running.load(Ordering::Relaxed) {
-            std::thread::park();
-        }
-        if !running.load(Ordering::Relaxed) {
-            tracing::info!("vCPU {vcpu_id}: shutdown observed after pause");
-            break;
-        }
-
-        // BSP (vCPU 0) handles bridge polling to avoid lock contention.
-        // poll_net_rx removed — handled by net-io worker thread.
-        // poll_vsock_rx removed — handled by vsock-io worker thread.
-        if vcpu_id == 0 && device_manager.poll_bridge_rx() {
-            if let Some(bid) = device_manager.bridge_device_id() {
-                device_manager.raise_interrupt_for_device(bid, 1);
+    // Resolve the first power-on: the BSP boots immediately; a secondary
+    // parks until the guest's first CPU_ON for it.
+    let (cpu_on_rx, mut entry_addr, mut x0_value) = match boot {
+        VcpuBoot::Immediate { entry, x0 } => (None, entry, x0),
+        VcpuBoot::AwaitCpuOn(rx) => match rx.recv() {
+            Ok(req) => {
+                tracing::info!(
+                    "vCPU {vcpu_id}: received CPU_ON, starting at {:#x}",
+                    req.entry_point
+                );
+                let (entry, x0) = (req.entry_point, req.context_id);
+                (Some(rx), entry, x0)
             }
-        }
+            Err(_) => {
+                tracing::debug!("vCPU {vcpu_id}: power channel closed, never started");
+                return;
+            }
+        },
+    };
 
-        // ABX-367 instrumentation: retained at trace level for future
-        // diagnosis of vCPUs stuck inside or between `vcpu.run()` calls
-        // during shutdown. Gated on `running=false` so normal operation
-        // is unaffected. Not live debug logging — use RUST_LOG=trace to see.
-        if !running.load(Ordering::Relaxed) {
-            tracing::trace!("vCPU {vcpu_id}: iteration during shutdown (before vcpu.run)");
+    // One iteration per power-on cycle; `continue` re-enters after a
+    // CPU_OFF → CPU_ON round trip with fresh entry/x0.
+    loop {
+        // Boot register state per ARM64 Linux boot protocol (re-applied on
+        // every power-on — PSCI CPU_ON semantics are reset-like):
+        //   PC    = entry address (kernel entry for BSP, PSCI entry point)
+        //   X0    = parameter (FDT address for BSP, context_id)
+        //   X1-X3 = 0 (reserved)
+        //   CPSR  = EL1h, DAIF masked; MMU off (SCTLR reset)
+        if let Err(e) = vcpu.set_reg(reg::PC, entry_addr) {
+            tracing::error!("vCPU {vcpu_id}: set PC failed: {e}");
+            return;
         }
-        let exit = match vcpu.run() {
-            Ok(e) => e,
-            Err(e) => {
-                tracing::error!("vCPU {vcpu_id}: run failed: {e}");
-                running.store(false, Ordering::SeqCst);
+        if let Err(e) = vcpu.set_reg(reg::X0, x0_value) {
+            tracing::error!("vCPU {vcpu_id}: set X0 failed: {e}");
+            return;
+        }
+        let _ = vcpu.set_reg(reg::X1, 0);
+        let _ = vcpu.set_reg(reg::X2, 0);
+        let _ = vcpu.set_reg(reg::X3, 0);
+        if let Err(e) = vcpu.set_reg(reg::CPSR, CPSR_EL1H) {
+            tracing::error!("vCPU {vcpu_id}: set CPSR failed: {e}");
+            return;
+        }
+        if let Err(e) = vcpu.set_sys_reg(arcbox_hv::sys_reg::HV_SYS_REG_SCTLR_EL1, SCTLR_EL1_RESET)
+        {
+            tracing::warn!("vCPU {vcpu_id}: set SCTLR_EL1 failed: {e}");
+        }
+        // A vtimer that fired right before a CPU_OFF leaves the mask set;
+        // clear it so the re-onlined CPU receives timer interrupts.
+        let _ = vcpu.set_vtimer_mask(false);
+
+        tracing::info!(
+            "vCPU {vcpu_id}: starting at PC={:#x}, X0={:#x}, SCTLR={:#x}",
+            entry_addr,
+            x0_value,
+            SCTLR_EL1_RESET,
+        );
+
+        let mut loop_exit = VcpuLoopExit::Shutdown;
+        loop {
+            if !running.load(Ordering::Relaxed) {
+                tracing::info!("vCPU {vcpu_id}: shutdown requested");
                 break;
             }
-        };
-        if !running.load(Ordering::Relaxed) {
-            tracing::trace!(
-                "vCPU {vcpu_id}: vcpu.run returned during shutdown, exit={:?}",
-                core::mem::discriminant(&exit)
-            );
-        }
 
-        match exit {
-            VcpuExit::Exception {
-                class: ExceptionClass::DataAbort(ref mmio),
-                ..
-            } => {
-                crate::vcpu_stats::VcpuStats::bump(if mmio.is_write {
-                    &stats.mmio_writes
-                } else {
-                    &stats.mmio_reads
-                });
+            // Cooperative pause: if the host has requested a pause, park here
+            // until resume clears the flag. Check after each `vcpu.run()` return
+            // so the vCPU never re-enters guest execution while paused. The
+            // host calls `hv_vcpus_exit` to kick us out of `vcpu.run()`, we
+            // observe `paused`, and park. `resume` unparks every registered
+            // vCPU thread via `vcpu_thread_handles`.
+            while paused.load(Ordering::Acquire) && running.load(Ordering::Relaxed) {
+                std::thread::park();
+            }
+            if !running.load(Ordering::Relaxed) {
+                tracing::info!("vCPU {vcpu_id}: shutdown observed after pause");
+                break;
+            }
 
-                // ISV=0: the syndrome carries no valid transfer register or
-                // access size (LDP/STP, atomics, some writeback-addressing
-                // forms). We cannot service the access correctly and must not
-                // fabricate a decode — that silently corrupts guest registers
-                // or MMIO state. Refuse loudly and skip the instruction rather
-                // than act on garbage. Linux's virtio-mmio driver only issues
-                // single-register `readl`/`writel` (ISV=1), so this is a
-                // defensive path; correct handling would single-step re-execute.
-                if !mmio.isv {
-                    tracing::error!(
-                        "vCPU {vcpu_id}: undecodable MMIO {} at {:#x} (ESR ISV=0) — skipping instruction",
-                        if mmio.is_write { "write" } else { "read" },
-                        mmio.address,
-                    );
-                    let pc = vcpu.get_reg(reg::PC).unwrap_or(0);
-                    let _ = vcpu.set_reg(reg::PC, pc.wrapping_add(4));
-                    continue;
+            // BSP (vCPU 0) handles bridge polling to avoid lock contention.
+            // poll_net_rx removed — handled by net-io worker thread.
+            // poll_vsock_rx removed — handled by vsock-io worker thread.
+            if vcpu_id == 0 && device_manager.poll_bridge_rx() {
+                if let Some(bid) = device_manager.bridge_device_id() {
+                    device_manager.raise_interrupt_for_device(bid, 1);
                 }
+            }
 
-                // Check PL011 UART region first, then fall through to DeviceManager.
-                let handled_by_pl011 = {
-                    let uart_match = {
-                        let guard = pl011.lock().unwrap();
-                        guard.contains(mmio.address)
-                    };
-                    if uart_match {
-                        if mmio.is_write {
-                            let value =
-                                read_mmio_write_reg(&vcpu, vcpu_id, mmio.register).unwrap_or(0);
-                            pl011.lock().unwrap().write(
-                                mmio.address,
-                                mmio.access_size as usize,
-                                value,
-                            );
-                        } else {
-                            let value = pl011
-                                .lock()
-                                .unwrap()
-                                .read(mmio.address, mmio.access_size as usize);
-                            complete_mmio_read(&vcpu, vcpu_id, mmio, value);
-                        }
-                        true
+            // ABX-367 instrumentation: retained at trace level for future
+            // diagnosis of vCPUs stuck inside or between `vcpu.run()` calls
+            // during shutdown. Gated on `running=false` so normal operation
+            // is unaffected. Not live debug logging — use RUST_LOG=trace to see.
+            if !running.load(Ordering::Relaxed) {
+                tracing::trace!("vCPU {vcpu_id}: iteration during shutdown (before vcpu.run)");
+            }
+            let exit = match vcpu.run() {
+                Ok(e) => e,
+                Err(e) => {
+                    tracing::error!("vCPU {vcpu_id}: run failed: {e}");
+                    running.store(false, Ordering::SeqCst);
+                    break;
+                }
+            };
+            if !running.load(Ordering::Relaxed) {
+                tracing::trace!(
+                    "vCPU {vcpu_id}: vcpu.run returned during shutdown, exit={:?}",
+                    core::mem::discriminant(&exit)
+                );
+            }
+
+            match exit {
+                VcpuExit::Exception {
+                    class: ExceptionClass::DataAbort(ref mmio),
+                    ..
+                } => {
+                    crate::vcpu_stats::VcpuStats::bump(if mmio.is_write {
+                        &stats.mmio_writes
                     } else {
-                        false
-                    }
-                };
+                        &stats.mmio_reads
+                    });
 
-                let handled_by_pl031 = !handled_by_pl011 && {
-                    let rtc_match = {
-                        let guard = pl031.lock().unwrap();
-                        guard.contains(mmio.address)
-                    };
-                    if rtc_match {
-                        if mmio.is_write {
-                            let value =
-                                read_mmio_write_reg(&vcpu, vcpu_id, mmio.register).unwrap_or(0);
-                            pl031.lock().unwrap().write(
-                                mmio.address,
-                                mmio.access_size as usize,
-                                value,
-                            );
-                        } else {
-                            let value = pl031
-                                .lock()
-                                .unwrap()
-                                .read(mmio.address, mmio.access_size as usize);
-                            complete_mmio_read(&vcpu, vcpu_id, mmio, value);
-                        }
-                        true
-                    } else {
-                        false
-                    }
-                };
-
-                if !handled_by_pl011 && !handled_by_pl031 {
-                    // Dispatch to DeviceManager for VirtIO MMIO devices.
-                    if mmio.is_write {
-                        let Some(value) = read_mmio_write_reg(&vcpu, vcpu_id, mmio.register) else {
-                            let pc = vcpu.get_reg(reg::PC).unwrap_or(0);
-                            let _ = vcpu.set_reg(reg::PC, pc + 4);
-                            continue;
-                        };
-                        tracing::trace!(
-                            "MMIO write: addr={:#x} offset={:#x} X{}={:#x} size={}",
+                    // ISV=0: the syndrome carries no valid transfer register or
+                    // access size (LDP/STP, atomics, some writeback-addressing
+                    // forms). We cannot service the access correctly and must not
+                    // fabricate a decode — that silently corrupts guest registers
+                    // or MMIO state. Refuse loudly and skip the instruction rather
+                    // than act on garbage. Linux's virtio-mmio driver only issues
+                    // single-register `readl`/`writel` (ISV=1), so this is a
+                    // defensive path; correct handling would single-step re-execute.
+                    if !mmio.isv {
+                        tracing::error!(
+                            "vCPU {vcpu_id}: undecodable MMIO {} at {:#x} (ESR ISV=0) — skipping instruction",
+                            if mmio.is_write { "write" } else { "read" },
                             mmio.address,
-                            mmio.address.saturating_sub(
-                                mmio.address & !0xFFF // base = addr & ~0xFFF
-                            ),
-                            mmio.register,
-                            value,
-                            mmio.access_size,
                         );
-                        if let Err(e) = device_manager.handle_mmio_write(
-                            mmio.address,
-                            mmio.access_size as usize,
-                            value,
-                        ) {
-                            tracing::warn!(
-                                "vCPU {vcpu_id}: MMIO write {:#x} failed: {e}",
-                                mmio.address
-                            );
+                        let pc = vcpu.get_reg(reg::PC).unwrap_or(0);
+                        let _ = vcpu.set_reg(reg::PC, pc.wrapping_add(4));
+                        continue;
+                    }
+
+                    // Check PL011 UART region first, then fall through to DeviceManager.
+                    let handled_by_pl011 = {
+                        let uart_match = {
+                            let guard = pl011.lock().unwrap();
+                            guard.contains(mmio.address)
+                        };
+                        if uart_match {
+                            if mmio.is_write {
+                                let value =
+                                    read_mmio_write_reg(&vcpu, vcpu_id, mmio.register).unwrap_or(0);
+                                pl011.lock().unwrap().write(
+                                    mmio.address,
+                                    mmio.access_size as usize,
+                                    value,
+                                );
+                            } else {
+                                let value = pl011
+                                    .lock()
+                                    .unwrap()
+                                    .read(mmio.address, mmio.access_size as usize);
+                                complete_mmio_read(&vcpu, vcpu_id, mmio, value);
+                            }
+                            true
+                        } else {
+                            false
                         }
-                    } else {
-                        let value = match device_manager
-                            .handle_mmio_read(mmio.address, mmio.access_size as usize)
-                        {
-                            Ok(v) => v,
-                            Err(e) => {
+                    };
+
+                    let handled_by_pl031 = !handled_by_pl011 && {
+                        let rtc_match = {
+                            let guard = pl031.lock().unwrap();
+                            guard.contains(mmio.address)
+                        };
+                        if rtc_match {
+                            if mmio.is_write {
+                                let value =
+                                    read_mmio_write_reg(&vcpu, vcpu_id, mmio.register).unwrap_or(0);
+                                pl031.lock().unwrap().write(
+                                    mmio.address,
+                                    mmio.access_size as usize,
+                                    value,
+                                );
+                            } else {
+                                let value = pl031
+                                    .lock()
+                                    .unwrap()
+                                    .read(mmio.address, mmio.access_size as usize);
+                                complete_mmio_read(&vcpu, vcpu_id, mmio, value);
+                            }
+                            true
+                        } else {
+                            false
+                        }
+                    };
+
+                    if !handled_by_pl011 && !handled_by_pl031 {
+                        // Dispatch to DeviceManager for VirtIO MMIO devices.
+                        if mmio.is_write {
+                            let Some(value) = read_mmio_write_reg(&vcpu, vcpu_id, mmio.register)
+                            else {
+                                let pc = vcpu.get_reg(reg::PC).unwrap_or(0);
+                                let _ = vcpu.set_reg(reg::PC, pc + 4);
+                                continue;
+                            };
+                            tracing::trace!(
+                                "MMIO write: addr={:#x} offset={:#x} X{}={:#x} size={}",
+                                mmio.address,
+                                mmio.address.saturating_sub(
+                                    mmio.address & !0xFFF // base = addr & ~0xFFF
+                                ),
+                                mmio.register,
+                                value,
+                                mmio.access_size,
+                            );
+                            if let Err(e) = device_manager.handle_mmio_write(
+                                mmio.address,
+                                mmio.access_size as usize,
+                                value,
+                            ) {
                                 tracing::warn!(
-                                    "vCPU {vcpu_id}: MMIO read {:#x} failed: {e}",
+                                    "vCPU {vcpu_id}: MMIO write {:#x} failed: {e}",
                                     mmio.address
                                 );
-                                0 // Return 0 for unknown reads.
                             }
-                        };
-                        complete_mmio_read(&vcpu, vcpu_id, mmio, value);
-                    }
-                }
-
-                // Advance PC past the trapped instruction (ARM64 = fixed 4 bytes).
-                // Hypervisor.framework does NOT auto-advance PC on data aborts.
-                let pc = vcpu.get_reg(reg::PC).unwrap_or(0);
-                let _ = vcpu.set_reg(reg::PC, pc + 4);
-            }
-
-            VcpuExit::Exception {
-                class: ExceptionClass::WaitForInterrupt,
-                ..
-            } => {
-                crate::vcpu_stats::VcpuStats::bump(&stats.wfi);
-                // Guest executed WFI — it is idle and waiting for an interrupt.
-                // Before parking, poll the bridge for incoming data. vsock and
-                // net injection are handled by their dedicated worker threads.
-                let wfi_has_bridge = device_manager.poll_bridge_rx();
-                if wfi_has_bridge {
-                    if let Some(bid) = device_manager.bridge_device_id() {
-                        device_manager.raise_interrupt_for_device(bid, 1);
-                    }
-                    continue; // Re-enter run loop immediately.
-                }
-                // No pending data — park with timeout.
-                std::thread::park_timeout(std::time::Duration::from_millis(1));
-                // Re-check `running` immediately after the park returns so
-                // that `stop_darwin_hv` does not have to race a fresh
-                // `vcpu.run()` re-entry. Without this, a vCPU parked in WFI
-                // could consume an `exit_all_vcpus` cancel intended for a
-                // different vCPU and then slip back into `vcpu.run()`
-                // unguarded. See ABX-367.
-                if !running.load(Ordering::Relaxed) {
-                    break;
-                }
-            }
-
-            VcpuExit::Exception {
-                class: ExceptionClass::HypercallHvc(_imm),
-                ..
-            } => {
-                crate::vcpu_stats::VcpuStats::bump(&stats.hvc);
-                let func_id = match vcpu.get_reg(reg::X0) {
-                    Ok(v) => v,
-                    Err(_) => continue,
-                };
-
-                match func_id {
-                    ARCBOX_HVC_PROBE => {
-                        // Return number of block devices available for fast path.
-                        // NOTE: Hypervisor.framework auto-advances PC on HVC exit.
-                        // Do NOT manually advance PC — that would skip an instruction.
-                        let _ = vcpu.set_reg(reg::X0, hvc_blk_fds.len() as u64);
-                    }
-                    ARCBOX_HVC_BLK_READ => {
-                        let result = handle_hvc_blk_io(&vcpu, &hvc_blk_fds, &device_manager, false);
-                        let _ = vcpu.set_reg(reg::X0, result);
-                    }
-                    ARCBOX_HVC_BLK_WRITE => {
-                        let result = handle_hvc_blk_io(&vcpu, &hvc_blk_fds, &device_manager, true);
-                        let _ = vcpu.set_reg(reg::X0, result);
-                    }
-                    ARCBOX_HVC_BLK_FLUSH => {
-                        let result = handle_hvc_blk_flush(&vcpu, &hvc_blk_fds);
-                        let _ = vcpu.set_reg(reg::X0, result);
-                    }
-                    _ => {
-                        // PSCI and other standard calls.
-                        let psci_exit = handle_psci(
-                            vcpu_id,
-                            func_id,
-                            &vcpu,
-                            &running,
-                            &reset_requested,
-                            cpu_power.as_ref(),
-                        );
-                        if !running.load(Ordering::Relaxed) {
-                            break;
-                        }
-                        if psci_exit == PsciExit::CpuOff {
-                            loop_exit = VcpuLoopExit::CpuOff;
-                            break;
+                        } else {
+                            let value = match device_manager
+                                .handle_mmio_read(mmio.address, mmio.access_size as usize)
+                            {
+                                Ok(v) => v,
+                                Err(e) => {
+                                    tracing::warn!(
+                                        "vCPU {vcpu_id}: MMIO read {:#x} failed: {e}",
+                                        mmio.address
+                                    );
+                                    0 // Return 0 for unknown reads.
+                                }
+                            };
+                            complete_mmio_read(&vcpu, vcpu_id, mmio, value);
                         }
                     }
-                }
-            }
 
-            VcpuExit::Exception {
-                class: ExceptionClass::SmcCall(_),
-                ..
-            } => {
-                crate::vcpu_stats::VcpuStats::bump(&stats.smc);
-                // Some guests route PSCI through SMC instead of HVC.
-                let func_id = match vcpu.get_reg(reg::X0) {
-                    Ok(v) => v,
-                    Err(_) => continue,
-                };
-                let psci_exit = handle_psci(
-                    vcpu_id,
-                    func_id,
-                    &vcpu,
-                    &running,
-                    &reset_requested,
-                    cpu_power.as_ref(),
-                );
-                if !running.load(Ordering::Relaxed) {
+                    // Advance PC past the trapped instruction (ARM64 = fixed 4 bytes).
+                    // Hypervisor.framework does NOT auto-advance PC on data aborts.
+                    let pc = vcpu.get_reg(reg::PC).unwrap_or(0);
+                    let _ = vcpu.set_reg(reg::PC, pc + 4);
+                }
+
+                VcpuExit::Exception {
+                    class: ExceptionClass::WaitForInterrupt,
+                    ..
+                } => {
+                    crate::vcpu_stats::VcpuStats::bump(&stats.wfi);
+                    // Guest executed WFI — it is idle and waiting for an interrupt.
+                    // Before parking, poll the bridge for incoming data. vsock and
+                    // net injection are handled by their dedicated worker threads.
+                    let wfi_has_bridge = device_manager.poll_bridge_rx();
+                    if wfi_has_bridge {
+                        if let Some(bid) = device_manager.bridge_device_id() {
+                            device_manager.raise_interrupt_for_device(bid, 1);
+                        }
+                        continue; // Re-enter run loop immediately.
+                    }
+                    // No pending data — park with timeout.
+                    std::thread::park_timeout(std::time::Duration::from_millis(1));
+                    // Re-check `running` immediately after the park returns so
+                    // that `stop_darwin_hv` does not have to race a fresh
+                    // `vcpu.run()` re-entry. Without this, a vCPU parked in WFI
+                    // could consume an `exit_all_vcpus` cancel intended for a
+                    // different vCPU and then slip back into `vcpu.run()`
+                    // unguarded. See ABX-367.
+                    if !running.load(Ordering::Relaxed) {
+                        break;
+                    }
+                }
+
+                VcpuExit::Exception {
+                    class: ExceptionClass::HypercallHvc(_imm),
+                    ..
+                } => {
+                    crate::vcpu_stats::VcpuStats::bump(&stats.hvc);
+                    let func_id = match vcpu.get_reg(reg::X0) {
+                        Ok(v) => v,
+                        Err(_) => continue,
+                    };
+
+                    match func_id {
+                        ARCBOX_HVC_PROBE => {
+                            // Return number of block devices available for fast path.
+                            // NOTE: Hypervisor.framework auto-advances PC on HVC exit.
+                            // Do NOT manually advance PC — that would skip an instruction.
+                            let _ = vcpu.set_reg(reg::X0, hvc_blk_fds.len() as u64);
+                        }
+                        ARCBOX_HVC_BLK_READ => {
+                            let result =
+                                handle_hvc_blk_io(&vcpu, &hvc_blk_fds, &device_manager, false);
+                            let _ = vcpu.set_reg(reg::X0, result);
+                        }
+                        ARCBOX_HVC_BLK_WRITE => {
+                            let result =
+                                handle_hvc_blk_io(&vcpu, &hvc_blk_fds, &device_manager, true);
+                            let _ = vcpu.set_reg(reg::X0, result);
+                        }
+                        ARCBOX_HVC_BLK_FLUSH => {
+                            let result = handle_hvc_blk_flush(&vcpu, &hvc_blk_fds);
+                            let _ = vcpu.set_reg(reg::X0, result);
+                        }
+                        _ => {
+                            // PSCI and other standard calls.
+                            let psci_exit = handle_psci(
+                                vcpu_id,
+                                func_id,
+                                &vcpu,
+                                &running,
+                                &reset_requested,
+                                cpu_power.as_ref(),
+                            );
+                            if !running.load(Ordering::Relaxed) {
+                                break;
+                            }
+                            if psci_exit == PsciExit::CpuOff {
+                                loop_exit = VcpuLoopExit::CpuOff;
+                                break;
+                            }
+                        }
+                    }
+                }
+
+                VcpuExit::Exception {
+                    class: ExceptionClass::SmcCall(_),
+                    ..
+                } => {
+                    crate::vcpu_stats::VcpuStats::bump(&stats.smc);
+                    // Some guests route PSCI through SMC instead of HVC.
+                    let func_id = match vcpu.get_reg(reg::X0) {
+                        Ok(v) => v,
+                        Err(_) => continue,
+                    };
+                    let psci_exit = handle_psci(
+                        vcpu_id,
+                        func_id,
+                        &vcpu,
+                        &running,
+                        &reset_requested,
+                        cpu_power.as_ref(),
+                    );
+                    if !running.load(Ordering::Relaxed) {
+                        break;
+                    }
+                    if psci_exit == PsciExit::CpuOff {
+                        loop_exit = VcpuLoopExit::CpuOff;
+                        break;
+                    }
+                }
+
+                VcpuExit::VtimerActivated => {
+                    crate::vcpu_stats::VcpuStats::bump(&stats.vtimer);
+                    // Virtual timer fired. Unmask it so the guest sees the interrupt.
+                    let _ = vcpu.set_vtimer_mask(false);
+                }
+
+                VcpuExit::Canceled => {
+                    crate::vcpu_stats::VcpuStats::bump(&stats.kicks_received);
+                    if running.load(Ordering::Relaxed) {
+                        // Woken by net-io thread for interrupt delivery.
+                        continue;
+                    }
+                    tracing::info!("vCPU {vcpu_id}: canceled (shutdown)");
                     break;
                 }
-                if psci_exit == PsciExit::CpuOff {
-                    loop_exit = VcpuLoopExit::CpuOff;
-                    break;
-                }
-            }
 
-            VcpuExit::VtimerActivated => {
-                crate::vcpu_stats::VcpuStats::bump(&stats.vtimer);
-                // Virtual timer fired. Unmask it so the guest sees the interrupt.
-                let _ = vcpu.set_vtimer_mask(false);
-            }
-
-            VcpuExit::Canceled => {
-                crate::vcpu_stats::VcpuStats::bump(&stats.kicks_received);
-                if running.load(Ordering::Relaxed) {
-                    // Woken by net-io thread for interrupt delivery.
-                    continue;
-                }
-                tracing::info!("vCPU {vcpu_id}: canceled (shutdown)");
-                break;
-            }
-
-            VcpuExit::Exception {
-                class:
-                    ExceptionClass::SystemRegister {
-                        op0,
-                        op1,
-                        crn,
-                        crm,
-                        op2,
+                VcpuExit::Exception {
+                    class:
+                        ExceptionClass::SystemRegister {
+                            op0,
+                            op1,
+                            crn,
+                            crm,
+                            op2,
+                            is_write,
+                            rt,
+                        },
+                    ..
+                } => {
+                    crate::vcpu_stats::VcpuStats::bump(&stats.sysreg);
+                    // Apple's framework forwards unknown sysreg accesses as
+                    // EC=0x18 without auto-advancing ELR_EL2. If we re-enter
+                    // guest execution with PC unchanged, the same MSR/MRS
+                    // traps again — infinite loop (observed: Linux early boot
+                    // writes OSDLR_EL1 = S2_0_C1_C3_4 and wedges).
+                    //
+                    // Treat every unhandled sysreg as read-as-zero /
+                    // write-ignored: Linux boot touches debug regs
+                    // (OSDLR_EL1, MDSCR_EL1, DBGBCR*, etc.) that are safe
+                    // to silently drop, and reads of unknown regs yield 0.
+                    if !is_write && rt != 31 {
+                        // MRS into Xrt. HV_REG_X0..X30 are 0..30 numerically,
+                        // so rt maps directly to the register ID. rt==31 is
+                        // XZR — the discard register; nothing to write.
+                        let _ = vcpu.set_reg(u32::from(rt), 0);
+                    }
+                    // Advance PC past the trapping instruction (A64 = 4 bytes).
+                    if let Ok(pc) = vcpu.get_reg(reg::PC) {
+                        let _ = vcpu.set_reg(reg::PC, pc.wrapping_add(4));
+                    }
+                    tracing::trace!(
+                        vcpu_id,
                         is_write,
+                        encoding = %format_args!("S{op0}_{op1}_C{crn}_C{crm}_{op2}"),
                         rt,
-                    },
-                ..
-            } => {
-                crate::vcpu_stats::VcpuStats::bump(&stats.sysreg);
-                // Apple's framework forwards unknown sysreg accesses as
-                // EC=0x18 without auto-advancing ELR_EL2. If we re-enter
-                // guest execution with PC unchanged, the same MSR/MRS
-                // traps again — infinite loop (observed: Linux early boot
-                // writes OSDLR_EL1 = S2_0_C1_C3_4 and wedges).
-                //
-                // Treat every unhandled sysreg as read-as-zero /
-                // write-ignored: Linux boot touches debug regs
-                // (OSDLR_EL1, MDSCR_EL1, DBGBCR*, etc.) that are safe
-                // to silently drop, and reads of unknown regs yield 0.
-                if !is_write && rt != 31 {
-                    // MRS into Xrt. HV_REG_X0..X30 are 0..30 numerically,
-                    // so rt maps directly to the register ID. rt==31 is
-                    // XZR — the discard register; nothing to write.
-                    let _ = vcpu.set_reg(u32::from(rt), 0);
+                        "sysreg access treated as RAZ/WI; PC advanced"
+                    );
                 }
-                // Advance PC past the trapping instruction (A64 = 4 bytes).
-                if let Ok(pc) = vcpu.get_reg(reg::PC) {
-                    let _ = vcpu.set_reg(reg::PC, pc.wrapping_add(4));
+
+                VcpuExit::Exception {
+                    class: ref other, ..
+                } => {
+                    crate::vcpu_stats::VcpuStats::bump(&stats.other);
+                    tracing::warn!("vCPU {vcpu_id}: unhandled exception: {other:?}");
                 }
-                tracing::trace!(
-                    vcpu_id,
-                    is_write,
-                    encoding = %format_args!("S{op0}_{op1}_C{crn}_C{crm}_{op2}"),
-                    rt,
-                    "sysreg access treated as RAZ/WI; PC advanced"
+
+                VcpuExit::Unknown(reason) => {
+                    crate::vcpu_stats::VcpuStats::bump(&stats.other);
+                    tracing::warn!("vCPU {vcpu_id}: unknown exit reason {reason}");
+                }
+            }
+        }
+
+        // Flush any remaining UART output.
+        pl011.lock().unwrap().flush();
+
+        if loop_exit != VcpuLoopExit::CpuOff {
+            tracing::info!("vCPU {vcpu_id}: exited");
+            return;
+        }
+
+        // Powered off: keep the HvVcpu alive (see the function doc — a
+        // re-create deadlocks against running vCPUs and would re-bind the
+        // GIC redistributor) and park until the next CPU_ON.
+        tracing::info!("vCPU {vcpu_id}: offline (CPU_OFF), awaiting CPU_ON");
+        let Some(rx) = cpu_on_rx.as_ref() else {
+            // Unreachable: CPU_OFF is DENIED for the BSP, the only vCPU
+            // without a receiver.
+            tracing::error!("vCPU {vcpu_id}: CPU_OFF without a power channel");
+            return;
+        };
+        match rx.recv() {
+            Ok(req) => {
+                tracing::info!(
+                    "vCPU {vcpu_id}: received CPU_ON, starting at {:#x}",
+                    req.entry_point
                 );
+                entry_addr = req.entry_point;
+                x0_value = req.context_id;
             }
-
-            VcpuExit::Exception {
-                class: ref other, ..
-            } => {
-                crate::vcpu_stats::VcpuStats::bump(&stats.other);
-                tracing::warn!("vCPU {vcpu_id}: unhandled exception: {other:?}");
-            }
-
-            VcpuExit::Unknown(reason) => {
-                crate::vcpu_stats::VcpuStats::bump(&stats.other);
-                tracing::warn!("vCPU {vcpu_id}: unknown exit reason {reason}");
+            Err(_) => {
+                tracing::debug!("vCPU {vcpu_id}: power channel closed while offline");
+                return;
             }
         }
     }
-
-    // Flush any remaining UART output.
-    pl011.lock().unwrap().flush();
-
-    if loop_exit == VcpuLoopExit::CpuOff {
-        // Unregister before dropping the HvVcpu: a stale raw handle in the
-        // ID registry would make the next `hv_vcpus_exit` pass a dangling
-        // handle to Apple's framework (UB per its contract, ABX-367), and a
-        // stale thread handle would take unparks meant for live vCPUs. The
-        // re-onlined loop re-registers both after setup succeeds.
-        let raw = vcpu.raw_handle();
-        hv_vcpu_ids
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner)
-            .retain(|&id| id != raw);
-        let self_id = std::thread::current().id();
-        vcpu_thread_handles
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner)
-            .retain(|t| t.id() != self_id);
-        tracing::info!("vCPU {vcpu_id}: offline (CPU_OFF), awaiting CPU_ON");
-    } else {
-        tracing::info!("vCPU {vcpu_id}: exited");
-    }
-    loop_exit
 }
 
 #[cfg(test)]

--- a/virt/arcbox-vmm/src/vmm/darwin_hv/vcpu_loop.rs
+++ b/virt/arcbox-vmm/src/vmm/darwin_hv/vcpu_loop.rs
@@ -16,7 +16,7 @@ use super::hvc_blk::{
     handle_hvc_blk_flush, handle_hvc_blk_io,
 };
 use super::psci::{CpuOnSenders, handle_psci};
-use super::{HvVcpuIds, Pl011, VcpuThreadHandles};
+use super::{HvVcpuIds, Pl011, Pl031, VcpuThreadHandles};
 
 /// ARM64 register IDs re-exported from arcbox-hv.
 pub(super) mod reg {
@@ -55,6 +55,8 @@ pub(super) struct VcpuContext {
     pub paused: Arc<AtomicBool>,
     /// Shared PL011 UART emulator for early console output.
     pub pl011: Arc<std::sync::Mutex<Pl011>>,
+    /// Shared PL031 RTC emulator backed by the host wall clock.
+    pub pl031: Arc<std::sync::Mutex<Pl031>>,
     /// Channel senders for waking secondary vCPUs via PSCI CPU_ON.
     /// `None` when the VM has only one vCPU.
     pub cpu_on_senders: Option<CpuOnSenders>,
@@ -159,6 +161,7 @@ pub(super) fn vcpu_run_loop(vcpu_id: u32, entry_addr: u64, x0_value: u64, ctx: V
         reset_requested,
         paused,
         pl011,
+        pl031,
         cpu_on_senders,
         vcpu_thread_handles,
         hv_vcpu_ids,
@@ -370,7 +373,34 @@ pub(super) fn vcpu_run_loop(vcpu_id: u32, entry_addr: u64, x0_value: u64, ctx: V
                     }
                 };
 
-                if !handled_by_pl011 {
+                let handled_by_pl031 = !handled_by_pl011 && {
+                    let rtc_match = {
+                        let guard = pl031.lock().unwrap();
+                        guard.contains(mmio.address)
+                    };
+                    if rtc_match {
+                        if mmio.is_write {
+                            let value =
+                                read_mmio_write_reg(&vcpu, vcpu_id, mmio.register).unwrap_or(0);
+                            pl031.lock().unwrap().write(
+                                mmio.address,
+                                mmio.access_size as usize,
+                                value,
+                            );
+                        } else {
+                            let value = pl031
+                                .lock()
+                                .unwrap()
+                                .read(mmio.address, mmio.access_size as usize);
+                            complete_mmio_read(&vcpu, vcpu_id, mmio, value);
+                        }
+                        true
+                    } else {
+                        false
+                    }
+                };
+
+                if !handled_by_pl011 && !handled_by_pl031 {
                     // Dispatch to DeviceManager for VirtIO MMIO devices.
                     if mmio.is_write {
                         let Some(value) = read_mmio_write_reg(&vcpu, vcpu_id, mmio.register) else {

--- a/virt/arcbox-vmm/src/vmm/mod.rs
+++ b/virt/arcbox-vmm/src/vmm/mod.rs
@@ -838,6 +838,14 @@ impl Vmm {
     /// macOS-only: the VF stop call can crash when the guest has already
     /// halted via ACPI. FDs and network resources are still cleaned up.
     /// Must only be called after ACPI shutdown.
+    ///
+    /// Only the VZ backend honors the skip: on the custom HV backend the
+    /// full stop path still runs on drop, because guest halt does not tear
+    /// down the host side — the io workers (vsock, blk, net-rx, console)
+    /// keep referencing guest RAM and must be joined before the mapping
+    /// drops (ABX-415), and `stop_darwin_hv` is safe after a guest halt
+    /// (the vCPU threads have already exited, so its cancel loop and joins
+    /// return immediately).
     #[cfg(target_os = "macos")]
     pub fn set_skip_hypervisor_stop(&mut self) {
         self.skip_hypervisor_stop = true;
@@ -848,13 +856,21 @@ impl Vmm {
 impl Drop for Vmm {
     fn drop(&mut self) {
         if self.state != VmmState::Stopped && self.state != VmmState::Created {
-            if self.skip_hypervisor_stop {
-                // The hypervisor stop path is unsafe (VF may crash when guest
-                // already halted). Only clean up network resources.
+            #[cfg(target_os = "macos")]
+            let skip = self.skip_hypervisor_stop && self.config.backend == VmBackend::Vz;
+            #[cfg(not(target_os = "macos"))]
+            let skip = self.skip_hypervisor_stop;
+            if skip {
+                // The VZ framework stop path is unsafe (VF may crash when
+                // the guest already halted). Only clean up network resources.
                 #[cfg(target_os = "macos")]
                 self.stop_network();
                 self.state = VmmState::Stopped;
             } else {
+                // Full teardown. On the HV backend this MUST run even when
+                // `skip_hypervisor_stop` is set: dropping guest memory while
+                // the io workers still run is a use-after-free that crashed
+                // the daemon on every guest-initiated poweroff (ABX-415).
                 let _ = self.stop();
             }
         }

--- a/virt/arcbox-vmm/src/vmm/mod.rs
+++ b/virt/arcbox-vmm/src/vmm/mod.rs
@@ -129,14 +129,10 @@ pub struct Vmm {
     /// Times the IRQ callback unparked all vCPU threads.
     #[cfg(target_os = "macos")]
     hv_unpark_broadcasts: std::sync::Arc<std::sync::atomic::AtomicU64>,
-    /// PSCI CPU_ON channel senders for secondary vCPUs (custom HV).
+    /// PSCI per-vCPU power registry (custom HV): power states plus the
+    /// CPU_ON wake channels for secondary vCPUs.
     #[cfg(target_os = "macos")]
-    #[allow(clippy::type_complexity)]
-    hv_cpu_on_senders: Option<
-        std::sync::Arc<
-            std::sync::Mutex<Vec<Option<std::sync::mpsc::Sender<darwin_hv::CpuOnRequest>>>>,
-        >,
-    >,
+    hv_cpu_power: Option<darwin_hv::CpuPower>,
     /// vmnet bridge interface for the bridge NIC (`vmnet` feature only).
     #[cfg(all(target_os = "macos", feature = "vmnet"))]
     vmnet_bridge: Option<std::sync::Arc<arcbox_vmnet::Vmnet>>,
@@ -327,7 +323,7 @@ impl Vmm {
             #[cfg(target_os = "macos")]
             hv_unpark_broadcasts: std::sync::Arc::new(std::sync::atomic::AtomicU64::new(0)),
             #[cfg(target_os = "macos")]
-            hv_cpu_on_senders: None,
+            hv_cpu_power: None,
             #[cfg(all(target_os = "macos", feature = "vmnet"))]
             vmnet_bridge: None,
             #[cfg(all(target_os = "macos", feature = "vmnet"))]

--- a/virt/arcbox-vmnet/src/relay.rs
+++ b/virt/arcbox-vmnet/src/relay.rs
@@ -46,9 +46,25 @@ impl VmnetRelay {
     ///
     /// Returns an error if the `AsyncFd` cannot be created.
     pub async fn run(self, guest_fd: OwnedFd) -> std::io::Result<()> {
+        // The fd MUST be non-blocking: `AsyncFd` requires it, and a blocking
+        // `read` here wedges the task inside the syscall — the select below
+        // never regains control, cancellation cannot propagate to the
+        // vmnet→guest worker, and the tokio blocking pool then waits forever
+        // in `Runtime::drop`, hanging daemon shutdown. (The write side
+        // already assumes non-blocking: it treats `WouldBlock` as guest
+        // backpressure.) `dup` shares the file status flags, so this covers
+        // the cloned writer fd too.
+        let raw_fd = guest_fd.as_raw_fd();
+        // SAFETY: fcntl F_GETFL/F_SETFL on a valid, owned fd.
+        unsafe {
+            let flags = libc::fcntl(raw_fd, libc::F_GETFL);
+            if flags < 0 || libc::fcntl(raw_fd, libc::F_SETFL, flags | libc::O_NONBLOCK) < 0 {
+                return Err(std::io::Error::last_os_error());
+            }
+        }
+
         // Clone the fd for the blocking thread (vmnet → guest direction).
         // SAFETY: dup is safe on a valid fd.
-        let raw_fd = guest_fd.as_raw_fd();
         let dup_fd = unsafe { libc::dup(raw_fd) };
         if dup_fd < 0 {
             return Err(std::io::Error::last_os_error());


### PR DESCRIPTION
## Summary

Four HV platform-correctness changes (R6 bundle):

### PL031 RTC device (ABX-416, host side)
- Emulates the PL031 time-of-day registers backed by the host wall clock, plus the AMBA PrimeCell ID words the bus core probes before binding `rtc-pl031`.
- FDT gains the `pl031@b001000` node and the `apb_pclk` fixed-clock the AMBA bus requires. The alarm interrupt is advertised but never raised.
- The guest kernel still needs `CONFIG_RTC_CLASS/RTC_DRV_PL031/RTC_HCTOSYS` (arcboxlabs/kernel PR follows) before it uses the device; until then the node is inert and the agent-ping clock sync remains the time source.

### PSCI CPU_OFF with re-onlinable vCPUs (ABX-403 remainder)
- Replaces the take-once `CpuOnSenders` vec with a `CpuPowerRegistry` (per-vCPU power state + persistent wake channel). CPU_OFF marks the CPU off and parks the vCPU thread back on its receiver; a later CPU_ON from any CPU re-onlines it. BSP CPU_OFF is DENIED.
- `PSCI_FEATURES` now advertises CPU_OFF; AFFINITY_INFO reads the same registry.
- An offlined vCPU unregisters its framework handle + thread handle before parking (ABX-367 dangling-handle class).
- Also fixes a hidden stop-path regression: since the registry became shared with every vCPU thread (#372), dropping the VMM's handle no longer disconnected parked `recv()`s; `close()` now drops senders under the lock (ABX-364 class).

**Hardware-validated**: 18-vCPU HV guest, `docker run --privileged` offline/online of cpu1-3 and all-17-secondaries × 3 rounds — every cycle returns to 18 online.

### Guest-halt teardown SIGSEGV (ABX-415)
- Root cause (symbolicated with an unstripped build): `skip_hypervisor_stop` skipped the whole stop path on both backends. On HV a guest poweroff tears down nothing host-side, so `Vmm::drop` unmapped guest RAM under the still-running io workers — the vsock-io worker segfaulted in `poll_rx_injection` on every graceful daemon shutdown (17 of 20 crash reports on this machine).
- The skip now applies only to the VZ backend; on HV the full ordered teardown always runs.

### vmnet relay shutdown hang (ABX-415 tail)
- `AsyncFd` wrapped a *blocking* socketpair fd: the guest→vmnet read parked the relay task inside `read(2)`, cancellation could never propagate, and `Runtime::drop` waited on the blocking pool forever — the daemon ignored SIGTERM until SIGKILL.
- `O_NONBLOCK` is now set before building the `AsyncFd`. Verified: SIGTERM to a ready HV daemon exits cleanly in ~6s (previously never exited).

## Validation
- `cargo test -p arcbox-vmm` (115 tests incl. new PL031/PSCI-registry/roundtrip tests), `cargo test -p arcbox-vmnet`; clippy/fmt clean.
- HV `boot_assets` e2e: full Docker lifecycle passes; teardown no longer SIGSEGVs.
- Manual SIGTERM probe: clean exit in ~6s.
- CPU hotplug stress in a real HV guest (above).