### PR TITLE
fix(docker): exempt passive observation streams from idle activity

### DIFF
--- a/app/arcbox-daemon/src/recovery.rs
+++ b/app/arcbox-daemon/src/recovery.rs
@@ -61,10 +61,23 @@ pub async fn run(ctx: &DaemonContext, runtime: &Arc<Runtime>) {
     }
 
     // Best-effort self-setup (non-blocking).
-    let dns_task = self_setup::DnsResolver {
-        domain: ctx.dns_domain.clone(),
-        port: ctx.dns_port,
-    };
+    //
+    // The `/etc/resolver/<domain>` entry belongs to the daemon serving the
+    // canonical DNS port. A daemon on any other port (an e2e harness daemon
+    // with an ephemeral port, an ad-hoc dev run) must never rewrite the
+    // host-global resolver away from the installed daemon — after it exits,
+    // host DNS would point at a dead port.
+    let dns_task =
+        (ctx.dns_port == crate::startup::DEFAULT_DNS_PORT).then(|| self_setup::DnsResolver {
+            domain: ctx.dns_domain.clone(),
+            port: ctx.dns_port,
+        });
+    if dns_task.is_none() {
+        tracing::debug!(
+            port = ctx.dns_port,
+            "non-default DNS port; skipping /etc/resolver self-setup"
+        );
+    }
     let socket_task = self_setup::DockerSocket {
         target: ctx.layout.docker_socket.clone(),
     };
@@ -88,12 +101,17 @@ pub async fn run(ctx: &DaemonContext, runtime: &Arc<Runtime>) {
 
     let setup_state_self = Arc::clone(&ctx.setup_state);
     tokio::spawn(async move {
-        let mut tasks: Vec<&dyn self_setup::SetupTask> = vec![&dns_task, &socket_task];
+        let mut tasks: Vec<&dyn self_setup::SetupTask> = vec![&socket_task];
+        if let Some(dns) = &dns_task {
+            tasks.insert(0, dns);
+        }
         for t in &cli_tasks {
             tasks.push(t.as_ref());
         }
         self_setup::run(&tasks).await;
-        setup_state_self.set_dns_installed(dns_task.is_satisfied());
+        if let Some(dns) = &dns_task {
+            setup_state_self.set_dns_installed(dns.is_satisfied());
+        }
         setup_state_self.set_docker_socket_linked(socket_task.is_satisfied());
     });
 

--- a/app/arcbox-daemon/src/startup/mod.rs
+++ b/app/arcbox-daemon/src/startup/mod.rs
@@ -25,6 +25,9 @@ use crate::context::{DaemonContext, EarlyContext, StartupHandles, VmArgs};
 
 const DNS_PREFIX: &str = "arcbox";
 const DEFAULT_DNS_DOMAIN: &str = "arcbox.local";
+/// Canonical host DNS port. Only the daemon serving this port owns the
+/// `/etc/resolver/<domain>` entry (see `recovery::run`).
+pub const DEFAULT_DNS_PORT: u16 = 5553;
 
 /// Phase 1: directories, config, sockets. No runtime, no lock yet.
 ///
@@ -262,7 +265,7 @@ fn dns_port() -> u16 {
     std::env::var(key)
         .ok()
         .and_then(|s| s.parse().ok())
-        .unwrap_or(5553)
+        .unwrap_or(DEFAULT_DNS_PORT)
 }
 
 fn dns_domain() -> String {

--- a/app/arcbox-docker/src/handlers/proxying.rs
+++ b/app/arcbox-docker/src/handlers/proxying.rs
@@ -3,7 +3,7 @@
 use crate::api::AppState;
 use crate::error::{DockerError, Result};
 use crate::proxy;
-use crate::proxy::ActivityLease;
+use crate::proxy::{ActivityClass, ActivityLease};
 use axum::body::Body;
 use axum::http::{Request, Uri};
 use axum::response::Response;
@@ -13,12 +13,16 @@ use std::task::{Context, Poll};
 
 /// Ensures the system VM is up before any request reaches the connector, then
 /// verifies guest dockerd with a real Docker `_ping`.
-pub async fn ensure_system_vm_ready(state: &AppState) -> Result<()> {
+///
+/// `activity` decides whether this request counts toward idle tracking;
+/// passive observation streams verify the endpoint without touching the
+/// idle clock (see [`ActivityClass`]).
+pub async fn ensure_system_vm_ready(state: &AppState, activity: ActivityClass) -> Result<()> {
     let runtime = Arc::clone(&state.runtime);
     let generation = runtime.system_vm_restart_generation();
     state
         .proxy
-        .ensure_endpoint_verified(generation, async move {
+        .ensure_endpoint_verified(generation, activity, async move {
             runtime
                 .ensure_system_vm_ready()
                 .await
@@ -36,12 +40,12 @@ pub async fn proxy_to_system_vm(
     uri: &Uri,
     req: Request<Body>,
 ) -> Result<Response> {
-    ensure_system_vm_ready(state).await?;
+    ensure_system_vm_ready(state, ActivityClass::Active).await?;
     proxy::invalidate_on_guest_error(
         state,
         proxy::proxy_to_guest_stream_pooled(state.proxy.client(), uri, req).await,
     )
-    .map(|resp| hold_activity_for_response(state, resp))
+    .map(|resp| hold_activity_for_response(state, ActivityClass::Active, resp))
 }
 
 /// Forward an upload request to guest dockerd.
@@ -50,19 +54,28 @@ pub async fn proxy_upload_to_system_vm(
     uri: &Uri,
     req: Request<Body>,
 ) -> Result<Response> {
-    ensure_system_vm_ready(state).await?;
+    ensure_system_vm_ready(state, ActivityClass::Active).await?;
     proxy::invalidate_on_guest_error(
         state,
         proxy::proxy_streaming_upload(state.proxy.connector(), uri, req).await,
     )
-    .map(|resp| hold_activity_for_response(state, resp))
+    .map(|resp| hold_activity_for_response(state, ActivityClass::Active, resp))
 }
 
 /// Ties an activity lease to the response body, so a streaming operation
-/// (pull progress, build output, log follow) holds the VM out of idle until
-/// its last byte. Plain bodies drop the lease when they finish; either way
-/// the idle clock restarts at the operation's end.
-pub fn hold_activity_for_response(state: &AppState, resp: Response) -> Response {
+/// (pull progress, build output) holds the VM out of idle until its last
+/// byte. Plain bodies drop the lease when they finish; either way the idle
+/// clock restarts at the operation's end. Passive observation streams pass
+/// through untouched — watching the VM must not hold it out of idle (see
+/// [`ActivityClass`]).
+pub fn hold_activity_for_response(
+    state: &AppState,
+    activity: ActivityClass,
+    resp: Response,
+) -> Response {
+    if activity == ActivityClass::PassiveObservation {
+        return resp;
+    }
     let Some(lease) = state.proxy.activity_lease() else {
         return resp;
     };

--- a/app/arcbox-docker/src/proxy/activity.rs
+++ b/app/arcbox-docker/src/proxy/activity.rs
@@ -1,0 +1,164 @@
+//! Idle-accounting classification of proxied Docker API requests.
+//!
+//! The System VM's idle tracking treats proxied Docker traffic as activity:
+//! each request resets the idle clock and holds an [`super::ActivityLease`]
+//! for the response's lifetime. That is right for operations that *use* the
+//! VM, but wrong for unbounded read-only streams that merely *watch* it —
+//! the ArcBox desktop UI keeps a `GET /events` subscription open for its
+//! entire lifetime, and counting that stream as activity pins the lease
+//! counter and disables idle reclaim outright (2026-07-15 follow-up to the
+//! idle-balloon incident).
+
+use axum::http::{Method, Uri};
+
+/// How a proxied Docker API request counts toward System VM idle tracking.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ActivityClass {
+    /// Uses the VM: resets the idle clock and holds the VM out of idle for
+    /// the response's full lifetime (pulls, builds, exec, one-shot reads).
+    Active,
+    /// Watches the VM: an unbounded read-only stream (`/events`, log
+    /// follow, streaming stats). Records no activity and takes no lease —
+    /// the idle balloon is transparent to readers, so a subscriber loses
+    /// nothing when the VM idles underneath it.
+    PassiveObservation,
+}
+
+/// Classifies a request by method and path (version prefix already stripped
+/// by the router middleware — see `api::strip_api_version_prefix`).
+///
+/// Only GET endpoints that stream observations indefinitely are passive.
+/// One-shot reads stay active: they are bounded, so the idle clock simply
+/// restarts when they finish; only unbounded streams can block idle forever.
+pub fn classify(method: &Method, uri: &Uri) -> ActivityClass {
+    if method != Method::GET {
+        return ActivityClass::Active;
+    }
+    let path = uri.path();
+    let query = uri.query().unwrap_or("");
+
+    // The event stream stays open for the subscriber's lifetime (with
+    // `until` it is bounded, but it is still pure observation).
+    if path == "/events" {
+        return ActivityClass::PassiveObservation;
+    }
+
+    // `/containers/{id}/logs?follow=…` and `/containers/{id}/stats`, which
+    // streams unless the client opts out.
+    let mut segments = path.trim_start_matches('/').split('/');
+    if let (Some("containers"), Some(_id), Some(op), None) = (
+        segments.next(),
+        segments.next(),
+        segments.next(),
+        segments.next(),
+    ) {
+        let streaming = match op {
+            "logs" => query_flag(query, "follow", false),
+            "stats" => query_flag(query, "stream", true),
+            _ => false,
+        };
+        if streaming {
+            return ActivityClass::PassiveObservation;
+        }
+    }
+
+    ActivityClass::Active
+}
+
+/// Reads a boolean query parameter with dockerd's semantics
+/// (`httputils.BoolValue`): missing → `default`; present with a value in
+/// {"", "0", "no", "false", "none"} (case-insensitive) → false; anything
+/// else → true. Values are compared literally — Docker clients never
+/// percent-encode these flags.
+fn query_flag(query: &str, key: &str, default: bool) -> bool {
+    for pair in query.split('&') {
+        let (k, v) = pair.split_once('=').unwrap_or((pair, ""));
+        if k == key {
+            let v = v.to_ascii_lowercase();
+            return !matches!(v.as_str(), "" | "0" | "no" | "false" | "none");
+        }
+    }
+    default
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn class(method: Method, uri: &str) -> ActivityClass {
+        classify(&method, &uri.parse::<Uri>().unwrap())
+    }
+
+    #[test]
+    fn events_subscription_is_passive() {
+        assert_eq!(
+            class(Method::GET, "/events"),
+            ActivityClass::PassiveObservation
+        );
+        assert_eq!(
+            class(Method::GET, "/events?since=123&filters=%7B%7D"),
+            ActivityClass::PassiveObservation
+        );
+    }
+
+    #[test]
+    fn non_get_methods_are_active() {
+        assert_eq!(class(Method::POST, "/events"), ActivityClass::Active);
+        assert_eq!(
+            class(Method::POST, "/containers/abc/logs?follow=1"),
+            ActivityClass::Active
+        );
+    }
+
+    #[test]
+    fn log_follow_is_passive_one_shot_logs_are_active() {
+        for uri in [
+            "/containers/abc/logs?follow=1&stdout=1",
+            "/containers/abc/logs?follow=true",
+            "/containers/abc/logs?follow=TRUE",
+        ] {
+            assert_eq!(class(Method::GET, uri), ActivityClass::PassiveObservation);
+        }
+        for uri in [
+            "/containers/abc/logs?stdout=1",
+            "/containers/abc/logs?follow=0",
+            "/containers/abc/logs?follow=false",
+            "/containers/abc/logs?follow=",
+        ] {
+            assert_eq!(class(Method::GET, uri), ActivityClass::Active);
+        }
+    }
+
+    #[test]
+    fn stats_stream_by_default_one_shot_on_opt_out() {
+        for uri in [
+            "/containers/abc/stats",
+            "/containers/abc/stats?stream=1",
+            "/containers/abc/stats?stream=true",
+        ] {
+            assert_eq!(class(Method::GET, uri), ActivityClass::PassiveObservation);
+        }
+        for uri in [
+            "/containers/abc/stats?stream=0",
+            "/containers/abc/stats?stream=false&one-shot=true",
+            "/containers/abc/stats?stream=",
+        ] {
+            assert_eq!(class(Method::GET, uri), ActivityClass::Active);
+        }
+    }
+
+    #[test]
+    fn bounded_reads_and_other_paths_stay_active() {
+        for uri in [
+            "/containers/json?all=true",
+            "/containers/abc/json",
+            "/images/json",
+            "/version",
+            "/_ping",
+            "/containers/abc/export",
+            "/containers/abc/nested/logs?follow=1",
+        ] {
+            assert_eq!(class(Method::GET, uri), ActivityClass::Active);
+        }
+    }
+}

--- a/app/arcbox-docker/src/proxy/fallback.rs
+++ b/app/arcbox-docker/src/proxy/fallback.rs
@@ -1,5 +1,6 @@
 //! Catch-all proxy handler for unmatched Docker API routes.
 
+use super::activity::{self, ActivityClass};
 use super::headers::HeaderMapProxyExt;
 use super::{forward, upgrade, upload};
 use crate::api::AppState;
@@ -25,6 +26,7 @@ use axum::http::Response;
         uri = %uri,
         utility_vm = "native",
         protocol = tracing::field::Empty,
+        idle_activity = tracing::field::Empty,
     ),
     err
 )]
@@ -33,7 +35,13 @@ pub async fn proxy_fallback(
     OriginalUri(uri): OriginalUri,
     req: axum::http::Request<Body>,
 ) -> Result<Response<Body>> {
-    ensure_system_vm_ready(&state).await?;
+    // Classified on the version-stripped URI; the versioned `uri` above is
+    // what gets forwarded to guest dockerd.
+    let class = activity::classify(req.method(), req.uri());
+    if class == ActivityClass::PassiveObservation {
+        tracing::Span::current().record("idle_activity", "passive");
+    }
+    ensure_system_vm_ready(&state, class).await?;
 
     if req.headers().wants_upgrade() {
         tracing::Span::current().record("protocol", "upgrade");
@@ -49,7 +57,7 @@ pub async fn proxy_fallback(
             &state,
             upload::proxy_streaming_upload(state.proxy.connector(), &uri, req).await,
         )
-        .map(|resp| hold_activity_for_response(&state, resp));
+        .map(|resp| hold_activity_for_response(&state, class, resp));
     }
 
     tracing::Span::current().record("protocol", "http");
@@ -57,7 +65,7 @@ pub async fn proxy_fallback(
         &state,
         forward::proxy_to_guest_stream_pooled(state.proxy.client(), &uri, req).await,
     )
-    .map(|resp| hold_activity_for_response(&state, resp))
+    .map(|resp| hold_activity_for_response(&state, class, resp))
 }
 
 /// Drops the cached endpoint readiness when — and only when — the proxy error

--- a/app/arcbox-docker/src/proxy/mod.rs
+++ b/app/arcbox-docker/src/proxy/mod.rs
@@ -3,6 +3,7 @@
 //! Provides HTTP/1.1 client over vsock to forward requests, with support
 //! for streaming responses and HTTP upgrades (attach, exec, BuildKit).
 
+mod activity;
 mod connector;
 mod fallback;
 mod forward;
@@ -13,6 +14,7 @@ mod upgrade;
 mod upload;
 mod uri;
 
+pub use activity::ActivityClass;
 pub use connector::VsockConnector;
 pub(crate) use fallback::invalidate_on_guest_error;
 pub use fallback::proxy_fallback;

--- a/app/arcbox-docker/src/proxy/state.rs
+++ b/app/arcbox-docker/src/proxy/state.rs
@@ -1,7 +1,7 @@
 //! Guest proxy transport state: connector, pooled client, and the cached
 //! endpoint-readiness state machine.
 
-use super::{GuestConnector, GuestHttpClient, proxy_to_guest_pooled};
+use super::{ActivityClass, GuestConnector, GuestHttpClient, proxy_to_guest_pooled};
 use crate::error::{DockerError, Result};
 use axum::http::{HeaderMap, Method, StatusCode};
 use bytes::Bytes;
@@ -16,14 +16,15 @@ use tokio::sync::Notify;
 /// operation is in flight (dropping it releases the hold).
 pub type ActivityLease = Box<dyn std::any::Any + Send>;
 
-/// Callback invoked once per proxied Docker request, before any readiness
-/// caching.
+/// Callback invoked once per activity-bearing ([`ActivityClass::Active`])
+/// proxied Docker request, before any readiness caching.
 ///
 /// Wired to the VM lifecycle's activity tracking so host-side API traffic
 /// keeps the System VM out of idle memory reclaim. The returned lease is
-/// attached to the response body so long-lived operations (pulls, builds,
-/// log streams) count as activity for their entire duration — an idle
-/// shrink once squeezed a guest mid-pull.
+/// attached to the response body so long-lived operations (pulls, builds)
+/// count as activity for their entire duration — an idle shrink once
+/// squeezed a guest mid-pull. Passive observation streams take no lease
+/// (see [`ActivityClass`]).
 pub type ActivityHook = Arc<dyn Fn() -> ActivityLease + Send + Sync>;
 
 /// Guest proxy transport state shared by handlers.
@@ -80,18 +81,22 @@ impl ProxyState {
     pub async fn ensure_endpoint_verified<F>(
         &self,
         generation: u64,
+        activity: ActivityClass,
         prepare_runtime: F,
     ) -> Result<()>
     where
         F: Future<Output = Result<()>>,
     {
-        // Before any caching: every proxied request is VM activity. With a
-        // warm readiness cache `prepare_runtime` (the lifecycle's activity
-        // path) never runs, and a loaded VM would otherwise be idled and
-        // ballooned into reclaim thrash (2026-07-15 incident). The short
-        // lease covers verification; the caller re-leases for the response
-        // body's lifetime.
-        let _lease = self.activity_hook.as_ref().map(|hook| hook());
+        // Before any caching: every active proxied request is VM activity.
+        // With a warm readiness cache `prepare_runtime` (the lifecycle's
+        // activity path) never runs, and a loaded VM would otherwise be
+        // idled and ballooned into reclaim thrash (2026-07-15 incident).
+        // The short lease covers verification; the caller re-leases for the
+        // response body's lifetime. Passive observation takes no lease:
+        // a permanent `/events` subscriber must not disable idle reclaim.
+        let _lease = (activity == ActivityClass::Active)
+            .then(|| self.activity_hook.as_ref().map(|hook| hook()))
+            .flatten();
         self.reset_if_restarted(generation);
         self.endpoint_readiness
             .ensure_verified(prepare_runtime, || self.ping_guest())

--- a/app/arcbox-docker/tests/proxy_integration.rs
+++ b/app/arcbox-docker/tests/proxy_integration.rs
@@ -8,7 +8,8 @@ mod support;
 use support::mock_guest::{self, MockGuest, UnixSocketConnector};
 
 use arcbox_docker::proxy::{
-    GuestHttpClient, proxy_to_guest_pooled, proxy_to_guest_stream_pooled, proxy_with_upgrade,
+    ActivityClass, GuestHttpClient, proxy_to_guest_pooled, proxy_to_guest_stream_pooled,
+    proxy_with_upgrade,
 };
 use axum::body::Body;
 use axum::http::{HeaderMap, Method, Request, StatusCode, Uri, header};
@@ -269,9 +270,15 @@ async fn ensure_endpoint_verified_notes_activity_even_when_cached() {
     };
 
     // First request: full verification (prepare + `_ping` against the mock).
-    proxy.ensure_endpoint_verified(1, prepare()).await.unwrap();
+    proxy
+        .ensure_endpoint_verified(1, ActivityClass::Active, prepare())
+        .await
+        .unwrap();
     // Second request: readiness is cached — prepare must NOT rerun...
-    proxy.ensure_endpoint_verified(1, prepare()).await.unwrap();
+    proxy
+        .ensure_endpoint_verified(1, ActivityClass::Active, prepare())
+        .await
+        .unwrap();
     assert_eq!(prepared.load(Ordering::SeqCst), 1, "readiness cache broken");
 
     // ...but activity must be noted on BOTH requests.
@@ -279,6 +286,46 @@ async fn ensure_endpoint_verified_notes_activity_even_when_cached() {
         activity.load(Ordering::SeqCst),
         2,
         "proxied requests must note activity even with warm readiness cache"
+    );
+    guest.cancel.cancel();
+}
+
+/// Passive observation (an `/events` subscription, a log follow) verifies
+/// the endpoint like any request but must never touch the activity hook:
+/// the desktop UI holds `/events` open for its whole lifetime, and counting
+/// it as activity would pin the VM out of idle reclaim permanently.
+#[tokio::test]
+async fn passive_observation_never_touches_the_activity_hook() {
+    use arcbox_docker::proxy::ProxyState;
+    use std::sync::atomic::AtomicUsize;
+
+    let (connector, guest, _tmp) = setup().await;
+
+    let activity = Arc::new(AtomicUsize::new(0));
+    let hook: arcbox_docker::proxy::ActivityHook = {
+        let activity = Arc::clone(&activity);
+        Arc::new(move || {
+            activity.fetch_add(1, Ordering::SeqCst);
+            Box::new(()) as _
+        })
+    };
+    let proxy = ProxyState::new(Arc::new(connector)).with_activity_hook(hook);
+
+    // Cold cache: the passive request still performs the full verification…
+    proxy
+        .ensure_endpoint_verified(1, ActivityClass::PassiveObservation, async { Ok(()) })
+        .await
+        .unwrap();
+    // …and a warm-cache passive request stays silent too.
+    proxy
+        .ensure_endpoint_verified(1, ActivityClass::PassiveObservation, async { Ok(()) })
+        .await
+        .unwrap();
+
+    assert_eq!(
+        activity.load(Ordering::SeqCst),
+        0,
+        "passive observation must not count as VM activity"
     );
     guest.cancel.cancel();
 }

--- a/tests/e2e/src/boot_assets.rs
+++ b/tests/e2e/src/boot_assets.rs
@@ -281,6 +281,29 @@ pub fn stage_dev_boot_assets(root: &Path, data_dir: &Path, version: &str) -> Res
         xshell::cmd!(shell, "cargo xtask dev boot-assets --version {version}").run()?;
     }
 
+    // Stale-but-complete dev assets are staged as-is (kernel-dev flows rely
+    // on that), but a version mismatch almost always means the daemon will
+    // refuse the manifest against its pinned assets.lock SHA — say so
+    // up front instead of leaving only the daemon's mismatch error.
+    let manifest_version = fs::read(dev_boot_dir.join("manifest.json"))
+        .ok()
+        .and_then(|bytes| serde_json::from_slice::<serde_json::Value>(&bytes).ok())
+        .and_then(|json| {
+            json.get("asset_version")
+                .and_then(serde_json::Value::as_str)
+                .map(str::to_owned)
+        });
+    if let Some(found) = manifest_version
+        && found != version
+    {
+        warn!(
+            found,
+            requested = version,
+            "boot-assets/dev is a different asset version; if the daemon \
+             rejects the manifest SHA, refresh with `cargo xtask dev boot-assets`"
+        );
+    }
+
     copy_file(&dev_boot_dir.join("kernel"), &test_boot_dir.join("kernel"))?;
     copy_file(
         &dev_boot_dir.join("rootfs.erofs"),

--- a/tests/e2e/src/daemon.rs
+++ b/tests/e2e/src/daemon.rs
@@ -83,6 +83,13 @@ impl DaemonHandle {
             .args(&config.args)
             .stdout(Stdio::from(log))
             .stderr(Stdio::from(stderr));
+        // The DNS service binds a fixed localhost port (5553 by default) —
+        // the one host-global a test daemon would still fight an installed
+        // ArcBox (or a sibling test) over. Give each daemon its own port
+        // unless the scenario pinned one.
+        if !config.env.iter().any(|(key, _)| key == "ARCBOX_DNS_PORT") {
+            command.env("ARCBOX_DNS_PORT", ephemeral_udp_port()?.to_string());
+        }
         for (key, value) in &config.env {
             command.env(key, value);
         }
@@ -332,6 +339,14 @@ impl Service<Uri> for UnixConnector {
             Ok(TokioIo::new(stream))
         })
     }
+}
+
+/// Reserves an OS-assigned localhost UDP port and releases it for the
+/// daemon's DNS service to claim. Racy in principle; in practice ephemeral
+/// ports don't collide within the spawn window.
+fn ephemeral_udp_port() -> Result<u16> {
+    let socket = std::net::UdpSocket::bind("127.0.0.1:0").context("probing for a free UDP port")?;
+    Ok(socket.local_addr()?.port())
 }
 
 #[cfg(test)]

--- a/tests/e2e/src/docker.rs
+++ b/tests/e2e/src/docker.rs
@@ -43,6 +43,50 @@ pub fn docker_output(data_dir: &Path, args: &[&str], timeout: Duration) -> Resul
     }
 }
 
+/// A long-lived `docker <args>` child (an `/events` subscription, a log
+/// follow) held open across a scenario, mimicking a persistent observer
+/// like the desktop UI. Killed on drop.
+pub struct DockerStream {
+    child: std::process::Child,
+    args: String,
+}
+
+/// Spawns `docker <args>` against the daemon under `data_dir` and leaves it
+/// running. Output is discarded — callers assert on daemon behavior, not on
+/// the stream's content.
+pub fn docker_stream(data_dir: &Path, args: &[&str]) -> Result<DockerStream> {
+    let child = Command::new("docker")
+        .env("DOCKER_HOST", docker_host(data_dir))
+        .args(args)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .with_context(|| format!("spawning docker {}", args.join(" ")))?;
+    Ok(DockerStream {
+        child,
+        args: args.join(" "),
+    })
+}
+
+impl DockerStream {
+    /// Fails if the stream exited: a dead subscriber would silently weaken
+    /// any scenario using it as a persistent-observer regression guard.
+    pub fn assert_alive(&mut self) -> Result<()> {
+        match self.child.try_wait()? {
+            None => Ok(()),
+            Some(status) => bail!("docker {} exited early with {status}", self.args),
+        }
+    }
+}
+
+impl Drop for DockerStream {
+    fn drop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
 /// Best-effort `docker <args>` for cleanup paths; failures are ignored.
 pub fn docker_ignore(data_dir: &Path, args: &[String]) {
     let _ = Command::new("docker")

--- a/tests/e2e/tests/idle_balloon.rs
+++ b/tests/e2e/tests/idle_balloon.rs
@@ -11,6 +11,11 @@
 //! incident) and require the guest-driven pressure exit: balloon restored,
 //! Docker responsive, no reclaim storm.
 //!
+//! The whole cycle runs under a persistent `docker events` subscription —
+//! the desktop UI holds one for its entire lifetime, and counting that
+//! passive stream as VM activity once pinned `active_ops` and disabled
+//! idle reclaim outright on desktop installs.
+//!
 //! Balloon moves have no RPC surface; the daemon log is the only oracle
 //! for them. That is an explicit exception to the "readiness only via
 //! `WatchSetupStatus`" rule — readiness itself still uses `wait_ready`.
@@ -22,7 +27,7 @@ use std::time::{Duration, Instant};
 use anyhow::{Context, Result, bail};
 use arcbox_e2e::boot_assets::{resolve_boot_version, stage_dev_boot_assets};
 use arcbox_e2e::daemon::{DaemonConfig, DaemonHandle};
-use arcbox_e2e::docker::docker_output;
+use arcbox_e2e::docker::{docker_output, docker_stream};
 use arcbox_e2e::metrics::RunMetrics;
 
 static TRACING: Once = Once::new();
@@ -106,6 +111,10 @@ fn scenario(daemon: &mut DaemonHandle, data_dir: &Path, metrics: &mut RunMetrics
 
     let image = std::env::var("ARCBOX_E2E_IMAGE").unwrap_or_else(|_| "alpine:latest".to_owned());
     metrics.time("docker_pull", || ensure_image(data_dir, &image))?;
+
+    // Persistent observer, held open for the whole cycle: the idle shrink
+    // below must engage despite this live `/events` subscription.
+    let mut events = docker_stream(data_dir, &["events"]).context("subscribing to events")?;
 
     // The ballast: hold ~256 MB immediately (tmpfs pages persist regardless
     // of process lifetime), then grow by 2 GiB after the VM has idled and
@@ -218,6 +227,12 @@ fn scenario(daemon: &mut DaemonHandle, data_dir: &Path, metrics: &mut RunMetrics
     if !log_contains(data_dir, r#""from":"idle","to":"running""#)? {
         bail!("balloon restore did not ride the lifecycle state machine");
     }
+
+    // The whole cycle ran under a live events subscription — prove the
+    // observer survived, so the shrink above really happened despite it.
+    events
+        .assert_alive()
+        .context("events subscription died mid-scenario")?;
 
     docker_output(data_dir, &["rm", "-f", "ballast"], DOCKER_ATTEMPT).ok();
     Ok(())


### PR DESCRIPTION
## Problem

Post-deploy verification of the idle-balloon fix (#390) on a production
desktop install found that **the System VM never enters idle anymore**:
35+ minutes idle-eligible, zero `VM entered idle state` entries, balloon
controller never probed.

Root cause: the ArcBox desktop UI keeps a `GET /events` subscription open
through the docker proxy for its entire lifetime. Since #390, every
proxied response body carries an `ActivityLease` (`LeasedBody`), so that
one passive subscriber pins `active_ops ≥ 1` forever and `on_idle_tick`
never passes its gate. Forensics that pinned it: all five gate inputs
eliminated one by one (`auto_stop`/env via `ps eww`, `kubernetes_hold`
via agent RPC log, lifecycle state, every `record_activity` caller, every
lease site), guest-side accepted-vs-done session accounting (2
outstanding), and finally `lsof` unix-socket peer matching the daemon's
`docker.sock` connection to the UI process.

There is a symmetry worth noting: the original incident happened because
the readiness cache ate **all** proxy activity (loaded VM shrunk →
18h reclaim thrash); this regression is the same signal over-corrected —
passive observation counted as activity (VM never idles). The e2e passed
because the harness had no persistent observer; the desktop shape was
exactly the untested configuration.

## Fix

Classify proxied requests for idle accounting (`proxy/activity.rs`):

- **`PassiveObservation`** — unbounded read-only streams: `GET /events`,
  `GET /containers/{id}/logs?follow=…`, `GET /containers/{id}/stats`
  (which streams unless the client opts out; boolean parsing mirrors
  dockerd's `httputils.BoolValue`). These verify the endpoint but take no
  lease and leave the idle clock alone. The idle balloon is transparent
  to readers — a subscriber loses nothing when the VM idles underneath
  it.
- **`Active`** — everything else, including one-shot reads: they are
  bounded, so the idle clock simply restarts when they finish. Only
  unbounded streams can block idle forever.

Classification happens in `proxy_fallback` (the only route serving these
endpoints — every explicit route is a mutating operation) and is recorded
on the request span as `idle_activity=passive` so the next forensics
session can see it. Explicit handlers keep `ActivityClass::Active`.

## Tests

- `proxy/activity.rs` — classifier unit tests (methods, follow/stream
  flag variants incl. dockerd's falsy set, non-matching paths).
- `tests/proxy_integration.rs` — `passive_observation_never_touches_the_activity_hook`,
  alongside the existing #390 warm-cache activity guarantee (now passing
  `ActivityClass::Active` explicitly).
- `tests/e2e idle_balloon` — the whole shrink/settle/arm/pressure-restore
  cycle now runs **under a live `docker events` subscription** (RAII
  `DockerStream` guard, liveness-asserted at scenario end). This is the
  desktop shape that was missing; the scenario is red without this fix.
  Hardware-validated on real VZ: descent engaged under the live
  subscription (16384 → 904 MB, usage-aware), guest-pressure restore in
  9 s via the armed path, zero reclaim storm, subscriber alive at
  scenario end (full cycle 305 s).

## Follow-ups (not in this PR)

- Bounded polling (e.g. an editor extension running `docker ps` every
  few seconds) still keeps the VM out of idle indefinitely. If that
  turns out to matter in practice, it needs a product decision
  (frequency-based accounting or UI-marked traffic), not endpoint
  classification.
- Exec/attach upgrade tunnels still hold no lease (pre-existing,
  documented in #390).
