### PR TITLE
fix(ci): build portable static fleet-agent with musl-cross on Ubuntu

### DIFF
--- a/.github/workflows/release-fleet-agent.yml
+++ b/.github/workflows/release-fleet-agent.yml
@@ -160,9 +160,15 @@ jobs:
           - arch: amd64
             target: x86_64-unknown-linux-musl
             musl_prefix: x86_64-linux-musl
+            # sha256 of https://musl.cc/x86_64-linux-musl-cross.tgz
+            # (Last-Modified: 2021-11-23). Bump both hash and cache key
+            # version if the upstream tarball is refreshed.
+            musl_sha256: c5d410d9f82a4f24c549fe5d24f988f85b2679b452413a9f7e5f7b956f2fe7ea
           - arch: arm64
             target: aarch64-unknown-linux-musl
             musl_prefix: aarch64-linux-musl
+            # sha256 of https://musl.cc/aarch64-linux-musl-cross.tgz
+            musl_sha256: c909817856d6ceda86aa510894fa3527eac7989f0ef6e87b5721c58737a06c38
     runs-on: ubuntu-latest
     timeout-minutes: 20
 
@@ -187,12 +193,18 @@ jobs:
           key: musl-cross-${{ matrix.musl_prefix }}-v1
 
       - name: Install musl-cross toolchain
+        # Pinned by sha256: this toolchain links the released binaries, and
+        # Linux release artifacts aren't codesigned, so a bad tarball would
+        # silently backdoor every Linux release. musl.cc is a single-
+        # maintainer host — retry + cache handle transient outages, the
+        # digest handles bad content.
         if: steps.musl-cross-cache.outputs.cache-hit != 'true'
         run: |
           set -euo pipefail
           curl -fsSL --retry 5 --retry-all-errors \
             -o /tmp/musl-cross.tgz \
             "https://musl.cc/${{ matrix.musl_prefix }}-cross.tgz"
+          echo "${{ matrix.musl_sha256 }}  /tmp/musl-cross.tgz" | sha256sum -c -
           sudo tar -xf /tmp/musl-cross.tgz -C /opt
           rm /tmp/musl-cross.tgz
 

--- a/.github/workflows/release-fleet-agent.yml
+++ b/.github/workflows/release-fleet-agent.yml
@@ -145,6 +145,12 @@ jobs:
           path: target/release/arcbox-fleet-agent
           retention-days: 5
 
+  # Cross-compile both Linux targets from a single x86_64 runner using the
+  # musl-cross-make prebuilt toolchains from musl.cc — the same toolchain
+  # FiloSottile's Homebrew tap builds on macOS, with the same tool naming
+  # (${target}-linux-musl-{gcc,ar,ld}) and the same fully-static defaults.
+  # Keeps `.cargo/config.toml` as the single source of truth across host OSes
+  # and avoids Ubuntu `musl-tools`' PIE-against-ld-musl default.
   build-linux:
     name: Build Linux ${{ matrix.arch }}
     needs: version
@@ -152,12 +158,12 @@ jobs:
       matrix:
         include:
           - arch: amd64
-            runner: ubuntu-latest
             target: x86_64-unknown-linux-musl
+            musl_prefix: x86_64-linux-musl
           - arch: arm64
-            runner: ubuntu-24.04-arm
             target: aarch64-unknown-linux-musl
-    runs-on: ${{ matrix.runner }}
+            musl_prefix: aarch64-linux-musl
+    runs-on: ubuntu-latest
     timeout-minutes: 20
 
     steps:
@@ -173,10 +179,28 @@ jobs:
           toolchain: stable
           targets: ${{ matrix.target }}
 
-      - name: Install musl toolchain and protobuf compiler
+      - name: Cache musl-cross toolchain
+        id: musl-cross-cache
+        uses: actions/cache@v4
+        with:
+          path: /opt/${{ matrix.musl_prefix }}-cross
+          key: musl-cross-${{ matrix.musl_prefix }}-v1
+
+      - name: Install musl-cross toolchain
+        if: steps.musl-cross-cache.outputs.cache-hit != 'true'
         run: |
+          set -euo pipefail
+          curl -fsSL --retry 5 --retry-all-errors \
+            -o /tmp/musl-cross.tgz \
+            "https://musl.cc/${{ matrix.musl_prefix }}-cross.tgz"
+          sudo tar -xf /tmp/musl-cross.tgz -C /opt
+          rm /tmp/musl-cross.tgz
+
+      - name: Add musl-cross to PATH and install protoc
+        run: |
+          echo "/opt/${{ matrix.musl_prefix }}-cross/bin" >> "$GITHUB_PATH"
           sudo apt-get update
-          sudo apt-get install -y musl-tools protobuf-compiler
+          sudo apt-get install -y protobuf-compiler
 
       - name: Cache cargo
         uses: actions/cache@v4
@@ -187,18 +211,28 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          key: ${{ runner.os }}-cargo-fleet-agent-musl-${{ matrix.arch }}-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-fleet-agent-${{ matrix.arch }}-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
-            ${{ runner.os }}-cargo-fleet-agent-musl-${{ matrix.arch }}-
+            ${{ runner.os }}-cargo-fleet-agent-${{ matrix.arch }}-
 
       - name: Build arcbox-fleet-agent
         timeout-minutes: 10
         run: cargo build --release --locked -p arcbox-fleet-agent --target ${{ matrix.target }}
 
-      - name: Verify artifact
+      - name: Verify artifact is fully static
+        # A stray ELF interpreter (PT_INTERP) means the binary needs a
+        # dynamic loader at runtime — defeats the point of a musl build.
+        # Regression-catch it here.
         run: |
-          ls -lh target/${{ matrix.target }}/release/arcbox-fleet-agent
-          file target/${{ matrix.target }}/release/arcbox-fleet-agent
+          set -euo pipefail
+          bin=target/${{ matrix.target }}/release/arcbox-fleet-agent
+          ls -lh "$bin"
+          file "$bin"
+          if readelf -l "$bin" | grep -q INTERP; then
+            echo "::error::binary has PT_INTERP; not fully static"
+            readelf -l "$bin" | grep -E '(INTERP|Requesting)'
+            exit 1
+          fi
 
       - name: Upload binary
         uses: actions/upload-artifact@v4

--- a/.github/workflows/release-fleet-agent.yml
+++ b/.github/workflows/release-fleet-agent.yml
@@ -161,8 +161,9 @@ jobs:
             target: x86_64-unknown-linux-musl
             musl_prefix: x86_64-linux-musl
             # sha256 of https://musl.cc/x86_64-linux-musl-cross.tgz
-            # (Last-Modified: 2021-11-23). Bump both hash and cache key
-            # version if the upstream tarball is refreshed.
+            # (Last-Modified: 2021-11-23). The digest is also baked into
+            # the cache key below, so refreshing the tarball auto-
+            # invalidates any previously-cached toolchain.
             musl_sha256: c5d410d9f82a4f24c549fe5d24f988f85b2679b452413a9f7e5f7b956f2fe7ea
           - arch: arm64
             target: aarch64-unknown-linux-musl
@@ -186,11 +187,14 @@ jobs:
           targets: ${{ matrix.target }}
 
       - name: Cache musl-cross toolchain
+        # Cache key includes the pinned sha256, so bumping the digest
+        # auto-invalidates any previously-cached toolchain — no coupled
+        # version bump required.
         id: musl-cross-cache
         uses: actions/cache@v4
         with:
           path: /opt/${{ matrix.musl_prefix }}-cross
-          key: musl-cross-${{ matrix.musl_prefix }}-v1
+          key: musl-cross-${{ matrix.musl_prefix }}-${{ matrix.musl_sha256 }}
 
       - name: Install musl-cross toolchain
         # Pinned by sha256: this toolchain links the released binaries, and


### PR DESCRIPTION
## Summary

The Fleet Agent Release workflow's `Build Linux amd64` job (run [29325823587](https://github.com/arcboxlabs/arcbox/actions/runs/29325823587)) failed to compile `ring`:

```
error occurred in cc-rs: failed to find tool "x86_64-linux-musl-ar":
No such file or directory (os error 2)
```

Two independent problems, both stemming from Ubuntu's `musl-tools` being a different beast from FiloSottile's musl-cross:

1. **Toolchain names don't match.** `.cargo/config.toml` pins the musl target's linker/CC/AR to `x86_64-linux-musl-gcc` / `-ar` (what `brew install FiloSottile/musl-cross/musl-cross` provides on the macOS runners). Ubuntu's `musl-tools` only ships `musl-gcc` — no `-ar`, wrong name.
2. **Not actually portable.** Ubuntu's `musl-gcc` wrapper defaults to a PIE with `/lib/ld-musl-x86_64.so.1` as ELF interpreter — the binary still needs a musl dynamic loader at that path, so it won't launch on distros without musl installed. The macOS-built `arcbox-agent` has been fully-static "by accident" because FiloSottile's musl-cross-make defaults the other way.

Fix: install the same underlying toolchain (musl-cross-make) on Linux via musl.cc's prebuilt tarballs — same tool naming, same fully-static defaults. `.cargo/config.toml` then resolves identically on both host OSes; no per-workflow env overrides or `RUSTFLAGS='-static'` hacks needed.

Also cross-compiles both arches from a single `ubuntu-latest` runner (matches how `arcbox-agent` is built) and adds a `readelf` check that fails CI if the binary ever regains a `PT_INTERP` header.

Locally verified: `arcbox-fleet-agent` 6.0 MB, `ELF ... static-pie linked, stripped`, no INTERP, no dynamic loader dependency.

## Test plan

- [ ] CI on this PR passes (proto checks + macOS build; the Linux path only runs on tag push / dispatch)
- [ ] After merge, dispatch `Fleet Agent Release` workflow with `tag: fleet-agent-v0.1.0` and confirm both Linux jobs build + upload
- [ ] Confirm the "Verify artifact is fully static" step passes (readelf finds no INTERP)
- [ ] Spot-check one of the uploaded release binaries: `file arcbox-fleet-agent-linux-amd64` → `static-pie linked`; runs on a bare-bones distro (e.g. `docker run --rm -v $PWD:/w alpine /w/arcbox-fleet-agent --help`)