### PR TITLE
fix(release): iterate all release PRs when refreshing Cargo.lock

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -28,22 +28,24 @@ jobs:
           manifest-file: .release-please-manifest.json
           token: ${{ steps.app-token.outputs.token }}
 
-      # After release-please creates/updates release PRs, regenerate
-      # Cargo.lock on each so the release tag can build with --locked.
-      # Iterates the `prs` array — under separate-pull-requests each
-      # component has its own PR, and `outputs.pr` (singular) only
-      # exposes one of them.
+      # Regenerate Cargo.lock on every open release PR so its release tag
+      # can build with --locked. The release-please `prs` output only
+      # includes PRs created or updated during the current run.
       - name: Update Cargo.lock on release PRs
-        if: steps.release.outputs.prs_created == 'true'
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          # Passed via env, not inline interpolation: the JSON contains
-          # changelog bodies, whose quotes would break the shell script.
-          RELEASE_PRS: ${{ steps.release.outputs.prs }}
         run: |
           git config --global user.name "arcbox-labs[bot]"
           git config --global user.email "254083426+arcbox-labs[bot]@users.noreply.github.com"
-          echo "$RELEASE_PRS" | jq -c '.[]' | while read -r pr; do
+          gh pr list \
+            --repo "$GITHUB_REPOSITORY" \
+            --base "$GITHUB_REF_NAME" \
+            --state open \
+            --label "autorelease: pending" \
+            --limit 100 \
+            --json headRefName,number |
+          jq -c '.[]' |
+          while read -r pr; do
             PR_BRANCH=$(jq -r '.headBranchName' <<< "$pr")
             PR_NUMBER=$(jq -r '.number' <<< "$pr")
             echo "::group::Update Cargo.lock for PR #${PR_NUMBER} (${PR_BRANCH})"

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -46,7 +46,7 @@ jobs:
             --json headRefName,number |
           jq -c '.[]' |
           while read -r pr; do
-            PR_BRANCH=$(jq -r '.headBranchName' <<< "$pr")
+            PR_BRANCH=$(jq -r '.headRefName' <<< "$pr")
             PR_NUMBER=$(jq -r '.number' <<< "$pr")
             echo "::group::Update Cargo.lock for PR #${PR_NUMBER} (${PR_BRANCH})"
             workdir=$(mktemp -d)

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -28,30 +28,42 @@ jobs:
           manifest-file: .release-please-manifest.json
           token: ${{ steps.app-token.outputs.token }}
 
-      # After release-please creates/updates the PR, regenerate Cargo.lock
-      # so the release tag can build with --locked.
-      - name: Update Cargo.lock on release PR
-        if: steps.release.outputs.pr
+      # After release-please creates/updates release PRs, regenerate
+      # Cargo.lock on each so the release tag can build with --locked.
+      # Iterates the `prs` array — under separate-pull-requests each
+      # component has its own PR, and `outputs.pr` (singular) only
+      # exposes one of them.
+      - name: Update Cargo.lock on release PRs
+        if: steps.release.outputs.prs_created == 'true'
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          # Passed via env, not inline interpolation: the JSON contains the
-          # changelog body, whose quotes would break the shell script.
-          RELEASE_PR: ${{ steps.release.outputs.pr }}
+          # Passed via env, not inline interpolation: the JSON contains
+          # changelog bodies, whose quotes would break the shell script.
+          RELEASE_PRS: ${{ steps.release.outputs.prs }}
         run: |
-          PR_BRANCH=$(jq -r '.headBranchName' <<< "$RELEASE_PR")
-          git clone --depth 1 --branch "$PR_BRANCH" \
-            "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git" /tmp/release-pr
-          cd /tmp/release-pr
-          cargo update --workspace
-          if git diff --quiet Cargo.lock; then
-            echo "Cargo.lock already up to date"
-            exit 0
-          fi
-          git config user.name "arcbox-labs[bot]"
-          git config user.email "254083426+arcbox-labs[bot]@users.noreply.github.com"
-          git add Cargo.lock
-          git commit -m "chore: update Cargo.lock for release"
-          git push
+          git config --global user.name "arcbox-labs[bot]"
+          git config --global user.email "254083426+arcbox-labs[bot]@users.noreply.github.com"
+          echo "$RELEASE_PRS" | jq -c '.[]' | while read -r pr; do
+            PR_BRANCH=$(jq -r '.headBranchName' <<< "$pr")
+            PR_NUMBER=$(jq -r '.number' <<< "$pr")
+            echo "::group::Update Cargo.lock for PR #${PR_NUMBER} (${PR_BRANCH})"
+            workdir=$(mktemp -d)
+            git clone --depth 1 --branch "$PR_BRANCH" \
+              "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git" "$workdir"
+            (
+              cd "$workdir"
+              cargo update --workspace
+              if git diff --quiet Cargo.lock; then
+                echo "Cargo.lock already up to date"
+              else
+                git add Cargo.lock
+                git commit -m "chore: update Cargo.lock for release"
+                git push
+              fi
+            )
+            rm -rf "$workdir"
+            echo "::endgroup::"
+          done
 
   # Update arcbox-desktop version file when a new release is created.
   update-desktop:


### PR DESCRIPTION
Follow-up to #381 / #382. Unblocks the fleet-agent release PR #383.

This supersedes the initial `cargo-workspace` plugin approach on this branch. The repository already has a dedicated lockfile refresh step, so the fix keeps that mechanism and corrects how it discovers release PRs.

## Root cause

`.github/workflows/release-please.yml` gated its lockfile refresh on `steps.release.outputs.pr` (singular). With `separate-pull-requests: true`, the run after #382 exposed PR #379 through that output, refreshed its `Cargo.lock`, and never touched fleet-agent PR #383.

The plural `prs` output is not a complete list of open release PRs either. Release Please only includes PRs created or updated during the current run, so an unchanged open component PR can still be omitted.

## Fix

Query GitHub directly for every open PR that:

- targets the triggering branch
- has the `autorelease: pending` label

For each matching PR, the workflow:

1. clones the release branch into an isolated temporary directory
2. runs `cargo update --workspace`
3. commits and pushes `Cargo.lock` only when it changed

The step runs after every push to `master` and naturally does nothing when no release PRs are open. It no longer depends on Release Please output filtering.

## Verification

The exact `gh pr list` query used by the workflow currently returns both release PRs:

- #379: `release-please--branches--master`
- #383: `release-please--branches--master--components--fleet-agent`

After this PR merges, the workflow will refresh both branches. PR #383 will receive a `chore: update Cargo.lock for release` commit that changes the fleet-agent lockfile entry to `0.1.0`, allowing the release build to use `--locked`.

## Ordering

1. Merge this PR to `master`.
2. Wait for Release Please to refresh the open release PR lockfiles.
3. Merge #383, creating tag `fleet-agent-v0.1.0`.
4. Remove the one-shot `release-as: "0.1.0"` override in a follow-up.