### PR TITLE
fix(ci): vendor musl-cross toolchain to a GitHub Release

### DIFF
--- a/.github/workflows/release-fleet-agent.yml
+++ b/.github/workflows/release-fleet-agent.yml
@@ -197,17 +197,23 @@ jobs:
           key: musl-cross-${{ matrix.musl_prefix }}-${{ matrix.musl_sha256 }}
 
       - name: Install musl-cross toolchain
-        # Pinned by sha256: this toolchain links the released binaries, and
+        # Downloaded from our own vendored release (mirror of the same
+        # musl.cc tarballs, verified by sha256 at upload time). Points off
+        # musl.cc's single-maintainer host — it's been unreliable from
+        # GHA runners — and keeps release bandwidth on GitHub's CDN.
+        # Pinned by sha256: this toolchain links the released binaries and
         # Linux release artifacts aren't codesigned, so a bad tarball would
-        # silently backdoor every Linux release. musl.cc is a single-
-        # maintainer host — retry + cache handle transient outages, the
-        # digest handles bad content.
+        # silently backdoor every Linux release. The digest is also baked
+        # into the cache key above, so bumping the tarball auto-invalidates
+        # any previously-cached toolchain.
         if: steps.musl-cross-cache.outputs.cache-hit != 'true'
+        env:
+          MUSL_CROSS_RELEASE: musl-cross-2021-11-23
         run: |
           set -euo pipefail
           curl -fsSL --retry 5 --retry-all-errors \
             -o /tmp/musl-cross.tgz \
-            "https://musl.cc/${{ matrix.musl_prefix }}-cross.tgz"
+            "https://github.com/${{ github.repository }}/releases/download/${MUSL_CROSS_RELEASE}/${{ matrix.musl_prefix }}-cross.tgz"
           echo "${{ matrix.musl_sha256 }}  /tmp/musl-cross.tgz" | sha256sum -c -
           sudo tar -xf /tmp/musl-cross.tgz -C /opt
           rm /tmp/musl-cross.tgz


### PR DESCRIPTION
## Summary

Follow-up to #386. The Fleet Agent Release run on `fleet-agent-v0.1.0` (run [29330152267](https://github.com/arcboxlabs/arcbox/actions/runs/29330152267)) stalled both Linux jobs on the musl.cc download for the full 20-minute timeout — the single-maintainer-host failure mode both pullfrog and greptile called out during review of #386.

Rather than keep our release pipeline hostage to musl.cc's reachability from GHA runners, mirror the two tarballs into a repo-owned pre-release ([musl-cross-2021-11-23](https://github.com/arcboxlabs/arcbox/releases/tag/musl-cross-2021-11-23)) and point the workflow at those URLs. GitHub Releases sits behind the same CDN as github.com, so runner ↔ release fetches are internal-fast and we're not leaning on someone else's server for our release bandwidth.

## Changes

- New pre-release `musl-cross-2021-11-23` with the two `.tgz` assets. Same content, same sha256 as the previously-pinned musl.cc tarballs.
- Workflow now curls `https://github.com/${{ github.repository }}/releases/download/musl-cross-2021-11-23/${prefix}-cross.tgz`. Using `github.repository` keeps the URL rename-safe on the upstream repo. Fork-triggered release runs would 404 here (releases don't clone to forks) — that's acceptable since publishing a fleet-agent release from a fork isn't a supported workflow: a fork wanting to release its own build would need to vendor its own `musl-cross-*` release anyway.
- sha256 verification stays in place. Digest is still baked into the cache key, so any future tarball refresh auto-invalidates the cache.
- Refresh procedure documented in the release notes: new tag `musl-cross-<upstream-last-modified>`, update `musl_sha256` in the matrix.

## Test plan

- [ ] CI on this PR passes
- [ ] After merge, re-dispatch `Fleet Agent Release` with `tag: fleet-agent-v0.1.0` and confirm both Linux jobs complete in ~normal time (previously timed out at 20m)
- [ ] Confirm the "Verify artifact is fully static" step passes on both arches
- [ ] Spot-check `file <artifact>` on the uploaded release binaries → `static-pie linked`, no INTERP