### PR TITLE
feat(balloon): free page reporting on the HV backend

### DIFF
--- a/virt/arcbox-virtio-balloon/src/lib.rs
+++ b/virt/arcbox-virtio-balloon/src/lib.rs
@@ -12,10 +12,18 @@
 //!   from the guest) and `actual` (guest → host current, written by the
 //!   guest as pages are inflated/deflated).
 //!
+//! - Free page reporting (`VIRTIO_BALLOON_F_REPORTING`, bit 5) — the guest
+//!   kernel periodically hands batches of currently-free pages to the host
+//!   on `reporting_vq` (fixed index 4); the host `madvise(MADV_DONTNEED)`s
+//!   the ranges and completes the buffers. Combined with
+//!   `DEFLATE_ON_OOM` this lets the guest kernel self-manage: idle memory
+//!   drains back to the host with no balloon-target policy at all.
+//!
 //! Not implemented (all optional per spec):
 //! - Stats virtqueue (`VIRTIO_BALLOON_F_STATS_VQ`)
-//! - Free-page hinting
-//! - Page poisoning, reporting
+//! - Free-page hinting (`VIRTIO_BALLOON_F_FREE_PAGE_HINT` — the migration
+//!   aid, distinct from reporting)
+//! - Page poisoning
 //!
 //! ## Inflate semantics
 //!
@@ -42,10 +50,21 @@ use arcbox_virtio_core::{QueueConfig, VirtioDevice, VirtioDeviceId, virtio_bindi
 /// VIRTIO balloon feature: guest may deflate on its own OOM.
 const VIRTIO_BALLOON_F_DEFLATE_ON_OOM: u64 = 1 << 2;
 
+/// VIRTIO balloon feature: free page reporting virtqueue.
+const VIRTIO_BALLOON_F_REPORTING: u64 = 1 << 5;
+
 /// Inflate queue index.
 const QUEUE_INFLATE: u16 = 0;
 /// Deflate queue index.
 const QUEUE_DEFLATE: u16 = 1;
+/// Free page reporting queue index. Fixed per the virtio spec / Linux
+/// driver (`VIRTIO_BALLOON_VQ_REPORTING = 4`); indices 2 (stats) and 3
+/// (free-page hinting) exist as slots even when those features are not
+/// negotiated.
+const QUEUE_REPORTING: u16 = 4;
+
+/// Number of per-queue cursor slots ([`QUEUE_REPORTING`] is the highest).
+const QUEUE_SLOTS: usize = 5;
 
 /// Traditional-balloon page size — fixed 4 KiB per spec §5.5.6.
 const BALLOON_PFN_SHIFT: u32 = 12;
@@ -63,9 +82,10 @@ pub struct VirtioBalloon {
     features: u64,
     /// Whether the guest driver has signalled `DRIVER_OK`.
     active: bool,
-    /// Last processed `avail_idx` per queue (inflate, deflate). Wraps at
-    /// u16 per VirtIO ring semantics.
-    last_avail: [u16; 2],
+    /// Last processed `avail_idx` per queue slot (indexed by queue index;
+    /// stats/hinting slots stay unused). Wraps at u16 per VirtIO ring
+    /// semantics.
+    last_avail: [u16; QUEUE_SLOTS],
     /// Host-requested target in 4 KiB pages. Set by
     /// [`Self::set_num_pages`]; read by guest via config space.
     num_pages: AtomicU32,
@@ -87,12 +107,15 @@ impl VirtioBalloon {
 
     /// Creates a new balloon device in the reset state.
     ///
-    /// Advertises `VIRTIO_F_VERSION_1` and `VIRTIO_BALLOON_F_DEFLATE_ON_OOM`.
+    /// Advertises `VIRTIO_F_VERSION_1`, `VIRTIO_BALLOON_F_DEFLATE_ON_OOM`
+    /// and `VIRTIO_BALLOON_F_REPORTING`.
     pub fn new() -> Self {
         Self {
-            features: Self::FEATURE_VERSION_1 | VIRTIO_BALLOON_F_DEFLATE_ON_OOM,
+            features: Self::FEATURE_VERSION_1
+                | VIRTIO_BALLOON_F_DEFLATE_ON_OOM
+                | VIRTIO_BALLOON_F_REPORTING,
             active: false,
-            last_avail: [0, 0],
+            last_avail: [0; QUEUE_SLOTS],
             num_pages: AtomicU32::new(0),
             actual: AtomicU32::new(0),
             inflated_total: AtomicU32::new(0),
@@ -185,7 +208,7 @@ impl VirtioDevice for VirtioBalloon {
 
     fn reset(&mut self) {
         self.active = false;
-        self.last_avail = [0, 0];
+        self.last_avail = [0; QUEUE_SLOTS];
         self.num_pages.store(0, Ordering::Release);
         self.actual.store(0, Ordering::Release);
     }
@@ -199,7 +222,11 @@ impl VirtioDevice for VirtioBalloon {
         if !queue_config.ready || queue_config.size == 0 {
             return Ok(Vec::new());
         }
-        if queue_idx != QUEUE_INFLATE && queue_idx != QUEUE_DEFLATE {
+        let reporting_negotiated = self.features & VIRTIO_BALLOON_F_REPORTING != 0;
+        let known = queue_idx == QUEUE_INFLATE
+            || queue_idx == QUEUE_DEFLATE
+            || (queue_idx == QUEUE_REPORTING && reporting_negotiated);
+        if !known {
             return Ok(Vec::new());
         }
 
@@ -216,29 +243,44 @@ impl VirtioDevice for VirtioBalloon {
 
         let mut completions = Vec::new();
         while let Some(chain) = queue.pop_avail() {
-            // Each read-only descriptor carries a little-endian u32 PFN array.
             let mut chain_pages_handled = 0u32;
             for desc in &chain.descriptors {
-                // Only read-only descriptors on the inflate queue carry PFNs.
-                if desc.is_write() || queue_idx != QUEUE_INFLATE {
-                    continue;
+                match queue_idx {
+                    // Each read-only descriptor carries a little-endian u32
+                    // PFN array.
+                    QUEUE_INFLATE if !desc.is_write() => {
+                        // Copy the PFN bytes out before madvise so the
+                        // immutable borrow on guest memory is released before
+                        // we take the raw pointer.
+                        let Some(buf) = queue.mem().slice(desc.addr as usize, desc.len as usize)
+                        else {
+                            continue;
+                        };
+                        let pfn_bytes = buf.to_vec();
+                        let ram_ptr = queue.mem().ptr();
+                        let ram_len = queue.mem().len();
+                        chain_pages_handled +=
+                            handle_pfn_list(&pfn_bytes, ram_ptr, ram_len, gpa_base);
+                    }
+                    // Reporting buffers ARE the free pages: each
+                    // device-writable descriptor directly addresses a free
+                    // range the guest promises not to touch until the chain
+                    // completes. Release the backing and complete.
+                    QUEUE_REPORTING if desc.is_write() => {
+                        let ram_ptr = queue.mem().ptr();
+                        let ram_len = queue.mem().len();
+                        chain_pages_handled +=
+                            handle_reported_range(desc.addr, desc.len, ram_ptr, ram_len, gpa_base);
+                    }
+                    _ => {}
                 }
-                // Copy the PFN bytes out before madvise so the immutable borrow
-                // on guest memory is released before we take the raw pointer.
-                let Some(buf) = queue.mem().slice(desc.addr as usize, desc.len as usize) else {
-                    continue;
-                };
-                let pfn_bytes = buf.to_vec();
-                let ram_ptr = queue.mem().ptr();
-                let ram_len = queue.mem().len();
-                chain_pages_handled += handle_pfn_list(&pfn_bytes, ram_ptr, ram_len, gpa_base);
             }
             // Balloon completions write 0 bytes (nothing is written into the
             // descriptor buffer). Deflate just completes the descriptor —
             // MADV_DONTNEED pages re-fault naturally, so no explicit remap.
             queue.push_used(chain.head_idx, 0);
             completions.push((chain.head_idx, 0));
-            if queue_idx == QUEUE_INFLATE && chain_pages_handled > 0 {
+            if chain_pages_handled > 0 {
                 self.inflated_total
                     .fetch_add(chain_pages_handled, Ordering::AcqRel);
             }
@@ -290,6 +332,56 @@ fn handle_pfn_list(buf: &[u8], ram_base: *mut u8, ram_len: usize, gpa_base: usiz
         handled += 1;
     }
     handled
+}
+
+/// Releases one guest-reported free range via `madvise(MADV_DONTNEED)`,
+/// returning the number of 4 KiB pages released. The range is
+/// guest-controlled: it must be page-aligned, non-empty, and fully inside
+/// the guest RAM mapping, or it is logged and skipped.
+fn handle_reported_range(
+    addr: u64,
+    len: u32,
+    ram_base: *mut u8,
+    ram_len: usize,
+    gpa_base: usize,
+) -> u32 {
+    let len = len as usize;
+    let page_size = BALLOON_PAGE_SIZE as usize;
+    if len == 0 || len % page_size != 0 || addr % BALLOON_PAGE_SIZE != 0 {
+        tracing::warn!("virtio-balloon: misaligned reported range {addr:#x}+{len:#x}");
+        return 0;
+    }
+    let Some(offset) = (addr as usize).checked_sub(gpa_base) else {
+        tracing::warn!("virtio-balloon: reported range {addr:#x} below ram base");
+        return 0;
+    };
+    let Some(end) = offset.checked_add(len) else {
+        tracing::warn!("virtio-balloon: reported range {addr:#x}+{len:#x} overflows");
+        return 0;
+    };
+    if end > ram_len {
+        tracing::warn!(
+            "virtio-balloon: reported range {addr:#x}+{len:#x} beyond ram ({ram_len:#x})"
+        );
+        return 0;
+    }
+    // SAFETY: ram_base points to a live host mapping of the guest RAM
+    // region, valid for ram_len bytes; offset..end was bounds-checked
+    // above. MADV_DONTNEED releases the physical backing without
+    // invalidating the mapping; the guest re-faults zero pages, which is
+    // the free-page-reporting contract (the pages are free right now and
+    // the guest keeps them off-limits until the buffer completes).
+    let ret = unsafe { libc::madvise(ram_base.add(offset).cast(), len, libc::MADV_DONTNEED) };
+    if ret != 0 {
+        tracing::warn!(
+            "virtio-balloon: madvise(MADV_DONTNEED) on reported range {:#x}+{:#x} failed: {}",
+            offset,
+            len,
+            std::io::Error::last_os_error()
+        );
+        return 0;
+    }
+    (len / page_size) as u32
 }
 
 #[cfg(test)]
@@ -365,6 +457,199 @@ mod tests {
         assert_eq!(b.num_pages(), 0);
         assert_eq!(b.actual(), 0);
         assert!(!b.active);
+    }
+
+    /// Page-aligned guest RAM for ring-level tests (madvise requires
+    /// page alignment, which a plain `Vec` does not guarantee).
+    struct TestRam {
+        ptr: *mut u8,
+        len: usize,
+        gpa_base: u64,
+    }
+
+    // Ring layout within the test RAM (offsets from gpa_base).
+    const DESC_OFF: u64 = 0x1000;
+    const AVAIL_OFF: u64 = 0x2000;
+    const USED_OFF: u64 = 0x3000;
+    const DATA_OFF: u64 = 0x4000;
+    const RING_SIZE: u16 = 8;
+
+    impl TestRam {
+        fn new(gpa_base: u64) -> Self {
+            let len = 0x1_0000;
+            // SAFETY: fresh anonymous private mapping owned by this struct.
+            let ptr = unsafe {
+                libc::mmap(
+                    std::ptr::null_mut(),
+                    len,
+                    libc::PROT_READ | libc::PROT_WRITE,
+                    libc::MAP_PRIVATE | libc::MAP_ANONYMOUS,
+                    -1,
+                    0,
+                )
+            };
+            assert_ne!(ptr, libc::MAP_FAILED);
+            Self {
+                ptr: ptr.cast(),
+                len,
+                gpa_base,
+            }
+        }
+
+        fn slice(&mut self) -> &mut [u8] {
+            // SAFETY: ptr/len describe the live private mapping above.
+            unsafe { std::slice::from_raw_parts_mut(self.ptr, self.len) }
+        }
+
+        fn cfg(&self) -> QueueConfig {
+            QueueConfig {
+                desc_addr: self.gpa_base + DESC_OFF,
+                avail_addr: self.gpa_base + AVAIL_OFF,
+                used_addr: self.gpa_base + USED_OFF,
+                size: RING_SIZE,
+                ready: true,
+                gpa_base: self.gpa_base,
+            }
+        }
+
+        fn off(&self, gpa: u64) -> usize {
+            (gpa - self.gpa_base) as usize
+        }
+
+        fn write_desc(&mut self, idx: u16, addr: u64, len: u32, flags: u16, next: u16) {
+            let o = self.off(self.gpa_base + DESC_OFF) + usize::from(idx) * 16;
+            let ram = self.slice();
+            ram[o..o + 8].copy_from_slice(&addr.to_le_bytes());
+            ram[o + 8..o + 12].copy_from_slice(&len.to_le_bytes());
+            ram[o + 12..o + 14].copy_from_slice(&flags.to_le_bytes());
+            ram[o + 14..o + 16].copy_from_slice(&next.to_le_bytes());
+        }
+
+        fn publish_avail(&mut self, pos: u16, head: u16) {
+            let ao = self.off(self.gpa_base + AVAIL_OFF);
+            let entry = ao + 4 + usize::from(pos % RING_SIZE) * 2;
+            let ram = self.slice();
+            ram[entry..entry + 2].copy_from_slice(&head.to_le_bytes());
+            let idx = pos + 1;
+            ram[ao + 2..ao + 4].copy_from_slice(&idx.to_le_bytes());
+        }
+
+        fn used_idx(&mut self) -> u16 {
+            let uo = self.off(self.gpa_base + USED_OFF);
+            let ram = self.slice();
+            u16::from_le_bytes([ram[uo + 2], ram[uo + 3]])
+        }
+    }
+
+    impl Drop for TestRam {
+        fn drop(&mut self) {
+            // SAFETY: mapping created in new() with this exact len.
+            unsafe { libc::munmap(self.ptr.cast(), self.len) };
+        }
+    }
+
+    /// Device-writable descriptor flag (VIRTQ_DESC_F_WRITE).
+    const F_WRITE: u16 = 2;
+
+    const GPA_BASE: u64 = 0x4000_0000;
+
+    fn reporting_device() -> VirtioBalloon {
+        let mut b = VirtioBalloon::new();
+        b.ack_features(b.features());
+        b
+    }
+
+    #[test]
+    fn reporting_releases_valid_range_and_completes() {
+        let mut ram = TestRam::new(GPA_BASE);
+        let mut b = reporting_device();
+        let cfg = ram.cfg();
+
+        // One device-writable descriptor covering two free pages.
+        ram.write_desc(
+            0,
+            GPA_BASE + DATA_OFF,
+            2 * BALLOON_PAGE_SIZE as u32,
+            F_WRITE,
+            0,
+        );
+        ram.publish_avail(0, 0);
+
+        let completions = b.process_queue(QUEUE_REPORTING, ram.slice(), &cfg).unwrap();
+        assert_eq!(completions, vec![(0, 0)]);
+        assert_eq!(ram.used_idx(), 1, "chain must be returned to the guest");
+        assert_eq!(b.inflated_total(), 2, "two pages released");
+    }
+
+    #[test]
+    fn reporting_rejects_hostile_ranges_but_completes_chains() {
+        let mut ram = TestRam::new(GPA_BASE);
+        let mut b = reporting_device();
+        let cfg = ram.cfg();
+
+        // Beyond RAM, misaligned, zero-length, address-overflow: all must be
+        // skipped without touching host memory — and every chain must still
+        // complete so the guest queue cannot wedge.
+        ram.write_desc(
+            0,
+            GPA_BASE + 0x10_0000,
+            BALLOON_PAGE_SIZE as u32,
+            F_WRITE,
+            0,
+        );
+        ram.write_desc(
+            1,
+            GPA_BASE + DATA_OFF + 3,
+            BALLOON_PAGE_SIZE as u32,
+            F_WRITE,
+            0,
+        );
+        ram.write_desc(2, GPA_BASE + DATA_OFF, 0, F_WRITE, 0);
+        ram.write_desc(3, u64::MAX - 0xFFF, BALLOON_PAGE_SIZE as u32, F_WRITE, 0);
+        for (pos, head) in [(0u16, 0u16), (1, 1), (2, 2), (3, 3)] {
+            ram.publish_avail(pos, head);
+        }
+
+        let completions = b.process_queue(QUEUE_REPORTING, ram.slice(), &cfg).unwrap();
+        assert_eq!(completions.len(), 4, "all chains complete");
+        assert_eq!(ram.used_idx(), 4);
+        assert_eq!(b.inflated_total(), 0, "no hostile range may be released");
+    }
+
+    #[test]
+    fn reporting_ignores_read_only_descriptors() {
+        let mut ram = TestRam::new(GPA_BASE);
+        let mut b = reporting_device();
+        let cfg = ram.cfg();
+
+        ram.write_desc(0, GPA_BASE + DATA_OFF, BALLOON_PAGE_SIZE as u32, 0, 0);
+        ram.publish_avail(0, 0);
+
+        let completions = b.process_queue(QUEUE_REPORTING, ram.slice(), &cfg).unwrap();
+        assert_eq!(completions, vec![(0, 0)]);
+        assert_eq!(b.inflated_total(), 0);
+    }
+
+    #[test]
+    fn reporting_queue_inert_when_feature_not_negotiated() {
+        let mut ram = TestRam::new(GPA_BASE);
+        let mut b = VirtioBalloon::new();
+        // Driver acks everything except reporting.
+        b.ack_features(VirtioBalloon::FEATURE_VERSION_1 | VIRTIO_BALLOON_F_DEFLATE_ON_OOM);
+        let cfg = ram.cfg();
+
+        ram.write_desc(0, GPA_BASE + DATA_OFF, BALLOON_PAGE_SIZE as u32, F_WRITE, 0);
+        ram.publish_avail(0, 0);
+
+        let completions = b.process_queue(QUEUE_REPORTING, ram.slice(), &cfg).unwrap();
+        assert!(completions.is_empty(), "unnegotiated queue must be inert");
+        assert_eq!(ram.used_idx(), 0);
+    }
+
+    #[test]
+    fn advertises_reporting_feature() {
+        let b = VirtioBalloon::new();
+        assert!(b.features() & VIRTIO_BALLOON_F_REPORTING != 0);
     }
 
     #[test]

--- a/virt/arcbox-virtio-balloon/src/lib.rs
+++ b/virt/arcbox-virtio-balloon/src/lib.rs
@@ -14,8 +14,10 @@
 //!
 //! - Free page reporting (`VIRTIO_BALLOON_F_REPORTING`, bit 5) — the guest
 //!   kernel periodically hands batches of currently-free pages to the host
-//!   on `reporting_vq` (fixed index 4); the host `madvise(MADV_DONTNEED)`s
-//!   the ranges and completes the buffers. Combined with
+//!   on `reporting_vq` (transport index computed from the negotiated
+//!   feature set — see [`reporting_queue_index`]); the host
+//!   `madvise(MADV_DONTNEED)`s the ranges and completes the buffers.
+//!   Combined with
 //!   `DEFLATE_ON_OOM` this lets the guest kernel self-manage: idle memory
 //!   drains back to the host with no balloon-target policy at all.
 //!

--- a/virt/arcbox-virtio-balloon/src/lib.rs
+++ b/virt/arcbox-virtio-balloon/src/lib.rs
@@ -57,13 +57,33 @@ const VIRTIO_BALLOON_F_REPORTING: u64 = 1 << 5;
 const QUEUE_INFLATE: u16 = 0;
 /// Deflate queue index.
 const QUEUE_DEFLATE: u16 = 1;
-/// Free page reporting queue index. Fixed per the virtio spec / Linux
-/// driver (`VIRTIO_BALLOON_VQ_REPORTING = 4`); indices 2 (stats) and 3
-/// (free-page hinting) exist as slots even when those features are not
-/// negotiated.
-const QUEUE_REPORTING: u16 = 4;
+/// Stats virtqueue feature bit — not advertised, but its bit position
+/// participates in [`reporting_queue_index`].
+const VIRTIO_BALLOON_F_STATS_VQ: u64 = 1 << 1;
+/// Free-page-hinting feature bit — not advertised; see above.
+const VIRTIO_BALLOON_F_FREE_PAGE_HINT: u64 = 1 << 3;
 
-/// Number of per-queue cursor slots ([`QUEUE_REPORTING`] is the highest).
+/// Transport-level index of the reporting queue for a negotiated feature
+/// set.
+///
+/// The driver-side `VIRTIO_BALLOON_VQ_*` enum is only an array position:
+/// the MMIO transport numbers queues *densely* over the virtqueues that
+/// actually exist (`vm_find_vqs` skips NULL-named entries without
+/// consuming an index). With neither stats nor free-page hinting
+/// negotiated, reporting is queue 2, right after inflate/deflate.
+const fn reporting_queue_index(features: u64) -> u16 {
+    let mut idx = 2;
+    if features & VIRTIO_BALLOON_F_STATS_VQ != 0 {
+        idx += 1;
+    }
+    if features & VIRTIO_BALLOON_F_FREE_PAGE_HINT != 0 {
+        idx += 1;
+    }
+    idx
+}
+
+/// Number of per-queue cursor slots (the reporting queue is the highest,
+/// at most index 4 with every optional queue negotiated).
 const QUEUE_SLOTS: usize = 5;
 
 /// Traditional-balloon page size — fixed 4 KiB per spec §5.5.6.
@@ -223,9 +243,10 @@ impl VirtioDevice for VirtioBalloon {
             return Ok(Vec::new());
         }
         let reporting_negotiated = self.features & VIRTIO_BALLOON_F_REPORTING != 0;
+        let queue_reporting = reporting_queue_index(self.features);
         let known = queue_idx == QUEUE_INFLATE
             || queue_idx == QUEUE_DEFLATE
-            || (queue_idx == QUEUE_REPORTING && reporting_negotiated);
+            || (queue_idx == queue_reporting && reporting_negotiated);
         if !known {
             return Ok(Vec::new());
         }
@@ -266,7 +287,7 @@ impl VirtioDevice for VirtioBalloon {
                     // device-writable descriptor directly addresses a free
                     // range the guest promises not to touch until the chain
                     // completes. Release the backing and complete.
-                    QUEUE_REPORTING if desc.is_write() => {
+                    q if q == queue_reporting && desc.is_write() => {
                         let ram_ptr = queue.mem().ptr();
                         let ram_len = queue.mem().len();
                         chain_pages_handled +=
@@ -557,6 +578,29 @@ mod tests {
         let mut b = VirtioBalloon::new();
         b.ack_features(b.features());
         b
+    }
+
+    /// The queue index the driver will use for reporting under this
+    /// device's advertised feature set (no stats, no hinting → dense 2).
+    const QUEUE_REPORTING: u16 = 2;
+
+    #[test]
+    fn reporting_queue_index_is_dense() {
+        // Transport numbering skips queues whose features were not
+        // negotiated (vm_find_vqs does not consume an index for them).
+        assert_eq!(reporting_queue_index(VirtioBalloon::new().features()), 2);
+        assert_eq!(
+            reporting_queue_index(VIRTIO_BALLOON_F_REPORTING | VIRTIO_BALLOON_F_STATS_VQ),
+            3
+        );
+        assert_eq!(
+            reporting_queue_index(
+                VIRTIO_BALLOON_F_REPORTING
+                    | VIRTIO_BALLOON_F_STATS_VQ
+                    | VIRTIO_BALLOON_F_FREE_PAGE_HINT
+            ),
+            4
+        );
     }
 
     #[test]


### PR DESCRIPTION
Follow-up from the idle-balloon incident work (#390): let the guest kernel self-manage memory on the HV backend, kernel-natively.

## What

- Advertise `VIRTIO_BALLOON_F_REPORTING` (bit 5) and serve `reporting_vq`. The transport numbers queues **densely** over the virtqueues that exist (`vm_find_vqs` skips un-negotiated ones), so with neither stats nor hinting the reporting queue is **2**; the index is computed from the negotiated feature set. (Initially implemented as a fixed 4 from the driver enum — a real guest-wedging bug caught by review, see the resolved thread.)
- The guest kernel periodically hands batches of currently-free pages to the host; the host releases their backing with `madvise(MADV_DONTNEED)` and completes the buffers. Idle memory drains back to the host **continuously, with no balloon-target policy involved**.
- Combined with the already-advertised `DEFLATE_ON_OOM`, OOM pressure inside the guest self-rescues by deflating — the guest kernel never has to kill a workload to satisfy the balloon.

## Guest side is already in place

- The arcbox kernel builds `virtio_balloon` in, and `VIRTIO_BALLOON` **selects `PAGE_REPORTING`** (verified against both the shipped 0.6.1 kernel image and the Linux 6.12 Kconfig) — no kernel change needed for this feature.
- (`CONFIG_PSI` for the VZ-side pressure watch upgrade is separate: arcboxlabs/kernel#9.)

## Safety

Reported ranges are guest-controlled input: page-aligned, non-empty, overflow-checked, and bounded to the guest RAM mapping before any `madvise`; hostile ranges are logged and skipped while their chains still complete, so the guest queue cannot wedge. The reporting queue is inert unless the feature was negotiated.

## Tests

Ring-level tests drive the real `process_queue` path over page-aligned mmap'd memory (the crate's existing tests only smoke-tested queue plumbing): valid-range release + completion, hostile ranges (beyond-RAM / misaligned / zero-length / address-overflow) rejected with chains completed, read-only descriptors ignored, un-negotiated queue inert.

## Notes for review

- VZ is unaffected (Apple's balloon device, not this crate). This engages when a machine runs the HV backend, where we own feature negotiation.
- P0-macOS HV: the device is registered via the generic virtio-MMIO path (`darwin_hv/setup.rs`), and queue 4 flows through the generic dispatch — no per-queue special-casing.
