### PR TITLE
chore(release-please): drop release-as pin for fleet-agent

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -32,7 +32,6 @@
     "fleet": {
       "component": "fleet-agent",
       "include-component-in-tag": true,
-      "release-as": "0.1.0",
       "extra-files": [
         {
           "type": "generic",


### PR DESCRIPTION
## Summary

`packages.fleet."release-as": "0.1.0"` in `release-please-config.json` was a one-shot bootstrap pin to force the fleet-agent's first release to be exactly 0.1.0. Now that 0.1.0 has actually shipped (release live at [fleet-agent-v0.1.0](https://github.com/arcboxlabs/arcbox/releases/tag/fleet-agent-v0.1.0), manifest records `"fleet": "0.1.0"`), keeping the pin would clobber any natural version bump on the next release-please run.

Dropping it hands control back to conventional-commit-driven semver — `fix(fleet-agent):` → patch, `feat(fleet-agent):` → minor, breaking → major (once we're past 1.0).

## Test plan

- [ ] Next release-please run against master proposes a release PR only when there's new fleet-agent history since v0.1.0
- [ ] When it does propose one, the version increment matches the commit types since v0.1.0 (not stuck on 0.1.0)