### PR TITLE
chore(assets): bump boot assets to 0.6.2 (kernel v0.0.17, PSI)

### DIFF
--- a/assets.lock
+++ b/assets.lock
@@ -11,9 +11,9 @@
 # skew to worry about when upgrading.
 
 [boot]
-version = "0.6.1"
+version = "0.6.2"
 cdn = "https://boot.arcboxcdn.com"
-manifest_sha256 = "6945c6c612c7e021ee709f7e50aeedc39ad3cefaf53c6a30b0aaac1919ac49d5"
+manifest_sha256 = "f82fa766db54d56c42e86ad831c92ab18cf7df0bc646d054f675f361284793de"
 
 [[tools]]
 name = "docker"


### PR DESCRIPTION
Boot assets **0.6.2** ships kernel **v0.0.17**, which enables `CONFIG_PSI` (arcboxlabs/kernel#9): the guest exposes `/proc/pressure/*`, so the agent's balloon pressure watch (#390) can later upgrade from meminfo/refault sampling to PSI triggers with no RPC contract change.

**Verified before this bump**:
- `manifest_sha256` recomputed from the CDN manifest and cross-checked against the method used for 0.6.1 (byte-identical match on the old entry).
- The v0.6.2 arm64 kernel image contains PSI (`psimon`/`avg10` strings present; both absent in 0.6.1).

**Also in the rebuilt assets** (boot-assets' own pipeline, not this repo's choices):
- manifest records the kernel release tag (`v0.0.17`) instead of `latest`;
- `manifest.binaries` bookkeeping for firecracker/jailer moves 1.10.1 → 1.16.1. arcbox's asset downloader does not consume that manifest section (sandbox binaries are provisioned separately), but flagging it for awareness given the sandbox stack's history with FC 1.10.1.

Live-boot validation of 0.6.2 (fresh data dir, CDN download, `/proc/pressure/memory` readable in a container) running now; result will be posted here.