### PR TITLE
fix(fleet): dedup TLS crypto stack on aws-lc-rs (tonic 0.14, russh aws-lc-rs)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -401,7 +401,7 @@ dependencies = [
  "arcbox-logging",
  "arcbox-net",
  "async-trait",
- "axum 0.8.8",
+ "axum",
  "bytes",
  "clap",
  "dirs",
@@ -452,7 +452,7 @@ dependencies = [
  "arcbox-error",
  "arcbox-protocol",
  "arcbox-transport",
- "axum 0.8.8",
+ "axum",
  "bytes",
  "chrono",
  "dirs",
@@ -472,7 +472,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tokio-util",
- "tower 0.5.3",
+ "tower",
  "tower-http",
  "tracing",
  "uuid",
@@ -513,7 +513,7 @@ dependencies = [
  "tokio-stream",
  "toml_edit 0.25.12+spec-1.1.0",
  "tonic",
- "tower 0.5.3",
+ "tower",
  "tracing",
  "tracing-subscriber",
  "xshell",
@@ -588,7 +588,8 @@ version = "0.4.18"
 dependencies = [
  "prost",
  "tonic",
- "tonic-build",
+ "tonic-prost",
+ "tonic-prost-build",
 ]
 
 [[package]]
@@ -597,7 +598,8 @@ version = "0.4.18"
 dependencies = [
  "prost",
  "tonic",
- "tonic-build",
+ "tonic-prost",
+ "tonic-prost-build",
 ]
 
 [[package]]
@@ -626,7 +628,8 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tonic",
- "tonic-build",
+ "tonic-prost",
+ "tonic-prost-build",
  "tracing",
 ]
 
@@ -1218,6 +1221,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4342d8937fc7e5dd9b1c60292261c0670c882a2cd1719cfc11b1af41731e32ad"
 dependencies = [
  "aws-lc-sys",
+ "untrusted 0.7.1",
  "zeroize",
 ]
 
@@ -1236,38 +1240,11 @@ dependencies = [
 
 [[package]]
 name = "axum"
-version = "0.7.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
-dependencies = [
- "async-trait",
- "axum-core 0.4.5",
- "bytes",
- "futures-util",
- "http",
- "http-body",
- "http-body-util",
- "itoa",
- "matchit 0.7.3",
- "memchr",
- "mime",
- "percent-encoding",
- "pin-project-lite",
- "rustversion",
- "serde",
- "sync_wrapper",
- "tower 0.5.3",
- "tower-layer",
- "tower-service",
-]
-
-[[package]]
-name = "axum"
 version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b52af3cb4058c895d37317bb27508dccc8e5f2d39454016b297bf4a400597b8"
 dependencies = [
- "axum-core 0.5.6",
+ "axum-core",
  "axum-macros",
  "bytes",
  "form_urlencoded",
@@ -1278,7 +1255,7 @@ dependencies = [
  "hyper",
  "hyper-util",
  "itoa",
- "matchit 0.8.4",
+ "matchit",
  "memchr",
  "mime",
  "percent-encoding",
@@ -1289,30 +1266,10 @@ dependencies = [
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
- "tower 0.5.3",
+ "tower",
  "tower-layer",
  "tower-service",
  "tracing",
-]
-
-[[package]]
-name = "axum-core"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199"
-dependencies = [
- "async-trait",
- "bytes",
- "futures-util",
- "http",
- "http-body",
- "http-body-util",
- "mime",
- "pin-project-lite",
- "rustversion",
- "sync_wrapper",
- "tower-layer",
- "tower-service",
 ]
 
 [[package]]
@@ -2823,7 +2780,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http",
- "indexmap 2.13.0",
+ "indexmap",
  "slab",
  "tokio",
  "tokio-util",
@@ -2840,12 +2797,6 @@ dependencies = [
  "crunchy",
  "zerocopy",
 ]
-
-[[package]]
-name = "hashbrown"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
@@ -3082,7 +3033,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots 1.0.6",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -3294,16 +3245,6 @@ checksum = "8b0793d4d06568004486fcd4dfe3946094f29abf4635c6400be80fd6c13a53e4"
 dependencies = [
  "bitflags 2.11.0",
  "libc",
-]
-
-[[package]]
-name = "indexmap"
-version = "1.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
-dependencies = [
- "autocfg",
- "hashbrown 0.12.3",
 ]
 
 [[package]]
@@ -3716,12 +3657,6 @@ checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
 dependencies = [
  "regex-automata",
 ]
-
-[[package]]
-name = "matchit"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
 
 [[package]]
 name = "matchit"
@@ -4261,7 +4196,7 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c8d427828b22ae1fff2833a03d8486c2c881367f1c336349f307f321e7f4d05"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap",
  "serde",
  "serde_json",
 ]
@@ -4526,12 +4461,13 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "petgraph"
-version = "0.7.1"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3672b37090dbd86368a4145bc067582552b29c27377cad4e0a306c97f9bd7772"
+checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
 dependencies = [
  "fixedbitset",
- "indexmap 2.13.0",
+ "hashbrown 0.15.5",
+ "indexmap",
 ]
 
 [[package]]
@@ -4629,7 +4565,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da1d65da6dd5d1e44199ac0f58712d241c0f439f80adea8924d832384087f85"
 dependencies = [
  "base64",
- "indexmap 2.13.0",
+ "indexmap",
  "quick-xml",
  "serde",
  "time",
@@ -4853,7 +4789,7 @@ checksum = "90f6d9109b04e005bbdec84cacec7e81cc15533f2b5dc505f0defc212d270c15"
 dependencies = [
  "heck",
  "http",
- "indexmap 2.13.0",
+ "indexmap",
  "openapiv3",
  "proc-macro2",
  "quote",
@@ -4887,9 +4823,9 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.13.5"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
+checksum = "528ac67416ff8646872a3c02cad9cc4ee5dc9f9540c9b10771855c95cb2e5ae1"
 dependencies = [
  "bytes",
  "prost-derive",
@@ -4897,19 +4833,20 @@ dependencies = [
 
 [[package]]
 name = "prost-build"
-version = "0.13.5"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
+checksum = "03da047801ff44bb6a4d407d4860c05fd70bb81714e6b2f3812603d5b145b042"
 dependencies = [
  "heck",
  "itertools 0.14.0",
  "log",
  "multimap",
- "once_cell",
  "petgraph",
  "prettyplease",
  "prost",
  "prost-types",
+ "pulldown-cmark",
+ "pulldown-cmark-to-cmark",
  "regex",
  "syn",
  "tempfile",
@@ -4917,9 +4854,9 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
-version = "0.13.5"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
+checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
  "itertools 0.14.0",
@@ -4930,11 +4867,31 @@ dependencies = [
 
 [[package]]
 name = "prost-types"
-version = "0.13.5"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52c2c1bf36ddb1a1c396b3601a3cec27c2462e45f07c386894ec3ccf5332bd16"
+checksum = "f94967dc7688f3054c7fac87473ffae4cc4c3904800e2d9f5b857246d8963b0a"
 dependencies = [
  "prost",
+]
+
+[[package]]
+name = "pulldown-cmark"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9f068eba8e7071c5f9511831b44f32c740d5adf574e990f946ddb53db2f314e"
+dependencies = [
+ "bitflags 2.11.0",
+ "memchr",
+ "unicase",
+]
+
+[[package]]
+name = "pulldown-cmark-to-cmark"
+version = "22.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50793def1b900256624a709439404384204a5dc3a6ec580281bfaac35e882e90"
+dependencies = [
+ "pulldown-cmark",
 ]
 
 [[package]]
@@ -5215,7 +5172,7 @@ dependencies = [
  "tokio-native-tls",
  "tokio-rustls",
  "tokio-util",
- "tower 0.5.3",
+ "tower",
  "tower-http",
  "tower-service",
  "url",
@@ -5223,7 +5180,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
- "webpki-roots 1.0.6",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -5252,7 +5209,7 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-rustls",
- "tower 0.5.3",
+ "tower",
  "tower-http",
  "tower-service",
  "url",
@@ -5281,7 +5238,7 @@ dependencies = [
  "cfg-if",
  "getrandom 0.2.17",
  "libc",
- "untrusted",
+ "untrusted 0.9.0",
  "windows-sys 0.52.0",
 ]
 
@@ -5292,6 +5249,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca6c3c1dd0a9ad3a9915a2f6e907d158f9a7e9ac32ddc772b003faafc027d9a8"
 dependencies = [
  "aes 0.9.1",
+ "aws-lc-rs",
  "bitflags 2.11.0",
  "block-padding 0.4.2",
  "byteorder",
@@ -5334,7 +5292,6 @@ dependencies = [
  "polyval",
  "rand 0.10.1",
  "rand_core 0.10.1",
- "ring",
  "russh-cryptovec",
  "russh-util",
  "salsa20",
@@ -5442,15 +5399,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustls-pemfile"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
-dependencies = [
- "rustls-pki-types",
-]
-
-[[package]]
 name = "rustls-pki-types"
 version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5496,7 +5444,7 @@ dependencies = [
  "aws-lc-rs",
  "ring",
  "rustls-pki-types",
- "untrusted",
+ "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -5805,7 +5753,7 @@ version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap",
  "itoa",
  "memchr",
  "serde",
@@ -5883,7 +5831,7 @@ version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap",
  "itoa",
  "ryu",
  "serde",
@@ -6520,7 +6468,7 @@ version = "1.1.0+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8195ca05e4eb728f4ba94f3e3291661320af739c4e43779cbdfae82ab239fcc"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap",
  "serde_core",
  "serde_spanned 1.1.0",
  "toml_datetime 1.1.1+spec-1.1.0",
@@ -6553,7 +6501,7 @@ version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap",
  "serde",
  "serde_spanned 0.6.9",
  "toml_datetime 0.6.11",
@@ -6567,7 +6515,7 @@ version = "0.25.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2153edc6955a6c354fad8f5efd38b6a8769bdccf9fe50f8e1329f81b0baa5d7"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap",
  "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
  "toml_writer",
@@ -6597,13 +6545,12 @@ checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "tonic"
-version = "0.12.3"
+version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "877c5b330756d856ffcc4553ab34a5684481ade925ecc54bcd1bf02b1d0d4d52"
+checksum = "ac2a5518c70fa84342385732db33fb3f44bc4cc748936eb5833d2df34d6445ef"
 dependencies = [
- "async-stream",
  "async-trait",
- "axum 0.7.9",
+ "axum",
  "base64",
  "bytes",
  "h2",
@@ -6615,24 +6562,46 @@ dependencies = [
  "hyper-util",
  "percent-encoding",
  "pin-project",
- "prost",
- "rustls-pemfile",
- "socket2 0.5.10",
+ "socket2 0.6.4",
+ "sync_wrapper",
  "tokio",
  "tokio-rustls",
  "tokio-stream",
- "tower 0.4.13",
+ "tower",
  "tower-layer",
  "tower-service",
  "tracing",
- "webpki-roots 0.26.11",
+ "webpki-roots",
 ]
 
 [[package]]
 name = "tonic-build"
-version = "0.12.3"
+version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9557ce109ea773b399c9b9e5dca39294110b74f1f342cb347a80d1fce8c26a11"
+checksum = "c68f61875ac5293cf72e6c8cf0158086428c82c37229e98c840878f1706b0322"
+dependencies = [
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tonic-prost"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50849f68853be452acf590cde0b146665b8d507b3b8af17261df47e02c209ea0"
+dependencies = [
+ "bytes",
+ "prost",
+ "tonic",
+]
+
+[[package]]
+name = "tonic-prost-build"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "654e5643eff75d7f8c99197ce1440ed19a3474eada74c12bbac488b2cafdae27"
 dependencies = [
  "prettyplease",
  "proc-macro2",
@@ -6640,39 +6609,22 @@ dependencies = [
  "prost-types",
  "quote",
  "syn",
+ "tempfile",
+ "tonic-build",
 ]
 
 [[package]]
 name = "tonic-reflection"
-version = "0.12.3"
+version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "878d81f52e7fcfd80026b7fdb6a9b578b3c3653ba987f87f0dce4b64043cba27"
+checksum = "acccd136a4bf19810a1fde9c74edc6129b42a66b44d0c1c8aaa67aeb49a146a7"
 dependencies = [
  "prost",
  "prost-types",
  "tokio",
  "tokio-stream",
  "tonic",
-]
-
-[[package]]
-name = "tower"
-version = "0.4.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
-dependencies = [
- "futures-core",
- "futures-util",
- "indexmap 1.9.3",
- "pin-project",
- "pin-project-lite",
- "rand 0.8.5",
- "slab",
- "tokio",
- "tokio-util",
- "tower-layer",
- "tower-service",
- "tracing",
+ "tonic-prost",
 ]
 
 [[package]]
@@ -6683,9 +6635,12 @@ checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
 dependencies = [
  "futures-core",
  "futures-util",
+ "indexmap",
  "pin-project-lite",
+ "slab",
  "sync_wrapper",
  "tokio",
+ "tokio-util",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -6704,7 +6659,7 @@ dependencies = [
  "http-body",
  "iri-string",
  "pin-project-lite",
- "tower 0.5.3",
+ "tower",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -6920,6 +6875,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicase"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6949,6 +6910,12 @@ checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "untrusted"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
+
+[[package]]
+name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
@@ -6966,7 +6933,7 @@ dependencies = [
  "rustls-pki-types",
  "ureq-proto",
  "utf8-zero",
- "webpki-roots 1.0.6",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -7211,7 +7178,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
 dependencies = [
  "anyhow",
- "indexmap 2.13.0",
+ "indexmap",
  "wasm-encoder",
  "wasmparser",
 ]
@@ -7237,7 +7204,7 @@ checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
  "bitflags 2.11.0",
  "hashbrown 0.15.5",
- "indexmap 2.13.0",
+ "indexmap",
  "semver",
 ]
 
@@ -7268,15 +7235,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d46a5a140e6f7afeccd8eae97eff335163939eac8b929834875168b29b3d267"
 dependencies = [
  "rustls-pki-types",
-]
-
-[[package]]
-name = "webpki-roots"
-version = "0.26.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
-dependencies = [
- "webpki-roots 1.0.6",
 ]
 
 [[package]]
@@ -7780,7 +7738,7 @@ checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
  "heck",
- "indexmap 2.13.0",
+ "indexmap",
  "prettyplease",
  "syn",
  "wasm-metadata",
@@ -7811,7 +7769,7 @@ checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
  "bitflags 2.11.0",
- "indexmap 2.13.0",
+ "indexmap",
  "log",
  "serde",
  "serde_derive",
@@ -7830,7 +7788,7 @@ checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
 dependencies = [
  "anyhow",
  "id-arena",
- "indexmap 2.13.0",
+ "indexmap",
  "log",
  "semver",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -790,7 +790,6 @@ dependencies = [
  "serde_json",
  "thiserror",
  "tonic",
- "tonic-build",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4844,8 +4844,6 @@ dependencies = [
  "prettyplease",
  "prost",
  "prost-types",
- "pulldown-cmark",
- "pulldown-cmark-to-cmark",
  "regex",
  "syn",
  "tempfile",
@@ -4871,26 +4869,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f94967dc7688f3054c7fac87473ffae4cc4c3904800e2d9f5b857246d8963b0a"
 dependencies = [
  "prost",
-]
-
-[[package]]
-name = "pulldown-cmark"
-version = "0.13.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9f068eba8e7071c5f9511831b44f32c740d5adf574e990f946ddb53db2f314e"
-dependencies = [
- "bitflags 2.11.0",
- "memchr",
- "unicase",
-]
-
-[[package]]
-name = "pulldown-cmark-to-cmark"
-version = "22.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50793def1b900256624a709439404384204a5dc3a6ec580281bfaac35e882e90"
-dependencies = [
- "pulldown-cmark",
 ]
 
 [[package]]
@@ -6872,12 +6850,6 @@ checksum = "e1b88fcfe09e89d3866a5c11019378088af2d24c3fbd4f0543f96b479ec90697"
 dependencies = [
  "version_check",
 ]
-
-[[package]]
-name = "unicase"
-version = "2.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
 name = "unicode-ident"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -130,7 +130,6 @@ clap_complete = "4"
 tonic = "0.14"
 tonic-prost = "0.14"
 prost = "0.14"
-tonic-build = "0.14"
 tonic-prost-build = "0.14"
 prost-build = "0.14"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -125,8 +125,8 @@ clap = { version = "4", features = ["derive"] }
 clap_complete = "4"
 
 # gRPC — tonic 0.14 split prost integration into tonic-prost / tonic-prost-build.
-# The runtime crate (tonic-prost) is a dep of every proto crate that generates
-# messages; the build crate (tonic-prost-build) replaces `tonic_build::configure()`.
+# Service-stub crates use tonic-prost for the runtime codec and
+# tonic-prost-build instead of `tonic_build::configure()` for code generation.
 tonic = "0.14"
 tonic-prost = "0.14"
 prost = "0.14"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -130,7 +130,10 @@ clap_complete = "4"
 tonic = "0.14"
 tonic-prost = "0.14"
 prost = "0.14"
-tonic-prost-build = "0.14"
+# default-features = false drops cleanup-markdown: it must stay off so proto
+# codegen output does not depend on which crates build together (feature
+# unification would otherwise mangle checked-in generated doc comments).
+tonic-prost-build = { version = "0.14", default-features = false, features = ["transport"] }
 prost-build = "0.14"
 
 # HTTP server (Docker REST API)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -124,11 +124,15 @@ sentry = { version = "0.46", default-features = false, features = [
 clap = { version = "4", features = ["derive"] }
 clap_complete = "4"
 
-# gRPC
-tonic = "0.12"
-prost = "0.13"
-tonic-build = "0.12"
-prost-build = "0.13"
+# gRPC — tonic 0.14 split prost integration into tonic-prost / tonic-prost-build.
+# The runtime crate (tonic-prost) is a dep of every proto crate that generates
+# messages; the build crate (tonic-prost-build) replaces `tonic_build::configure()`.
+tonic = "0.14"
+tonic-prost = "0.14"
+prost = "0.14"
+tonic-build = "0.14"
+tonic-prost-build = "0.14"
+prost-build = "0.14"
 
 # HTTP server (Docker REST API)
 axum = { version = "0.8", features = ["macros"] }

--- a/app/arcbox-daemon/Cargo.toml
+++ b/app/arcbox-daemon/Cargo.toml
@@ -39,7 +39,7 @@ tokio-util = "0.7"
 arcbox-docker-tools.workspace = true
 filetime = "0.2.29"
 arcbox-grpc = { version = "0.4.16", path = "../../rpc/arcbox-grpc" }
-tonic-reflection = "0.12"
+tonic-reflection = "0.14"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 macos-resolver = { workspace = true }

--- a/fleet/arcbox-fleet-agent/Cargo.toml
+++ b/fleet/arcbox-fleet-agent/Cargo.toml
@@ -18,7 +18,7 @@ arcbox-fleet-proto = { workspace = true }
 arcbox-fleet-control-proto = { workspace = true }
 arcbox-logging = { workspace = true }
 
-tonic = { workspace = true, features = ["tls", "tls-webpki-roots"] }
+tonic = { workspace = true, features = ["tls-aws-lc", "tls-webpki-roots"] }
 prost = { workspace = true }
 
 tokio = { workspace = true }
@@ -41,7 +41,7 @@ hyper-util = "0.1"
 arcbox-grpc.workspace = true
 arcbox-protocol.workspace = true
 arcbox-constants.workspace = true
-russh = { version = "0.62.1", default-features = false, features = ["ring", "flate2"] }
+russh = { version = "0.62.1", default-features = false, features = ["aws-lc-rs", "flate2"] }
 thiserror.workspace = true
 plist = "1.10.0"
 libc.workspace = true

--- a/fleet/arcbox-fleet-control-proto/Cargo.toml
+++ b/fleet/arcbox-fleet-control-proto/Cargo.toml
@@ -11,10 +11,11 @@ authors.workspace = true
 
 [dependencies]
 tonic = { workspace = true }
+tonic-prost = { workspace = true }
 prost = { workspace = true }
 
 [build-dependencies]
-tonic-build = { workspace = true }
+tonic-prost-build = { workspace = true }
 
 [lints]
 workspace = true

--- a/fleet/arcbox-fleet-control-proto/build.rs
+++ b/fleet/arcbox-fleet-control-proto/build.rs
@@ -7,7 +7,7 @@
 fn main() {
     let proto = "proto/arcbox/fleet/control/v1/control.proto";
 
-    tonic_build::configure()
+    tonic_prost_build::configure()
         .build_client(true)
         .build_server(true)
         .compile_protos(&[proto], &["proto"])

--- a/fleet/arcbox-fleet-proto/Cargo.toml
+++ b/fleet/arcbox-fleet-proto/Cargo.toml
@@ -11,10 +11,11 @@ authors.workspace = true
 
 [dependencies]
 tonic = { workspace = true }
+tonic-prost = { workspace = true }
 prost = { workspace = true }
 
 [build-dependencies]
-tonic-build = { workspace = true }
+tonic-prost-build = { workspace = true }
 
 [lints]
 workspace = true

--- a/fleet/arcbox-fleet-proto/build.rs
+++ b/fleet/arcbox-fleet-proto/build.rs
@@ -8,7 +8,7 @@
 fn main() {
     let proto = "proto/arcbox/fleet/v1/fleet.proto";
 
-    tonic_build::configure()
+    tonic_prost_build::configure()
         .build_client(true)
         .build_server(true)
         .compile_protos(&[proto], &["proto"])

--- a/rpc/arcbox-grpc/Cargo.toml
+++ b/rpc/arcbox-grpc/Cargo.toml
@@ -14,6 +14,7 @@ arcbox-protocol = { workspace = true }
 
 # gRPC
 tonic = { workspace = true }
+tonic-prost = { workspace = true }
 prost = { workspace = true }
 
 # Async
@@ -27,7 +28,7 @@ thiserror = { workspace = true }
 tracing = { workspace = true }
 
 [build-dependencies]
-tonic-build = { workspace = true }
+tonic-prost-build = { workspace = true }
 
 [lints]
 workspace = true

--- a/rpc/arcbox-grpc/build.rs
+++ b/rpc/arcbox-grpc/build.rs
@@ -25,8 +25,8 @@ fn main() {
         std::path::PathBuf::from(std::env::var("OUT_DIR").expect("OUT_DIR set by cargo"))
             .join("arcbox_descriptor.bin");
 
-    // Configure tonic-build
-    tonic_build::configure()
+    // Configure tonic-prost-build (tonic 0.14 split prost integration out of tonic-build)
+    tonic_prost_build::configure()
         // Emit the file descriptor set for gRPC server reflection.
         .file_descriptor_set_path(&descriptor_path)
         // Map arcbox.v1 package to arcbox_protocol::v1 types

--- a/rpc/arcbox-grpc/build.rs
+++ b/rpc/arcbox-grpc/build.rs
@@ -1,7 +1,7 @@
 //! Build script for gRPC service code generation.
 //!
 //! This generates Rust client and server code for gRPC services
-//! defined in the proto files using tonic-build.
+//! defined in the proto files using tonic-prost-build.
 //!
 //! Message types are imported from arcbox-protocol (prost-generated).
 //! All protos use the unified `arcbox.v1` package namespace.

--- a/rpc/arcbox-protocol/Cargo.toml
+++ b/rpc/arcbox-protocol/Cargo.toml
@@ -16,7 +16,6 @@ tonic = { workspace = true }
 
 [build-dependencies]
 prost-build = { workspace = true }
-tonic-build = { workspace = true }
 
 [dev-dependencies]
 serde_json = { workspace = true }

--- a/rpc/arcbox-protocol/src/generated/arcbox.v1.rs
+++ b/rpc/arcbox-protocol/src/generated/arcbox.v1.rs
@@ -2,12 +2,12 @@
 /// Empty message for requests/responses that don't need data.
 #[derive(serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[derive(Clone, Copy, PartialEq, ::prost::Message)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct Empty {}
 /// Timestamp with nanosecond precision.
 #[derive(serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[derive(Clone, Copy, PartialEq, ::prost::Message)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct Timestamp {
     /// Seconds since Unix epoch.
     #[prost(int64, tag = "1")]
@@ -19,7 +19,7 @@ pub struct Timestamp {
 /// Key-value pair for labels, environment variables, etc.
 #[derive(serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct KeyValue {
     #[prost(string, tag = "1")]
     pub key: ::prost::alloc::string::String,
@@ -29,7 +29,7 @@ pub struct KeyValue {
 /// Mount specification for bind mounts and volumes.
 #[derive(serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct Mount {
     /// Source path on host.
     #[prost(string, tag = "1")]
@@ -47,7 +47,7 @@ pub struct Mount {
 /// Port binding specification.
 #[derive(serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct PortBinding {
     /// Port inside the container.
     #[prost(uint32, tag = "1")]
@@ -128,7 +128,7 @@ pub struct CreateMachineRequest {
 /// Request that targets a machine's guest agent.
 #[derive(serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct MachineAgentRequest {
     /// Machine ID or name.
     #[prost(string, tag = "1")]
@@ -137,7 +137,7 @@ pub struct MachineAgentRequest {
 /// Ping response from machine guest agent.
 #[derive(serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct MachinePingResponse {
     /// Response payload.
     #[prost(string, tag = "1")]
@@ -188,7 +188,7 @@ pub struct MachineSystemInfo {
 /// Directory mount configuration.
 #[derive(serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct DirectoryMount {
     /// Host directory path.
     #[prost(string, tag = "1")]
@@ -203,7 +203,7 @@ pub struct DirectoryMount {
 /// Response to create machine.
 #[derive(serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct CreateMachineResponse {
     /// Machine ID.
     #[prost(string, tag = "1")]
@@ -212,7 +212,7 @@ pub struct CreateMachineResponse {
 /// Request to start a machine.
 #[derive(serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct StartMachineRequest {
     /// Machine ID or name.
     #[prost(string, tag = "1")]
@@ -221,7 +221,7 @@ pub struct StartMachineRequest {
 /// Request to stop a machine.
 #[derive(serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct StopMachineRequest {
     /// Machine ID or name.
     #[prost(string, tag = "1")]
@@ -233,7 +233,7 @@ pub struct StopMachineRequest {
 /// Request to remove a machine.
 #[derive(serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct RemoveMachineRequest {
     /// Machine ID or name.
     #[prost(string, tag = "1")]
@@ -248,7 +248,7 @@ pub struct RemoveMachineRequest {
 /// Request to list machines.
 #[derive(serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[derive(Clone, Copy, PartialEq, ::prost::Message)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct ListMachinesRequest {
     /// Show all machines (including stopped).
     #[prost(bool, tag = "1")]
@@ -266,7 +266,7 @@ pub struct ListMachinesResponse {
 /// Summary information about a machine.
 #[derive(serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct MachineSummary {
     /// Machine ID.
     #[prost(string, tag = "1")]
@@ -296,7 +296,7 @@ pub struct MachineSummary {
 /// Request to inspect a machine.
 #[derive(serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct InspectMachineRequest {
     /// Machine ID or name.
     #[prost(string, tag = "1")]
@@ -341,7 +341,7 @@ pub struct MachineInfo {
 /// Machine hardware configuration.
 #[derive(serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct MachineHardware {
     /// Number of CPUs.
     #[prost(uint32, tag = "1")]
@@ -356,7 +356,7 @@ pub struct MachineHardware {
 /// Machine network configuration.
 #[derive(serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct MachineNetwork {
     /// IP address.
     #[prost(string, tag = "1")]
@@ -377,7 +377,7 @@ pub struct MachineNetwork {
 /// Machine storage configuration.
 #[derive(serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct MachineStorage {
     /// Disk size in bytes.
     #[prost(uint64, tag = "1")]
@@ -392,7 +392,7 @@ pub struct MachineStorage {
 /// Machine OS information.
 #[derive(serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct MachineOs {
     /// Distribution name.
     #[prost(string, tag = "1")]
@@ -432,7 +432,7 @@ pub struct MachineExecRequest {
 /// Exec output from a machine.
 #[derive(serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct MachineExecOutput {
     /// Stream type: stdout or stderr.
     #[prost(string, tag = "1")]
@@ -450,7 +450,7 @@ pub struct MachineExecOutput {
 /// Request for SSH connection info.
 #[derive(serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct SshInfoRequest {
     /// Machine ID or name.
     #[prost(string, tag = "1")]
@@ -459,7 +459,7 @@ pub struct SshInfoRequest {
 /// SSH connection information.
 #[derive(serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct SshInfoResponse {
     /// Host to connect to.
     #[prost(string, tag = "1")]
@@ -480,7 +480,7 @@ pub struct SshInfoResponse {
 /// Request to create a macOS guest from a base image.
 #[derive(serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct CreateMacosMachineRequest {
     /// Guest name (unique).
     #[prost(string, tag = "1")]
@@ -498,7 +498,7 @@ pub struct CreateMacosMachineRequest {
 /// Request to start a macOS guest.
 #[derive(serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct StartMacosMachineRequest {
     /// Guest name.
     #[prost(string, tag = "1")]
@@ -507,7 +507,7 @@ pub struct StartMacosMachineRequest {
 /// Request to stop a macOS guest.
 #[derive(serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct StopMacosMachineRequest {
     /// Guest name.
     #[prost(string, tag = "1")]
@@ -516,7 +516,7 @@ pub struct StopMacosMachineRequest {
 /// Request to remove a macOS guest.
 #[derive(serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct RemoveMacosMachineRequest {
     /// Guest name.
     #[prost(string, tag = "1")]
@@ -528,7 +528,7 @@ pub struct RemoveMacosMachineRequest {
 /// Request to inspect a macOS guest.
 #[derive(serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct InspectMacosMachineRequest {
     /// Guest name.
     #[prost(string, tag = "1")]
@@ -537,7 +537,7 @@ pub struct InspectMacosMachineRequest {
 /// Summary of a macOS guest.
 #[derive(serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct MacosMachineSummary {
     /// Guest name.
     #[prost(string, tag = "1")]
@@ -570,7 +570,7 @@ pub struct MacosMachineListResponse {
 /// Detailed information about a macOS guest.
 #[derive(serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct MacosMachineInfo {
     /// Guest name.
     #[prost(string, tag = "1")]
@@ -605,7 +605,7 @@ pub struct MacosMachineInfo {
 /// characteristics come from the published manifest, not the request.
 #[derive(serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct MacosImagePullRequest {
     /// Image reference: a stream name with an optional pinned version,
     /// e.g. "tahoe-base" or "tahoe-base@2026.07.02".
@@ -637,7 +637,7 @@ pub struct MacosImagePullEvent {
 /// MacosImagePullRequest: exactly one of `reference` / `manifest_url`.
 #[derive(serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct MacosImageResolveRequest {
     /// Image reference: a stream name with an optional pinned version.
     #[prost(string, tag = "1")]
@@ -649,7 +649,7 @@ pub struct MacosImageResolveRequest {
 /// What a reference resolves to, without pulling.
 #[derive(serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct MacosImageResolveResponse {
     /// Stream name (e.g. "tahoe-base").
     #[prost(string, tag = "1")]
@@ -676,7 +676,7 @@ pub struct MacosImageResolveResponse {
 /// Summary of a macOS base image.
 #[derive(serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct MacosImageSummary {
     /// Image name.
     #[prost(string, tag = "1")]
@@ -715,7 +715,7 @@ pub struct MacosImageListResponse {
 /// Request to remove a macOS base image.
 #[derive(serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct MacosImageRemoveRequest {
     /// Image name.
     #[prost(string, tag = "1")]
@@ -777,7 +777,7 @@ pub struct CreateContainerRequest {
 /// Response to create container.
 #[derive(serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct CreateContainerResponse {
     /// Container ID.
     #[prost(string, tag = "1")]
@@ -789,7 +789,7 @@ pub struct CreateContainerResponse {
 /// Request to start a container.
 #[derive(serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct StartContainerRequest {
     /// Container ID or name.
     #[prost(string, tag = "1")]
@@ -798,7 +798,7 @@ pub struct StartContainerRequest {
 /// Request to stop a container.
 #[derive(serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct StopContainerRequest {
     /// Container ID or name.
     #[prost(string, tag = "1")]
@@ -810,7 +810,7 @@ pub struct StopContainerRequest {
 /// Request to kill a container.
 #[derive(serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct KillContainerRequest {
     /// Container ID or name.
     #[prost(string, tag = "1")]
@@ -822,7 +822,7 @@ pub struct KillContainerRequest {
 /// Request to remove a container.
 #[derive(serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct RemoveContainerRequest {
     /// Container ID or name.
     #[prost(string, tag = "1")]
@@ -837,7 +837,7 @@ pub struct RemoveContainerRequest {
 /// Request to list containers.
 #[derive(serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct ListContainersRequest {
     /// Show all containers (not just running).
     #[prost(bool, tag = "1")]
@@ -907,7 +907,7 @@ pub struct ContainerSummary {
 /// Request to inspect a container.
 #[derive(serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct InspectContainerRequest {
     /// Container ID or name.
     #[prost(string, tag = "1")]
@@ -955,7 +955,7 @@ pub struct ContainerInfo {
 /// Container state information.
 #[derive(serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct ContainerState {
     /// Current status.
     #[prost(string, tag = "1")]
@@ -1034,7 +1034,7 @@ pub struct ContainerConfig {
 /// Network settings.
 #[derive(serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct NetworkSettings {
     /// IP address.
     #[prost(string, tag = "1")]
@@ -1052,7 +1052,7 @@ pub struct NetworkSettings {
 /// Mount point information.
 #[derive(serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct MountPoint {
     /// Mount type.
     #[prost(string, tag = "1")]
@@ -1070,7 +1070,7 @@ pub struct MountPoint {
 /// Request for container logs.
 #[derive(serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct LogsRequest {
     /// Container ID or name.
     #[prost(string, tag = "1")]
@@ -1100,7 +1100,7 @@ pub struct LogsRequest {
 /// Log entry.
 #[derive(serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct LogEntry {
     /// Stream type: stdout or stderr.
     #[prost(string, tag = "1")]
@@ -1115,7 +1115,7 @@ pub struct LogEntry {
 /// Request to create an exec instance.
 #[derive(serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct ExecCreateRequest {
     /// Container ID or name.
     #[prost(string, tag = "1")]
@@ -1151,7 +1151,7 @@ pub struct ExecCreateRequest {
 /// Response to create exec.
 #[derive(serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct ExecCreateResponse {
     /// Exec ID.
     #[prost(string, tag = "1")]
@@ -1160,7 +1160,7 @@ pub struct ExecCreateResponse {
 /// Request to start an exec instance.
 #[derive(serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct ExecStartRequest {
     /// Exec ID.
     #[prost(string, tag = "1")]
@@ -1178,7 +1178,7 @@ pub struct ExecStartRequest {
 /// Exec output.
 #[derive(serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct ExecOutput {
     /// Stream type: stdout or stderr.
     #[prost(string, tag = "1")]
@@ -1190,7 +1190,7 @@ pub struct ExecOutput {
 /// Attach input.
 #[derive(serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct AttachInput {
     /// Input data.
     #[prost(bytes = "vec", tag = "1")]
@@ -1208,7 +1208,7 @@ pub struct AttachInput {
 /// Attach output.
 #[derive(serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct AttachOutput {
     /// Stream type.
     #[prost(string, tag = "1")]
@@ -1220,7 +1220,7 @@ pub struct AttachOutput {
 /// Request to wait for a container.
 #[derive(serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct WaitContainerRequest {
     /// Container ID or name.
     #[prost(string, tag = "1")]
@@ -1232,7 +1232,7 @@ pub struct WaitContainerRequest {
 /// Response when container exits.
 #[derive(serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct WaitContainerResponse {
     /// Exit code.
     #[prost(int64, tag = "1")]
@@ -1244,7 +1244,7 @@ pub struct WaitContainerResponse {
 /// Request to pause a container.
 #[derive(serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct PauseContainerRequest {
     /// Container ID or name.
     #[prost(string, tag = "1")]
@@ -1253,7 +1253,7 @@ pub struct PauseContainerRequest {
 /// Request to unpause a container.
 #[derive(serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct UnpauseContainerRequest {
     /// Container ID or name.
     #[prost(string, tag = "1")]
@@ -1262,7 +1262,7 @@ pub struct UnpauseContainerRequest {
 /// Request for container stats.
 #[derive(serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct ContainerStatsRequest {
     /// Container ID or name.
     #[prost(string, tag = "1")]
@@ -1271,7 +1271,7 @@ pub struct ContainerStatsRequest {
 /// Container stats response.
 #[derive(serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[derive(Clone, Copy, PartialEq, ::prost::Message)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct ContainerStatsResponse {
     /// CPU usage in nanoseconds.
     #[prost(uint64, tag = "1")]
@@ -1307,7 +1307,7 @@ pub struct ContainerStatsResponse {
 /// Request for container top (process list).
 #[derive(serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct ContainerTopRequest {
     /// Container ID or name.
     #[prost(string, tag = "1")]
@@ -1331,7 +1331,7 @@ pub struct ContainerTopResponse {
 /// A single process row.
 #[derive(serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct ProcessRow {
     /// Values for each column.
     #[prost(string, repeated, tag = "1")]
@@ -1340,7 +1340,7 @@ pub struct ProcessRow {
 /// Request to pull an image.
 #[derive(serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct PullImageRequest {
     /// Image reference (e.g., "ubuntu:22.04", "docker.io/library/nginx:latest").
     #[prost(string, tag = "1")]
@@ -1355,7 +1355,7 @@ pub struct PullImageRequest {
 /// Progress update during pull.
 #[derive(serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct PullProgress {
     /// Layer ID or digest.
     #[prost(string, tag = "1")]
@@ -1376,7 +1376,7 @@ pub struct PullProgress {
 /// Request to push an image.
 #[derive(serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct PushImageRequest {
     /// Image reference to push.
     #[prost(string, tag = "1")]
@@ -1388,7 +1388,7 @@ pub struct PushImageRequest {
 /// Progress update during push.
 #[derive(serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct PushProgress {
     /// Layer ID.
     #[prost(string, tag = "1")]
@@ -1409,7 +1409,7 @@ pub struct PushProgress {
 /// Request to list images.
 #[derive(serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct ListImagesRequest {
     /// Show all images (including intermediate layers).
     #[prost(bool, tag = "1")]
@@ -1464,7 +1464,7 @@ pub struct ImageSummary {
 /// Request to inspect an image.
 #[derive(serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct InspectImageRequest {
     /// Image ID or reference.
     #[prost(string, tag = "1")]
@@ -1558,7 +1558,7 @@ pub struct ImageConfig {
 /// Root filesystem information.
 #[derive(serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct RootFs {
     /// Type (usually "layers").
     #[prost(string, tag = "1")]
@@ -1570,7 +1570,7 @@ pub struct RootFs {
 /// Request to remove an image.
 #[derive(serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct RemoveImageRequest {
     /// Image ID or reference.
     #[prost(string, tag = "1")]
@@ -1585,7 +1585,7 @@ pub struct RemoveImageRequest {
 /// Response to remove image.
 #[derive(serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct RemoveImageResponse {
     /// Deleted image IDs.
     #[prost(string, repeated, tag = "1")]
@@ -1597,7 +1597,7 @@ pub struct RemoveImageResponse {
 /// Request to tag an image.
 #[derive(serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct TagImageRequest {
     /// Source image ID or reference.
     #[prost(string, tag = "1")]
@@ -1612,7 +1612,7 @@ pub struct TagImageRequest {
 /// Build context chunk.
 #[derive(serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct BuildContext {
     /// Tar archive chunk.
     #[prost(bytes = "vec", tag = "1")]
@@ -1624,7 +1624,7 @@ pub struct BuildContext {
 /// Progress update during build.
 #[derive(serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct BuildProgress {
     /// Stream type.
     #[prost(string, tag = "1")]
@@ -1645,7 +1645,7 @@ pub struct BuildProgress {
 /// Request to check if an image exists.
 #[derive(serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct ExistsImageRequest {
     /// Image reference.
     #[prost(string, tag = "1")]
@@ -1654,7 +1654,7 @@ pub struct ExistsImageRequest {
 /// Response to exists check.
 #[derive(serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct ExistsImageResponse {
     /// Whether the image exists.
     #[prost(bool, tag = "1")]
@@ -1666,7 +1666,7 @@ pub struct ExistsImageResponse {
 /// Ping request.
 #[derive(serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct AgentPingRequest {
     /// Optional payload.
     #[prost(string, tag = "1")]
@@ -1678,7 +1678,7 @@ pub struct AgentPingRequest {
 /// Ping response.
 #[derive(serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct AgentPingResponse {
     /// Response payload.
     #[prost(string, tag = "1")]
@@ -1735,7 +1735,7 @@ pub struct SystemInfo {
 /// Request to ensure runtime services are available.
 #[derive(serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[derive(Clone, Copy, PartialEq, ::prost::Message)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct RuntimeEnsureRequest {
     /// Whether to attempt starting services when not ready.
     #[prost(bool, tag = "1")]
@@ -1744,7 +1744,7 @@ pub struct RuntimeEnsureRequest {
 /// Response from runtime ensure operation.
 #[derive(serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct RuntimeEnsureResponse {
     /// Whether runtime is ready for Docker API requests.
     #[prost(bool, tag = "1")]
@@ -1762,12 +1762,12 @@ pub struct RuntimeEnsureResponse {
 /// Request for runtime status.
 #[derive(serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[derive(Clone, Copy, PartialEq, ::prost::Message)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct RuntimeStatusRequest {}
 /// Request for guest-driven readiness events.
 #[derive(serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[derive(Clone, Copy, PartialEq, ::prost::Message)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct WatchReadinessRequest {
     /// Whether the agent should start the runtime if it is not ready.
     #[prost(bool, tag = "1")]
@@ -1843,7 +1843,7 @@ pub mod readiness_event {
 /// re-issues the request to keep watching.
 #[derive(serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[derive(Clone, Copy, PartialEq, ::prost::Message)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct WatchMemoryPressureRequest {
     /// Watch window in milliseconds; the agent ends the stream with a
     /// WINDOW_ELAPSED frame when it passes.
@@ -1869,7 +1869,7 @@ pub struct WatchMemoryPressureRequest {
 /// One frame on the memory pressure stream.
 #[derive(serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[derive(Clone, Copy, PartialEq, ::prost::Message)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct MemoryPressureEvent {
     /// Why this frame was emitted.
     #[prost(enumeration = "memory_pressure_event::Reason", tag = "1")]
@@ -1955,12 +1955,12 @@ pub struct RuntimeStatusResponse {
 /// Request to trigger an immediate fstrim on data mount points.
 #[derive(serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[derive(Clone, Copy, PartialEq, ::prost::Message)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct DiskTrimRequest {}
 /// Response from a disk trim operation.
 #[derive(serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct DiskTrimResponse {
     /// Human-readable result summary (e.g. bytes trimmed per mount).
     #[prost(string, tag = "1")]
@@ -1981,7 +1981,7 @@ pub struct PortBindingsChanged {
 /// Notification that a container no longer has active published ports.
 #[derive(serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct PortBindingsRemoved {
     /// Container ID.
     #[prost(string, tag = "1")]
@@ -1990,7 +1990,7 @@ pub struct PortBindingsRemoved {
 /// Individual service status within the guest runtime stack.
 #[derive(serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct ServiceStatus {
     /// Service name (e.g. "containerd", "dockerd", "runc").
     #[prost(string, tag = "1")]
@@ -2005,12 +2005,12 @@ pub struct ServiceStatus {
 /// Request to start the native Kubernetes cluster.
 #[derive(serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[derive(Clone, Copy, PartialEq, ::prost::Message)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct KubernetesStartRequest {}
 /// Response from starting the native Kubernetes cluster.
 #[derive(serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct KubernetesStartResponse {
     /// Whether the cluster process is running.
     #[prost(bool, tag = "1")]
@@ -2028,12 +2028,12 @@ pub struct KubernetesStartResponse {
 /// Request to stop the native Kubernetes cluster.
 #[derive(serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[derive(Clone, Copy, PartialEq, ::prost::Message)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct KubernetesStopRequest {}
 /// Response from stopping the native Kubernetes cluster.
 #[derive(serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct KubernetesStopResponse {
     /// Whether the cluster is fully stopped.
     #[prost(bool, tag = "1")]
@@ -2045,12 +2045,12 @@ pub struct KubernetesStopResponse {
 /// Request to delete the native Kubernetes cluster state.
 #[derive(serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[derive(Clone, Copy, PartialEq, ::prost::Message)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct KubernetesDeleteRequest {}
 /// Response from deleting the native Kubernetes cluster state.
 #[derive(serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct KubernetesDeleteResponse {
     /// Human-readable detail for diagnostics.
     #[prost(string, tag = "1")]
@@ -2059,7 +2059,7 @@ pub struct KubernetesDeleteResponse {
 /// Request for Kubernetes cluster status.
 #[derive(serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[derive(Clone, Copy, PartialEq, ::prost::Message)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct KubernetesStatusRequest {}
 /// Runtime status report for the native Kubernetes cluster.
 #[derive(serde::Serialize, serde::Deserialize)]
@@ -2085,12 +2085,12 @@ pub struct KubernetesStatusResponse {
 /// Request for managed kubeconfig content.
 #[derive(serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[derive(Clone, Copy, PartialEq, ::prost::Message)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct KubernetesKubeconfigRequest {}
 /// Managed kubeconfig payload exported from the guest cluster.
 #[derive(serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct KubernetesKubeconfigResponse {
     /// Raw kubeconfig YAML.
     #[prost(string, tag = "1")]
@@ -2105,7 +2105,7 @@ pub struct KubernetesKubeconfigResponse {
 /// Graceful shutdown request from host.
 #[derive(serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[derive(Clone, Copy, PartialEq, ::prost::Message)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct ShutdownRequest {
     /// Grace period in seconds for processes to exit after SIGTERM.
     /// 0 means use the agent's default (currently 25 seconds).
@@ -2115,7 +2115,7 @@ pub struct ShutdownRequest {
 /// Shutdown acknowledgement. Sent before the agent begins teardown.
 #[derive(serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[derive(Clone, Copy, PartialEq, ::prost::Message)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct ShutdownResponse {
     /// Always true when the agent accepts the request.
     #[prost(bool, tag = "1")]
@@ -2126,7 +2126,7 @@ pub struct ShutdownResponse {
 /// Used by the ABX-362 E2E harness. Not intended for production callers.
 #[derive(serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct MmapReadFileRequest {
     /// Absolute guest path (typically a file inside a VirtioFS mount).
     #[prost(string, tag = "1")]
@@ -2142,12 +2142,12 @@ pub struct MmapReadFileRequest {
 /// Response to `MmapReadFileRequest`.
 #[derive(serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct MmapReadFileResponse {
     /// Bytes read, trimmed to the originally requested length.
     #[prost(bytes = "vec", tag = "1")]
     pub data: ::prost::alloc::vec::Vec<u8>,
-    /// Number of bytes actually read (<= length). Short if file smaller
+    /// Number of bytes actually read (\<= length). Short if file smaller
     /// than offset+length.
     #[prost(uint64, tag = "2")]
     pub bytes_read: u64,
@@ -2196,7 +2196,7 @@ pub struct IpamConfig {
 /// IPAM subnet configuration.
 #[derive(serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct IpamSubnet {
     /// Subnet in CIDR format.
     #[prost(string, tag = "1")]
@@ -2211,7 +2211,7 @@ pub struct IpamSubnet {
 /// Response to create network.
 #[derive(serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct CreateNetworkResponse {
     /// Network ID.
     #[prost(string, tag = "1")]
@@ -2223,7 +2223,7 @@ pub struct CreateNetworkResponse {
 /// Request to remove a network.
 #[derive(serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct RemoveNetworkRequest {
     /// Network ID or name.
     #[prost(string, tag = "1")]
@@ -2282,7 +2282,7 @@ pub struct NetworkSummary {
 /// Request to inspect a network.
 #[derive(serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct InspectNetworkRequest {
     /// Network ID or name.
     #[prost(string, tag = "1")]
@@ -2335,7 +2335,7 @@ pub struct NetworkInfo {
 /// Container connected to a network.
 #[derive(serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct NetworkContainer {
     /// Container name.
     #[prost(string, tag = "1")]
@@ -2356,7 +2356,7 @@ pub struct NetworkContainer {
 /// The System VM's hypervisor backend.
 #[derive(serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[derive(Clone, Copy, PartialEq, ::prost::Message)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct SystemVmBackendInfo {
     #[prost(enumeration = "SystemVmBackend", tag = "1")]
     pub backend: i32,
@@ -2364,7 +2364,7 @@ pub struct SystemVmBackendInfo {
 /// Request to switch the System VM's hypervisor backend.
 #[derive(serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[derive(Clone, Copy, PartialEq, ::prost::Message)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct SetSystemVmBackendRequest {
     #[prost(enumeration = "SystemVmBackend", tag = "1")]
     pub backend: i32,
@@ -2389,7 +2389,7 @@ pub struct VirtioDebugInfo {
 /// Cumulative exit counters for one vCPU.
 #[derive(serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[derive(Clone, Copy, PartialEq, ::prost::Message)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct VcpuDebug {
     #[prost(uint32, tag = "1")]
     pub vcpu: u32,
@@ -2455,7 +2455,7 @@ pub struct VirtioDeviceDebug {
 /// address was configured and lies inside guest RAM.
 #[derive(serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[derive(Clone, Copy, PartialEq, ::prost::Message)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct VirtioQueueDebug {
     /// Queue index within the device.
     #[prost(uint32, tag = "1")]
@@ -2492,12 +2492,12 @@ pub struct VirtioQueueDebug {
 /// Request to get system info.
 #[derive(serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[derive(Clone, Copy, PartialEq, ::prost::Message)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct GetInfoRequest {}
 /// Response to get system info.
 #[derive(serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct GetInfoResponse {
     /// Number of containers.
     #[prost(int64, tag = "1")]
@@ -2554,12 +2554,12 @@ pub struct GetInfoResponse {
 /// Request to get version.
 #[derive(serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[derive(Clone, Copy, PartialEq, ::prost::Message)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct GetVersionRequest {}
 /// Response to get version.
 #[derive(serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct GetVersionResponse {
     /// Version string.
     #[prost(string, tag = "1")]
@@ -2589,12 +2589,12 @@ pub struct GetVersionResponse {
 /// Request to ping the server.
 #[derive(serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[derive(Clone, Copy, PartialEq, ::prost::Message)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct SystemPingRequest {}
 /// Response to ping.
 #[derive(serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct SystemPingResponse {
     /// API version.
     #[prost(string, tag = "1")]
@@ -2669,7 +2669,7 @@ pub struct PruneRequest {
 /// Response to prune.
 #[derive(serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct PruneResponse {
     /// Space reclaimed in bytes.
     #[prost(uint64, tag = "1")]
@@ -2690,7 +2690,7 @@ pub struct PruneResponse {
 /// Request to get the icon URL for a container image.
 #[derive(serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct GetImageIconRequest {
     /// Fully qualified image name (e.g., "nginx", "localstack/localstack", "ghcr.io/astral-sh/uv").
     #[prost(string, tag = "1")]
@@ -2699,7 +2699,7 @@ pub struct GetImageIconRequest {
 /// Response containing the icon URL.
 #[derive(serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct GetImageIconResponse {
     /// Icon URL, empty if not found.
     #[prost(string, tag = "1")]
@@ -2731,7 +2731,7 @@ pub struct CreateVolumeRequest {
 /// Response to create volume.
 #[derive(serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct CreateVolumeResponse {
     /// Volume name.
     #[prost(string, tag = "1")]
@@ -2746,7 +2746,7 @@ pub struct CreateVolumeResponse {
 /// Request to remove a volume.
 #[derive(serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct RemoveVolumeRequest {
     /// Volume name.
     #[prost(string, tag = "1")]
@@ -2780,7 +2780,7 @@ pub struct ListVolumesResponse {
 /// Request to inspect a volume.
 #[derive(serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct InspectVolumeRequest {
     /// Volume name.
     #[prost(string, tag = "1")]
@@ -2825,7 +2825,7 @@ pub struct VolumeInfo {
 /// Volume usage data.
 #[derive(serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[derive(Clone, Copy, PartialEq, ::prost::Message)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct VolumeUsage {
     /// Size in bytes.
     #[prost(int64, tag = "1")]
@@ -2837,7 +2837,7 @@ pub struct VolumeUsage {
 /// Request to prepare a migration.
 #[derive(serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct PrepareMigrationRequest {
     /// Stable source runtime identifier (for example, "docker-desktop" or "orbstack").
     #[prost(string, tag = "1")]
@@ -2852,7 +2852,7 @@ pub struct PrepareMigrationRequest {
 /// Prepared migration summary.
 #[derive(serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct PrepareMigrationResponse {
     /// Opaque identifier for the prepared plan.
     #[prost(string, tag = "1")]
@@ -2888,7 +2888,7 @@ pub struct PrepareMigrationResponse {
 /// Request to run a prepared migration.
 #[derive(serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct RunMigrationRequest {
     /// Opaque identifier returned by PrepareMigration.
     #[prost(string, tag = "1")]
@@ -2900,7 +2900,7 @@ pub struct RunMigrationRequest {
 /// Streaming migration progress event.
 #[derive(serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct RunMigrationEvent {
     /// Opaque identifier of the plan being executed.
     #[prost(string, tag = "1")]
@@ -2930,7 +2930,7 @@ pub struct RunMigrationEvent {
 /// Shell input for interactive sessions.
 #[derive(serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct ShellInput {
     /// Input data.
     #[prost(bytes = "vec", tag = "1")]
@@ -2942,7 +2942,7 @@ pub struct ShellInput {
 /// Shell output for interactive sessions.
 #[derive(serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct ShellOutput {
     /// Output data.
     #[prost(bytes = "vec", tag = "1")]
@@ -2957,7 +2957,7 @@ pub struct ShellOutput {
 /// Terminal size.
 #[derive(serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[derive(Clone, Copy, PartialEq, ::prost::Message)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct TerminalSize {
     /// Terminal width.
     #[prost(uint32, tag = "1")]
@@ -2971,7 +2971,7 @@ pub struct TerminalSize {
 /// without managing its lifecycle.
 #[derive(serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct SetupStatus {
     /// Current daemon phase.
     #[prost(enumeration = "setup_status::Phase", tag = "1")]

--- a/rpc/arcbox-protocol/src/generated/arcbox.v1.rs
+++ b/rpc/arcbox-protocol/src/generated/arcbox.v1.rs
@@ -2147,7 +2147,7 @@ pub struct MmapReadFileResponse {
     /// Bytes read, trimmed to the originally requested length.
     #[prost(bytes = "vec", tag = "1")]
     pub data: ::prost::alloc::vec::Vec<u8>,
-    /// Number of bytes actually read (\<= length). Short if file smaller
+    /// Number of bytes actually read (<= length). Short if file smaller
     /// than offset+length.
     #[prost(uint64, tag = "2")]
     pub bytes_read: u64,

--- a/rpc/arcbox-protocol/src/generated/sandbox.v1.rs
+++ b/rpc/arcbox-protocol/src/generated/sandbox.v1.rs
@@ -2,12 +2,12 @@
 /// Empty response / request.
 #[derive(serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[derive(Clone, Copy, PartialEq, ::prost::Message)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct Empty {}
 /// Network configuration for a sandbox.
 #[derive(serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct NetworkSpec {
     /// Network mode: "tap" (default, TAP + IP pool) or "none" (no network).
     #[prost(string, tag = "1")]
@@ -16,7 +16,7 @@ pub struct NetworkSpec {
 /// A single bind mount into the sandbox.
 #[derive(serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct Mount {
     /// Source path on the host.
     #[prost(string, tag = "1")]
@@ -31,7 +31,7 @@ pub struct Mount {
 /// CPU and memory resource limits.
 #[derive(serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[derive(Clone, Copy, PartialEq, ::prost::Message)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct ResourceLimits {
     /// Number of vCPUs (0 = daemon default).
     #[prost(uint32, tag = "1")]
@@ -43,7 +43,7 @@ pub struct ResourceLimits {
 /// Terminal size for TTY resize events.
 #[derive(serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[derive(Clone, Copy, PartialEq, ::prost::Message)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct TerminalSize {
     /// Terminal width in columns.
     #[prost(uint32, tag = "1")]
@@ -126,7 +126,7 @@ pub struct CreateSandboxRequest {
 /// Returned immediately; the sandbox may still be booting (state "starting").
 #[derive(serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct CreateSandboxResponse {
     /// Assigned or caller-supplied sandbox ID.
     #[prost(string, tag = "1")]
@@ -172,7 +172,7 @@ pub struct RunRequest {
 /// A single chunk of streaming output from Run.
 #[derive(serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct RunOutput {
     /// Stream name: "stdout" | "stderr" | "exit".
     #[prost(string, tag = "1")]
@@ -246,7 +246,7 @@ pub struct ExecRequest {
 /// A single chunk of streaming output from Exec.
 #[derive(serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct ExecOutput {
     /// Stream name: "stdout" | "stderr" | "exit".
     #[prost(string, tag = "1")]
@@ -264,7 +264,7 @@ pub struct ExecOutput {
 /// Request to read a file from a sandbox.
 #[derive(serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct ReadFileRequest {
     /// Sandbox ID.
     #[prost(string, tag = "1")]
@@ -276,7 +276,7 @@ pub struct ReadFileRequest {
 /// One chunk of file data in a ReadFile / WriteFile stream.
 #[derive(serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct FileChunk {
     /// Raw bytes (may be empty on the final chunk).
     #[prost(bytes = "vec", tag = "1")]
@@ -288,7 +288,7 @@ pub struct FileChunk {
 /// Opens a WriteFile stream. Must be the first WriteFileRequest message.
 #[derive(serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct WriteFileOpen {
     /// Sandbox ID.
     #[prost(string, tag = "1")]
@@ -303,7 +303,7 @@ pub struct WriteFileOpen {
 /// A single client message in a WriteFile stream.
 #[derive(serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct WriteFileRequest {
     #[prost(oneof = "write_file_request::Payload", tags = "1, 2")]
     pub payload: ::core::option::Option<write_file_request::Payload>,
@@ -312,7 +312,7 @@ pub struct WriteFileRequest {
 pub mod write_file_request {
     #[derive(serde::Serialize, serde::Deserialize)]
     #[serde(rename_all = "camelCase")]
-    #[derive(Clone, PartialEq, ::prost::Oneof)]
+    #[derive(Clone, PartialEq, Eq, Hash, ::prost::Oneof)]
     pub enum Payload {
         /// Stream header — sandbox, path, and mode.
         #[prost(message, tag = "1")]
@@ -325,7 +325,7 @@ pub mod write_file_request {
 /// Request to expose a sandbox port on the host.
 #[derive(serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct ExposePortRequest {
     /// Sandbox ID.
     #[prost(string, tag = "1")]
@@ -343,7 +343,7 @@ pub struct ExposePortRequest {
 /// Response to ExposePort.
 #[derive(serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[derive(Clone, Copy, PartialEq, ::prost::Message)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct ExposePortResponse {
     /// Host port the service is reachable on (via loopback).
     #[prost(uint32, tag = "1")]
@@ -355,7 +355,7 @@ pub struct ExposePortResponse {
 /// Request to remove an exposed port mapping.
 #[derive(serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct UnexposePortRequest {
     /// Sandbox ID.
     #[prost(string, tag = "1")]
@@ -370,7 +370,7 @@ pub struct UnexposePortRequest {
 /// Ask the guest agent to DNAT a reserved guest port to a sandbox port.
 #[derive(serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct SandboxPortForwardRequest {
     /// Sandbox ID.
     #[prost(string, tag = "1")]
@@ -385,7 +385,7 @@ pub struct SandboxPortForwardRequest {
 /// Guest agent's answer: the allocated reserved-range guest port.
 #[derive(serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[derive(Clone, Copy, PartialEq, ::prost::Message)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct SandboxPortForwardResponse {
     /// Guest port now DNATed to the sandbox.
     #[prost(uint32, tag = "1")]
@@ -394,7 +394,7 @@ pub struct SandboxPortForwardResponse {
 /// Ask the guest agent to remove a DNAT mapping.
 #[derive(serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct SandboxPortForwardRemoveRequest {
     /// Sandbox ID.
     #[prost(string, tag = "1")]
@@ -409,7 +409,7 @@ pub struct SandboxPortForwardRemoveRequest {
 /// Request to stop a sandbox gracefully.
 #[derive(serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct StopSandboxRequest {
     /// Sandbox ID.
     #[prost(string, tag = "1")]
@@ -422,7 +422,7 @@ pub struct StopSandboxRequest {
 /// Request to forcibly remove a sandbox.
 #[derive(serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct RemoveSandboxRequest {
     /// Sandbox ID.
     #[prost(string, tag = "1")]
@@ -434,7 +434,7 @@ pub struct RemoveSandboxRequest {
 /// Request to inspect a sandbox.
 #[derive(serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct InspectSandboxRequest {
     /// Sandbox ID.
     #[prost(string, tag = "1")]
@@ -444,11 +444,11 @@ pub struct InspectSandboxRequest {
 ///
 /// State machine:
 ///
-///    starting ──► ready ──► running ──► ready   (cmd/Run exited, sandbox alive)
-///                   │          │
-///                   └──────────┴──► stopping ──► stopped
-///                                        │
-///                                     failed
+/// starting ──► ready ──► running ──► ready   (cmd/Run exited, sandbox alive)
+/// │          │
+/// └──────────┴──► stopping ──► stopped
+/// │
+/// failed
 ///
 /// "idle" is an alias for "ready" used in event payloads to signal that a
 /// previously running workload has just finished.
@@ -491,7 +491,7 @@ pub struct SandboxInfo {
 /// Network details of a sandbox.
 #[derive(serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct SandboxNetwork {
     /// Assigned IP address.
     #[prost(string, tag = "1")]
@@ -549,7 +549,7 @@ pub struct SandboxSummary {
 /// Request to subscribe to sandbox lifecycle events.
 #[derive(serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct SandboxEventsRequest {
     /// Filter by sandbox ID (empty = all sandboxes).
     #[prost(string, tag = "1")]
@@ -567,22 +567,22 @@ pub struct SandboxEvent {
     #[prost(string, tag = "1")]
     pub sandbox_id: ::prost::alloc::string::String,
     /// Action:
-    ///    "created"  — sandbox record created, VM booting
-    ///    "ready"    — VM booted, sandbox accepting workloads
-    ///    "running"  — a workload (cmd or Run) started
-    ///    "idle"     — active workload exited, sandbox back to ready
-    ///    "stopping" — Stop called, draining workload
-    ///    "stopped"  — VM shut down
-    ///    "failed"   — unrecoverable error
-    ///    "removed"  — sandbox deleted
+    /// "created"  — sandbox record created, VM booting
+    /// "ready"    — VM booted, sandbox accepting workloads
+    /// "running"  — a workload (cmd or Run) started
+    /// "idle"     — active workload exited, sandbox back to ready
+    /// "stopping" — Stop called, draining workload
+    /// "stopped"  — VM shut down
+    /// "failed"   — unrecoverable error
+    /// "removed"  — sandbox deleted
     #[prost(string, tag = "2")]
     pub action: ::prost::alloc::string::String,
     /// Unix nanoseconds.
     #[prost(int64, tag = "3")]
     pub timestamp: i64,
     /// Additional context, e.g.:
-    ///    "exit_code" on "idle" / "stopped"
-    ///    "error"     on "failed"
+    /// "exit_code" on "idle" / "stopped"
+    /// "error"     on "failed"
     #[prost(map = "string, string", tag = "4")]
     pub attributes:
         ::std::collections::HashMap<::prost::alloc::string::String, ::prost::alloc::string::String>,
@@ -607,7 +607,7 @@ pub struct CheckpointRequest {
 /// Response to Checkpoint.
 #[derive(serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct CheckpointResponse {
     /// Snapshot ID.
     #[prost(string, tag = "1")]
@@ -652,7 +652,7 @@ pub struct RestoreRequest {
 /// The restored sandbox starts in "ready" state immediately.
 #[derive(serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct RestoreResponse {
     /// ID of the newly created sandbox.
     #[prost(string, tag = "1")]
@@ -710,7 +710,7 @@ pub struct SnapshotSummary {
 /// Request to delete a snapshot.
 #[derive(serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct DeleteSnapshotRequest {
     /// Snapshot ID.
     #[prost(string, tag = "1")]

--- a/rpc/arcbox-protocol/src/generated/sandbox.v1.rs
+++ b/rpc/arcbox-protocol/src/generated/sandbox.v1.rs
@@ -444,11 +444,11 @@ pub struct InspectSandboxRequest {
 ///
 /// State machine:
 ///
-/// starting ──► ready ──► running ──► ready   (cmd/Run exited, sandbox alive)
-/// │          │
-/// └──────────┴──► stopping ──► stopped
-/// │
-/// failed
+///    starting ──► ready ──► running ──► ready   (cmd/Run exited, sandbox alive)
+///                   │          │
+///                   └──────────┴──► stopping ──► stopped
+///                                        │
+///                                     failed
 ///
 /// "idle" is an alias for "ready" used in event payloads to signal that a
 /// previously running workload has just finished.
@@ -567,22 +567,22 @@ pub struct SandboxEvent {
     #[prost(string, tag = "1")]
     pub sandbox_id: ::prost::alloc::string::String,
     /// Action:
-    /// "created"  — sandbox record created, VM booting
-    /// "ready"    — VM booted, sandbox accepting workloads
-    /// "running"  — a workload (cmd or Run) started
-    /// "idle"     — active workload exited, sandbox back to ready
-    /// "stopping" — Stop called, draining workload
-    /// "stopped"  — VM shut down
-    /// "failed"   — unrecoverable error
-    /// "removed"  — sandbox deleted
+    ///    "created"  — sandbox record created, VM booting
+    ///    "ready"    — VM booted, sandbox accepting workloads
+    ///    "running"  — a workload (cmd or Run) started
+    ///    "idle"     — active workload exited, sandbox back to ready
+    ///    "stopping" — Stop called, draining workload
+    ///    "stopped"  — VM shut down
+    ///    "failed"   — unrecoverable error
+    ///    "removed"  — sandbox deleted
     #[prost(string, tag = "2")]
     pub action: ::prost::alloc::string::String,
     /// Unix nanoseconds.
     #[prost(int64, tag = "3")]
     pub timestamp: i64,
     /// Additional context, e.g.:
-    /// "exit_code" on "idle" / "stopped"
-    /// "error"     on "failed"
+    ///    "exit_code" on "idle" / "stopped"
+    ///    "error"     on "failed"
     #[prost(map = "string, string", tag = "4")]
     pub attributes:
         ::std::collections::HashMap<::prost::alloc::string::String, ::prost::alloc::string::String>,

--- a/virt/arcbox-vm/src/sandbox/workload.rs
+++ b/virt/arcbox-vm/src/sandbox/workload.rs
@@ -321,8 +321,7 @@ mod tests {
         assert_eq!(state_of("s", &instances), SandboxState::Ready);
         let last_exit_code = {
             let guard = instances.read().unwrap();
-            let code = guard["s"].lock().unwrap().last_exit_code;
-            code
+            guard["s"].lock().unwrap().last_exit_code
         };
         assert_eq!(last_exit_code, Some(7));
     }


### PR DESCRIPTION
## Summary

`arcbox-fleet-agent v0.1.1` panics on every TLS handshake:

```
thread 'main' panicked at rustls-0.23.37/src/crypto/mod.rs:249
Could not automatically determine the process-level CryptoProvider
from Rustls crate features. Call CryptoProvider::install_default()
before this point to select a provider manually, or make sure exactly
one of the 'aws-lc-rs' and 'ring' features is enabled.
```

Two independent branches of the dep graph pull different rustls crypto providers:

| Dep | Feature | Provider activated |
|---|---|---|
| `reqwest 0.13` | `"rustls"` (via `__rustls-aws-lc-rs`) | **aws-lc-rs** |
| `tonic 0.12` | `["tls", "tls-webpki-roots"]` → tokio-rustls default | **ring** |

Cargo features are additive, so both providers get compiled in and rustls 0.23 refuses to pick between them. Introduced in 73844b35 (`feat(fleet): self-update executor and managed binary layout`, 2026-07-10) — the same commit that added `reqwest` as a fleet-agent dep. The blast radius covers every TLS-using code path: `quick enroll`, `quick self-update`, and the gateway `Attach` in `serve`/`quick run`.

## Approach

Converge on **aws-lc-rs** at compile time so exactly one provider is enabled:

- Bump `tonic` 0.12 → 0.14 workspace-wide. tonic 0.14 unbundled the `tls` umbrella feature into explicit `tls-ring` / `tls-aws-lc` selectors (per tonic v0.13.0 release notes: "AWS Libcrypto Support" #2008).
- `fleet/arcbox-fleet-agent/Cargo.toml`: `tonic` features `["tls", ...]` → `["tls-aws-lc", ...]`.
- `fleet/arcbox-fleet-agent/Cargo.toml`: `russh` features `["ring", "flate2"]` → `["aws-lc-rs", "flate2"]` (russh 0.61+ supports both; upstream recommends aws-lc-rs).
- Reqwest was already on aws-lc-rs — no change there.

tonic 0.14 also split prost integration into `tonic-prost` (runtime) and `tonic-prost-build` (build-time). Proto crates (`arcbox-grpc`, `arcbox-fleet-proto`, `arcbox-fleet-control-proto`) migrate to the new crates, and workspace `prost` bumps 0.13 → 0.14 to keep a single prost version in the graph.

Preferred this over the one-line `CryptoProvider::install_default()` workaround: `install_default()` leaves both providers compiled in (~300KB of dead ring code), papers over the ambiguity so any future dep re-triggers the panic silently, and creates a runtime failure mode (double-install panics).

## Migration reference

tonic 0.12 → 0.14 spans two major hops. Migration signal reviewed against the tonic release notes:

- **v0.13.0**: axum bumped to 0.8 (already on 0.8 here); `feat!: Add Body type` (#2013) — no handwritten tower/hyper glue in this workspace; `feat!(server): Remove into_service api` (#1996) — grep-clean; `feat!(reflection): Expose ReflectionService` (#2066) — daemon's `Builder::configure().build_v1()/build_v1alpha()` pattern unchanged; `feat(tls): AWS Libcrypto Support` (#2008) — the split we're leveraging.
- **v0.14.0**: prost extracted to `tonic-prost` / `tonic-prost-build` — handled by migrating three `build.rs` files and adding the two new deps.

No `into_service()`, `InterceptorLayer::new`, or custom `Body`/`BoxBody` construction sites in this workspace — the surface used is `Server::builder().add_service().serve_with_incoming[_shutdown]` on the server, `Endpoint::from_static(...).connect[_lazy]` on the client, and `ClientTlsConfig::new().with_webpki_roots()` for TLS — all source-compatible across the hop.

## Verification

### Static

- `cargo check --workspace --all-targets` clean.
- `cargo clippy --workspace --all-targets -- -D warnings` clean.
- `cargo fmt --all -- --check` clean.
- `cargo tree -p arcbox-fleet-agent -i ring` → **empty** (ring is entirely out of the dep graph).
- `cargo tree -p arcbox-fleet-agent -i aws-lc-rs` → single provider, serving both rustls (TLS via reqwest + tonic + hyper-rustls + tokio-rustls + rustls-platform-verifier) and russh (SSH).

### Unit / integration tests (all green under tonic 0.14)

- `arcbox-fleet-agent`: 87 unit tests + 1 integration test — includes `unenrolled_agent_reports_status_and_rejects_drain` which stands up a real tonic 0.14 server (`Server::builder().serve_with_incoming(...)`) with a client channel (`Endpoint::from_static().connect()`).
- `arcbox-core`: 143 tests
- `arcbox-api`: 41 tests
- `arcbox-daemon`: 4 tests
- `arcbox-cli`: 7 tests

### Runtime (live daemon on this branch)

Signed debug daemon started against real gRPC socket at `~/.arcbox/run/arcbox.sock`:

| Path exercised | Command | Result |
|---|---|---|
| Server startup + client `Endpoint` | `arcbox daemon status` | `running`, gRPC responsive |
| `MachineService/List` roundtrip | `arcbox machine list` | Returns the `default` machine row |
| `SystemService.GetInfo` | `arcbox info` | Correct version / OS / arch / cpus |
| `SandboxService/List` (empty result) | `arcbox sandbox list` | `No sandboxes found.` |
| Direct gRPC without reflection | `grpcurl -plaintext -authority localhost -d '{}' -proto machine.proto unix://…/arcbox.sock arcbox.v1.MachineService/List` | JSON response matches schema |

### fleet-agent enroll path

Built the debug fleet-agent binary and ran `quick enroll` with a bogus token against the real gateway: TLS handshake completes, no CryptoProvider panic. Gateway rejects with a proto wire-type error on `EnrollRequest.protocol_version` — that's a separate pre-existing wire-compat issue between the vendored proto and the gateway, unrelated to this PR.

## Test plan

- [x] Workspace builds, lints, and formats clean.
- [x] `arcbox-fleet-agent quick enroll` no longer panics; TLS handshake succeeds.
- [x] `ring` crate absent from the fleet-agent dep tree.
- [x] Live daemon + CLI roundtrip on tonic 0.14 (server start, three RPCs, direct grpcurl).
- [x] Fleet-agent's own local control-plane gRPC roundtrip test passes.
- [ ] CI green.
- [ ] Cut `fleet-agent-v0.1.2` after merge.

## Incidentals

- Trivial `clippy::let_and_return` fix in `virt/arcbox-vm/src/sandbox/workload.rs:322-326` — preexisting on master, surfaced by the clippy run for this PR.
- Regenerated `rpc/arcbox-protocol/src/generated/{arcbox,sandbox}.v1.rs` picks up prost 0.14's automatic `Eq`/`Hash` derives on messages containing only hashable fields. No wire-format changes.