### PR TITLE
fix(vz): dispatch queue-affine VZ calls onto the VM's queue

### DIFF
--- a/virt/arcbox-vz/src/device/balloon.rs
+++ b/virt/arcbox-vz/src/device/balloon.rs
@@ -83,23 +83,39 @@ impl Drop for MemoryBalloonDeviceConfiguration {
 ///
 /// This represents an active balloon device on a running VM.
 /// Use `set_target_memory_size()` to adjust the balloon.
+///
+/// Every accessor dispatches onto the VM's serial queue: Virtualization
+/// framework device objects are queue-affine, and calling them from any
+/// other thread trips `dispatch_assert_queue` inside the framework and
+/// aborts the process (observed on the idle-state balloon shrink).
 pub struct MemoryBalloonDevice {
     inner: *mut AnyObject,
+    /// The owning VM's dispatch queue (non-owned handle).
+    queue: crate::ffi::DispatchQueue,
 }
 
-// SAFETY: The inner pointer refers to a VZ framework-managed object. Access is synchronized by the framework's internal dispatch queue.
+// SAFETY: The inner pointer refers to a VZ framework-managed object and is
+// only messaged through `queue.sync`, which serializes access on the VM's
+// queue as the framework requires.
 unsafe impl Send for MemoryBalloonDevice {}
-// SAFETY: See above — access is synchronized by the framework's dispatch queue.
+// SAFETY: See above — every method dispatches onto the VM's serial queue.
 unsafe impl Sync for MemoryBalloonDevice {}
 
 impl MemoryBalloonDevice {
-    /// Creates a balloon device wrapper from a raw pointer.
+    /// Creates a balloon device wrapper from a raw pointer plus the owning
+    /// VM's dispatch queue.
     ///
     /// # Safety
     ///
-    /// The caller must ensure that `ptr` is a valid `VZVirtioTraditionalMemoryBalloonDevice`.
-    pub(crate) fn from_raw(ptr: *mut AnyObject) -> Self {
-        Self { inner: ptr }
+    /// The caller must ensure that `ptr` is a valid
+    /// `VZVirtioTraditionalMemoryBalloonDevice` and `queue_ptr` is the
+    /// owning VM's dispatch queue, both outliving this wrapper.
+    pub(crate) unsafe fn from_raw(ptr: *mut AnyObject, queue_ptr: *mut AnyObject) -> Self {
+        Self {
+            inner: ptr,
+            // SAFETY: caller guarantees `queue_ptr` outlives the wrapper.
+            queue: unsafe { crate::ffi::DispatchQueue::from_raw(queue_ptr) },
+        }
     }
 
     /// Sets the target virtual machine memory size.
@@ -116,10 +132,13 @@ impl MemoryBalloonDevice {
             tracing::warn!("set_target_memory_size called on null device");
             return;
         }
-        // SAFETY: self.inner is checked non-null above. Sending setTargetVirtualMachineMemorySize: with a u64 value.
-        unsafe {
-            msg_send_void_u64!(self.inner, setTargetVirtualMachineMemorySize: bytes);
-        }
+        self.queue.sync(|| {
+            // SAFETY: self.inner is checked non-null above; we are on the
+            // VM's dispatch queue as the framework requires.
+            unsafe {
+                msg_send_void_u64!(self.inner, setTargetVirtualMachineMemorySize: bytes);
+            }
+        });
         tracing::debug!(
             "Set balloon target memory to {} bytes ({}MB)",
             bytes,
@@ -135,8 +154,10 @@ impl MemoryBalloonDevice {
             tracing::warn!("target_memory_size called on null device");
             return 0;
         }
-        // SAFETY: self.inner is checked non-null above. Sending targetVirtualMachineMemorySize to a valid balloon device.
-        unsafe { msg_send_u64!(self.inner, targetVirtualMachineMemorySize) }
+        // SAFETY: self.inner is checked non-null above; dispatched onto the
+        // VM's queue as the framework requires.
+        self.queue
+            .sync(|| unsafe { msg_send_u64!(self.inner, targetVirtualMachineMemorySize) })
     }
 
     /// Returns the raw object pointer.
@@ -155,11 +176,16 @@ impl MemoryBalloonDevice {
 /// # Arguments
 ///
 /// * `vm_ptr` - Raw pointer to `VZVirtualMachine`
+/// * `queue_ptr` - The VM's dispatch queue, which every returned wrapper
+///   uses for its (queue-affine) framework calls
 ///
 /// # Returns
 ///
 /// A vector of `MemoryBalloonDevice` wrappers.
-pub fn vm_memory_balloon_devices(vm_ptr: *mut AnyObject) -> Vec<MemoryBalloonDevice> {
+pub fn vm_memory_balloon_devices(
+    vm_ptr: *mut AnyObject,
+    queue_ptr: *mut AnyObject,
+) -> Vec<MemoryBalloonDevice> {
     if vm_ptr.is_null() {
         return Vec::new();
     }
@@ -177,7 +203,7 @@ pub fn vm_memory_balloon_devices(vm_ptr: *mut AnyObject) -> Vec<MemoryBalloonDev
         for i in 0..count {
             let device = crate::ffi::nsarray_object_at_index(devices, i);
             if !device.is_null() {
-                result.push(MemoryBalloonDevice::from_raw(device));
+                result.push(MemoryBalloonDevice::from_raw(device, queue_ptr));
             }
         }
 

--- a/virt/arcbox-vz/src/vm.rs
+++ b/virt/arcbox-vz/src/vm.rs
@@ -426,7 +426,7 @@ impl VirtualMachine {
     /// These can be used for dynamic memory management between host and guest.
     #[must_use]
     pub fn memory_balloon_devices(&self) -> Vec<MemoryBalloonDevice> {
-        vm_memory_balloon_devices(self.inner)
+        vm_memory_balloon_devices(self.inner, self.queue.as_ptr())
     }
 
     /// Returns the first memory balloon device, if any.

--- a/virt/arcbox-vz/src/vm.rs
+++ b/virt/arcbox-vz/src/vm.rs
@@ -90,35 +90,41 @@ impl VirtualMachine {
 
     /// Returns the current state of the VM.
     pub fn state(&self) -> VirtualMachineState {
-        // SAFETY: self.inner is a valid VZVirtualMachine pointer. Sending state returns an i64 enum value.
-        unsafe {
+        // SAFETY: self.inner is a valid VZVirtualMachine pointer; dispatched
+        // onto the VM's queue (VZVirtualMachine properties are queue-affine
+        // and assert when read from any other thread).
+        self.queue.sync(|| unsafe {
             let state = msg_send_i64!(self.inner, state);
             VirtualMachineState::from(state)
-        }
+        })
     }
 
     /// Returns whether the VM can be started.
     pub fn can_start(&self) -> bool {
-        // SAFETY: Sending canStart to a valid VZVirtualMachine.
-        unsafe { msg_send_bool!(self.inner, canStart).as_bool() }
+        // SAFETY: Sending canStart to a valid VZVirtualMachine on its queue.
+        self.queue
+            .sync(|| unsafe { msg_send_bool!(self.inner, canStart).as_bool() })
     }
 
     /// Returns whether the VM can be stopped.
     pub fn can_stop(&self) -> bool {
-        // SAFETY: Sending canStop to a valid VZVirtualMachine.
-        unsafe { msg_send_bool!(self.inner, canStop).as_bool() }
+        // SAFETY: Sending canStop to a valid VZVirtualMachine on its queue.
+        self.queue
+            .sync(|| unsafe { msg_send_bool!(self.inner, canStop).as_bool() })
     }
 
     /// Returns whether the VM can be paused.
     pub fn can_pause(&self) -> bool {
-        // SAFETY: Sending canPause to a valid VZVirtualMachine.
-        unsafe { msg_send_bool!(self.inner, canPause).as_bool() }
+        // SAFETY: Sending canPause to a valid VZVirtualMachine on its queue.
+        self.queue
+            .sync(|| unsafe { msg_send_bool!(self.inner, canPause).as_bool() })
     }
 
     /// Returns whether the VM can be resumed.
     pub fn can_resume(&self) -> bool {
-        // SAFETY: Sending canResume to a valid VZVirtualMachine.
-        unsafe { msg_send_bool!(self.inner, canResume).as_bool() }
+        // SAFETY: Sending canResume to a valid VZVirtualMachine on its queue.
+        self.queue
+            .sync(|| unsafe { msg_send_bool!(self.inner, canResume).as_bool() })
     }
 
     /// Starts the virtual machine.
@@ -399,9 +405,10 @@ impl VirtualMachine {
     ///
     /// These can be used for vsock communication with the guest.
     pub fn socket_devices(&self) -> Vec<VirtioSocketDevice> {
-        // SAFETY: Sending socketDevices to a valid VZVirtualMachine. NSArray elements are valid
-        // VZVirtioSocketDevice pointers retained by the framework.
-        unsafe {
+        // SAFETY: Sending socketDevices to a valid VZVirtualMachine on its
+        // queue (device-array properties are queue-affine). NSArray elements
+        // are valid VZVirtioSocketDevice pointers retained by the framework.
+        self.queue.sync(|| unsafe {
             let devices: *mut AnyObject = msg_send!(self.inner, socketDevices);
             if devices.is_null() {
                 return Vec::new();
@@ -418,7 +425,7 @@ impl VirtualMachine {
             }
 
             result
-        }
+        })
     }
 
     /// Returns the memory balloon devices configured on this VM.
@@ -426,7 +433,8 @@ impl VirtualMachine {
     /// These can be used for dynamic memory management between host and guest.
     #[must_use]
     pub fn memory_balloon_devices(&self) -> Vec<MemoryBalloonDevice> {
-        vm_memory_balloon_devices(self.inner, self.queue.as_ptr())
+        self.queue
+            .sync(|| vm_memory_balloon_devices(self.inner, self.queue.as_ptr()))
     }
 
     /// Returns the first memory balloon device, if any.


### PR DESCRIPTION
## Summary

Two 100%-reproducible daemon aborts from calling queue-affine Virtualization.framework objects off the VM's dispatch queue (`dispatch_assert_queue` aborts the process):

1. **Idle balloon shrink** — `VZVirtioTraditionalMemoryBalloonDevice setTargetVirtualMachineMemorySize:` was sent from a tokio worker on every `running -> idle` lifecycle transition (~300s after last activity). The dev daemon died on every idle transition; three crash reports on this machine today alone.
2. **VM property reads** — `state`, `canStart/canStop/canPause/canResume`, `socketDevices`, `memoryBalloonDevices` were plain `msg_send`s. Observed crash: `EXC_BREAKPOINT` in `canStop` when a failed startup dropped the Vmm from a tokio worker (`Vmm::drop -> stop -> DarwinVm::stop`).

`MemoryBalloonDevice` now carries the owning VM's dispatch queue (the same pattern `VirtioSocketDevice` already uses) and every accessor routes through `queue.sync`. The `Send`/`Sync` justifications are corrected: the framework *asserts* queue affinity, it does not synchronize on our behalf.

## Validation
- `cargo test -p arcbox-vz`, clippy/fmt clean.
- Dev daemon (VZ) rebuilt with the fix survives the idle transition + balloon shrink and served a multi-minute `docker run` kernel-compile workload.