### PR TITLE
refactor(fleet): isolate socketless lifecycle commands under quick

### DIFF
--- a/fleet/arcbox-fleet-agent/src/config.rs
+++ b/fleet/arcbox-fleet-agent/src/config.rs
@@ -9,6 +9,8 @@ use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
 use tonic::transport::{ClientTlsConfig, Endpoint};
 
+use crate::credentials::CredentialStore;
+
 /// Production gateway endpoint. Overridable via `ARCBOX_FLEET_GATEWAY` for
 /// local/e2e testing (e.g. `http://127.0.0.1:50061`).
 pub const DEFAULT_GATEWAY: &str = "https://fleet.arcbox.dev";
@@ -153,6 +155,13 @@ impl AgentConfig {
     /// Path to the persisted machine credential.
     pub fn credentials_path(&self) -> PathBuf {
         self.data_dir.join("credentials.json")
+    }
+
+    /// Build the credential store scoped to `gateway`. Stores are constructed
+    /// per operation because the keychain backend keys entries by gateway URI,
+    /// and the effective gateway can change over the process lifetime.
+    pub fn credential_store_for(&self, gateway: &str) -> CredentialStore {
+        CredentialStore::new(self.credential_store, self.credentials_path(), gateway)
     }
 
     /// Path to the local control-plane Unix socket.

--- a/fleet/arcbox-fleet-agent/src/config.rs
+++ b/fleet/arcbox-fleet-agent/src/config.rs
@@ -70,7 +70,7 @@ pub struct AgentConfig {
     pub gateway: String,
     /// Direct path to the pre-installed GitHub Actions runner's entry point
     /// (`run.sh`) — not its containing directory. `None` until set; required
-    /// only by the `run` command.
+    /// only by the `quick run` command.
     pub runner_script: Option<PathBuf>,
     /// Reject an offer when 1-minute load average per core exceeds this.
     pub load_ceiling: f64,

--- a/fleet/arcbox-fleet-agent/src/control/mod.rs
+++ b/fleet/arcbox-fleet-agent/src/control/mod.rs
@@ -227,10 +227,10 @@ enum State {
 
 /// Owns the agent's enrollment state machine.
 ///
-/// `Run` no longer requires a credential up front: with none on disk the
+/// The `serve` command does not require a credential up front: with none on disk the
 /// agent starts `Unenrolled` and idles until `Enroll` delivers one — the
-/// desktop-managed handoff (RUN-8) — while the CLI's one-shot `enroll`
-/// subcommand still works entirely offline, before this process even starts.
+/// desktop-managed handoff (RUN-8) — while the CLI's `quick enroll`
+/// subcommand works entirely offline, before this process even starts.
 pub struct AgentSupervisor {
     config: AgentConfig,
     docker: Option<DockerRunner>,

--- a/fleet/arcbox-fleet-agent/src/control/mod.rs
+++ b/fleet/arcbox-fleet-agent/src/control/mod.rs
@@ -32,7 +32,7 @@ use tonic::transport::Server;
 use tracing::{info, warn};
 
 use crate::config::AgentConfig;
-use crate::credentials::{Credential, CredentialStore};
+use crate::credentials::Credential;
 use crate::docker::DockerRunner;
 use crate::runner::RunnerSupervisor;
 use crate::settings::SettingsStore;
@@ -115,12 +115,6 @@ pub async fn serve(
 /// own runner teardown is separately bounded by `attach::run`'s
 /// `SHUTDOWN_GRACE`; this only needs to cover that plus scheduling overhead.
 const TEARDOWN_GRACE: Duration = Duration::from_secs(20);
-
-/// Bound on the best-effort gateway `Unenroll` call inside
-/// [`AgentSupervisor::unenroll`]. Generous for a healthy round-trip, but a
-/// blackholed gateway (no connect timeout is configured on the endpoint)
-/// must not hang the RPC — the local clear proceeds without the server half.
-const GATEWAY_UNENROLL_TIMEOUT: Duration = Duration::from_secs(10);
 
 /// Wait up to `grace` for `task` to finish on its own; if it doesn't, abort
 /// it and wait for that reap too, so `task` is guaranteed stopped by the
@@ -269,7 +263,7 @@ impl AgentSupervisor {
             settings_store,
         };
         let gateway = this.agent_state.gateway_target();
-        let existing = this.credential_store_for(&gateway).load()?;
+        let existing = this.config.credential_store_for(&gateway).load()?;
         if let Some(credential) = existing {
             if this.agent_state.participate_target() {
                 info!(machine_id = %credential.machine_id, "starting fleet agent (credential on disk)");
@@ -287,19 +281,6 @@ impl AgentSupervisor {
             }
         }
         Ok(this)
-    }
-
-    /// The credential store scoped to `gateway`. Built per operation rather
-    /// than held: the keychain backend keys its entry by gateway URI, and the
-    /// effective gateway can change over this supervisor's lifetime (an
-    /// `Enroll` `control_plane` override, or a settings update), so a store
-    /// captured at startup could read or clear the wrong entry.
-    fn credential_store_for(&self, gateway: &str) -> CredentialStore {
-        CredentialStore::new(
-            self.config.credential_store,
-            self.config.credentials_path(),
-            gateway,
-        )
     }
 
     /// A handle to the process-lifetime Docker runtime, if configured — read
@@ -445,7 +426,8 @@ impl AgentSupervisor {
 
         // Scoped to the gateway just persisted above, so the restart load
         // finds it under the same key.
-        self.credential_store_for(&gateway)
+        self.config
+            .credential_store_for(&gateway)
             .store(&credential)
             .map_err(Internal)?;
 
@@ -533,35 +515,14 @@ impl AgentSupervisor {
             self.agent_state.set_enrollment(Enrollment::Unenrolled, "");
         }
 
-        // The server half, best-effort and time-bounded: decommission the
-        // machine and revoke the credential at the gateway (RUN-40). An
-        // unreachable gateway must not block leaving — proceed with the
-        // local clear, and the org can decommission the leftover record
-        // from its side.
-        match tokio::time::timeout(
-            GATEWAY_UNENROLL_TIMEOUT,
-            enroll::unenroll(&self.config, &credential_gateway, &credential.machine_token),
-        )
-        .await
-        {
-            Ok(Ok(())) => {}
-            Ok(Err(e)) => {
-                warn!(error = %e, gateway = %credential_gateway,
-                      "gateway unenroll failed; clearing the local credential anyway");
-            }
-            Err(_) => {
-                warn!(gateway = %credential_gateway,
-                      "gateway unenroll timed out; clearing the local credential anyway");
-            }
-        }
-
         // Keyed by the gateway this attachment enrolled against, not the
         // live `gateway_target`, which a settings update may have moved
         // while attached (see `Attachment::credential_gateway`).
-        Ok(self
-            .credential_store_for(&credential_gateway)
-            .clear()
-            .map_err(Internal)?)
+        Ok(
+            enroll::unenroll_and_clear(&self.config, &credential_gateway, &credential)
+                .await
+                .map_err(Internal)?,
+        )
     }
 
     /// Converge the attachment onto the `participate` target: detach (keep
@@ -898,7 +859,7 @@ mod tests {
         let agent_state = AgentState::new(&seed());
         let supervisor = test_supervisor(&dir, agent_state.clone()).await;
 
-        let store = supervisor.credential_store_for("http://127.0.0.1:1");
+        let store = supervisor.config.credential_store_for("http://127.0.0.1:1");
         store
             .store(&test_credential())
             .expect("persist test credential");
@@ -926,13 +887,10 @@ mod tests {
     async fn startup_honors_persisted_participate_false() {
         let dir = std::env::temp_dir().join(format!("fleet-start-det-{}", std::process::id()));
         let config = test_config(dir.clone());
-        CredentialStore::new(
-            config.credential_store,
-            config.credentials_path(),
-            "http://127.0.0.1:1",
-        )
-        .store(&test_credential())
-        .expect("persist test credential");
+        config
+            .credential_store_for("http://127.0.0.1:1")
+            .store(&test_credential())
+            .expect("persist test credential");
 
         let agent_state = AgentState::new(&PersistedSettings {
             participate: false,
@@ -1002,7 +960,7 @@ mod tests {
             machine_id: "fltm_test".to_owned(),
             machine_token: "flt_token_test".to_owned(),
         };
-        let store = supervisor.credential_store_for("http://127.0.0.1:1");
+        let store = supervisor.config.credential_store_for("http://127.0.0.1:1");
         store.store(&credential).expect("persist test credential");
         *supervisor.state.lock().await = State::Attached(Attachment {
             supervisor: runner,

--- a/fleet/arcbox-fleet-agent/src/enroll.rs
+++ b/fleet/arcbox-fleet-agent/src/enroll.rs
@@ -2,15 +2,22 @@
 //! machine credential) and unenroll (decommission the machine, revoking
 //! that credential server-side).
 
+use std::time::Duration;
+
 use anyhow::{Context, Result};
 use arcbox_fleet_proto::v1::fleet_gateway_service_client::FleetGatewayServiceClient;
 use arcbox_fleet_proto::v1::{Capability, EnrollRequest, UnenrollRequest};
-use tracing::info;
+use tracing::{info, warn};
 
 use crate::attach::authenticated_request;
 use crate::config::{AgentConfig, PROTOCOL_VERSION};
 use crate::credentials::Credential;
 use crate::host;
+
+/// Bound on the best-effort gateway `Unenroll` call. Generous for a healthy
+/// round-trip, but a blackholed gateway must not prevent the terminal local
+/// credential clear.
+const GATEWAY_UNENROLL_TIMEOUT: Duration = Duration::from_secs(10);
 
 /// Call `Enroll` on `gateway` and return the machine credential — persisting
 /// it is the caller's job, done only once the caller has committed to the
@@ -59,12 +66,43 @@ pub async fn enroll(
     Ok(credential)
 }
 
-/// Call `Unenroll` on `gateway`, authenticated with `machine_token` — the
-/// server half of leaving the fleet: marks the machine decommissioned and
-/// revokes this credential. `UNAUTHENTICATED` means the credential is
-/// already revoked, which is exactly the state unenrolling wants, so it
-/// counts as success.
-pub async fn unenroll(config: &AgentConfig, gateway: &str, machine_token: &str) -> Result<()> {
+/// Decommission the machine at `gateway` on a best-effort, time-bounded basis,
+/// then remove its persisted credential unconditionally. Both control-plane
+/// and socketless unenrollment use this terminal workflow so remote failures
+/// cannot leave the host believing it is still enrolled.
+pub async fn unenroll_and_clear(
+    config: &AgentConfig,
+    gateway: &str,
+    credential: &Credential,
+) -> Result<()> {
+    match tokio::time::timeout(
+        GATEWAY_UNENROLL_TIMEOUT,
+        unenroll_gateway(config, gateway, &credential.machine_token),
+    )
+    .await
+    {
+        Ok(Ok(())) => {}
+        Ok(Err(e)) => {
+            warn!(
+                error = %e,
+                gateway,
+                "gateway unenroll failed; clearing the local credential anyway"
+            );
+        }
+        Err(_) => {
+            warn!(
+                gateway,
+                "gateway unenroll timed out; clearing the local credential anyway"
+            );
+        }
+    }
+
+    config.credential_store_for(gateway).clear()
+}
+
+/// Call `Unenroll` on `gateway`, authenticated with `machine_token`. An
+/// already-revoked credential is the desired outcome and counts as success.
+async fn unenroll_gateway(config: &AgentConfig, gateway: &str, machine_token: &str) -> Result<()> {
     let channel = config
         .endpoint_for(gateway)?
         .connect()

--- a/fleet/arcbox-fleet-agent/src/enroll.rs
+++ b/fleet/arcbox-fleet-agent/src/enroll.rs
@@ -14,13 +14,13 @@ use crate::host;
 
 /// Call `Enroll` on `gateway` and return the machine credential — persisting
 /// it is the caller's job, done only once the caller has committed to the
-/// result: the CLI `enroll` subcommand stores it straight away, while the
-/// control-plane `Enroll` RPC stores it only after winning the enrollment
+/// result: the CLI `quick enroll` subcommand stores it straight away, while
+/// the control-plane `Enroll` RPC stores it only after winning the enrollment
 /// race, so a losing concurrent enroll never overwrites the winner's
 /// credential (see `AgentSupervisor::enroll`). The caller also resolves
-/// `gateway`: the CLI uses the persisted-settings (or configured default)
-/// gateway; the RPC uses its `control_plane` override if given, else the
-/// current settings target.
+/// `gateway`: `quick enroll` uses the persisted-settings (or configured
+/// default) gateway; the RPC uses its `control_plane` override if given, else
+/// the current settings target.
 pub async fn enroll(
     config: &AgentConfig,
     token: String,

--- a/fleet/arcbox-fleet-agent/src/fsutil.rs
+++ b/fleet/arcbox-fleet-agent/src/fsutil.rs
@@ -1,7 +1,7 @@
 //! Small filesystem helper shared by anything that persists state to the
 //! data directory with an owner-only file mode. The directory itself gets
 //! the same owner-only barrier: callers persist secrets here from paths
-//! that never run `control::serve` (the headless `enroll`), so the helper
+//! that never run `control::serve` (the headless `quick enroll`), so the helper
 //! cannot rely on the socket startup's chmod.
 
 use std::path::{Path, PathBuf};
@@ -46,7 +46,7 @@ pub fn write_json_atomic<T: Serialize>(path: &Path, value: &T) -> Result<()> {
         // Owner-only like the file below, and unconditional (not just on
         // creation) so a dir left behind by an older or umask-lenient run
         // gets the same traversal barrier `control::serve` applies at
-        // startup — the headless `enroll` persists here without `serve`.
+        // startup — the headless `quick enroll` persists here without `serve`.
         std::fs::set_permissions(parent, std::fs::Permissions::from_mode(0o700))
             .with_context(|| format!("chmod 0700 {}", parent.display()))?;
     }
@@ -65,7 +65,7 @@ mod tests {
     use std::os::unix::fs::PermissionsExt;
 
     /// The parent directory must come out owner-only even when this write is
-    /// what creates it (the headless `enroll` path, which never runs
+    /// what creates it (the headless `quick enroll` path, which never runs
     /// `control::serve`), and even when it pre-exists with a lenient mode.
     #[test]
     fn write_json_atomic_makes_the_parent_owner_only() {

--- a/fleet/arcbox-fleet-agent/src/main.rs
+++ b/fleet/arcbox-fleet-agent/src/main.rs
@@ -74,8 +74,8 @@ enum Command {
     /// Start the local control-plane API (`agent.sock`) and, once enrolled,
     /// attach to the gateway and run dispatched jobs until terminated.
     ///
-    /// Unlike `run`, a credential is not required at startup: if one is
-    /// already persisted this behaves like `run`, but with none it idles
+    /// Unlike `quick run`, a credential is not required at startup: if one is
+    /// already persisted this behaves like `quick run`, but with none it idles
     /// until an `Enroll` call arrives over the socket (the desktop-managed
     /// handoff) or `unenroll`/`enroll` change that from another
     /// invocation. This is what a launchd LaunchAgent should invoke.
@@ -235,7 +235,7 @@ async fn run(command: Command, config: AgentConfig) -> Result<()> {
             // runners once this fires.
             let shutdown = spawn_shutdown_signal("termination signal received; draining runners");
 
-            // `run` opens no control socket, so nothing ever subscribes to
+            // `quick run` opens no control socket, so nothing ever subscribes to
             // this over `Watch` — but `RunnerSupervisor` still reads
             // admission thresholds live from it, so it's load-bearing.
             let agent_state = AgentState::new(&seed);

--- a/fleet/arcbox-fleet-agent/src/main.rs
+++ b/fleet/arcbox-fleet-agent/src/main.rs
@@ -53,7 +53,6 @@ use tokio_util::sync::CancellationToken;
 use tracing::{info, warn};
 
 use crate::config::{AgentConfig, DockerMode};
-use crate::credentials::CredentialStore;
 use crate::docker::DockerRunner;
 use crate::settings::{PersistedSettings, SettingsStore};
 use crate::state::AgentState;
@@ -117,6 +116,11 @@ enum QuickCommand {
     /// Requires a credential from a prior `quick enroll` and does not expose
     /// the local control-plane API.
     Run,
+    /// Decommission the machine and remove its persisted credential without
+    /// contacting a running control server.
+    ///
+    /// Does not stop a concurrently running `quick run` process.
+    Unenroll,
 }
 
 #[derive(Debug, Args)]
@@ -212,12 +216,9 @@ async fn run(command: Command, config: AgentConfig) -> Result<()> {
             // without probing the runtime.
             let capabilities = capabilities(seed.runner_script.is_some(), None);
             let credential = enroll::enroll(&config, token, capabilities, &seed.gateway).await?;
-            CredentialStore::new(
-                config.credential_store,
-                config.credentials_path(),
-                &seed.gateway,
-            )
-            .store(&credential)?;
+            config
+                .credential_store_for(&seed.gateway)
+                .store(&credential)?;
             Ok(())
         }
         Command::Quick(QuickCommand::Run) => {
@@ -225,13 +226,7 @@ async fn run(command: Command, config: AgentConfig) -> Result<()> {
             let seed = load_or_seed_settings(&settings_store, &config)?;
             let docker = init_docker(seed.docker_mode, &seed.linux_runner_image).await?;
             let capabilities = capabilities(seed.runner_script.is_some(), docker.as_ref());
-            let credential = CredentialStore::new(
-                config.credential_store,
-                config.credentials_path(),
-                &seed.gateway,
-            )
-            .load()?
-            .context(
+            let credential = config.credential_store_for(&seed.gateway).load()?.context(
                 "no credential found — run `arcbox-fleet-agent quick enroll --token-file …` first",
             )?;
             info!(machine_id = %credential.machine_id, "starting fleet agent");
@@ -260,6 +255,17 @@ async fn run(command: Command, config: AgentConfig) -> Result<()> {
                 agent_state,
             )
             .await
+        }
+        Command::Quick(QuickCommand::Unenroll) => {
+            let settings_store = SettingsStore::new(config.settings_path());
+            let seed = load_or_seed_settings(&settings_store, &config)?;
+            let credential = config
+                .credential_store_for(&seed.gateway)
+                .load()?
+                .context("not enrolled")?;
+            enroll::unenroll_and_clear(&config, &seed.gateway, &credential).await?;
+            println!("unenrolled");
+            Ok(())
         }
         Command::Serve => {
             let settings_store = SettingsStore::new(config.settings_path());

--- a/fleet/arcbox-fleet-agent/src/main.rs
+++ b/fleet/arcbox-fleet-agent/src/main.rs
@@ -6,17 +6,18 @@
 //! is available; other jobs run via the pre-installed runner
 //! (`run.sh --jitconfig …`).
 //!
-//! Configuration is environment-driven (`ARCBOX_FLEET_*`). The `enroll`
-//! subcommand reads the fleet join token from a file (`--token-file`) or stdin
-//! by default; `--token` is accepted for convenience but discouraged, as it
-//! leaks the token through the process argument list and shell history.
+//! Configuration is environment-driven (`ARCBOX_FLEET_*`). The `enroll` and
+//! `quick enroll` subcommands read the fleet join token from a file
+//! (`--token-file`) or stdin by default; `--token` is accepted for convenience
+//! but discouraged, as it leaks the token through the process argument list
+//! and shell history.
 //!
-//! Two ways to run: `run` requires a credential from a prior `enroll` (the
-//! headless/farm path) and does nothing else. `serve` additionally exposes
-//! the local control-plane API on `agent.sock`, and does not require a
-//! credential up front — `enroll`/`drain`/`resume`/`unenroll` can drive it
-//! from another invocation of this CLI, or from the desktop app, while it
-//! runs.
+//! Two ways to run: `quick run` requires a credential from a prior
+//! `quick enroll` (the socketless headless/farm path) and does nothing else.
+//! `serve` additionally exposes the local control-plane API on `agent.sock`,
+//! and does not require a credential up front — `enroll`/`drain`/`resume`/
+//! `unenroll` can drive it from another invocation of this CLI, or from the
+//! desktop app, while it runs.
 
 // The local control-plane API (agent.sock) is a Unix domain socket with no
 // Windows equivalent implemented, so this crate targets macOS and Linux
@@ -47,7 +48,7 @@ use arcbox_fleet_control_proto::v1::fleet_lifecycle_service_client::FleetLifecyc
 use arcbox_fleet_control_proto::v1::fleet_settings_service_client::FleetSettingsServiceClient;
 use arcbox_fleet_proto::v1::Capability;
 use arcbox_logging::LogConfig;
-use clap::{Parser, Subcommand};
+use clap::{Args, Parser, Subcommand};
 use tokio_util::sync::CancellationToken;
 use tracing::{info, warn};
 
@@ -66,30 +67,11 @@ struct Cli {
 
 #[derive(Debug, Subcommand)]
 enum Command {
-    /// Exchange an enrollment token for the machine credential and persist it.
-    ///
-    /// The token is a multi-use fleet join token (valid until it expires or is
-    /// rotated). Provide it via `--token-file`, on stdin, or — discouraged —
-    /// `--token`.
-    Enroll {
-        /// File holding the enrollment token (recommended). Keeps the token out
-        /// of the process argument list, shell history, and service logs.
-        #[arg(long, value_name = "PATH")]
-        token_file: Option<PathBuf>,
-
-        /// Enrollment token passed directly. Convenient but insecure: it leaks
-        /// via the process argument list and shell history. Prefer
-        /// `--token-file`, or pipe the token on stdin.
-        #[arg(long, conflicts_with = "token_file")]
-        token: Option<String>,
-    },
-    /// Attach to the gateway and run dispatched jobs until terminated.
-    ///
-    /// Requires a credential from a prior `enroll` — the headless/farm path,
-    /// unchanged by the local control-plane API. For the desktop-managed
-    /// handoff, where enrollment arrives later over `agent.sock`, use `serve`
-    /// instead.
-    Run,
+    /// Enroll through the running agent's local control socket.
+    Enroll(EnrollArgs),
+    /// Run socketless actions for headless and farm deployments.
+    #[command(subcommand)]
+    Quick(QuickCommand),
     /// Start the local control-plane API (`agent.sock`) and, once enrolled,
     /// attach to the gateway and run dispatched jobs until terminated.
     ///
@@ -108,7 +90,7 @@ enum Command {
     Resume,
     /// Leave the fleet — terminal. Stops attaching and removes the machine
     /// credential; the server keeps the machine record, so a fresh `enroll`
-    /// (or the control-plane `Enroll` RPC) joins as a new machine.
+    /// joins as a new machine.
     Unenroll,
     /// Get or update the running agent's live-settable configuration.
     #[command(subcommand)]
@@ -122,6 +104,33 @@ enum Command {
         /// every kind the agent supports.
         kinds: Vec<String>,
     },
+}
+
+#[derive(Debug, Subcommand)]
+enum QuickCommand {
+    /// Exchange an enrollment token directly with the Fleet gateway and
+    /// persist the resulting machine credential.
+    Enroll(EnrollArgs),
+    /// Attach directly to the gateway and run dispatched jobs until
+    /// terminated.
+    ///
+    /// Requires a credential from a prior `quick enroll` and does not expose
+    /// the local control-plane API.
+    Run,
+}
+
+#[derive(Debug, Args)]
+struct EnrollArgs {
+    /// File holding the enrollment token (recommended). Keeps the token out
+    /// of the process argument list, shell history, and service logs.
+    #[arg(long, value_name = "PATH")]
+    token_file: Option<PathBuf>,
+
+    /// Enrollment token passed directly. Convenient but insecure: it leaks
+    /// via the process argument list and shell history. Prefer `--token-file`,
+    /// or pipe the token on stdin.
+    #[arg(long, conflicts_with = "token_file")]
+    token: Option<String>,
 }
 
 #[derive(Debug, Subcommand)]
@@ -177,7 +186,22 @@ fn main() -> Result<()> {
 
 async fn run(command: Command, config: AgentConfig) -> Result<()> {
     match command {
-        Command::Enroll { token_file, token } => {
+        Command::Enroll(EnrollArgs { token_file, token }) => {
+            let token = resolve_enrollment_token(token_file, token)?;
+            let channel = control::client::connect_default(&config).await?;
+            let mut client = FleetLifecycleServiceClient::new(channel);
+            let response = client
+                .enroll(control_proto::EnrollRequest {
+                    enrollment_token: token,
+                    control_plane: String::new(),
+                })
+                .await
+                .context("Enroll RPC failed")?
+                .into_inner();
+            println!("enrolled (machine_id={})", response.machine_id);
+            Ok(())
+        }
+        Command::Quick(QuickCommand::Enroll(EnrollArgs { token_file, token })) => {
             let token = resolve_enrollment_token(token_file, token)?;
             let settings_store = SettingsStore::new(config.settings_path());
             let seed = load_or_seed_settings(&settings_store, &config)?;
@@ -196,7 +220,7 @@ async fn run(command: Command, config: AgentConfig) -> Result<()> {
             .store(&credential)?;
             Ok(())
         }
-        Command::Run => {
+        Command::Quick(QuickCommand::Run) => {
             let settings_store = SettingsStore::new(config.settings_path());
             let seed = load_or_seed_settings(&settings_store, &config)?;
             let docker = init_docker(seed.docker_mode, &seed.linux_runner_image).await?;
@@ -208,7 +232,7 @@ async fn run(command: Command, config: AgentConfig) -> Result<()> {
             )
             .load()?
             .context(
-                "no credential found — run `arcbox-fleet-agent enroll --token-file …` first",
+                "no credential found — run `arcbox-fleet-agent quick enroll --token-file …` first",
             )?;
             info!(machine_id = %credential.machine_id, "starting fleet agent");
 
@@ -414,7 +438,7 @@ async fn run(command: Command, config: AgentConfig) -> Result<()> {
 
 /// Build a `CancellationToken` cancelled on the first termination signal
 /// (see [`shutdown_signal`]), logging `message` when it fires. Shared by
-/// `run` and `serve`, whose shutdown trigger is otherwise identical.
+/// `quick run` and `serve`, whose shutdown trigger is otherwise identical.
 fn spawn_shutdown_signal(message: &'static str) -> CancellationToken {
     let shutdown = CancellationToken::new();
     let signal_token = shutdown.clone();

--- a/fleet/arcbox-fleet-agent/tests/control.rs
+++ b/fleet/arcbox-fleet-agent/tests/control.rs
@@ -3,7 +3,7 @@
 //! `arcbox-fleet-agent` ships only a binary (no library target), so this
 //! spawns the real compiled `serve` subcommand against a scratch data dir
 //! and exercises `FleetLifecycleService` over the real Unix socket — the
-//! same path the CLI's `status`/`drain`/`resume`/`unenroll` subcommands
+//! same path the CLI's `enroll`/`status`/`drain`/`resume`/`unenroll` subcommands
 //! and the desktop app use.
 
 #![allow(

--- a/fleet/arcbox-fleet-control-proto/proto/arcbox/fleet/control/v1/control.proto
+++ b/fleet/arcbox-fleet-control-proto/proto/arcbox/fleet/control/v1/control.proto
@@ -17,7 +17,7 @@ service FleetLifecycleService {
   // handoff: the machine credential is created and persisted here, in the
   // agent — never in the desktop. Fails if already enrolled; Unenroll
   // first. The headless/farm path instead uses the `arcbox-fleet-agent
-  // enroll` CLI subcommand before this process is even running.
+  // quick enroll` CLI subcommand before this process is even running.
   rpc Enroll(EnrollRequest) returns (EnrollResponse);
 
   // Stops accepting new offers; in-flight jobs finish normally.


### PR DESCRIPTION
## Summary

- route normal enrollment through the running agent control socket
- move socketless enrollment and execution under the quick command group
- add quick unenroll and share gateway decommission plus credential cleanup across both unenroll paths

## Testing

- cargo fmt --all -- --check
- cargo clippy -p arcbox-fleet-agent --all-targets
- cargo test -p arcbox-fleet-agent (67 existing tests passed)