### PR TITLE
fix(agent): match dockerd bridge MTU to the primary NIC

### DIFF
--- a/guest/arcbox-agent/src/agent/linux/runtime.rs
+++ b/guest/arcbox-agent/src/agent/linux/runtime.rs
@@ -223,6 +223,22 @@ pub(super) async fn ensure_containerd_ready(
     false
 }
 
+/// Reads the primary NIC's MTU so dockerd's default bridge can match the
+/// host-negotiated link MTU.
+fn primary_nic_mtu() -> Option<u32> {
+    docker_bridge_mtu(&std::fs::read_to_string("/sys/class/net/eth0/mtu").ok()?)
+}
+
+/// Parses a `/sys/class/net/*/mtu` value into a dockerd `--mtu` override.
+///
+/// Returns `None` for an unparseable value or the default 1500 (nothing to
+/// override), so links that stay at 1500 keep Docker's own default and only a
+/// jumbo link (e.g. the VZ 4000 MTU) forces the bridge to match.
+fn docker_bridge_mtu(raw: &str) -> Option<u32> {
+    let mtu: u32 = raw.trim().parse().ok()?;
+    (mtu > 1500).then_some(mtu)
+}
+
 async fn ensure_dockerd_ready(runtime_bin_dir: &Path, notes: &mut Vec<String>) {
     if probe_unix_socket(DOCKER_API_UNIX_SOCKET).await {
         return;
@@ -237,8 +253,20 @@ async fn ensure_dockerd_ready(runtime_bin_dir: &Path, notes: &mut Vec<String>) {
         .arg("--exec-root=/var/run/docker")
         .arg(format!("--data-root={DOCKER_DATA_MOUNT_POINT}"))
         .arg("--userland-proxy=false")
-        .arg(format!("--init-path={}", init_bin.display()))
-        .env("PATH", &path_env)
+        .arg(format!("--init-path={}", init_bin.display()));
+
+    // Match the default bridge MTU to the primary NIC. The VZ backend raises
+    // eth0 above 1500 (macOS 13+), but Docker keeps its bridge at 1500, so the
+    // guest silently drops host→container frames it cannot forward onto the
+    // smaller bridge — host→VM traffic to a bridged container stalls. Deriving
+    // from the live interface keeps dockerd in lockstep with whatever MTU the
+    // host negotiated, with no override on links that stay at 1500.
+    if let Some(mtu) = primary_nic_mtu() {
+        cmd.arg(format!("--mtu={mtu}"));
+        tracing::info!(mtu, "dockerd bridge MTU matched to primary NIC");
+    }
+
+    cmd.env("PATH", &path_env)
         .stdin(Stdio::null())
         .stdout(daemon_log_file("dockerd"))
         .stderr(daemon_log_file("dockerd"));
@@ -658,7 +686,17 @@ async fn try_start_bundled_runtime() -> String {
 mod tests {
     use arcbox_constants::status::{SERVICE_ERROR, SERVICE_NOT_READY, SERVICE_READY};
 
-    use super::{DockerProbe, shared_containerd_config};
+    use super::{DockerProbe, docker_bridge_mtu, shared_containerd_config};
+
+    #[test]
+    fn docker_bridge_mtu_overrides_only_above_default() {
+        assert_eq!(docker_bridge_mtu("4000\n"), Some(4000));
+        assert_eq!(docker_bridge_mtu("  4000  "), Some(4000));
+        assert_eq!(docker_bridge_mtu("1500"), None); // default — no override
+        assert_eq!(docker_bridge_mtu("1400"), None); // never below default
+        assert_eq!(docker_bridge_mtu(""), None);
+        assert_eq!(docker_bridge_mtu("garbage"), None);
+    }
 
     #[test]
     fn shared_containerd_config_uses_k3s_cni_paths() {


### PR DESCRIPTION
## Completes the MTU=4000 rollout (#361 / #376)

#361 made VZ actually raise the guest link MTU to 4000; #376 sized the
host socket so those frames don't `EMSGSIZE`. Hardware validation then
surfaced the remaining gap: **single-flow Host→VM to a default-bridge
container stalls to 0 bits/sec.**

### Root cause

Guest `eth0` = MTU 4000, but Docker's default bridge (`docker0`) stays at
1500. The host datapath injects ~4000-byte frames toward the container;
the guest kernel can't forward them onto the 1500-MTU bridge (DF set, no
working PMTUD) and drops them. Only the inject (Host→VM) direction breaks
— VM→Host is guest-side TCP and respects the peer MSS. #376 was necessary
but couldn't fix a mismatch that lives entirely inside the guest.

### Fix

Derive dockerd `--mtu` from `eth0`'s live MTU, so the default bridge
tracks whatever the host negotiated:
- jumbo link (VZ 4000) → bridge 4000, matched;
- link at 1500 (macOS <13, or a future non-jumbo backend) → no override,
  Docker keeps its default.

No hardcoded coupling to the host's 4000 constant — the guest reads the
actual interface, so it stays correct if that value ever changes.

### Validation (VZ, signed release daemon, Apple Silicon)

Rebuilt the agent (musl), redeployed, rebooted the VM:

| Test | Before | After |
|---|---|---|
| Host→VM, **default bridge** | **0 bit/s** (stall) | **2.2 Gbit/s**, 0 retr |
| VM→Host (`-R`) | 3.6 Gbit/s | 3.5 Gbit/s |
| `docker0` MTU | 1500 | 4000 |

Agent log: `dockerd bridge MTU matched to primary NIC mtu=4000`. Default
`bridge` network now reports `com.docker.network.driver.mtu=4000`.

Added a unit test for the parse/gate (`docker_bridge_mtu`). Note: the
agent's linux tests don't run in CI (workspace gate excludes the crate,
no musl test job) — compile-checked for `aarch64-unknown-linux-musl` and
the fix is hardware-validated above.

> Commit is **unsigned** (1Password ssh signing needs an interactive
> prompt unavailable here); squash-merge re-authors anyway.
