### PR TITLE
fix(release): separate release PRs and bootstrap fleet-agent at 0.1.0

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,6 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "release-type": "simple",
   "include-component-in-tag": false,
+  "separate-pull-requests": true,
   "bump-minor-pre-major": true,
   "bump-patch-for-minor-pre-major": true,
   "changelog-sections": [
@@ -31,6 +32,7 @@
     "fleet": {
       "component": "fleet-agent",
       "include-component-in-tag": true,
+      "release-as": "0.1.0",
       "extra-files": [
         {
           "type": "generic",


### PR DESCRIPTION
Follow-up to #381. Two issues surfaced once release-please processed the split.

## Issue 1 — combined release PR

release-please's default is a single manifest-wide release PR, so PR #379 currently bundles both:

- main arcbox: `0.4.17 → 0.4.18`
- fleet-agent: `0.0.0 → 1.0.0`

They must be merged together, which defeats the independent release cadence that #381 set up. `separate-pull-requests: true` at the top level splits this into one PR per component.

## Issue 2 — fleet-agent bootstraps at `1.0.0` instead of `0.1.0`

With the fleet manifest seeded at `0.0.0`, release-please treats the component as unreleased and hard-codes the first tag to `1.0.0`, ignoring `bump-minor-pre-major`. Neither `0.0.1` nor `0.1.0` as a seed produces `0.1.0` as the *first* release under the current bump flags.

A one-shot `"release-as": "0.1.0"` on the fleet package forces the bootstrap tag to be exactly `fleet-agent-v0.1.0`.

## After merge

- PR #379 will be superseded — release-please will close it and open two:
  - `chore(main): release 0.4.18`
  - `chore(fleet-agent): release 0.1.0`
- Merging the fleet PR fires `.github/workflows/release-fleet-agent.yml` with tag `fleet-agent-v0.1.0`.
- Once `fleet-agent-v0.1.0` is cut, a follow-up PR should remove the `release-as` line so subsequent fleet releases advance via the normal bump rules (`0.1.0 + fix → 0.1.1`, `0.1.0 + feat → 0.1.1` under `bump-patch-for-minor-pre-major`).