### PR TITLE
fix(net): clamp host→guest TCP segments to the peer's advertised MSS

### DIFF
--- a/common/splicetcp/src/direct_rx.rs
+++ b/common/splicetcp/src/direct_rx.rs
@@ -71,6 +71,10 @@ pub struct PromotedConn {
     pub remote_port: u16,
     /// Guest TCP port.
     pub guest_port: u16,
+    /// MSS the guest peer advertised. A sink that segments by its own MTU must
+    /// clamp to this so it never emits a frame the guest can't forward onto its
+    /// link (e.g. a 4000-MTU sink feeding a 1460-MSS bridged container).
+    pub peer_mss: u16,
     /// Our SEQ number for frames sent TO guest (shared atomic so both
     /// the inject thread's writes and the fast-path intercept's ACK
     /// frames stay in sync).
@@ -167,6 +171,7 @@ impl ConnSink for TokioFrameConnSink {
             guest_ip,
             remote_port,
             guest_port,
+            peer_mss,
             our_seq,
             last_ack,
             down_bytes,
@@ -186,7 +191,11 @@ impl ConnSink for TokioFrameConnSink {
             down_bytes,
             gw_mac,
             guest_mac,
-            guest_mss: self.guest_mss,
+            // Bound this sink's own MTU-derived segmentation by the peer's MSS so
+            // a high-MTU sink never oversizes frames for a smaller-link guest.
+            guest_mss: self
+                .guest_mss
+                .min((peer_mss as usize).max(crate::tcp_bridge::TCP_MIN_MSS as usize)),
         };
         tokio::spawn(read_promoted_conn(stream, conn, self.tx.clone()));
         true
@@ -304,6 +313,7 @@ mod tests {
             guest_ip: std::net::Ipv4Addr::new(192, 168, 64, 2),
             remote_port: 443,
             guest_port: 50000,
+            peer_mss: 1460,
             our_seq: our_seq.clone(),
             last_ack,
             down_bytes: Some(down.clone()),
@@ -350,6 +360,7 @@ mod tests {
             guest_ip: std::net::Ipv4Addr::new(192, 168, 64, 2),
             remote_port: 443,
             guest_port: 50000,
+            peer_mss: 9000, // jumbo → the configured 4000 MTU drives sizing
             our_seq: our_seq.clone(),
             last_ack: Arc::new(AtomicU32::new(2000)),
             down_bytes: None,
@@ -376,5 +387,63 @@ mod tests {
         assert_eq!(first_ip_len, 4000);
         assert_eq!(second_ip_len, 1080);
         assert_eq!(our_seq.load(Ordering::Relaxed), 6000);
+    }
+
+    /// Regression: a sink configured for a jumbo MTU must still clamp its
+    /// segments to the peer's advertised MSS, or it re-introduces the Host→VM
+    /// stall for a bridged container (1460 MSS) behind a 4000-MTU eth0.
+    #[tokio::test]
+    async fn tokio_frame_conn_sink_clamps_to_peer_mss() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let client = tokio::net::TcpStream::connect(addr).await.unwrap();
+        let (mut upstream, accepted) = tokio::join!(async { client }, async {
+            listener.accept().await.unwrap().0
+        },);
+
+        // Jumbo 4000-MTU sink, but the peer advertised only MSS 1460.
+        let (sink, mut rx) = TokioFrameConnSink::channel_with_mtu(8, 4000);
+        let accepted_conn = PromotedConn {
+            stream: accepted.into_std().unwrap(),
+            remote_ip: std::net::Ipv4Addr::new(203, 0, 113, 10),
+            guest_ip: std::net::Ipv4Addr::new(192, 168, 64, 2),
+            remote_port: 443,
+            guest_port: 50000,
+            peer_mss: 1460,
+            our_seq: Arc::new(AtomicU32::new(1000)),
+            last_ack: Arc::new(AtomicU32::new(2000)),
+            down_bytes: None,
+            gw_mac: [0x02, 0, 0, 0, 0, 1],
+            guest_mac: [0x02, 0, 0, 0, 0, 2],
+        };
+        assert!(sink.send_conn(accepted_conn));
+
+        upstream.write_all(&vec![0xAB; 5000]).await.unwrap();
+        // Drain frames until the whole payload arrives (or time out).
+        let mut frames: Vec<Vec<u8>> = Vec::new();
+        let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(2);
+        let mut got = 0usize;
+        while got < 5000 && tokio::time::Instant::now() < deadline {
+            match tokio::time::timeout(std::time::Duration::from_millis(200), rx.recv()).await {
+                Ok(Some(f)) => {
+                    got += f.len().saturating_sub(ETH_HEADER_LEN + 40);
+                    frames.push(f);
+                }
+                _ => break,
+            }
+        }
+
+        assert!(
+            frames.iter().all(|f| {
+                let ip_len = u16::from_be_bytes([f[ETH_HEADER_LEN + 2], f[ETH_HEADER_LEN + 3]]);
+                ip_len <= 1500
+            }),
+            "peer MSS 1460 must clamp every frame to ≤1500 despite the 4000 sink MTU",
+        );
+        assert!(
+            frames.len() >= 4,
+            "expected ≥4 clamped frames, got {}",
+            frames.len()
+        );
     }
 }

--- a/common/splicetcp/src/tcp_bridge/fast_path.rs
+++ b/common/splicetcp/src/tcp_bridge/fast_path.rs
@@ -377,6 +377,7 @@ impl TcpBridge {
                         guest_ip: key.src_ip,
                         remote_port: key.dst_port,
                         guest_port: key.src_port,
+                        peer_mss,
                         our_seq: std::sync::Arc::clone(&our_seq_atomic),
                         last_ack: std::sync::Arc::clone(&last_ack_atomic),
                         down_bytes: down_shared.clone(),

--- a/common/splicetcp/src/tcp_bridge/fast_path.rs
+++ b/common/splicetcp/src/tcp_bridge/fast_path.rs
@@ -1,4 +1,4 @@
-use super::{FastPathConn, SynFlowKey, TcpBridge};
+use super::{FastPathConn, SynFlowKey, TCP_MIN_MSS, TcpBridge};
 use crate::ethernet::ETH_HEADER_LEN;
 use std::net::Ipv4Addr;
 
@@ -240,11 +240,19 @@ impl TcpBridge {
                             .fetch_add(data.len() as u32, std::sync::atomic::Ordering::Relaxed);
                         frames.push(data_frame);
                     } else {
-                        // Non-GSO path: segment at the configured guest MSS so
-                        // each emitted IP packet fits the consumer's MTU.
+                        // Non-GSO path: segment at the smaller of the configured
+                        // guest MSS and the MSS the peer advertised, so each
+                        // emitted IP packet fits every link on the path to the
+                        // guest endpoint — including a 1500-MTU docker bridge
+                        // behind a 4000-MTU eth0. Without the peer_mss bound a
+                        // container silently drops these oversized frames and
+                        // Host→VM stalls.
+                        let seg = self
+                            .fast_path_guest_mss
+                            .min(conn.peer_mss.max(TCP_MIN_MSS) as usize);
                         let mut offset = 0;
                         while offset < data.len() {
-                            let chunk_end = (offset + self.fast_path_guest_mss).min(data.len());
+                            let chunk_end = (offset + seg).min(data.len());
                             let chunk = &data[offset..chunk_end];
                             let seq_now = conn.our_seq.load(std::sync::atomic::Ordering::Relaxed);
                             let data_frame = crate::ethernet::build_tcp_data_frame(
@@ -329,6 +337,7 @@ impl TcpBridge {
         stream: std::net::TcpStream,
         our_seq: u32,
         last_ack: u32,
+        peer_mss: u16,
     ) {
         // Set non-blocking for polling in the event loop.
         stream.set_nonblocking(true).ok();
@@ -407,6 +416,7 @@ impl TcpBridge {
                 guest_ip: key.src_ip,
                 remote_port: key.dst_port,
                 guest_port: key.src_port,
+                peer_mss,
                 read_buf: if inline_owned {
                     Vec::new()
                 } else {

--- a/common/splicetcp/src/tcp_bridge/fast_path.rs
+++ b/common/splicetcp/src/tcp_bridge/fast_path.rs
@@ -1,4 +1,4 @@
-use super::{FastPathConn, SynFlowKey, TCP_MIN_MSS, TcpBridge};
+use super::{FastPathConn, GSO_SEGMENT_MSS, SynFlowKey, TCP_MIN_MSS, TcpBridge};
 use crate::ethernet::ETH_HEADER_LEN;
 use std::net::Ipv4Addr;
 
@@ -215,9 +215,11 @@ impl TcpBridge {
                     conn.down_bytes += n as u64;
                     // Channel/inject path: send the entire read as one large
                     // frame (the inject thread's GSO hint lets the guest
-                    // re-segment at MSS).
+                    // re-segment at MSS). Gated on the peer accepting the fixed
+                    // 1460-byte GSO segments; a smaller-MSS peer falls through to
+                    // the clamped segmentation below.
                     let data = &conn.read_buf[..n];
-                    if self.large_frames_enabled {
+                    if self.large_frames_enabled && conn.peer_mss >= GSO_SEGMENT_MSS {
                         let large = ETH_HEADER_LEN + 40 + data.len() > 1500;
                         let seq_now = conn.our_seq.load(std::sync::atomic::Ordering::Relaxed);
                         let params = crate::ethernet::TcpFrameParams {
@@ -359,7 +361,12 @@ impl TcpBridge {
         // immediately for zero-copy host→guest reads.
         let mut inline_owned = false;
 
-        if let Some(ref sink) = self.conn_sink {
+        // Only hand a flow to the inline/GSO inject path when its peer can accept
+        // the fixed 1460-byte GSO segments that path emits. A smaller-MSS peer
+        // (e.g. a sub-1500 overlay bridge behind eth0) stays on the clamped
+        // polling path below, where each segment matches its advertised MSS.
+        let inline_eligible = peer_mss >= GSO_SEGMENT_MSS;
+        if let Some(sink) = self.conn_sink.as_ref().filter(|_| inline_eligible) {
             match stream.try_clone() {
                 Ok(cloned) => {
                     let gw_mac = self.fast_path_gateway_mac;

--- a/common/splicetcp/src/tcp_bridge/handshake.rs
+++ b/common/splicetcp/src/tcp_bridge/handshake.rs
@@ -421,10 +421,11 @@ impl TcpBridge {
                 let conn = self.handshake_conns.remove(&key)?;
                 let our_seq = conn.our_isn.wrapping_add(1);
                 let last_ack = conn.peer_isn.wrapping_add(1);
+                let peer_mss = conn.peer_mss;
                 let Some(stream) = conn.host_stream else {
                     return Some(Vec::new());
                 };
-                self.promote_to_fast_path(key, stream, our_seq, last_ack);
+                self.promote_to_fast_path(key, stream, our_seq, last_ack, peer_mss);
                 Some(Vec::new())
             }
             HandshakeRole::ActiveOpen => {
@@ -452,6 +453,12 @@ impl TcpBridge {
                 if peer_opts.sack_permitted {
                     conn.peer_sack = true;
                 }
+                // Record the guest endpoint's real MSS so host→guest segments
+                // are sized to what it can forward (a bridged container behind
+                // eth0 advertises its own, smaller, veth MSS here).
+                if let Some(mss) = peer_opts.mss {
+                    conn.peer_mss = mss;
+                }
 
                 // Build ACK completing the handshake.
                 let our_seq = conn.our_isn.wrapping_add(1);
@@ -470,10 +477,11 @@ impl TcpBridge {
                         dst_mac: conn.guest_mac,
                     });
 
+                let peer_mss = conn.peer_mss;
                 let Some(stream) = conn.host_stream else {
                     return Some(vec![ack_frame]);
                 };
-                self.promote_to_fast_path(key, stream, our_seq, last_ack);
+                self.promote_to_fast_path(key, stream, our_seq, last_ack, peer_mss);
                 Some(vec![ack_frame])
             }
         }

--- a/common/splicetcp/src/tcp_bridge/mod.rs
+++ b/common/splicetcp/src/tcp_bridge/mod.rs
@@ -68,7 +68,7 @@ const SHIM_MSS: u16 = 1460;
 /// Floor for a peer-advertised MSS when sizing host→guest segments. 536 is the
 /// IPv4 minimum (576-byte MTU − 40), so it is always safe to send; it also
 /// guards against a missing or malformed MSS option collapsing segments to 0.
-const TCP_MIN_MSS: u16 = 536;
+pub(crate) const TCP_MIN_MSS: u16 = 536;
 
 /// Fixed segment size the GSO/inline injection paths let the guest re-segment
 /// at (the `gso_size` stamped by `arcbox-net-inject`'s `write_inline_headers`

--- a/common/splicetcp/src/tcp_bridge/mod.rs
+++ b/common/splicetcp/src/tcp_bridge/mod.rs
@@ -70,6 +70,14 @@ const SHIM_MSS: u16 = 1460;
 /// guards against a missing or malformed MSS option collapsing segments to 0.
 const TCP_MIN_MSS: u16 = 536;
 
+/// Fixed segment size the GSO/inline injection paths let the guest re-segment
+/// at (the `gso_size` stamped by `arcbox-net-inject`'s `write_inline_headers`
+/// and `inject_one_frame` — keep in sync). A flow whose peer advertised a
+/// smaller MSS must NOT take the GSO path, or the guest re-segments at 1460 and
+/// drops frames it can't forward onto its smaller link; such flows stay on the
+/// non-GSO polling path where each segment is clamped to the exact peer MSS.
+const GSO_SEGMENT_MSS: u16 = 1460;
+
 /// Monotonically advancing ISN source. Stepped by a large odd constant
 /// (Knuth multiplicative) for well-distributed values without a `rand`
 /// dependency.

--- a/common/splicetcp/src/tcp_bridge/mod.rs
+++ b/common/splicetcp/src/tcp_bridge/mod.rs
@@ -65,6 +65,11 @@ const SHIM_WSCALE: u8 = 7;
 /// GSO are unaffected — MSS only bounds the *guest's* segment size.
 const SHIM_MSS: u16 = 1460;
 
+/// Floor for a peer-advertised MSS when sizing host→guest segments. 536 is the
+/// IPv4 minimum (576-byte MTU − 40), so it is always safe to send; it also
+/// guards against a missing or malformed MSS option collapsing segments to 0.
+const TCP_MIN_MSS: u16 = 536;
+
 /// Monotonically advancing ISN source. Stepped by a large odd constant
 /// (Knuth multiplicative) for well-distributed values without a `rand`
 /// dependency.
@@ -109,7 +114,7 @@ pub(super) enum HandshakeRole {
 /// peer options to mirror/record, the ISNs on both sides, and retransmit
 /// bookkeeping. No send/recv buffers, no sliding window state, no
 /// congestion control — those are the host and guest kernels' responsibility.
-#[allow(dead_code)] // `flow_key` mirrors the HashMap key; `peer_mss` reserved for frame sizing
+#[allow(dead_code)] // `flow_key` mirrors the HashMap key
 pub(super) struct HandshakeConn {
     flow_key: SynFlowKey,
     role: HandshakeRole,
@@ -209,6 +214,11 @@ pub(super) struct FastPathConn {
     remote_port: u16,
     /// Guest port.
     guest_port: u16,
+    /// MSS the guest peer advertised for this flow (from its SYN / SYN-ACK).
+    /// Bounds the host→guest segment size so emitted frames never exceed the
+    /// path the guest can forward them over (e.g. a 1500-MTU docker bridge
+    /// behind a 4000-MTU `eth0`). See `poll_fast_path`.
+    peer_mss: u16,
     /// Read buffer for host → guest data (reused across polls).
     read_buf: Vec<u8>,
     /// True if host stream has reached EOF.

--- a/common/splicetcp/src/tcp_bridge/tests.rs
+++ b/common/splicetcp/src/tcp_bridge/tests.rs
@@ -507,3 +507,67 @@ async fn poll_fast_path_clamps_segments_to_peer_mss() {
         frames.len()
     );
 }
+
+/// Regression: the GSO/large-frame path (HV) is gated on the peer accepting the
+/// fixed 1460-byte GSO segments. A peer that advertised a smaller MSS (e.g. a
+/// sub-1500 overlay bridge) must fall back to the clamped polling path instead
+/// of a single super-frame the guest would re-segment at 1460 and drop.
+#[tokio::test]
+async fn large_frames_below_gso_mss_falls_back_to_clamped_segmentation() {
+    use tokio::io::AsyncWriteExt;
+
+    let mut bridge = TcpBridge::new(GW_IP);
+    bridge.set_fast_path_macs(GW_MAC, GUEST_MAC);
+    bridge.enable_large_frames(); // HV-style large-frame mode…
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let connect = tokio::net::TcpStream::connect(addr);
+    let (client, accepted) = tokio::join!(connect, listener.accept());
+    let client = client.unwrap();
+    let (mut accepted, _) = accepted.unwrap();
+
+    let key = SynFlowKey {
+        src_ip: GUEST_IP,
+        src_port: 12345,
+        dst_ip: Ipv4Addr::new(198, 18, 30, 95),
+        dst_port: 443,
+    };
+    // …but the peer advertised MSS 1400, below the 1460 GSO segment size.
+    bridge.promote_to_fast_path(key, client.into_std().unwrap(), 1, 1, 1400);
+
+    let payload = vec![0xAB; 5000];
+    accepted.write_all(&payload).await.unwrap();
+
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(2);
+    let mut frames: Vec<Vec<u8>> = Vec::new();
+    loop {
+        let batch = bridge.poll_fast_path();
+        let had_new = !batch.is_empty();
+        frames.extend(batch);
+        let received: usize = frames
+            .iter()
+            .map(|frame| frame.len().saturating_sub(ETH_HEADER_LEN + 40))
+            .sum();
+        if received >= payload.len() || std::time::Instant::now() >= deadline {
+            break;
+        }
+        if !had_new {
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+    }
+
+    // Not a single 5000-byte super-frame: clamped to the 1400 peer MSS.
+    assert!(
+        frames.iter().all(|frame| {
+            let ip_len = u16::from_be_bytes([frame[ETH_HEADER_LEN + 2], frame[ETH_HEADER_LEN + 3]]);
+            ip_len <= 1440 // 1400 payload + 20 IP + 20 TCP
+        }),
+        "sub-GSO-MSS peer must stay on the clamped path, not emit a super-frame",
+    );
+    assert!(
+        frames.len() >= 4,
+        "expected ≥4 clamped segments, got {}",
+        frames.len()
+    );
+}

--- a/common/splicetcp/src/tcp_bridge/tests.rs
+++ b/common/splicetcp/src/tcp_bridge/tests.rs
@@ -344,7 +344,8 @@ async fn poll_fast_path_segments_frames_for_unix_dgram_limit() {
         dst_ip: Ipv4Addr::new(198, 18, 30, 95),
         dst_port: 443,
     };
-    bridge.promote_to_fast_path(key, client.into_std().unwrap(), 1, 1);
+    // Jumbo peer MSS so the dgram limit — not the peer bound — drives sizing.
+    bridge.promote_to_fast_path(key, client.into_std().unwrap(), 1, 1, 9000);
 
     let payload = vec![0xAB; FAST_PATH_GUEST_MSS * 2 + 128];
     accepted.write_all(&payload).await.unwrap();
@@ -407,7 +408,8 @@ async fn poll_fast_path_segments_frames_for_configured_mtu() {
         dst_ip: Ipv4Addr::new(198, 18, 30, 95),
         dst_port: 443,
     };
-    bridge.promote_to_fast_path(key, client.into_std().unwrap(), 1, 1);
+    // Jumbo peer MSS so the configured MTU — not the peer bound — drives sizing.
+    bridge.promote_to_fast_path(key, client.into_std().unwrap(), 1, 1, 9000);
 
     let payload = vec![0xAB; 5000];
     accepted.write_all(&payload).await.unwrap();
@@ -438,4 +440,70 @@ async fn poll_fast_path_segments_frames_for_configured_mtu() {
         u16::from_be_bytes([frames[1][ETH_HEADER_LEN + 2], frames[1][ETH_HEADER_LEN + 3]]);
     assert_eq!(first_ip_len, 4000);
     assert_eq!(second_ip_len, 1080);
+}
+
+/// Regression: even with a jumbo configured MTU, host→guest segments must be
+/// bounded by the peer's advertised MSS. A container behind a 1500-MTU docker
+/// bridge advertises MSS 1460; without this clamp the shim emits ~4000-byte
+/// frames the guest cannot forward onto the bridge and Host→VM stalls.
+#[tokio::test]
+async fn poll_fast_path_clamps_segments_to_peer_mss() {
+    use tokio::io::AsyncWriteExt;
+
+    let mut bridge = TcpBridge::new(GW_IP);
+    bridge.set_fast_path_macs(GW_MAC, GUEST_MAC);
+    bridge.set_fast_path_mtu(4000); // jumbo host-side budget…
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let connect = tokio::net::TcpStream::connect(addr);
+    let (client, accepted) = tokio::join!(connect, listener.accept());
+    let client = client.unwrap();
+    let (mut accepted, _) = accepted.unwrap();
+
+    let key = SynFlowKey {
+        src_ip: GUEST_IP,
+        src_port: 12345,
+        dst_ip: Ipv4Addr::new(198, 18, 30, 95),
+        dst_port: 443,
+    };
+    // …but the peer (a 1500-MTU bridged container) advertised MSS 1460.
+    bridge.promote_to_fast_path(key, client.into_std().unwrap(), 1, 1, 1460);
+
+    let payload = vec![0xAB; 5000];
+    accepted.write_all(&payload).await.unwrap();
+
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(2);
+    let mut frames: Vec<Vec<u8>> = Vec::new();
+    loop {
+        let batch = bridge.poll_fast_path();
+        let had_new = !batch.is_empty();
+        frames.extend(batch);
+        let received: usize = frames
+            .iter()
+            .map(|frame| frame.len().saturating_sub(ETH_HEADER_LEN + 40))
+            .sum();
+        if received >= payload.len() || std::time::Instant::now() >= deadline {
+            break;
+        }
+        if !had_new {
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+    }
+
+    // Every emitted IP packet must fit a 1500-MTU link (20 IP + 20 TCP + ≤1460).
+    assert!(
+        frames.iter().all(|frame| {
+            let ip_len = u16::from_be_bytes([frame[ETH_HEADER_LEN + 2], frame[ETH_HEADER_LEN + 3]]);
+            ip_len <= 1500
+        }),
+        "peer MSS 1460 must bound every host→guest frame to ≤1500 bytes",
+    );
+    // 5000 bytes at ≤1460 payload each ⇒ at least 4 segments (not the 2 the
+    // jumbo budget alone would produce).
+    assert!(
+        frames.len() >= 4,
+        "expected ≥4 segments, got {}",
+        frames.len()
+    );
 }


### PR DESCRIPTION
## Root fix for the MTU=4000 Host→VM container stall (supersedes #377)

The VZ datapath's TCP fast path segmented host→guest data at its own
configured guest MSS (the AF_UNIX datagram budget, ~1994) and **ignored the
MSS the guest endpoint advertised**. After #361 raised `eth0` to MTU 4000,
frames toward a container on a 1500-MTU docker bridge exceeded what the guest
could forward onto that bridge — the guest dropped them and single-flow
**Host→VM to any bridged container stalled to 0**.

`peer_mss` was already parsed during the handshake but **dropped at promotion**
to `FastPathConn` (literally commented "reserved for frame sizing"). This wires
it through and bounds every emitted segment by `min(configured_mss, peer_mss)`
(floored at the 536-byte IPv4 minimum). The container advertises its real veth
MSS — 1460 on a 1500 bridge, 3960 on a jumbo one — so segments always fit every
link on the path, with **no docker MTU configuration**.

### Why this supersedes #377

#377 raised dockerd's default-bridge MTU to match `eth0`. Review surfaced two
gaps it couldn't close, both resolved here because docker stays at 1500:
- **Codex (P2):** the vmnet direct-routing path (host↔container over the
  1500-MTU vmnet bridge) would drop jumbo container frames. With MSS-clamp the
  container advertises 1460, so nothing jumbo is emitted.
- **pullfrog (scope):** `dockerd --mtu` doesn't apply to user-defined / compose
  networks, so those would still stall. MSS-clamp is network-agnostic.

HV is unaffected — its inject path already emits GSO super-frames
(`gso_size=1460`) and the guest re-segments.

### Validation (VZ, signed release daemon, Apple Silicon; docker0 left at 1500)

| Test | Before | After |
|---|---|---|
| Host→VM **default bridge** | 0 (stall) | **4.23 Gbit/s**, 0 retr |
| Host→VM **user-defined network** | 0 (stall) | **3.02 Gbit/s**, 0 retr — the #377 gap |
| VM→Host (`-R`) | 3.6 Gbit/s | 3.62 Gbit/s |

New unit test `poll_fast_path_clamps_segments_to_peer_mss` asserts a peer MSS of
1460 bounds every host→guest frame to ≤1500 even under a 4000-byte configured
budget.

### Relationship to the other PRs
- **#376** (host_fd socket sizing) — still valid; general burst-buffer headroom.
- **#377** (dockerd `--mtu` from eth0) — **close in favor of this PR.**

> Commit is **unsigned** (1Password ssh signing needs an interactive prompt
> unavailable here); squash-merge re-authors anyway.
