### PR TITLE
fix(vz): size host-side network socket for enhanced MTU

### DIFF
--- a/common/splicetcp/src/classifier.rs
+++ b/common/splicetcp/src/classifier.rs
@@ -29,7 +29,7 @@ use crate::ethernet::{ArpResponder, ETH_HEADER_LEN};
 #[cfg(test)]
 const DEFAULT_ETHERNET_MTU: usize = 1500;
 
-/// Enhanced MTU for VZ framework with `maximumTransmissionUnit` (macOS 14+).
+/// Enhanced MTU for VZ framework with `maximumTransmissionUnit` (macOS 13+).
 /// Reduces frame count by ~2.7x vs 1500.
 pub const ENHANCED_ETHERNET_MTU: usize = 4000;
 

--- a/virt/arcbox-vmm/src/vmm/darwin.rs
+++ b/virt/arcbox-vmm/src/vmm/darwin.rs
@@ -10,6 +10,17 @@ use arcbox_hypervisor::darwin::DarwinVm;
 use arcbox_hypervisor::traits::VirtualMachine;
 use tokio_util::sync::CancellationToken;
 
+/// Socket buffer size (`SO_SNDBUF`/`SO_RCVBUF`) for both ends of a network
+/// socketpair. 8 MiB accommodates burst traffic.
+///
+/// Both ends must be sized, not just the VZ side: on macOS a `SOCK_DGRAM` unix
+/// socket rejects any datagram larger than its `SO_SNDBUF` with `EMSGSIZE`. The
+/// host datapath end is the *sender* of guest-inbound frames, so once VZ's
+/// `setMaximumTransmissionUnit:` raises the link to `VZ_NETWORK_MTU` (4000) a
+/// default-sized (~2 KiB) host end would silently drop every frame above the
+/// default 1500 MTU.
+const NET_SOCKET_BUF_BYTES: libc::c_int = 8 * 1024 * 1024;
+
 impl Vmm {
     /// Darwin-specific initialization using Virtualization.framework.
     pub(super) fn initialize_darwin(&mut self) -> Result<()> {
@@ -228,6 +239,36 @@ impl Vmm {
         Ok(())
     }
 
+    /// Enlarges `SO_SNDBUF` and `SO_RCVBUF` to `NET_SOCKET_BUF_BYTES` on `fd`.
+    ///
+    /// Failures are logged and tolerated — the socket still works with default
+    /// buffers, only with less headroom (see `NET_SOCKET_BUF_BYTES` for why the
+    /// host end in particular must be sized once the enhanced MTU is active).
+    fn set_socket_buffers(fd: libc::c_int) {
+        let size = NET_SOCKET_BUF_BYTES;
+        // SAFETY: setsockopt on a valid fd with a correctly-sized `c_int` value.
+        unsafe {
+            for (opt, name) in [
+                (libc::SO_SNDBUF, "SO_SNDBUF"),
+                (libc::SO_RCVBUF, "SO_RCVBUF"),
+            ] {
+                if libc::setsockopt(
+                    fd,
+                    libc::SOL_SOCKET,
+                    opt,
+                    (&raw const size).cast::<libc::c_void>(),
+                    std::mem::size_of::<libc::c_int>() as libc::socklen_t,
+                ) != 0
+                {
+                    tracing::warn!(
+                        "setsockopt {name} failed: {}",
+                        std::io::Error::last_os_error()
+                    );
+                }
+            }
+        }
+    }
+
     /// Creates the network device configuration for Darwin.
     ///
     /// Sets up a socketpair for `VZFileHandleNetworkDeviceAttachment` and a
@@ -272,38 +313,11 @@ impl Vmm {
         // SAFETY: fds are valid file descriptors returned by socketpair.
         let host_fd = unsafe { OwnedFd::from_raw_fd(fds[1]) };
 
-        // Set a large socket buffer for the VZ side to avoid drops.
-        // 8 MB accommodates burst traffic (increased from 2 MB).
-        // SAFETY: setsockopt with valid fd and parameters.
-        let buf_size: libc::c_int = 8 * 1024 * 1024;
-        unsafe {
-            if libc::setsockopt(
-                vz_fd.as_raw_fd(),
-                libc::SOL_SOCKET,
-                libc::SO_SNDBUF,
-                (&raw const buf_size).cast::<libc::c_void>(),
-                std::mem::size_of::<libc::c_int>() as libc::socklen_t,
-            ) != 0
-            {
-                tracing::warn!(
-                    "setsockopt SO_SNDBUF failed: {}",
-                    std::io::Error::last_os_error()
-                );
-            }
-            if libc::setsockopt(
-                vz_fd.as_raw_fd(),
-                libc::SOL_SOCKET,
-                libc::SO_RCVBUF,
-                (&raw const buf_size).cast::<libc::c_void>(),
-                std::mem::size_of::<libc::c_int>() as libc::socklen_t,
-            ) != 0
-            {
-                tracing::warn!(
-                    "setsockopt SO_RCVBUF failed: {}",
-                    std::io::Error::last_os_error()
-                );
-            }
-        }
+        // Size both ends of the pair: the VZ side buffers bursts, and the host
+        // datapath side must be able to *send* a full enhanced-MTU frame to the
+        // guest (see NET_SOCKET_BUF_BYTES).
+        Self::set_socket_buffers(vz_fd.as_raw_fd());
+        Self::set_socket_buffers(host_fd.as_raw_fd());
 
         // 2. Cancellation token shared by all spawned network tasks.
         let cancel = CancellationToken::new();
@@ -339,12 +353,12 @@ impl Vmm {
         // 5. Build the datapath and spawn it on the tokio runtime.
 
         // NOTE(MTU): Hardcoded to 4000 intentionally — our platform target is
-        // macOS 14+ Apple Silicon (P0) where VZ's setMaximumTransmissionUnit:
-        // always succeeds. On macOS <14 the VZ setter is skipped via
+        // macOS 13+ Apple Silicon (P0) where VZ's setMaximumTransmissionUnit:
+        // always succeeds. On macOS <13 the VZ setter is skipped via
         // respondsToSelector: (see arcbox-vz/device/network.rs), and the VZ
         // device stays at 1500 while the classifier gets 4000. This mismatch
-        // would cause frames >1500 to be dropped — acceptable since macOS <14
-        // is not a supported target. If macOS <14 support is ever needed,
+        // would cause frames >1500 to be dropped — acceptable since macOS <13
+        // is not a supported target. If macOS <13 support is ever needed,
         // plumb the actual MTU from NetworkDeviceConfiguration::mtu() through
         // the hypervisor abstraction layer.
         let net_mtu = arcbox_net::darwin::classifier::ENHANCED_ETHERNET_MTU;
@@ -435,37 +449,11 @@ impl Vmm {
         // SAFETY: fds are valid from socketpair.
         let relay_fd = unsafe { OwnedFd::from_raw_fd(fds[1]) };
 
-        // Set large buffers on the VZ side (8 MB, matching primary NIC).
-        let buf_size: libc::c_int = 8 * 1024 * 1024;
-        // SAFETY: setsockopt with valid fd and parameters.
-        unsafe {
-            if libc::setsockopt(
-                vz_fd.as_raw_fd(),
-                libc::SOL_SOCKET,
-                libc::SO_SNDBUF,
-                (&raw const buf_size).cast::<libc::c_void>(),
-                std::mem::size_of::<libc::c_int>() as libc::socklen_t,
-            ) != 0
-            {
-                tracing::warn!(
-                    "setsockopt SO_SNDBUF (vmnet bridge) failed: {}",
-                    std::io::Error::last_os_error()
-                );
-            }
-            if libc::setsockopt(
-                vz_fd.as_raw_fd(),
-                libc::SOL_SOCKET,
-                libc::SO_RCVBUF,
-                (&raw const buf_size).cast::<libc::c_void>(),
-                std::mem::size_of::<libc::c_int>() as libc::socklen_t,
-            ) != 0
-            {
-                tracing::warn!(
-                    "setsockopt SO_RCVBUF (vmnet bridge) failed: {}",
-                    std::io::Error::last_os_error()
-                );
-            }
-        }
+        // Size both ends (matching the primary NIC): the bridge guest NIC also
+        // negotiates the enhanced MTU, so the relay end must be able to send a
+        // full-size frame to the guest.
+        Self::set_socket_buffers(vz_fd.as_raw_fd());
+        Self::set_socket_buffers(relay_fd.as_raw_fd());
 
         // Spawn the relay task.
         let cancel = CancellationToken::new();
@@ -804,5 +792,62 @@ impl Vmm {
         }
 
         Some(Ok(()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::os::unix::io::AsRawFd;
+
+    /// A `SOCK_DGRAM` unix socket caps datagram size at `SO_SNDBUF`; the host
+    /// end of the network socketpair must be enlarged or a full enhanced-MTU
+    /// frame (4000 + 14-byte Ethernet header) to the guest fails with
+    /// `EMSGSIZE` and is silently dropped. Guards the host-side sizing that
+    /// pairs with VZ's `setMaximumTransmissionUnit:`.
+    #[test]
+    fn enlarged_socket_buffer_accepts_enhanced_mtu_frame() {
+        let mut fds = [0 as libc::c_int; 2];
+        // SAFETY: socketpair with a valid out pointer.
+        let ret = unsafe { libc::socketpair(libc::AF_UNIX, libc::SOCK_DGRAM, 0, fds.as_mut_ptr()) };
+        assert_eq!(ret, 0, "socketpair failed");
+        // SAFETY: fds are valid file descriptors returned by socketpair.
+        let send = unsafe { OwnedFd::from_raw_fd(fds[0]) };
+        // SAFETY: fds are valid file descriptors returned by socketpair.
+        let _recv = unsafe { OwnedFd::from_raw_fd(fds[1]) };
+        let send_fd = send.as_raw_fd();
+
+        // Enhanced MTU (4000) plus a 14-byte Ethernet header.
+        let frame = vec![0u8; arcbox_net::darwin::classifier::ENHANCED_ETHERNET_MTU + 14];
+
+        // Precondition: a small send buffer rejects the frame with EMSGSIZE.
+        let small: libc::c_int = 1024;
+        // SAFETY: setsockopt on a valid fd with a `c_int` option value.
+        unsafe {
+            libc::setsockopt(
+                send_fd,
+                libc::SOL_SOCKET,
+                libc::SO_SNDBUF,
+                (&raw const small).cast::<libc::c_void>(),
+                std::mem::size_of::<libc::c_int>() as libc::socklen_t,
+            );
+        }
+        // SAFETY: send on a valid fd from a valid buffer.
+        let n = unsafe { libc::send(send_fd, frame.as_ptr().cast(), frame.len(), 0) };
+        assert!(
+            n < 0,
+            "small SO_SNDBUF should reject a {}-byte datagram",
+            frame.len()
+        );
+
+        // Enlarging the buffers lets the same frame through.
+        Vmm::set_socket_buffers(send_fd);
+        // SAFETY: send on a valid fd from a valid buffer.
+        let n = unsafe { libc::send(send_fd, frame.as_ptr().cast(), frame.len(), 0) };
+        assert_eq!(
+            n,
+            isize::try_from(frame.len()).unwrap(),
+            "enlarged SO_SNDBUF must accept a full enhanced-MTU frame"
+        );
     }
 }

--- a/virt/arcbox-vz/src/device/network.rs
+++ b/virt/arcbox-vz/src/device/network.rs
@@ -6,7 +6,8 @@ use crate::{msg_send, msg_send_void, msg_send_void_u64};
 use objc2::runtime::AnyObject;
 use std::os::unix::io::RawFd;
 
-/// MTU configured on VZ network devices.
+/// MTU configured on VZ network devices when `setMaximumTransmissionUnit:` is
+/// available (macOS 13+). Exported so the VMM can pass it to the datapath.
 ///
 /// 4000 is chosen based on macOS XNU internals: the kernel has a 4096-byte
 /// internal threshold above which performance degrades for loopback/utun paths.
@@ -15,8 +16,6 @@ use std::os::unix::io::RawFd;
 ///
 /// This reduces frame count by ~2.7x vs the default 1500, directly reducing
 /// per-frame overhead through the entire datapath.
-/// The enhanced MTU value set on VZ network devices when the selector is
-/// available (macOS 13+). Exported so the VMM can pass it to the datapath.
 pub const VZ_NETWORK_MTU: u64 = 4000;
 
 /// Configuration for a `VirtIO` network device.


### PR DESCRIPTION
## Follow-up to #361

#361 fixed the `setMaximumTransmissionUnit:` selector probe (it was
checking `VZVirtioNetworkDeviceConfiguration` instead of the attachment),
so VZ now **actually** raises the guest link MTU to 4000 for the first
time. This PR closes the gap that fix exposes and cleans up the related
docs.

### The bug this activates

`create_network_device` sets an 8 MiB `SO_SNDBUF`/`SO_RCVBUF` only on the
**VZ-side** fd of the socketpair. The **host datapath** end (`host_fd`,
the one the datapath writes guest-inbound frames to) kept the macOS
default. On a `SOCK_DGRAM` unix socket a datagram larger than `SO_SNDBUF`
is rejected with `EMSGSIZE` (default `net.local.dgram.maxdgram` is 2048),
so once the link MTU is 4000 the host→guest RX injection silently drops
every inbound frame above the old 1500 MTU (`write_to_guest` logs a warn
and drops).

Verified empirically: a 4014-byte datagram on a default-buffer unix
`SOCK_DGRAM` fails `EMSGSIZE`; after enlarging `SO_SNDBUF` it sends.

Apple's own docs for this selector require it:
> The client side of the associated datagram socket must be properly
> configured with the appropriate values for SO_SNDBUF, and SO_RCVBUF.

### Changes

- Factor the duplicated 8 MiB `setsockopt` block into
  `Vmm::set_socket_buffers` and apply it to **both** ends of the primary
  NIC socketpair and the vmnet bridge socketpair (the bridge guest NIC
  also negotiates the enhanced MTU).
- Regression test: a full enhanced-MTU frame (4000 + 14) is rejected
  under a small send buffer and accepted after `set_socket_buffers`.
- Correct stale "macOS 14+" availability notes to **macOS 13+**
  (Ventura, matching Apple docs and #361) in `darwin.rs` NOTE(MTU) and
  `classifier.rs`; fold the orphaned `VZ_NETWORK_MTU` doc summary line.

### Validation

- `cargo test -p arcbox-vmm -p splicetcp -p arcbox-vz --lib` — green
  (incl. new test).
- `cargo clippy -p arcbox-vmm -p splicetcp -p arcbox-vz --all-targets`
  and `--features vmnet` — zero warnings.
- **Datapath not yet exercised on hardware.** The buffer sizing is the
  provable half; a host↔guest iperf3 (both directions) on a real VZ boot
  is still the right gate to confirm no large-frame drops remain — I
  couldn't run a full VM boot here.

> Note: commit is currently **unsigned** (1Password ssh signing needs an
> interactive prompt that isn't available in this environment). Happy to
> `--amend -S` once you unlock, or squash-merge will re-author anyway.
