### PR TITLE
feat(ci): mirror fleet-agent binaries to release CDN

### DIFF
--- a/.github/workflows/release-fleet-agent.yml
+++ b/.github/workflows/release-fleet-agent.yml
@@ -263,6 +263,93 @@ jobs:
           path: target/${{ matrix.target }}/release/arcbox-fleet-agent
           retention-days: 5
 
+  # Mirror the fleet-agent binaries to the release CDN
+  # (release.arcboxcdn.com, backed by Backblaze B2). This is the primary
+  # distribution channel the gateway resolves for AgentUpdate.binary_url —
+  # the URL is a pure function of (version, host_os, host_arch):
+  #
+  #   https://release.arcboxcdn.com/runner/${version}/arcbox-fleet-agent-${os}-${arch}
+  #
+  # `${version}` is the git tag with the `fleet-agent-` component prefix
+  # stripped (so `fleet-agent-v0.1.0` → `v0.1.0`) — under `runner/` the
+  # component prefix is redundant, and the leading `v` matches semver-tag
+  # convention. `--size-only` on the sync is safe because the artifacts
+  # under a version are immutable; re-releasing the same version is a
+  # workflow re-dispatch, not a content-differs replace.
+  upload-cdn:
+    name: Upload to CDN
+    needs: [version, build-macos, build-linux]
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.version.outputs.tag }}
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Download binaries
+        uses: actions/download-artifact@v4
+        with:
+          pattern: fleet-agent-binary-*
+          path: artifacts/
+
+      - name: Stage assets
+        id: stage
+        run: |
+          set -eu
+          TAG="${{ needs.version.outputs.tag }}"
+          VERSION="${TAG#fleet-agent-}"
+          mkdir -p "cdn-staging/runner/${VERSION}"
+          for platform in darwin-arm64 darwin-amd64 linux-amd64 linux-arm64; do
+            cargo xtask release fleet-asset \
+              --platform "$platform" \
+              --binary "artifacts/fleet-agent-binary-$platform/arcbox-fleet-agent"
+          done
+          mv arcbox-fleet-agent-* "cdn-staging/runner/${VERSION}/"
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "=== CDN staging ==="
+          find "cdn-staging/runner/${VERSION}" -type f | sort
+
+      - name: Upload to B2 (size-only, immutable)
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.RELEASE_B2_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.RELEASE_B2_SECRET_ACCESS_KEY }}
+          AWS_REGION: ${{ secrets.RELEASE_B2_REGION }}
+        run: |
+          VERSION="${{ steps.stage.outputs.version }}"
+          aws s3 sync \
+            "cdn-staging/runner/${VERSION}/" \
+            "s3://${{ secrets.RELEASE_B2_BUCKET }}/runner/${VERSION}/" \
+            --endpoint-url "https://s3.${{ secrets.RELEASE_B2_REGION }}.backblazeb2.com" \
+            --size-only
+
+      - name: Verify CDN URLs
+        uses: actions/github-script@v7
+        env:
+          VERSION: ${{ steps.stage.outputs.version }}
+        with:
+          script: |
+            const { VERSION } = process.env;
+            await new Promise((r) => setTimeout(r, 5000));
+            const platforms = ['darwin-arm64', 'darwin-amd64', 'linux-amd64', 'linux-arm64'];
+            let failed = false;
+            for (const p of platforms) {
+              const url = `https://release.arcboxcdn.com/runner/${VERSION}/arcbox-fleet-agent-${p}`;
+              let status = 0;
+              try {
+                status = (await fetch(url, { method: 'HEAD', signal: AbortSignal.timeout(15000) })).status;
+              } catch { /* status stays 0 */ }
+              core.info(`CDN check: ${url} -> HTTP ${status}`);
+              if (status !== 200) {
+                core.warning(`CDN returned HTTP ${status} for ${url}`);
+                failed = true;
+              }
+            }
+            if (failed) core.warning('Some CDN URLs did not return HTTP 200 — check propagation');
+
   publish:
     name: Publish Release Assets
     needs: [version, build-macos, build-linux]

--- a/.github/workflows/release-fleet-agent.yml
+++ b/.github/workflows/release-fleet-agent.yml
@@ -268,14 +268,16 @@ jobs:
   # distribution channel the gateway resolves for AgentUpdate.binary_url —
   # the URL is a pure function of (version, host_os, host_arch):
   #
-  #   https://release.arcboxcdn.com/runner/${version}/arcbox-fleet-agent-${os}-${arch}
+  #   https://release.arcboxcdn.com/runner/fleet-agent/${version}/arcbox-fleet-agent-${os}-${arch}
   #
-  # `${version}` is the git tag with the `fleet-agent-` component prefix
-  # stripped (so `fleet-agent-v0.1.0` → `v0.1.0`) — under `runner/` the
-  # component prefix is redundant, and the leading `v` matches semver-tag
-  # convention. `--size-only` on the sync is safe because the artifacts
-  # under a version are immutable; re-releasing the same version is a
-  # workflow re-dispatch, not a content-differs replace.
+  # Layout: `runner/` is the top-level namespace for runner-side
+  # components; `fleet-agent/` is this specific component, leaving room
+  # for sibling components at `runner/<other>/...` without collision.
+  # `${version}` is the git tag with the `fleet-agent-` prefix stripped
+  # (so `fleet-agent-v0.1.0` → `v0.1.0`). `--size-only` on the sync is
+  # safe because the artifacts under a version are immutable;
+  # re-releasing the same version is a workflow re-dispatch, not a
+  # content-differs replace.
   upload-cdn:
     name: Upload to CDN
     needs: [version, build-macos, build-linux]
@@ -302,16 +304,16 @@ jobs:
           set -eu
           TAG="${{ needs.version.outputs.tag }}"
           VERSION="${TAG#fleet-agent-}"
-          mkdir -p "cdn-staging/runner/${VERSION}"
+          mkdir -p "cdn-staging/runner/fleet-agent/${VERSION}"
           for platform in darwin-arm64 darwin-amd64 linux-amd64 linux-arm64; do
             cargo xtask release fleet-asset \
               --platform "$platform" \
               --binary "artifacts/fleet-agent-binary-$platform/arcbox-fleet-agent"
           done
-          mv arcbox-fleet-agent-* "cdn-staging/runner/${VERSION}/"
+          mv arcbox-fleet-agent-* "cdn-staging/runner/fleet-agent/${VERSION}/"
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
           echo "=== CDN staging ==="
-          find "cdn-staging/runner/${VERSION}" -type f | sort
+          find "cdn-staging/runner/fleet-agent/${VERSION}" -type f | sort
 
       - name: Upload to B2 (size-only, immutable)
         env:
@@ -321,8 +323,8 @@ jobs:
         run: |
           VERSION="${{ steps.stage.outputs.version }}"
           aws s3 sync \
-            "cdn-staging/runner/${VERSION}/" \
-            "s3://${{ secrets.RELEASE_B2_BUCKET }}/runner/${VERSION}/" \
+            "cdn-staging/runner/fleet-agent/${VERSION}/" \
+            "s3://${{ secrets.RELEASE_B2_BUCKET }}/runner/fleet-agent/${VERSION}/" \
             --endpoint-url "https://s3.${{ secrets.RELEASE_B2_REGION }}.backblazeb2.com" \
             --size-only
 
@@ -337,7 +339,7 @@ jobs:
             const platforms = ['darwin-arm64', 'darwin-amd64', 'linux-amd64', 'linux-arm64'];
             let failed = false;
             for (const p of platforms) {
-              const url = `https://release.arcboxcdn.com/runner/${VERSION}/arcbox-fleet-agent-${p}`;
+              const url = `https://release.arcboxcdn.com/runner/fleet-agent/${VERSION}/arcbox-fleet-agent-${p}`;
               let status = 0;
               try {
                 status = (await fetch(url, { method: 'HEAD', signal: AbortSignal.timeout(15000) })).status;

--- a/.github/workflows/release-fleet-agent.yml
+++ b/.github/workflows/release-fleet-agent.yml
@@ -300,6 +300,11 @@ jobs:
 
       - name: Stage assets
         id: stage
+        # Also writes runner/fleet-agent/latest.json for stable releases so
+        # consumers can resolve the current version without hitting the
+        # GitHub API. A pre-release tag (`v0.1.0-rc.1`, `v0.2.0-beta.2`,
+        # etc. — anything with a `-` in the version string) keeps its
+        # binaries uploaded but does NOT clobber latest.json.
         run: |
           set -eu
           TAG="${{ needs.version.outputs.tag }}"
@@ -311,11 +316,20 @@ jobs:
               --binary "artifacts/fleet-agent-binary-$platform/arcbox-fleet-agent"
           done
           mv arcbox-fleet-agent-* "cdn-staging/runner/fleet-agent/${VERSION}/"
-          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
-          echo "=== CDN staging ==="
-          find "cdn-staging/runner/fleet-agent/${VERSION}" -type f | sort
 
-      - name: Upload to B2 (size-only, immutable)
+          IS_STABLE=false
+          if [[ "$VERSION" != *-* ]]; then
+            IS_STABLE=true
+            printf '{"version":"%s"}\n' "$VERSION" \
+              > "cdn-staging/runner/fleet-agent/latest.json"
+          fi
+
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "is_stable=${IS_STABLE}" >> "$GITHUB_OUTPUT"
+          echo "=== CDN staging ==="
+          find "cdn-staging/runner/fleet-agent" -type f | sort
+
+      - name: Upload binaries to B2 (size-only, immutable)
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.RELEASE_B2_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.RELEASE_B2_SECRET_ACCESS_KEY }}
@@ -328,13 +342,27 @@ jobs:
             --endpoint-url "https://s3.${{ secrets.RELEASE_B2_REGION }}.backblazeb2.com" \
             --size-only
 
+      - name: Upload latest.json to B2
+        if: steps.stage.outputs.is_stable == 'true'
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.RELEASE_B2_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.RELEASE_B2_SECRET_ACCESS_KEY }}
+          AWS_REGION: ${{ secrets.RELEASE_B2_REGION }}
+        run: |
+          aws s3 cp \
+            "cdn-staging/runner/fleet-agent/latest.json" \
+            "s3://${{ secrets.RELEASE_B2_BUCKET }}/runner/fleet-agent/latest.json" \
+            --endpoint-url "https://s3.${{ secrets.RELEASE_B2_REGION }}.backblazeb2.com" \
+            --content-type "application/json"
+
       - name: Verify CDN URLs
         uses: actions/github-script@v7
         env:
           VERSION: ${{ steps.stage.outputs.version }}
+          IS_STABLE: ${{ steps.stage.outputs.is_stable }}
         with:
           script: |
-            const { VERSION } = process.env;
+            const { VERSION, IS_STABLE } = process.env;
             await new Promise((r) => setTimeout(r, 5000));
             const platforms = ['darwin-arm64', 'darwin-amd64', 'linux-amd64', 'linux-arm64'];
             let failed = false;
@@ -350,7 +378,24 @@ jobs:
                 failed = true;
               }
             }
-            if (failed) core.warning('Some CDN URLs did not return HTTP 200 — check propagation');
+            if (IS_STABLE === 'true') {
+              const url = 'https://release.arcboxcdn.com/runner/fleet-agent/latest.json';
+              let status = 0, body = null;
+              try {
+                const res = await fetch(url, { signal: AbortSignal.timeout(15000) });
+                status = res.status;
+                if (res.ok) body = await res.json();
+              } catch { /* status stays 0 */ }
+              core.info(`CDN check: ${url} -> HTTP ${status} (body: ${JSON.stringify(body)})`);
+              if (status !== 200) {
+                core.warning(`latest.json returned HTTP ${status}`);
+                failed = true;
+              } else if (body?.version !== VERSION) {
+                core.warning(`latest.json version=${body?.version}, expected ${VERSION} (propagation lag likely)`);
+                failed = true;
+              }
+            }
+            if (failed) core.warning('Some CDN URLs did not return the expected state — check propagation');
 
   publish:
     name: Publish Release Assets


### PR DESCRIPTION
## Summary

Adds an `upload-cdn` job to `release-fleet-agent.yml` that mirrors the four fleet-agent binaries (+ `.sha256`) to `release.arcboxcdn.com` — the primary distribution channel the gateway resolves for `AgentUpdate.binary_url`. Also publishes a small `latest.json` pointer for the current stable version.

Runs in parallel to the existing `publish` job (GitHub Release upload). GH Release stays as a human-facing artifact store; the CDN is what the gateway actually points agents at.

## Layout

```
https://release.arcboxcdn.com/runner/fleet-agent/latest.json
                                             ├── v0.1.0/
                                             │   ├── arcbox-fleet-agent-darwin-amd64
                                             │   ├── arcbox-fleet-agent-darwin-amd64.sha256
                                             │   ├── arcbox-fleet-agent-darwin-arm64
                                             │   ├── arcbox-fleet-agent-darwin-arm64.sha256
                                             │   ├── arcbox-fleet-agent-linux-amd64
                                             │   ├── arcbox-fleet-agent-linux-amd64.sha256
                                             │   ├── arcbox-fleet-agent-linux-arm64
                                             │   └── arcbox-fleet-agent-linux-arm64.sha256
                                             └── ...
```

- `runner/` is the top-level namespace for runner-side components; `fleet-agent/` is the component slot, leaving room for siblings (`runner/<other>/...`) without collision.
- `${version}` is the git tag with the `fleet-agent-` component prefix stripped, so `fleet-agent-v0.1.0` → `v0.1.0`.
- `latest.json` shape: `{"version": "v0.1.0"}` — deliberately minimal; sha256s and per-arch URLs remain derivable from `(version, os, arch)`.
- **Pre-release tags** (anything with a `-` in the version string, e.g. `v0.1.0-rc.1`) upload their binaries but do NOT overwrite `latest.json`. Stable tags overwrite unconditionally — re-dispatching an old stable tag would revert `latest.json`.

## Reused patterns from arcbox-desktop

- `aws s3 sync --size-only` against the Backblaze S3 endpoint (safe for immutable per-version artifacts)
- `aws s3 cp --content-type application/json` for `latest.json`
- HTTP HEAD verify with a 5s propagation delay, non-blocking (`core.warning`, not `setFailed`) — matches desktop's approach
- Org-level secrets already in place: `RELEASE_B2_BUCKET`, `RELEASE_B2_REGION`, `RELEASE_B2_ACCESS_KEY_ID`, `RELEASE_B2_SECRET_ACCESS_KEY`

## Test plan

- [ ] CI on this PR passes (YAML validates; no build/test impact)
- [ ] After merge, re-dispatch `Fleet Agent Release` with `tag: fleet-agent-v0.1.0` and confirm the new `Upload to CDN` job completes green
- [ ] `curl -I https://release.arcboxcdn.com/runner/fleet-agent/v0.1.0/arcbox-fleet-agent-linux-amd64` → HTTP 200 (all four platforms)
- [ ] `curl https://release.arcboxcdn.com/runner/fleet-agent/latest.json` → `{"version": "v0.1.0"}`
- [ ] Download the amd64 binary via CDN URL, hash it, confirm it matches the `.sha256` sibling