### PR TITLE
feat(stats): live machine resource monitor (ABX-115 P1)

### DIFF
--- a/app/arcbox-api/src/grpc/mod.rs
+++ b/app/arcbox-api/src/grpc/mod.rs
@@ -13,6 +13,7 @@ mod machine;
 mod macos;
 mod sandbox;
 mod snapshot;
+mod stats;
 
 pub use icon::IconServiceImpl;
 pub use kubernetes::KubernetesServiceImpl;
@@ -21,6 +22,7 @@ pub use machine::MachineServiceImpl;
 pub use macos::MacosServiceImpl;
 pub use sandbox::SandboxServiceImpl;
 pub use snapshot::SandboxSnapshotServiceImpl;
+pub use stats::StatsServiceImpl;
 
 use std::sync::{Arc, OnceLock};
 

--- a/app/arcbox-api/src/grpc/stats.rs
+++ b/app/arcbox-api/src/grpc/stats.rs
@@ -1,0 +1,60 @@
+//! Stats service gRPC implementation.
+//!
+//! Bridges [`arcbox_core::stats_hub::StatsHub`]'s broadcast channel to a
+//! tonic server stream. Dropping the response stream drops the broadcast
+//! receiver, which is what lets the hub stop the guest-side sampling when
+//! the last watcher disconnects.
+
+use std::pin::Pin;
+
+use arcbox_core::DEFAULT_MACHINE_NAME;
+use arcbox_grpc::v1::stats_service_server;
+use arcbox_protocol::v1::{MachineStats, StatsWatchRequest};
+use tokio_stream::Stream;
+use tonic::{Request, Response, Status};
+
+use super::{SharedRuntime, SharedRuntimeExt};
+
+/// Stats service implementation.
+pub struct StatsServiceImpl {
+    runtime: SharedRuntime,
+}
+
+impl StatsServiceImpl {
+    /// Creates a new stats service with a deferred runtime.
+    #[must_use]
+    pub fn new(runtime: SharedRuntime) -> Self {
+        Self { runtime }
+    }
+}
+
+#[tonic::async_trait]
+impl stats_service_server::StatsService for StatsServiceImpl {
+    type WatchStream = Pin<Box<dyn Stream<Item = Result<MachineStats, Status>> + Send + 'static>>;
+
+    async fn watch(
+        &self,
+        request: Request<StatsWatchRequest>,
+    ) -> Result<Response<Self::WatchStream>, Status> {
+        let req = request.into_inner();
+        if !req.machine_id.is_empty() && req.machine_id != DEFAULT_MACHINE_NAME {
+            return Err(Status::unimplemented(
+                "per-machine stats are not implemented yet; omit machine_id for the System VM",
+            ));
+        }
+        let runtime = self.runtime.ready()?;
+        let mut rx = runtime.subscribe_machine_stats();
+        let stream = async_stream::stream! {
+            loop {
+                match rx.recv().await {
+                    Ok(sample) => yield Ok(sample),
+                    // This subscriber lagged; newer samples follow, which
+                    // is exactly what a live monitor wants.
+                    Err(tokio::sync::broadcast::error::RecvError::Lagged(_)) => {}
+                    Err(tokio::sync::broadcast::error::RecvError::Closed) => break,
+                }
+            }
+        };
+        Ok(Response::new(Box::pin(stream)))
+    }
+}

--- a/app/arcbox-api/src/lib.rs
+++ b/app/arcbox-api/src/lib.rs
@@ -17,6 +17,7 @@ pub mod system;
 pub use arcbox_grpc::v1::{
     kubernetes_service_client, kubernetes_service_server, machine_service_client,
     machine_service_server, migration_service_client, migration_service_server,
+    stats_service_client, stats_service_server,
 };
 #[cfg(target_os = "macos")]
 pub use arcbox_grpc::v1::{macos_service_client, macos_service_server};
@@ -32,7 +33,7 @@ pub use error::{ApiError, Result};
 pub use grpc::MacosServiceImpl;
 pub use grpc::{
     IconServiceImpl, KubernetesServiceImpl, MachineServiceImpl, SandboxServiceImpl,
-    SandboxSnapshotServiceImpl, SharedRuntime,
+    SandboxSnapshotServiceImpl, SharedRuntime, StatsServiceImpl,
 };
 pub use migration::MigrationServiceImpl;
 pub use system::{SetupState, SystemServiceImpl};

--- a/app/arcbox-cli/src/commands/mod.rs
+++ b/app/arcbox-cli/src/commands/mod.rs
@@ -64,6 +64,7 @@ pub mod sandbox;
 pub mod setup;
 pub mod symlink;
 pub mod system;
+pub mod top;
 #[cfg(target_os = "macos")]
 pub mod uninstall;
 pub mod version;
@@ -166,6 +167,9 @@ pub enum Commands {
 
     /// Run diagnostic checks on the ArcBox runtime
     Doctor,
+
+    /// Live resource monitor for the System VM
+    Top(top::TopArgs),
 
     /// Internal: install helper + register daemon (used by brew/DMG installers)
     #[cfg(target_os = "macos")]

--- a/app/arcbox-cli/src/commands/top.rs
+++ b/app/arcbox-cli/src/commands/top.rs
@@ -1,0 +1,223 @@
+//! Live resource monitor for the System VM (`abctl top`).
+//!
+//! Subscribes to `StatsService.Watch` and renders one refreshed frame per
+//! sample. Samples carry cumulative counters; the rates shown are deltas
+//! between consecutive samples over the guest's monotonic clock, so a
+//! stalled stream never fabricates activity.
+
+use anyhow::{Context, Result, bail};
+use arcbox_grpc::v1::stats_service_client::StatsServiceClient;
+use arcbox_protocol::v1::{MachineStats, StatsWatchRequest};
+use clap::Args;
+use tonic::transport::Endpoint;
+
+use super::OutputFormat;
+use super::machine::UnixConnector;
+
+/// Arguments for `abctl top`.
+#[derive(Debug, Args)]
+pub struct TopArgs {
+    /// Print a single computed sample and exit (implied by --format json).
+    #[arg(long)]
+    pub once: bool,
+}
+
+pub async fn execute(args: TopArgs, format: OutputFormat) -> Result<()> {
+    let socket_path = super::resolve_grpc_socket_path();
+    let channel = Endpoint::from_static("http://[::]:50051")
+        .connect_with_connector(UnixConnector::new(socket_path.clone()))
+        .await
+        .with_context(|| {
+            format!(
+                "Failed to connect to ArcBox gRPC daemon at {}",
+                socket_path.display()
+            )
+        })?;
+    let mut client = StatsServiceClient::new(channel);
+    let mut stream = client
+        .watch(StatsWatchRequest {
+            machine_id: String::new(),
+        })
+        .await
+        .context("subscribing to machine stats")?
+        .into_inner();
+
+    let once = args.once || matches!(format, OutputFormat::Json | OutputFormat::Quiet);
+    let mut previous: Option<MachineStats> = None;
+    loop {
+        let sample = match stream.message().await? {
+            Some(sample) => sample,
+            None => bail!("stats stream ended (daemon shutting down?)"),
+        };
+        let Some(prev) = previous.replace(sample) else {
+            continue; // baseline for the first delta
+        };
+        let Some(computed) = ComputedStats::from_delta(&prev, &sample) else {
+            continue; // counters reset (guest rebooted): rebaseline
+        };
+
+        match format {
+            OutputFormat::Json | OutputFormat::Quiet => {
+                println!("{}", serde_json::to_string_pretty(&computed)?);
+            }
+            OutputFormat::Table => {
+                if !args.once {
+                    // Clear screen and home the cursor between frames.
+                    print!("\x1b[2J\x1b[H");
+                }
+                print!("{}", computed.render());
+            }
+        }
+        if once {
+            return Ok(());
+        }
+    }
+}
+
+/// Rates and gauges derived from two consecutive samples.
+#[derive(Debug, serde::Serialize)]
+struct ComputedStats {
+    cpu_percent: f64,
+    online_cpus: u32,
+    loadavg1: f64,
+    memory_total_bytes: u64,
+    memory_used_bytes: u64,
+    memory_used_percent: f64,
+    /// Negative when the guest kernel lacks CONFIG_PSI.
+    memory_psi_full_avg10: f64,
+    disk_read_bytes_per_sec: f64,
+    disk_write_bytes_per_sec: f64,
+    net_rx_bytes_per_sec: f64,
+    net_tx_bytes_per_sec: f64,
+}
+
+impl ComputedStats {
+    /// `None` when the guest clock or CPU counters went backwards — the
+    /// counters reset (guest reboot) and `cur` must become the new
+    /// baseline instead of producing nonsense rates.
+    fn from_delta(prev: &MachineStats, cur: &MachineStats) -> Option<Self> {
+        if cur.monotonic_ms <= prev.monotonic_ms || cur.cpu_total_ticks <= prev.cpu_total_ticks {
+            return None;
+        }
+        let dt = (cur.monotonic_ms - prev.monotonic_ms) as f64 / 1000.0;
+        let total_ticks = (cur.cpu_total_ticks - prev.cpu_total_ticks) as f64;
+        let busy_ticks = cur.cpu_busy_ticks.saturating_sub(prev.cpu_busy_ticks) as f64;
+        let rate =
+            |cur_bytes: u64, prev_bytes: u64| cur_bytes.saturating_sub(prev_bytes) as f64 / dt;
+
+        let memory_used = cur
+            .memory_total_bytes
+            .saturating_sub(cur.memory_available_bytes);
+        Some(Self {
+            cpu_percent: (busy_ticks / total_ticks * 100.0).min(100.0),
+            online_cpus: cur.online_cpus,
+            loadavg1: cur.loadavg1,
+            memory_total_bytes: cur.memory_total_bytes,
+            memory_used_bytes: memory_used,
+            memory_used_percent: if cur.memory_total_bytes == 0 {
+                0.0
+            } else {
+                memory_used as f64 / cur.memory_total_bytes as f64 * 100.0
+            },
+            memory_psi_full_avg10: cur.memory_psi_full_avg10,
+            disk_read_bytes_per_sec: rate(cur.disk_read_bytes, prev.disk_read_bytes),
+            disk_write_bytes_per_sec: rate(cur.disk_written_bytes, prev.disk_written_bytes),
+            net_rx_bytes_per_sec: rate(cur.net_rx_bytes, prev.net_rx_bytes),
+            net_tx_bytes_per_sec: rate(cur.net_tx_bytes, prev.net_tx_bytes),
+        })
+    }
+
+    fn render(&self) -> String {
+        let psi = if self.memory_psi_full_avg10 < 0.0 {
+            "n/a".to_owned()
+        } else {
+            format!("{:.2}%", self.memory_psi_full_avg10)
+        };
+        format!(
+            "ArcBox System VM\n\
+             \n\
+             CPU     {:>6.1}%  of {} cpus   load {:.2}\n\
+             Memory  {:>6.1}%  {} / {}   pressure {}\n\
+             Disk    R {}/s   W {}/s\n\
+             Net     ↓ {}/s   ↑ {}/s\n",
+            self.cpu_percent,
+            self.online_cpus,
+            self.loadavg1,
+            self.memory_used_percent,
+            fmt_bytes(self.memory_used_bytes),
+            fmt_bytes(self.memory_total_bytes),
+            psi,
+            fmt_bytes(self.disk_read_bytes_per_sec as u64),
+            fmt_bytes(self.disk_write_bytes_per_sec as u64),
+            fmt_bytes(self.net_rx_bytes_per_sec as u64),
+            fmt_bytes(self.net_tx_bytes_per_sec as u64),
+        )
+    }
+}
+
+/// Binary-scaled human size ("3.2 GiB").
+fn fmt_bytes(bytes: u64) -> String {
+    const UNITS: [&str; 5] = ["B", "KiB", "MiB", "GiB", "TiB"];
+    let mut value = bytes as f64;
+    let mut unit = 0;
+    while value >= 1024.0 && unit < UNITS.len() - 1 {
+        value /= 1024.0;
+        unit += 1;
+    }
+    if unit == 0 {
+        format!("{bytes} B")
+    } else {
+        format!("{value:.1} {}", UNITS[unit])
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample(monotonic_ms: u64, busy: u64, total: u64) -> MachineStats {
+        MachineStats {
+            monotonic_ms,
+            cpu_busy_ticks: busy,
+            cpu_total_ticks: total,
+            online_cpus: 4,
+            loadavg1: 0.5,
+            memory_total_bytes: 8 * 1024 * 1024 * 1024,
+            memory_available_bytes: 6 * 1024 * 1024 * 1024,
+            memory_psi_full_avg10: 0.5,
+            disk_read_bytes: 1000,
+            disk_written_bytes: 2000,
+            net_rx_bytes: 3000,
+            net_tx_bytes: 4000,
+        }
+    }
+
+    #[test]
+    fn rates_come_from_deltas_over_guest_time() {
+        let prev = sample(10_000, 100, 1000);
+        let mut cur = sample(12_000, 150, 1200); // +2s, 50/200 busy
+        cur.disk_read_bytes = 1000 + 2048;
+        cur.net_tx_bytes = 4000 + 1024;
+
+        let c = ComputedStats::from_delta(&prev, &cur).unwrap();
+        assert!((c.cpu_percent - 25.0).abs() < f64::EPSILON);
+        assert!((c.disk_read_bytes_per_sec - 1024.0).abs() < f64::EPSILON);
+        assert!((c.net_tx_bytes_per_sec - 512.0).abs() < f64::EPSILON);
+        assert!((c.memory_used_percent - 25.0).abs() < 0.01);
+    }
+
+    #[test]
+    fn counter_reset_asks_for_a_new_baseline() {
+        // Guest rebooted: monotonic clock and ticks both went backwards.
+        let prev = sample(500_000, 4000, 50_000);
+        let cur = sample(3_000, 10, 100);
+        assert!(ComputedStats::from_delta(&prev, &cur).is_none());
+    }
+
+    #[test]
+    fn bytes_format_scales() {
+        assert_eq!(fmt_bytes(512), "512 B");
+        assert_eq!(fmt_bytes(2048), "2.0 KiB");
+        assert_eq!(fmt_bytes(3 * 1024 * 1024 * 1024), "3.0 GiB");
+    }
+}

--- a/app/arcbox-cli/src/main.rs
+++ b/app/arcbox-cli/src/main.rs
@@ -82,6 +82,7 @@ fn main() -> Result<()> {
                 Commands::Logs(args) => commands::logs::execute(args).await,
                 Commands::Setup(cmd) => commands::setup::execute(cmd, cli.format).await,
                 Commands::Doctor => commands::doctor::execute().await,
+                Commands::Top(args) => commands::top::execute(args, cli.format).await,
                 #[cfg(target_os = "macos")]
                 Commands::Install(args) => commands::install::execute(args).await,
                 #[cfg(target_os = "macos")]

--- a/app/arcbox-core/src/agent_client.rs
+++ b/app/arcbox-core/src/agent_client.rs
@@ -13,10 +13,10 @@ use arcbox_protocol::agent::{
     DiskTrimRequest, DiskTrimResponse, KubernetesDeleteRequest, KubernetesDeleteResponse,
     KubernetesKubeconfigRequest, KubernetesKubeconfigResponse, KubernetesStartRequest,
     KubernetesStartResponse, KubernetesStatusRequest, KubernetesStatusResponse,
-    KubernetesStopRequest, KubernetesStopResponse, MemoryPressureEvent, MmapReadFileRequest,
-    MmapReadFileResponse, PingRequest, PingResponse, ReadinessEvent, RuntimeEnsureRequest,
-    RuntimeEnsureResponse, RuntimeStatusRequest, RuntimeStatusResponse, SystemInfo,
-    WatchMemoryPressureRequest, WatchReadinessRequest,
+    KubernetesStopRequest, KubernetesStopResponse, MachineStats, MemoryPressureEvent,
+    MmapReadFileRequest, MmapReadFileResponse, PingRequest, PingResponse, ReadinessEvent,
+    RuntimeEnsureRequest, RuntimeEnsureResponse, RuntimeStatusRequest, RuntimeStatusResponse,
+    SystemInfo, WatchMemoryPressureRequest, WatchReadinessRequest, WatchStatsRequest,
 };
 use arcbox_protocol::sandbox_v1::{
     CheckpointRequest, CheckpointResponse, CreateSandboxRequest, CreateSandboxResponse,
@@ -682,6 +682,71 @@ impl AgentClient {
                 Self::decode_memory_pressure_event(&raw)
             }),
         }
+    }
+
+    /// Opens a guest machine stats watch (`WatchStats`).
+    ///
+    /// The agent streams one [`MachineStats`] frame per sample interval;
+    /// consume them with [`Self::next_machine_stats`]. The connection is
+    /// dedicated to the watch until the agent closes the window.
+    pub async fn watch_stats(&mut self, req: WatchStatsRequest) -> Result<()> {
+        if !self.connected {
+            self.connect().await?;
+        }
+
+        let payload = req.encode_to_vec();
+        let buf = Self::build_message(MessageType::WatchStatsRequest, "", &payload);
+
+        match &mut self.transport {
+            AgentTransport::Async(t) => t.send(buf).await.map_err(|e| {
+                CoreError::Machine(format!("failed to send stats watch request: {e}"))
+            }),
+            AgentTransport::Blocking(t) => tokio::task::block_in_place(|| {
+                let deadline = Instant::now() + Duration::from_secs(5);
+                t.send(&buf, deadline).map_err(|e| {
+                    CoreError::Machine(format!("failed to send stats watch request: {e}"))
+                })
+            }),
+        }
+    }
+
+    /// Receives the next frame on an open stats watch, waiting at most
+    /// `max_wait`. Frames double as keepalives, so a timeout means the
+    /// stream is stale (window elapsed or agent gone) and the caller
+    /// should re-open the watch.
+    pub async fn next_machine_stats(&mut self, max_wait: Duration) -> Result<MachineStats> {
+        match &mut self.transport {
+            AgentTransport::Async(t) => {
+                let raw = tokio::time::timeout(max_wait, t.recv())
+                    .await
+                    .map_err(|_| CoreError::Machine("timeout waiting for stats frame".to_string()))?
+                    .map_err(|e| {
+                        CoreError::Machine(format!("failed to receive stats frame: {e}"))
+                    })?;
+                Self::decode_machine_stats(&raw)
+            }
+            AgentTransport::Blocking(t) => tokio::task::block_in_place(|| {
+                let raw = t.recv(Instant::now() + max_wait).map_err(|e| {
+                    CoreError::Machine(format!("failed to receive stats frame: {e}"))
+                })?;
+                Self::decode_machine_stats(&raw)
+            }),
+        }
+    }
+
+    fn decode_machine_stats(raw: &[u8]) -> Result<MachineStats> {
+        let (resp_type, _, resp_payload) = wire::parse_response(raw)?;
+        if resp_type == MessageType::Error as u32 {
+            let (code, message) = wire::parse_error_response(&resp_payload)?;
+            return Err(CoreError::Agent { code, message });
+        }
+        if resp_type != MessageType::MachineStats as u32 {
+            return Err(CoreError::Machine(format!(
+                "unexpected stats response type: 0x{resp_type:04x}"
+            )));
+        }
+        MachineStats::decode(&resp_payload[..])
+            .map_err(|e| CoreError::Machine(format!("failed to decode machine stats: {e}")))
     }
 
     fn decode_memory_pressure_event(raw: &[u8]) -> Result<MemoryPressureEvent> {

--- a/app/arcbox-core/src/lib.rs
+++ b/app/arcbox-core/src/lib.rs
@@ -44,6 +44,7 @@ pub mod persistence;
 #[cfg(target_os = "macos")]
 pub mod route_reconciler;
 pub mod runtime;
+pub mod stats_hub;
 pub mod trace;
 pub mod vm;
 pub mod vm_lifecycle;

--- a/app/arcbox-core/src/runtime.rs
+++ b/app/arcbox-core/src/runtime.rs
@@ -112,6 +112,9 @@ pub struct Runtime {
     /// round-trip. Populated at registration, updated on rename, cleared with
     /// the rest of the container's host state.
     container_aliases: Arc<TokioRwLock<HashMap<String, String>>>,
+    /// Fan-out for System VM machine stats: one guest stream shared by all
+    /// subscribers, none while nobody watches.
+    stats_hub: Arc<crate::stats_hub::StatsHub<crate::stats_hub::AgentStatsSource>>,
 }
 
 /// Parameters of one sandbox port exposure (the host listener half).
@@ -210,6 +213,11 @@ impl Runtime {
         #[cfg(target_os = "macos")]
         let mac_machine_manager = Arc::new(MacMachineManager::new(&config.data_dir));
 
+        let stats_hub = crate::stats_hub::StatsHub::new(crate::stats_hub::AgentStatsSource::new(
+            Arc::clone(&machine_manager),
+            DEFAULT_MACHINE_NAME,
+        ));
+
         Ok(Self {
             config,
             event_bus,
@@ -230,7 +238,18 @@ impl Runtime {
             sandbox_port_keys: Arc::new(TokioRwLock::new(HashMap::new())),
             dns_entries: Arc::new(TokioRwLock::new(HashMap::new())),
             container_aliases: Arc::new(TokioRwLock::new(HashMap::new())),
+            stats_hub,
         })
+    }
+
+    /// Subscribes to live System VM machine stats (see
+    /// [`crate::stats_hub::StatsHub::subscribe`]). Passive observation:
+    /// subscribing never records VM activity or blocks idle reclaim.
+    #[must_use]
+    pub fn subscribe_machine_stats(
+        &self,
+    ) -> tokio::sync::broadcast::Receiver<arcbox_protocol::agent::MachineStats> {
+        self.stats_hub.subscribe()
     }
 
     /// Returns the configuration.

--- a/app/arcbox-core/src/stats_hub.rs
+++ b/app/arcbox-core/src/stats_hub.rs
@@ -1,0 +1,278 @@
+//! Shared machine-stats fan-out.
+//!
+//! One guest `WatchStats` stream serves every subscriber (desktop monitor,
+//! `abctl top`, …), and no stream — no guest-side sampling at all — exists
+//! while nobody subscribes. The pump starts on the first subscriber, stops
+//! shortly after the last one drops, and re-issues the agent watch each
+//! time its window elapses.
+//!
+//! Monitoring is passive observation: nothing in this module records VM
+//! activity, so an always-on monitor never holds the VM out of idle
+//! reclaim (the balloon is transparent to `/proc` readers).
+
+use std::future::Future;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use arcbox_protocol::agent::{MachineStats, WatchStatsRequest};
+use tokio::sync::broadcast;
+
+use crate::error::Result;
+use crate::machine::MachineManager;
+
+/// Sample cadence requested from the agent.
+const SAMPLE_INTERVAL: Duration = Duration::from_secs(1);
+
+/// Watch window requested per agent stream; the pump re-issues the watch
+/// when it elapses.
+const WATCH_WINDOW: Duration = Duration::from_secs(300);
+
+/// Patience for one frame before the stream counts as stale. Frames arrive
+/// every [`SAMPLE_INTERVAL`] and double as keepalives, so this only trips
+/// on a window boundary or a dead agent.
+const FRAME_PATIENCE: Duration = Duration::from_secs(5);
+
+/// Backoff between watch-open attempts while subscribers are waiting
+/// (VM restarting, agent briefly unreachable).
+const RECONNECT_BACKOFF: Duration = Duration::from_secs(3);
+
+/// Broadcast depth per subscriber. A lagging reader misses old samples and
+/// resumes at the newest — exactly right for a live monitor.
+const CHANNEL_DEPTH: usize = 8;
+
+/// Opens guest stats streams. Abstracted so the hub's lifecycle is
+/// unit-testable without a VM.
+pub trait StatsSource: Send + Sync + 'static {
+    /// The stream type produced by [`Self::open`].
+    type Stream: StatsStream;
+
+    /// Opens a fresh guest stats stream on a dedicated agent connection.
+    fn open(&self) -> impl Future<Output = Result<Self::Stream>> + Send;
+}
+
+/// One open guest stats stream.
+pub trait StatsStream: Send {
+    /// Receives the next sample, waiting at most `max_wait`.
+    fn next(&mut self, max_wait: Duration) -> impl Future<Output = Result<MachineStats>> + Send;
+}
+
+/// Fan-out hub: one pump task per subscribed period, N broadcast readers.
+pub struct StatsHub<S: StatsSource> {
+    source: S,
+    state: Mutex<PumpSlot>,
+}
+
+/// The currently live pump, if any. `generation` lets an exiting pump tell
+/// whether it is still the live one (a new subscriber may have replaced it
+/// while it was winding down).
+struct PumpSlot {
+    generation: u64,
+    sender: Option<broadcast::Sender<MachineStats>>,
+}
+
+impl<S: StatsSource> StatsHub<S> {
+    /// Creates a hub over `source`. No guest traffic until someone
+    /// subscribes.
+    pub fn new(source: S) -> Arc<Self> {
+        Arc::new(Self {
+            source,
+            state: Mutex::new(PumpSlot {
+                generation: 0,
+                sender: None,
+            }),
+        })
+    }
+
+    /// Subscribes to machine stats, starting the pump when it is the first
+    /// live subscription. Samples are cumulative counters; consumers
+    /// derive rates from deltas between consecutive samples.
+    pub fn subscribe(self: &Arc<Self>) -> broadcast::Receiver<MachineStats> {
+        let mut state = self.state.lock().expect("stats hub lock poisoned");
+        if let Some(sender) = &state.sender
+            && sender.receiver_count() > 0
+        {
+            return sender.subscribe();
+        }
+        // First subscriber (or the previous pump is winding down with zero
+        // receivers): start a fresh pump on a fresh channel.
+        let (tx, rx) = broadcast::channel(CHANNEL_DEPTH);
+        state.generation += 1;
+        state.sender = Some(tx.clone());
+        let hub = Arc::clone(self);
+        let generation = state.generation;
+        drop(tokio::spawn(async move { hub.pump(tx, generation).await }));
+        rx
+    }
+
+    /// Streams samples from the guest into the broadcast channel until the
+    /// last receiver is gone.
+    async fn pump(self: Arc<Self>, tx: broadcast::Sender<MachineStats>, generation: u64) {
+        tracing::info!("stats pump started");
+        'reopen: while tx.receiver_count() > 0 {
+            let mut stream = match self.source.open().await {
+                Ok(stream) => stream,
+                Err(e) => {
+                    tracing::debug!("stats watch open failed: {e}; retrying");
+                    tokio::time::sleep(RECONNECT_BACKOFF).await;
+                    continue;
+                }
+            };
+            let window_started = tokio::time::Instant::now();
+            loop {
+                if tx.receiver_count() == 0 {
+                    break 'reopen;
+                }
+                match stream.next(FRAME_PATIENCE).await {
+                    Ok(sample) => {
+                        // Send fails only with zero receivers; the loop
+                        // condition handles that on the next pass.
+                        let _ = tx.send(sample);
+                    }
+                    Err(e) => {
+                        // A clean window end goes quiet right around
+                        // WATCH_WINDOW; anything earlier is a real failure
+                        // and deserves a backoff before reconnecting.
+                        if window_started.elapsed() < WATCH_WINDOW.saturating_sub(FRAME_PATIENCE) {
+                            tracing::debug!("stats stream interrupted: {e}; reopening");
+                            tokio::time::sleep(RECONNECT_BACKOFF).await;
+                        }
+                        continue 'reopen;
+                    }
+                }
+            }
+        }
+        let mut state = self.state.lock().expect("stats hub lock poisoned");
+        if state.generation == generation {
+            state.sender = None;
+        }
+        tracing::info!("stats pump stopped");
+    }
+}
+
+/// Production [`StatsSource`]: a dedicated agent connection per stream,
+/// mirroring how the idle-balloon pressure watch connects.
+pub struct AgentStatsSource {
+    machine_manager: Arc<MachineManager>,
+    machine_name: String,
+}
+
+impl AgentStatsSource {
+    /// A source for the named machine's agent.
+    pub fn new(machine_manager: Arc<MachineManager>, machine_name: impl Into<String>) -> Self {
+        Self {
+            machine_manager,
+            machine_name: machine_name.into(),
+        }
+    }
+}
+
+impl StatsSource for AgentStatsSource {
+    type Stream = AgentStatsStream;
+
+    async fn open(&self) -> Result<AgentStatsStream> {
+        let mut agent = self.machine_manager.connect_agent(&self.machine_name)?;
+        agent
+            .watch_stats(WatchStatsRequest {
+                timeout_ms: u32::try_from(WATCH_WINDOW.as_millis()).unwrap_or(u32::MAX),
+                interval_ms: u32::try_from(SAMPLE_INTERVAL.as_millis()).unwrap_or(u32::MAX),
+            })
+            .await?;
+        Ok(AgentStatsStream { agent })
+    }
+}
+
+/// [`StatsStream`] over the agent's `WatchStats` frames.
+pub struct AgentStatsStream {
+    agent: crate::agent_client::AgentClient,
+}
+
+impl StatsStream for AgentStatsStream {
+    async fn next(&mut self, max_wait: Duration) -> Result<MachineStats> {
+        self.agent.next_machine_stats(max_wait).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    /// Source whose streams yield a fixed sample per call, counting opens.
+    struct FakeSource {
+        opens: Arc<AtomicUsize>,
+    }
+
+    struct FakeStream;
+
+    impl StatsSource for FakeSource {
+        type Stream = FakeStream;
+
+        async fn open(&self) -> Result<FakeStream> {
+            self.opens.fetch_add(1, Ordering::SeqCst);
+            Ok(FakeStream)
+        }
+    }
+
+    impl StatsStream for FakeStream {
+        async fn next(&mut self, _max_wait: Duration) -> Result<MachineStats> {
+            // Pace the fake so a pump doesn't spin the executor.
+            tokio::time::sleep(Duration::from_millis(1)).await;
+            Ok(MachineStats {
+                monotonic_ms: 1,
+                ..Default::default()
+            })
+        }
+    }
+
+    fn hub_with_counter() -> (Arc<StatsHub<FakeSource>>, Arc<AtomicUsize>) {
+        let opens = Arc::new(AtomicUsize::new(0));
+        let hub = StatsHub::new(FakeSource {
+            opens: Arc::clone(&opens),
+        });
+        (hub, opens)
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn concurrent_subscribers_share_one_stream() {
+        let (hub, opens) = hub_with_counter();
+
+        let mut a = hub.subscribe();
+        let mut b = hub.subscribe();
+        let sample_a = a.recv().await.unwrap();
+        let sample_b = b.recv().await.unwrap();
+        assert_eq!(sample_a.monotonic_ms, 1);
+        assert_eq!(sample_b.monotonic_ms, 1);
+        assert_eq!(opens.load(Ordering::SeqCst), 1, "one guest stream shared");
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn pump_stops_after_last_subscriber_and_restarts_on_next() {
+        let (hub, opens) = hub_with_counter();
+
+        let mut rx = hub.subscribe();
+        rx.recv().await.unwrap();
+        drop(rx);
+
+        // The pump notices the empty channel on its next send/check and
+        // clears the slot.
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+        loop {
+            {
+                let state = hub.state.lock().unwrap();
+                if state.sender.is_none() {
+                    break;
+                }
+            }
+            assert!(
+                tokio::time::Instant::now() < deadline,
+                "pump did not stop after last subscriber"
+            );
+            tokio::time::sleep(Duration::from_millis(5)).await;
+        }
+
+        // A later subscriber gets a fresh pump (and a fresh guest stream).
+        let mut rx = hub.subscribe();
+        rx.recv().await.unwrap();
+        assert_eq!(opens.load(Ordering::SeqCst), 2);
+    }
+}

--- a/app/arcbox-daemon/src/services.rs
+++ b/app/arcbox-daemon/src/services.rs
@@ -11,9 +11,9 @@ use anyhow::{Context, Result};
 use arcbox_api::{
     IconServiceImpl, IconServiceServer, KubernetesServiceImpl, MachineServiceImpl,
     MigrationServiceImpl, MigrationServiceServer, SandboxServiceImpl, SandboxServiceServer,
-    SandboxSnapshotServiceImpl, SandboxSnapshotServiceServer, SharedRuntime, SystemServiceImpl,
-    SystemServiceServer, kubernetes_service_server::KubernetesServiceServer,
-    machine_service_server::MachineServiceServer,
+    SandboxSnapshotServiceImpl, SandboxSnapshotServiceServer, SharedRuntime, StatsServiceImpl,
+    SystemServiceImpl, SystemServiceServer, kubernetes_service_server::KubernetesServiceServer,
+    machine_service_server::MachineServiceServer, stats_service_server::StatsServiceServer,
 };
 #[cfg(target_os = "macos")]
 use arcbox_api::{MacosServiceImpl, macos_service_server::MacosServiceServer};
@@ -63,6 +63,7 @@ pub async fn start_grpc(
         Arc::clone(&shared_runtime),
         Arc::clone(&ctx.early_runtime),
     );
+    let stats_service = StatsServiceImpl::new(Arc::clone(&shared_runtime));
     let icon_service = IconServiceImpl::new();
 
     // Server reflection lets SDK authors and grpcurl discover the API
@@ -86,6 +87,7 @@ pub async fn start_grpc(
             .add_service(SandboxServiceServer::new(sandbox_service))
             .add_service(SandboxSnapshotServiceServer::new(sandbox_snapshot_service))
             .add_service(SystemServiceServer::new(system_service))
+            .add_service(StatsServiceServer::new(stats_service))
             .add_service(IconServiceServer::new(icon_service));
         // macOS guests are served only on Apple Silicon hosts; on other
         // platforms the service is simply absent (the CLI `macos` noun is

--- a/common/arcbox-constants/src/paths.rs
+++ b/common/arcbox-constants/src/paths.rs
@@ -126,6 +126,9 @@ impl core::fmt::Display for ArcboxProfile {
     }
 }
 
+/// Gated on the `std` feature: the error message is an allocated `String`,
+/// which `no_std` builds of this crate don't have.
+#[cfg(feature = "std")]
 impl core::str::FromStr for ArcboxProfile {
     type Err = String;
 

--- a/common/arcbox-constants/src/wire.rs
+++ b/common/arcbox-constants/src/wire.rs
@@ -58,6 +58,9 @@ pub enum MessageType {
     /// Opens a guest-driven memory pressure event stream (used by the host
     /// while the idle balloon is shrunk).
     WatchMemoryPressureRequest = 0x000F,
+    /// Opens a guest-driven machine resource stats stream (payload:
+    /// `arcbox.v1.WatchStatsRequest`).
+    WatchStatsRequest = 0x0010,
 
     // Sandbox CRUD request types (0x0020 - 0x0026).
     SandboxCreateRequest = 0x0020,
@@ -120,6 +123,9 @@ pub enum MessageType {
     KillAgentResponse = 0x100E,
     /// Guest-driven memory pressure event frame.
     MemoryPressureEvent = 0x100F,
+    /// One machine resource sample frame (payload:
+    /// `arcbox.v1.MachineStats`).
+    MachineStats = 0x1010,
     PortBindingsChanged = 0x1030,
     PortBindingsRemoved = 0x1031,
 
@@ -176,6 +182,7 @@ impl MessageType {
             0x000D => Some(Self::WatchReadinessRequest),
             0x000E => Some(Self::KillAgentRequest),
             0x000F => Some(Self::WatchMemoryPressureRequest),
+            0x0010 => Some(Self::WatchStatsRequest),
             // Sandbox CRUD requests.
             0x0020 => Some(Self::SandboxCreateRequest),
             0x0021 => Some(Self::SandboxStopRequest),
@@ -214,6 +221,7 @@ impl MessageType {
             0x100D => Some(Self::ReadinessEvent),
             0x100E => Some(Self::KillAgentResponse),
             0x100F => Some(Self::MemoryPressureEvent),
+            0x1010 => Some(Self::MachineStats),
             0x1030 => Some(Self::PortBindingsChanged),
             0x1031 => Some(Self::PortBindingsRemoved),
             // Sandbox CRUD responses.
@@ -302,7 +310,9 @@ mod tests {
             (0x000D, MessageType::WatchReadinessRequest),
             (0x000E, MessageType::KillAgentRequest),
             (0x000F, MessageType::WatchMemoryPressureRequest),
+            (0x0010, MessageType::WatchStatsRequest),
             (0x100F, MessageType::MemoryPressureEvent),
+            (0x1010, MessageType::MachineStats),
             (0x1001, MessageType::PingResponse),
             (0x1002, MessageType::GetSystemInfoResponse),
             (0x1003, MessageType::EnsureRuntimeResponse),
@@ -369,7 +379,7 @@ mod tests {
     #[test]
     fn message_type_rejects_unknown_values() {
         assert_eq!(MessageType::from_u32(0x9999), None);
-        assert_eq!(MessageType::from_u32(0x1010), None);
+        assert_eq!(MessageType::from_u32(0x1011), None);
     }
 
     #[test]

--- a/guest/arcbox-agent/src/agent/linux/mod.rs
+++ b/guest/arcbox-agent/src/agent/linux/mod.rs
@@ -15,6 +15,7 @@ mod proxy;
 mod rpc;
 mod runtime;
 mod sandbox;
+mod stats;
 mod system_info;
 mod vsock;
 

--- a/guest/arcbox-agent/src/agent/linux/rpc.rs
+++ b/guest/arcbox-agent/src/agent/linux/rpc.rs
@@ -86,6 +86,10 @@ where
                     .await?;
                 continue;
             }
+            Ok(RpcRequest::WatchStats(req)) => {
+                super::stats::handle_watch_stats(&mut stream, req, &trace_id).await?;
+                continue;
+            }
             Ok(request) => handle_request(request).await,
             Err(e) => {
                 tracing::warn!(trace_id = %trace_id, "Failed to parse request: {}", e);
@@ -134,6 +138,7 @@ async fn handle_request(request: RpcRequest) -> RequestResult {
         RpcRequest::WatchMemoryPressure(_) => {
             unreachable!("watch memory pressure is streaming")
         }
+        RpcRequest::WatchStats(_) => unreachable!("watch stats is streaming"),
     }
 }
 

--- a/guest/arcbox-agent/src/agent/linux/stats.rs
+++ b/guest/arcbox-agent/src/agent/linux/stats.rs
@@ -1,0 +1,131 @@
+//! `WatchStats` streaming handler: samples machine-level resource counters
+//! and pushes one frame per tick to the host.
+//!
+//! The host opens this stream only while a stats subscriber exists (the
+//! desktop monitor, `abctl top`), so the sampling cost is zero when nobody
+//! is watching. Parsing lives in the platform-neutral [`crate::stats`]
+//! module; this file owns the `/proc` reads and the frame writing.
+
+use std::time::Duration;
+
+use anyhow::Result;
+use prost::Message as _;
+use tokio::io::AsyncWrite;
+
+use arcbox_protocol::agent::{MachineStats, WatchStatsRequest};
+
+use crate::rpc::{MessageType, write_message};
+use crate::stats::{
+    parse_cpu_ticks, parse_diskstats, parse_loadavg1, parse_meminfo, parse_net_dev,
+    parse_psi_full_avg10, parse_uptime_ms,
+};
+
+/// Default watch window when the request leaves `timeout_ms` at 0.
+const DEFAULT_WINDOW: Duration = Duration::from_secs(300);
+
+/// Default sample cadence when the request leaves `interval_ms` at 0.
+const DEFAULT_INTERVAL: Duration = Duration::from_millis(1000);
+
+/// Fastest cadence the agent will sample at, whatever the host asks for —
+/// guest self-protection against a misbehaving subscriber.
+const MIN_INTERVAL: Duration = Duration::from_millis(200);
+
+/// Handles one `WatchStats` request, streaming one sample per tick until
+/// the window elapses or the peer goes away (write error).
+///
+/// Every frame doubles as a keepalive; a tick whose `/proc` reads fail is
+/// skipped (the host tolerates gaps and reconnects on sustained silence).
+pub(super) async fn handle_watch_stats<S>(
+    stream: &mut S,
+    req: WatchStatsRequest,
+    trace_id: &str,
+) -> Result<()>
+where
+    S: AsyncWrite + Unpin,
+{
+    let window = if req.timeout_ms == 0 {
+        DEFAULT_WINDOW
+    } else {
+        Duration::from_millis(u64::from(req.timeout_ms))
+    };
+    let interval = if req.interval_ms == 0 {
+        DEFAULT_INTERVAL
+    } else {
+        Duration::from_millis(u64::from(req.interval_ms)).max(MIN_INTERVAL)
+    };
+
+    tracing::info!(
+        trace_id = %trace_id,
+        window_secs = window.as_secs(),
+        interval_ms = interval.as_millis(),
+        "stats watch opened"
+    );
+
+    let started = tokio::time::Instant::now();
+    let mut warned_unreadable = false;
+    let mut ticker = tokio::time::interval(interval);
+    ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+    // An immediate first sample: the subscriber gets its baseline for rate
+    // deltas without waiting a full interval.
+    loop {
+        ticker.tick().await;
+        if started.elapsed() >= window {
+            // End of window: return to the connection loop, which accepts
+            // the host's next WatchStats request on this same connection.
+            return Ok(());
+        }
+        match read_machine_stats() {
+            Some(sample) => {
+                write_message(
+                    stream,
+                    MessageType::MachineStats,
+                    trace_id,
+                    &sample.encode_to_vec(),
+                )
+                .await?;
+            }
+            None if !warned_unreadable => {
+                warned_unreadable = true;
+                tracing::warn!(trace_id = %trace_id, "machine stats unreadable; skipping ticks");
+            }
+            None => {}
+        }
+    }
+}
+
+/// One pass over `/proc`, assembled into a [`MachineStats`] frame.
+///
+/// `None` when any mandatory source is unreadable; PSI is optional (kernels
+/// without `CONFIG_PSI` report a negative gauge).
+fn read_machine_stats() -> Option<MachineStats> {
+    let stat = std::fs::read_to_string("/proc/stat").ok()?;
+    let meminfo = std::fs::read_to_string("/proc/meminfo").ok()?;
+    let loadavg = std::fs::read_to_string("/proc/loadavg").ok()?;
+    let uptime = std::fs::read_to_string("/proc/uptime").ok()?;
+    let diskstats = std::fs::read_to_string("/proc/diskstats").unwrap_or_default();
+    let net_dev = std::fs::read_to_string("/proc/net/dev").unwrap_or_default();
+    let psi = std::fs::read_to_string("/proc/pressure/memory").ok();
+
+    let (cpu_busy_ticks, cpu_total_ticks) = parse_cpu_ticks(&stat)?;
+    let (memory_total_bytes, memory_available_bytes) = parse_meminfo(&meminfo)?;
+    let (disk_read_bytes, disk_written_bytes) = parse_diskstats(&diskstats);
+    let (net_rx_bytes, net_tx_bytes) = parse_net_dev(&net_dev);
+
+    Some(MachineStats {
+        monotonic_ms: parse_uptime_ms(&uptime)?,
+        cpu_busy_ticks,
+        cpu_total_ticks,
+        online_cpus: std::thread::available_parallelism().map_or(0, |n| n.get() as u32),
+        loadavg1: parse_loadavg1(&loadavg)?,
+        memory_total_bytes,
+        memory_available_bytes,
+        memory_psi_full_avg10: psi
+            .as_deref()
+            .and_then(parse_psi_full_avg10)
+            .unwrap_or(-1.0),
+        disk_read_bytes,
+        disk_written_bytes,
+        net_rx_bytes,
+        net_tx_bytes,
+    })
+}

--- a/guest/arcbox-agent/src/lib.rs
+++ b/guest/arcbox-agent/src/lib.rs
@@ -13,6 +13,6 @@ pub mod dns_server;
 pub mod error;
 pub mod memory_pressure;
 pub mod rootfs_builder;
-pub mod stats;
 #[cfg(target_os = "linux")]
 pub mod sandbox;
+pub mod stats;

--- a/guest/arcbox-agent/src/lib.rs
+++ b/guest/arcbox-agent/src/lib.rs
@@ -13,5 +13,6 @@ pub mod dns_server;
 pub mod error;
 pub mod memory_pressure;
 pub mod rootfs_builder;
+pub mod stats;
 #[cfg(target_os = "linux")]
 pub mod sandbox;

--- a/guest/arcbox-agent/src/main.rs
+++ b/guest/arcbox-agent/src/main.rs
@@ -19,6 +19,10 @@ mod supervisor;
 #[cfg(target_os = "linux")]
 mod memory_pressure;
 
+// Same arrangement for the WatchStats handler's /proc parsers.
+#[cfg(target_os = "linux")]
+mod stats;
+
 #[cfg(target_os = "linux")]
 mod error;
 

--- a/guest/arcbox-agent/src/rpc.rs
+++ b/guest/arcbox-agent/src/rpc.rs
@@ -21,7 +21,7 @@ use arcbox_protocol::agent::{
     MmapReadFileResponse, PingRequest, PingResponse, PortBindingsChanged, PortBindingsRemoved,
     ReadinessEvent, RuntimeEnsureRequest, RuntimeEnsureResponse, RuntimeStatusRequest,
     RuntimeStatusResponse, ShutdownRequest, ShutdownResponse, SystemInfo,
-    WatchMemoryPressureRequest, WatchReadinessRequest,
+    WatchMemoryPressureRequest, WatchReadinessRequest, WatchStatsRequest,
 };
 
 /// Agent version string.
@@ -83,6 +83,7 @@ pub enum RpcRequest {
     DiskTrim(DiskTrimRequest),
     WatchReadiness(WatchReadinessRequest),
     WatchMemoryPressure(WatchMemoryPressureRequest),
+    WatchStats(WatchStatsRequest),
     /// Test-only: exit the agent so PID 1 (busybox init) respawns it.
     KillAgent,
 }
@@ -339,6 +340,10 @@ pub fn parse_request(msg_type: MessageType, payload: &[u8]) -> Result<RpcRequest
             let req = WatchMemoryPressureRequest::decode(payload)?;
             Ok(RpcRequest::WatchMemoryPressure(req))
         }
+        MessageType::WatchStatsRequest => {
+            let req = WatchStatsRequest::decode(payload)?;
+            Ok(RpcRequest::WatchStats(req))
+        }
         MessageType::KillAgentRequest => Ok(RpcRequest::KillAgent),
         _ => anyhow::bail!("unexpected message type: {:?}", msg_type),
     }
@@ -397,8 +402,8 @@ mod tests {
     #[test]
     fn test_message_type_from_u32_invalid() {
         assert_eq!(MessageType::from_u32(0x9999), None);
-        assert_eq!(MessageType::from_u32(0x0010), None);
-        assert_eq!(MessageType::from_u32(0x1010), None);
+        assert_eq!(MessageType::from_u32(0x0011), None);
+        assert_eq!(MessageType::from_u32(0x1011), None);
     }
 
     #[test]

--- a/guest/arcbox-agent/src/stats.rs
+++ b/guest/arcbox-agent/src/stats.rs
@@ -123,8 +123,16 @@ fn is_whole_disk(name: &str) -> bool {
     false
 }
 
-/// Cumulative `(rx, tx)` bytes across non-loopback interfaces from
+/// Cumulative `(rx, tx)` bytes across physical/uplink interfaces from
 /// `/proc/net/dev`.
+///
+/// Only real NICs are counted (see [`is_physical_nic`]). The System VM's
+/// root netns also carries container bridges and veths (`docker0`,
+/// `br-<hash>`, `veth<hash>`, `cni0`, …); summing those would count the
+/// same bytes once per internal hop (veth → bridge → uplink), inflating
+/// the machine's reported throughput — the same double-count the disk
+/// parser avoids with [`is_whole_disk`]. In a container's own netns this
+/// leaves just its `eth0`, so per-container reads are unaffected.
 #[must_use]
 pub fn parse_net_dev(net_dev: &str) -> (u64, u64) {
     let mut rx = 0u64;
@@ -133,7 +141,7 @@ pub fn parse_net_dev(net_dev: &str) -> (u64, u64) {
         let Some((name, rest)) = line.split_once(':') else {
             continue; // header lines
         };
-        if name.trim() == "lo" {
+        if !is_physical_nic(name.trim()) {
             continue;
         }
         let fields: Vec<&str> = rest.split_ascii_whitespace().collect();
@@ -145,6 +153,16 @@ pub fn parse_net_dev(net_dev: &str) -> (u64, u64) {
         tx = tx.saturating_add(tx_bytes.parse().unwrap_or(0));
     }
     (rx, tx)
+}
+
+/// Whether an interface name is a physical/uplink NIC, as opposed to a
+/// container bridge or veth. An allowlist of the kernel's predictable NIC
+/// prefixes (`eth`, `en*`) is robust because virtual-interface naming
+/// varies widely (`docker0`, `br-<hash>`, `veth<hash>`, `cni0`,
+/// `flannel.1`, `vxlan*`, `virbr*`, `tap*`, …) and none of them share
+/// these prefixes — `veth` starts with `v`, not `e`.
+fn is_physical_nic(name: &str) -> bool {
+    name.starts_with("eth") || name.starts_with("en")
 }
 
 #[cfg(test)]
@@ -229,13 +247,41 @@ mod tests {
     }
 
     #[test]
-    fn net_dev_sums_everything_but_loopback() {
+    fn net_dev_counts_uplinks_and_skips_bridges_veths() {
+        // The System VM's root netns: real uplinks (eth0/eth1) plus the
+        // container bridges/veths whose bytes would otherwise be counted
+        // again on the uplink.
         let net_dev = "\
 Inter-|   Receive                                                |  Transmit\n\
  face |bytes    packets errs drop fifo frame compressed multicast|bytes    packets errs drop fifo colls carrier compressed\n\
-    lo: 9999999    100    0    0    0     0          0         0  9999999    100    0    0    0     0       0          0\n\
-  eth0: 1000     10    0    0    0     0          0         0  2000     20    0    0    0     0       0          0\n\
-  eth1:  500      5    0    0    0     0          0         0   700      7    0    0    0     0       0          0\n";
+       lo: 9999999    100    0    0    0     0          0         0  9999999    100    0    0    0     0       0          0\n\
+     eth0: 1000     10    0    0    0     0          0         0  2000     20    0    0    0     0       0          0\n\
+     eth1:  500      5    0    0    0     0          0         0   700      7    0    0    0     0       0          0\n\
+  docker0: 8000     80    0    0    0     0          0         0  8000     80    0    0    0     0       0          0\n\
+veth1a2b3c: 8000     80    0    0    0     0          0         0  8000     80    0    0    0     0       0          0\n\
+ br-abc123: 8000     80    0    0    0     0          0         0  8000     80    0    0    0     0       0          0\n";
+        // Only eth0 + eth1 count; the bridges/veths are excluded.
         assert_eq!(parse_net_dev(net_dev), (1500, 2700));
+    }
+
+    #[test]
+    fn physical_nic_allowlist() {
+        for nic in ["eth0", "eth1", "en0", "ens1", "enp0s5"] {
+            assert!(is_physical_nic(nic), "{nic}");
+        }
+        for virt in [
+            "lo",
+            "docker0",
+            "br-abc123",
+            "veth1a2b",
+            "cni0",
+            "flannel.1",
+            "vxlan.calico",
+            "virbr0",
+            "tap0",
+            "tun0",
+        ] {
+            assert!(!is_physical_nic(virt), "{virt}");
+        }
     }
 }

--- a/guest/arcbox-agent/src/stats.rs
+++ b/guest/arcbox-agent/src/stats.rs
@@ -1,0 +1,231 @@
+//! Machine-level resource stat parsers for the `WatchStats` stream.
+//!
+//! Pure text parsing over `/proc` file contents, kept platform-neutral so
+//! the logic is unit-testable on any host. The Linux handler
+//! (`agent::linux::stats`) owns the actual file reads and frame writing.
+//!
+//! All extracted counters are cumulative-since-boot; consumers derive
+//! rates from deltas between samples (see `MachineStats` in agent.proto).
+
+/// Sector size `/proc/diskstats` counts in, independent of the device's
+/// real block size (fixed by the kernel ABI).
+const DISKSTATS_SECTOR_BYTES: u64 = 512;
+
+/// Aggregate CPU ticks from `/proc/stat`'s first line: `(busy, total)`.
+///
+/// Busy is everything except idle and iowait. Fields beyond `idle` may be
+/// absent on old kernels; missing fields count as zero.
+#[must_use]
+pub fn parse_cpu_ticks(stat: &str) -> Option<(u64, u64)> {
+    let line = stat.lines().find(|l| l.starts_with("cpu "))?;
+    let fields: Vec<u64> = line
+        .split_ascii_whitespace()
+        .skip(1)
+        .map_while(|f| f.parse().ok())
+        .collect();
+    if fields.len() < 4 {
+        return None;
+    }
+    let total: u64 = fields.iter().sum();
+    let idle = fields[3] + fields.get(4).copied().unwrap_or(0);
+    Some((total.saturating_sub(idle), total))
+}
+
+/// 1-minute load average from `/proc/loadavg`.
+#[must_use]
+pub fn parse_loadavg1(loadavg: &str) -> Option<f64> {
+    loadavg.split_ascii_whitespace().next()?.parse().ok()
+}
+
+/// Guest monotonic milliseconds from `/proc/uptime`.
+#[must_use]
+pub fn parse_uptime_ms(uptime: &str) -> Option<u64> {
+    let secs: f64 = uptime.split_ascii_whitespace().next()?.parse().ok()?;
+    if !secs.is_finite() || secs < 0.0 {
+        return None;
+    }
+    Some((secs * 1000.0) as u64)
+}
+
+/// `(MemTotal, MemAvailable)` in bytes from `/proc/meminfo`.
+#[must_use]
+pub fn parse_meminfo(meminfo: &str) -> Option<(u64, u64)> {
+    Some((
+        meminfo_field_bytes(meminfo, "MemTotal:")?,
+        meminfo_field_bytes(meminfo, "MemAvailable:")?,
+    ))
+}
+
+fn meminfo_field_bytes(meminfo: &str, key: &str) -> Option<u64> {
+    let line = meminfo.lines().find(|l| l.starts_with(key))?;
+    let kb: u64 = line.split_ascii_whitespace().nth(1)?.parse().ok()?;
+    kb.checked_mul(1024)
+}
+
+/// The `full avg10` percentage from `/proc/pressure/memory`.
+///
+/// `None` on kernels without `CONFIG_PSI` (missing file is the caller's
+/// case; this handles a present-but-unparsable file the same way).
+#[must_use]
+pub fn parse_psi_full_avg10(pressure: &str) -> Option<f64> {
+    let line = pressure.lines().find(|l| l.starts_with("full "))?;
+    let avg10 = line
+        .split_ascii_whitespace()
+        .find_map(|f| f.strip_prefix("avg10="))?;
+    avg10.parse().ok()
+}
+
+/// Cumulative `(read, written)` bytes across whole physical disks.
+///
+/// Partitions are excluded so traffic is not counted twice; virtual
+/// devices (loop, dm-*, zram, ram, md) are excluded so stacked block
+/// layers do not multiply it either.
+#[must_use]
+pub fn parse_diskstats(diskstats: &str) -> (u64, u64) {
+    let mut read = 0u64;
+    let mut written = 0u64;
+    for line in diskstats.lines() {
+        let fields: Vec<&str> = line.split_ascii_whitespace().collect();
+        // major minor name reads _ sectors_read _ writes _ sectors_written …
+        let (Some(name), Some(sectors_read), Some(sectors_written)) =
+            (fields.get(2), fields.get(5), fields.get(9))
+        else {
+            continue;
+        };
+        if !is_whole_disk(name) {
+            continue;
+        }
+        let r: u64 = sectors_read.parse().unwrap_or(0);
+        let w: u64 = sectors_written.parse().unwrap_or(0);
+        read = read.saturating_add(r.saturating_mul(DISKSTATS_SECTOR_BYTES));
+        written = written.saturating_add(w.saturating_mul(DISKSTATS_SECTOR_BYTES));
+    }
+    (read, written)
+}
+
+/// Whether a `/proc/diskstats` device name is a whole physical disk (as
+/// opposed to a partition or a virtual/stacked device).
+fn is_whole_disk(name: &str) -> bool {
+    for prefix in ["vd", "sd", "xvd"] {
+        if let Some(rest) = name.strip_prefix(prefix) {
+            // Whole disks are letters only ("vda"); partitions end in
+            // digits ("vda1").
+            return !rest.is_empty() && rest.bytes().all(|b| b.is_ascii_lowercase());
+        }
+    }
+    // NVMe namespaces ("nvme0n1") vs partitions ("nvme0n1p2"); the same
+    // 'p'-suffix convention holds for mmcblk.
+    for prefix in ["nvme", "mmcblk"] {
+        if let Some(rest) = name.strip_prefix(prefix) {
+            return !rest.is_empty() && !rest.contains('p');
+        }
+    }
+    false
+}
+
+/// Cumulative `(rx, tx)` bytes across non-loopback interfaces from
+/// `/proc/net/dev`.
+#[must_use]
+pub fn parse_net_dev(net_dev: &str) -> (u64, u64) {
+    let mut rx = 0u64;
+    let mut tx = 0u64;
+    for line in net_dev.lines() {
+        let Some((name, rest)) = line.split_once(':') else {
+            continue; // header lines
+        };
+        if name.trim() == "lo" {
+            continue;
+        }
+        let fields: Vec<&str> = rest.split_ascii_whitespace().collect();
+        // rx: bytes packets errs drop fifo frame compressed multicast, then tx.
+        let (Some(rx_bytes), Some(tx_bytes)) = (fields.first(), fields.get(8)) else {
+            continue;
+        };
+        rx = rx.saturating_add(rx_bytes.parse().unwrap_or(0));
+        tx = tx.saturating_add(tx_bytes.parse().unwrap_or(0));
+    }
+    (rx, tx)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cpu_ticks_split_busy_from_idle_and_iowait() {
+        let stat = "cpu  100 20 50 800 30 5 5 0 0 0\ncpu0 10 2 5 80 3 1 1 0 0 0\n";
+        let (busy, total) = parse_cpu_ticks(stat).unwrap();
+        assert_eq!(total, 1010);
+        assert_eq!(busy, 1010 - 800 - 30);
+    }
+
+    #[test]
+    fn cpu_ticks_tolerate_short_old_kernel_lines() {
+        // Pre-2.6 shape: user nice system idle only.
+        let (busy, total) = parse_cpu_ticks("cpu  10 0 20 70\n").unwrap();
+        assert_eq!((busy, total), (30, 100));
+        assert!(parse_cpu_ticks("cpu  1 2 3\n").is_none());
+        assert!(parse_cpu_ticks("intr 12345\n").is_none());
+    }
+
+    #[test]
+    fn loadavg_and_uptime_parse_first_field() {
+        assert_eq!(parse_loadavg1("0.42 0.36 0.34 2/1290 12345\n"), Some(0.42));
+        assert_eq!(parse_uptime_ms("352.62 6082.49\n"), Some(352_620));
+        assert_eq!(parse_uptime_ms("-1 0"), None);
+    }
+
+    #[test]
+    fn meminfo_scales_kb_to_bytes() {
+        let meminfo = "MemTotal:       16296128 kB\nMemFree:         1234 kB\nMemAvailable:   15000000 kB\n";
+        let (total, available) = parse_meminfo(meminfo).unwrap();
+        assert_eq!(total, 16_296_128 * 1024);
+        assert_eq!(available, 15_000_000 * 1024);
+        assert!(parse_meminfo("MemTotal: 1 kB\n").is_none());
+    }
+
+    #[test]
+    fn psi_reads_full_avg10() {
+        let pressure = "some avg10=0.12 avg60=0.05 avg300=0.01 total=417963\n\
+                        full avg10=7.68 avg60=1.23 avg300=0.30 total=291211\n";
+        assert_eq!(parse_psi_full_avg10(pressure), Some(7.68));
+        assert_eq!(parse_psi_full_avg10("some avg10=0.00 total=0\n"), None);
+    }
+
+    #[test]
+    fn diskstats_sum_whole_disks_only() {
+        let diskstats = "\
+ 254       0 vda 100 0 2000 50 200 0 4000 100 0 0 0\n\
+ 254       1 vda1 90 0 1800 45 190 0 3800 95 0 0 0\n\
+ 254      16 vdb 10 0 100 5 20 0 200 10 0 0 0\n\
+   7       0 loop0 5 0 50 1 0 0 0 0 0 0 0\n\
+ 253       0 dm-0 5 0 50 1 5 0 50 1 0 0 0\n";
+        let (read, written) = parse_diskstats(diskstats);
+        assert_eq!(read, (2000 + 100) * 512);
+        assert_eq!(written, (4000 + 200) * 512);
+    }
+
+    #[test]
+    fn whole_disk_classification() {
+        for disk in ["vda", "sdb", "xvdc", "nvme0n1", "mmcblk0"] {
+            assert!(is_whole_disk(disk), "{disk}");
+        }
+        for other in [
+            "vda1", "sdb2", "nvme0n1p1", "mmcblk0p2", "loop0", "ram0", "dm-0", "zram0", "md0",
+            "sr0", "vd",
+        ] {
+            assert!(!is_whole_disk(other), "{other}");
+        }
+    }
+
+    #[test]
+    fn net_dev_sums_everything_but_loopback() {
+        let net_dev = "\
+Inter-|   Receive                                                |  Transmit\n\
+ face |bytes    packets errs drop fifo frame compressed multicast|bytes    packets errs drop fifo colls carrier compressed\n\
+    lo: 9999999    100    0    0    0     0          0         0  9999999    100    0    0    0     0       0          0\n\
+  eth0: 1000     10    0    0    0     0          0         0  2000     20    0    0    0     0       0          0\n\
+  eth1:  500      5    0    0    0     0          0         0   700      7    0    0    0     0       0          0\n";
+        assert_eq!(parse_net_dev(net_dev), (1500, 2700));
+    }
+}

--- a/guest/arcbox-agent/src/stats.rs
+++ b/guest/arcbox-agent/src/stats.rs
@@ -177,7 +177,8 @@ mod tests {
 
     #[test]
     fn meminfo_scales_kb_to_bytes() {
-        let meminfo = "MemTotal:       16296128 kB\nMemFree:         1234 kB\nMemAvailable:   15000000 kB\n";
+        let meminfo =
+            "MemTotal:       16296128 kB\nMemFree:         1234 kB\nMemAvailable:   15000000 kB\n";
         let (total, available) = parse_meminfo(meminfo).unwrap();
         assert_eq!(total, 16_296_128 * 1024);
         assert_eq!(available, 15_000_000 * 1024);
@@ -211,8 +212,17 @@ mod tests {
             assert!(is_whole_disk(disk), "{disk}");
         }
         for other in [
-            "vda1", "sdb2", "nvme0n1p1", "mmcblk0p2", "loop0", "ram0", "dm-0", "zram0", "md0",
-            "sr0", "vd",
+            "vda1",
+            "sdb2",
+            "nvme0n1p1",
+            "mmcblk0p2",
+            "loop0",
+            "ram0",
+            "dm-0",
+            "zram0",
+            "md0",
+            "sr0",
+            "vd",
         ] {
             assert!(!is_whole_disk(other), "{other}");
         }

--- a/rpc/arcbox-grpc/build.rs
+++ b/rpc/arcbox-grpc/build.rs
@@ -19,6 +19,7 @@ fn main() {
         "../arcbox-protocol/proto/api.proto",
         "../arcbox-protocol/proto/kubernetes.proto",
         "../arcbox-protocol/proto/sandbox.proto",
+        "../arcbox-protocol/proto/stats.proto",
     ];
 
     let descriptor_path =

--- a/rpc/arcbox-protocol/build.rs
+++ b/rpc/arcbox-protocol/build.rs
@@ -29,6 +29,7 @@ fn main() {
         "proto/api.proto",
         "proto/kubernetes.proto",
         "proto/sandbox.proto",
+        "proto/stats.proto",
     ];
 
     // Configure prost-build (no tonic - services are in arcbox-grpc).

--- a/rpc/arcbox-protocol/proto/agent.proto
+++ b/rpc/arcbox-protocol/proto/agent.proto
@@ -244,7 +244,9 @@ message MachineStats {
     // partitions excluded so traffic is not double-counted).
     uint64 disk_read_bytes = 9;
     uint64 disk_written_bytes = 10;
-    // Cumulative bytes across non-loopback interfaces (/proc/net/dev).
+    // Cumulative bytes across the VM's physical/uplink interfaces
+    // (/proc/net/dev; container bridges and veths are excluded so their
+    // traffic is not counted once per internal hop).
     uint64 net_rx_bytes = 11;
     uint64 net_tx_bytes = 12;
 }

--- a/rpc/arcbox-protocol/proto/agent.proto
+++ b/rpc/arcbox-protocol/proto/agent.proto
@@ -50,6 +50,9 @@ service AgentService {
 
     // Streams guest memory pressure events while the balloon is shrunk.
     rpc WatchMemoryPressure(WatchMemoryPressureRequest) returns (stream MemoryPressureEvent);
+
+    // Streams machine-level resource samples (CPU/memory/disk/network).
+    rpc WatchStats(WatchStatsRequest) returns (stream MachineStats);
 }
 
 // Ping request.
@@ -199,6 +202,51 @@ message MemoryPressureEvent {
     uint64 available_bytes = 2;
     // Observed refault rate, pages/second.
     uint64 refault_rate = 3;
+}
+
+// Request for a guest-driven machine resource stats stream.
+//
+// The agent reads /proc once per interval and emits one MachineStats frame
+// per tick; every frame doubles as a keepalive. The stream ends after
+// `timeout_ms`; the host re-issues the request to keep watching.
+message WatchStatsRequest {
+    // Watch window in milliseconds (0 = agent default).
+    uint32 timeout_ms = 1;
+    // Sample interval in milliseconds (0 = agent default, 1000).
+    uint32 interval_ms = 2;
+}
+
+// One machine-level resource sample.
+//
+// Counter fields are cumulative since guest boot; consumers derive rates
+// from deltas between samples, which stays correct across missed samples
+// and stream restarts.
+message MachineStats {
+    // Guest monotonic clock at sample time (from /proc/uptime), in
+    // milliseconds. Rate denominators come from deltas of this field, not
+    // from host receive times (delivery jitter would distort rates).
+    uint64 monotonic_ms = 1;
+    // Aggregate CPU ticks since boot across all CPUs (/proc/stat "cpu"):
+    // busy = everything except idle + iowait.
+    uint64 cpu_busy_ticks = 2;
+    uint64 cpu_total_ticks = 3;
+    // Online CPU count.
+    uint32 online_cpus = 4;
+    // 1-minute load average.
+    double loadavg1 = 5;
+    // Bytes, from /proc/meminfo.
+    uint64 memory_total_bytes = 6;
+    uint64 memory_available_bytes = 7;
+    // PSI memory "full avg10" percentage (0-100), from
+    // /proc/pressure/memory. Negative when the kernel lacks CONFIG_PSI.
+    double memory_psi_full_avg10 = 8;
+    // Cumulative bytes across whole physical disks (/proc/diskstats,
+    // partitions excluded so traffic is not double-counted).
+    uint64 disk_read_bytes = 9;
+    uint64 disk_written_bytes = 10;
+    // Cumulative bytes across non-loopback interfaces (/proc/net/dev).
+    uint64 net_rx_bytes = 11;
+    uint64 net_tx_bytes = 12;
 }
 
 // Runtime status report.

--- a/rpc/arcbox-protocol/proto/stats.proto
+++ b/rpc/arcbox-protocol/proto/stats.proto
@@ -1,0 +1,28 @@
+// Machine resource stats service.
+//
+// Serves the live resource monitor (desktop Activity Monitor, `abctl top`).
+// Samples originate from the guest agent's WatchStats stream (agent.proto);
+// the daemon fans a single guest stream out to every subscriber.
+
+syntax = "proto3";
+
+package arcbox.v1;
+
+import "agent.proto";
+
+// StatsService streams live resource stats.
+service StatsService {
+    // Streams machine-level samples while the client stays subscribed.
+    //
+    // Samples carry cumulative counters (see MachineStats); consumers
+    // derive rates from deltas between consecutive samples. Subscribing is
+    // passive observation — it never counts as VM activity, so a monitor
+    // left open does not block idle reclaim.
+    rpc Watch(StatsWatchRequest) returns (stream MachineStats);
+}
+
+// Subscription request for machine stats.
+message StatsWatchRequest {
+    // Machine to watch. Empty selects the System VM.
+    string machine_id = 1;
+}

--- a/rpc/arcbox-protocol/src/generated/arcbox.v1.rs
+++ b/rpc/arcbox-protocol/src/generated/arcbox.v1.rs
@@ -1988,7 +1988,9 @@ pub struct MachineStats {
     pub disk_read_bytes: u64,
     #[prost(uint64, tag = "10")]
     pub disk_written_bytes: u64,
-    /// Cumulative bytes across non-loopback interfaces (/proc/net/dev).
+    /// Cumulative bytes across the VM's physical/uplink interfaces
+    /// (/proc/net/dev; container bridges and veths are excluded so their
+    /// traffic is not counted once per internal hop).
     #[prost(uint64, tag = "11")]
     pub net_rx_bytes: u64,
     #[prost(uint64, tag = "12")]

--- a/rpc/arcbox-protocol/src/generated/arcbox.v1.rs
+++ b/rpc/arcbox-protocol/src/generated/arcbox.v1.rs
@@ -3159,3 +3159,12 @@ impl SystemVmBackend {
         }
     }
 }
+/// Subscription request for machine stats.
+#[derive(serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct StatsWatchRequest {
+    /// Machine to watch. Empty selects the System VM.
+    #[prost(string, tag = "1")]
+    pub machine_id: ::prost::alloc::string::String,
+}

--- a/rpc/arcbox-protocol/src/generated/arcbox.v1.rs
+++ b/rpc/arcbox-protocol/src/generated/arcbox.v1.rs
@@ -1931,6 +1931,69 @@ pub mod memory_pressure_event {
         }
     }
 }
+/// Request for a guest-driven machine resource stats stream.
+///
+/// The agent reads /proc once per interval and emits one MachineStats frame
+/// per tick; every frame doubles as a keepalive. The stream ends after
+/// `timeout_ms`; the host re-issues the request to keep watching.
+#[derive(serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[derive(Clone, Copy, PartialEq, ::prost::Message)]
+pub struct WatchStatsRequest {
+    /// Watch window in milliseconds (0 = agent default).
+    #[prost(uint32, tag = "1")]
+    pub timeout_ms: u32,
+    /// Sample interval in milliseconds (0 = agent default, 1000).
+    #[prost(uint32, tag = "2")]
+    pub interval_ms: u32,
+}
+/// One machine-level resource sample.
+///
+/// Counter fields are cumulative since guest boot; consumers derive rates
+/// from deltas between samples, which stays correct across missed samples
+/// and stream restarts.
+#[derive(serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[derive(Clone, Copy, PartialEq, ::prost::Message)]
+pub struct MachineStats {
+    /// Guest monotonic clock at sample time (from /proc/uptime), in
+    /// milliseconds. Rate denominators come from deltas of this field, not
+    /// from host receive times (delivery jitter would distort rates).
+    #[prost(uint64, tag = "1")]
+    pub monotonic_ms: u64,
+    /// Aggregate CPU ticks since boot across all CPUs (/proc/stat "cpu"):
+    /// busy = everything except idle + iowait.
+    #[prost(uint64, tag = "2")]
+    pub cpu_busy_ticks: u64,
+    #[prost(uint64, tag = "3")]
+    pub cpu_total_ticks: u64,
+    /// Online CPU count.
+    #[prost(uint32, tag = "4")]
+    pub online_cpus: u32,
+    /// 1-minute load average.
+    #[prost(double, tag = "5")]
+    pub loadavg1: f64,
+    /// Bytes, from /proc/meminfo.
+    #[prost(uint64, tag = "6")]
+    pub memory_total_bytes: u64,
+    #[prost(uint64, tag = "7")]
+    pub memory_available_bytes: u64,
+    /// PSI memory "full avg10" percentage (0-100), from
+    /// /proc/pressure/memory. Negative when the kernel lacks CONFIG_PSI.
+    #[prost(double, tag = "8")]
+    pub memory_psi_full_avg10: f64,
+    /// Cumulative bytes across whole physical disks (/proc/diskstats,
+    /// partitions excluded so traffic is not double-counted).
+    #[prost(uint64, tag = "9")]
+    pub disk_read_bytes: u64,
+    #[prost(uint64, tag = "10")]
+    pub disk_written_bytes: u64,
+    /// Cumulative bytes across non-loopback interfaces (/proc/net/dev).
+    #[prost(uint64, tag = "11")]
+    pub net_rx_bytes: u64,
+    #[prost(uint64, tag = "12")]
+    pub net_tx_bytes: u64,
+}
 /// Runtime status report.
 #[derive(serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]

--- a/rpc/arcbox-protocol/src/lib.rs
+++ b/rpc/arcbox-protocol/src/lib.rs
@@ -97,11 +97,11 @@ pub mod agent {
         KubernetesDeleteRequest, KubernetesDeleteResponse, KubernetesKubeconfigRequest,
         KubernetesKubeconfigResponse, KubernetesStartRequest, KubernetesStartResponse,
         KubernetesStatusRequest, KubernetesStatusResponse, KubernetesStopRequest,
-        KubernetesStopResponse, MemoryPressureEvent, MmapReadFileRequest, MmapReadFileResponse,
-        PortBindingsChanged, PortBindingsRemoved, ReadinessEvent, RuntimeEnsureRequest,
-        RuntimeEnsureResponse, RuntimeStatusRequest, RuntimeStatusResponse, ServiceStatus,
-        ShutdownRequest, ShutdownResponse, SystemInfo, WatchMemoryPressureRequest,
-        WatchReadinessRequest, memory_pressure_event, readiness_event,
+        KubernetesStopResponse, MachineStats, MemoryPressureEvent, MmapReadFileRequest,
+        MmapReadFileResponse, PortBindingsChanged, PortBindingsRemoved, ReadinessEvent,
+        RuntimeEnsureRequest, RuntimeEnsureResponse, RuntimeStatusRequest, RuntimeStatusResponse,
+        ServiceStatus, ShutdownRequest, ShutdownResponse, SystemInfo, WatchMemoryPressureRequest,
+        WatchReadinessRequest, WatchStatsRequest, memory_pressure_event, readiness_event,
     };
 
     // Backward compatibility type aliases (short names without Agent prefix).

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -69,6 +69,15 @@ restore (no reclaim storm, Docker responsive):
 cargo test -p arcbox-e2e --test idle_balloon -- --ignored --nocapture
 ```
 
+Machine stats stream — boots a VZ daemon, subscribes to
+`StatsService.Watch`, and asserts sane progressing samples plus the
+StatsHub lifecycle (concurrent subscribers share one guest stream; the
+pump stops when the last one leaves):
+
+```bash
+cargo test -p arcbox-e2e --test stats_watch -- --ignored --nocapture
+```
+
 Dual-backend matrix — the boot-assets scenario once per backend, VZ first.
 VZ is the oracle: HV-only red means an HV implementation bug, double red means
 the bug is above the hypervisor layer:

--- a/tests/e2e/tests/stats_watch.rs
+++ b/tests/e2e/tests/stats_watch.rs
@@ -130,12 +130,15 @@ fn scenario(daemon: &mut DaemonHandle, data_dir: &Path, metrics: &mut RunMetrics
         );
         Ok::<_, anyhow::Error>(())
     })?;
-    // Both streams (and their broadcast receivers) died with the runtime's
-    // connections above.
-
     if count_log_matches(data_dir, "stats pump started")? != 1 {
         bail!("concurrent subscribers did not share a single stats pump");
     }
+
+    // Dropping the runtime tears down the client's connection tasks and
+    // closes the gRPC socket — merely letting `block_on` return would
+    // freeze (not drop) them, and the daemon would keep both response
+    // streams (and their broadcast receivers) alive indefinitely.
+    drop(runtime);
 
     // Phase 2 — the pump winds down without subscribers, and a later
     // subscriber gets a fresh one.

--- a/tests/e2e/tests/stats_watch.rs
+++ b/tests/e2e/tests/stats_watch.rs
@@ -49,6 +49,16 @@ fn stats_watch_streams_sane_shared_samples() -> Result<()> {
         let shell = xshell::Shell::new()?;
         shell.change_dir(&root);
         xshell::cmd!(shell, "cargo build --release -p arcbox-daemon").run()?;
+        // The scenario exercises the WatchStats agent RPC, so the guest
+        // must run a matching agent. Build it here rather than relying on
+        // a pre-staged one — an older agent lacks WatchStats and the stream
+        // never yields. Keep this in sync with the xtask `stats_watch`
+        // prebuild recipe.
+        xshell::cmd!(
+            shell,
+            "cargo build --release -p arcbox-agent --target aarch64-unknown-linux-musl"
+        )
+        .run()?;
     }
 
     let version = resolve_boot_version(&root)?;

--- a/tests/e2e/tests/stats_watch.rs
+++ b/tests/e2e/tests/stats_watch.rs
@@ -1,0 +1,232 @@
+//! StatsService.Watch e2e: live machine stats from a real VZ daemon.
+//!
+//! Boots the System VM, subscribes to the stats stream over the daemon's
+//! gRPC socket, and asserts the P1 acceptance criteria: samples flow with
+//! sane values, concurrent subscribers share a single guest stream (the
+//! daemon log is the oracle for pump lifecycle, as with the idle-balloon
+//! scenario), and a later subscriber gets a fresh pump after the first
+//! generation wound down.
+
+use std::path::Path;
+use std::sync::Once;
+use std::time::Duration;
+
+use anyhow::{Context, Result, bail};
+use arcbox_e2e::boot_assets::{resolve_boot_version, stage_dev_boot_assets};
+use arcbox_e2e::daemon::{DaemonConfig, DaemonHandle, connect_unix};
+use arcbox_e2e::metrics::RunMetrics;
+use arcbox_grpc::v1::stats_service_client::StatsServiceClient;
+use arcbox_protocol::v1::{MachineStats, StatsWatchRequest};
+use tonic::Streaming;
+
+static TRACING: Once = Once::new();
+
+const READY_TIMEOUT: Duration = Duration::from_secs(180);
+/// Budget for one stats frame; the agent samples at 1 Hz.
+const SAMPLE_BUDGET: Duration = Duration::from_secs(10);
+/// Budget for the first pump to stop after its subscribers disconnect
+/// (the pump notices within its frame patience).
+const PUMP_STOP_BUDGET: Duration = Duration::from_secs(15);
+
+fn init_tracing() {
+    TRACING.call_once(|| {
+        let _ = tracing_subscriber::fmt()
+            .with_env_filter(
+                tracing_subscriber::EnvFilter::try_from_default_env()
+                    .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info")),
+            )
+            .try_init();
+    });
+}
+
+#[test]
+#[ignore = "boots a VZ System VM through a real daemon and streams live machine stats"]
+fn stats_watch_streams_sane_shared_samples() -> Result<()> {
+    init_tracing();
+
+    let root = arcbox_e2e::repo_root();
+    if !arcbox_e2e::env_flag("SKIP_BUILD") {
+        let shell = xshell::Shell::new()?;
+        shell.change_dir(&root);
+        xshell::cmd!(shell, "cargo build --release -p arcbox-daemon").run()?;
+    }
+
+    let version = resolve_boot_version(&root)?;
+    let data_dir = tempfile::Builder::new()
+        .prefix("arcbox-stats-watch-")
+        .tempdir()?;
+    stage_dev_boot_assets(&root, data_dir.path(), &version)?;
+
+    let mut daemon = DaemonHandle::spawn(DaemonConfig {
+        binary: root.join("target/release/arcbox-daemon"),
+        data_dir: data_dir.path().to_owned(),
+        args: vec![],
+        env: vec![
+            ("ARCBOX_BOOT_ASSET_VERSION".to_owned(), version),
+            ("ARCBOX_VM_BACKEND".to_owned(), "vz".to_owned()),
+            // Port 0 = kernel-assigned: the DNS service is not under test
+            // and must not fight an installed ArcBox over the default port.
+            ("ARCBOX_DNS_PORT".to_owned(), "0".to_owned()),
+        ],
+    })?;
+
+    let mut metrics = RunMetrics::new("stats_watch", Some("vz"));
+    let result = scenario(&mut daemon, data_dir.path(), &mut metrics);
+    metrics.passed = result.is_ok();
+    if let Err(error) = metrics.write(Some(data_dir.path())) {
+        tracing::warn!("writing run metrics failed: {error:#}");
+    }
+    if result.is_err() {
+        let kept = data_dir.keep();
+        tracing::warn!(path = %kept.display(), "preserving test directory");
+    }
+    result
+}
+
+fn scenario(daemon: &mut DaemonHandle, data_dir: &Path, metrics: &mut RunMetrics) -> Result<()> {
+    metrics.time("daemon_ready", || daemon.wait_ready_blocking(READY_TIMEOUT))?;
+    let socket = daemon.grpc_socket();
+
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .context("building tokio runtime")?;
+
+    // Phase 1 — two concurrent subscribers, sane and progressing samples.
+    runtime.block_on(async {
+        let channel = connect_unix(&socket).await?;
+        let mut client = StatsServiceClient::new(channel);
+
+        let mut stream_a = watch(&mut client).await?;
+        let first = next_sample(&mut stream_a).await.context("first sample")?;
+        assert_sane(&first)?;
+
+        // A second subscriber must ride the same pump (asserted from the
+        // daemon log below), and still receive frames.
+        let mut stream_b = watch(&mut client).await?;
+        next_sample(&mut stream_b)
+            .await
+            .context("second subscriber's sample")?;
+
+        let second = next_sample(&mut stream_a).await.context("second sample")?;
+        if second.monotonic_ms <= first.monotonic_ms {
+            bail!(
+                "guest clock did not advance between samples ({} -> {})",
+                first.monotonic_ms,
+                second.monotonic_ms
+            );
+        }
+        if second.cpu_total_ticks < first.cpu_total_ticks
+            || second.disk_read_bytes < first.disk_read_bytes
+            || second.net_rx_bytes < first.net_rx_bytes
+        {
+            bail!("cumulative counters went backwards without a guest reboot");
+        }
+        tracing::info!(
+            monotonic_ms = second.monotonic_ms,
+            cpu_total_ticks = second.cpu_total_ticks,
+            psi = second.memory_psi_full_avg10,
+            "samples flow and progress"
+        );
+        Ok::<_, anyhow::Error>(())
+    })?;
+    // Both streams (and their broadcast receivers) died with the runtime's
+    // connections above.
+
+    if count_log_matches(data_dir, "stats pump started")? != 1 {
+        bail!("concurrent subscribers did not share a single stats pump");
+    }
+
+    // Phase 2 — the pump winds down without subscribers, and a later
+    // subscriber gets a fresh one.
+    metrics.time("pump_stop", || {
+        wait_for_log_count(data_dir, "stats pump stopped", 1, PUMP_STOP_BUDGET)
+    })?;
+
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .context("building tokio runtime")?;
+    runtime.block_on(async {
+        let channel = connect_unix(&socket).await?;
+        let mut client = StatsServiceClient::new(channel);
+        let mut stream = watch(&mut client).await?;
+        let sample = next_sample(&mut stream)
+            .await
+            .context("post-restart sample")?;
+        assert_sane(&sample)
+    })?;
+    if count_log_matches(data_dir, "stats pump started")? != 2 {
+        bail!("resubscription did not start a fresh stats pump");
+    }
+
+    Ok(())
+}
+
+async fn watch(
+    client: &mut StatsServiceClient<tonic::transport::Channel>,
+) -> Result<Streaming<MachineStats>> {
+    Ok(client
+        .watch(StatsWatchRequest {
+            machine_id: String::new(),
+        })
+        .await
+        .context("subscribing to machine stats")?
+        .into_inner())
+}
+
+async fn next_sample(stream: &mut Streaming<MachineStats>) -> Result<MachineStats> {
+    match tokio::time::timeout(SAMPLE_BUDGET, stream.message()).await {
+        Err(_) => bail!("no stats frame within {}s", SAMPLE_BUDGET.as_secs()),
+        Ok(Err(status)) => bail!("stats stream error: {status}"),
+        Ok(Ok(None)) => bail!("stats stream ended unexpectedly"),
+        Ok(Ok(Some(sample))) => Ok(sample),
+    }
+}
+
+fn assert_sane(sample: &MachineStats) -> Result<()> {
+    if sample.memory_total_bytes == 0 {
+        bail!("memory_total_bytes is zero");
+    }
+    if sample.memory_available_bytes > sample.memory_total_bytes {
+        bail!("more memory available than exists");
+    }
+    if sample.online_cpus == 0 {
+        bail!("online_cpus is zero");
+    }
+    if sample.cpu_busy_ticks > sample.cpu_total_ticks {
+        bail!("busy CPU ticks exceed total");
+    }
+    if !(-1.0..=100.0).contains(&sample.memory_psi_full_avg10) {
+        bail!("PSI gauge out of range: {}", sample.memory_psi_full_avg10);
+    }
+    Ok(())
+}
+
+fn count_log_matches(data_dir: &Path, needle: &str) -> Result<usize> {
+    let path = data_dir.join("log/daemon.log");
+    let log =
+        std::fs::read_to_string(&path).with_context(|| format!("reading {}", path.display()))?;
+    Ok(log.matches(needle).count())
+}
+
+fn wait_for_log_count(
+    data_dir: &Path,
+    needle: &str,
+    at_least: usize,
+    budget: Duration,
+) -> Result<()> {
+    let deadline = std::time::Instant::now() + budget;
+    loop {
+        if count_log_matches(data_dir, needle)? >= at_least {
+            return Ok(());
+        }
+        if std::time::Instant::now() >= deadline {
+            bail!(
+                "log never showed {at_least}x {needle:?} within {}s",
+                budget.as_secs()
+            );
+        }
+        std::thread::sleep(Duration::from_millis(250));
+    }
+}

--- a/xtask/src/commands/e2e.rs
+++ b/xtask/src/commands/e2e.rs
@@ -142,9 +142,15 @@ fn prebuild(root: &std::path::Path, test: &str) -> Result<bool> {
             xshell::cmd!(shell, "cargo build --release -p arcbox-e2e --bin hv_e2e").run()?;
             Ok(true)
         }
-        // Must match tests/e2e/tests/stats_watch.rs's own build.
+        // Must match tests/e2e/tests/stats_watch.rs's own build: the daemon
+        // plus the musl guest agent (the scenario needs WatchStats support).
         "stats_watch" => {
             xshell::cmd!(shell, "cargo build --release -p arcbox-daemon").run()?;
+            xshell::cmd!(
+                shell,
+                "cargo build --release -p arcbox-agent --target aarch64-unknown-linux-musl"
+            )
+            .run()?;
             Ok(true)
         }
         // Must match tests/e2e/src/sandbox.rs::build_binaries exactly

--- a/xtask/src/commands/e2e.rs
+++ b/xtask/src/commands/e2e.rs
@@ -142,6 +142,11 @@ fn prebuild(root: &std::path::Path, test: &str) -> Result<bool> {
             xshell::cmd!(shell, "cargo build --release -p arcbox-e2e --bin hv_e2e").run()?;
             Ok(true)
         }
+        // Must match tests/e2e/tests/stats_watch.rs's own build.
+        "stats_watch" => {
+            xshell::cmd!(shell, "cargo build --release -p arcbox-daemon").run()?;
+            Ok(true)
+        }
         // Must match tests/e2e/src/sandbox.rs::build_binaries exactly
         // (packages AND profiles), or SKIP_BUILD runs stale binaries.
         "sandbox" => {


### PR DESCRIPTION
Implements phase P1 of ABX-115 (resource monitor data plane) — the
machine-level stats pipeline, end to end.

## Architecture

```
guest /proc ──1 pass per tick──▶ agent WatchStats (vsock stream)
                                      │  one stream, ever
                                      ▼
                            core StatsHub (broadcast fan-out)
                             │ starts on 1st subscriber,
                             │ stops after the last
                             ▼
                    StatsService.Watch (tonic server stream)
                     │                │
                     ▼                ▼
                abctl top      desktop monitor (P3)
```

- **Efficiency stance (the OrbStack-parity goal):** a single guest-side
  sampler serves every subscriber, and *nothing* runs while nobody
  watches — no vsock stream, no `/proc` reads, zero idle cost. The agent
  additionally clamps the sample interval to ≥200 ms as self-protection.
- **Wire format:** cumulative counters (CPU ticks, disk/net bytes) plus
  gauges (`MemAvailable`, PSI `full avg10`), stamped with the guest
  monotonic clock. Consumers derive rates from deltas, which stays
  correct across missed samples, stream restarts, and guest reboots
  (`abctl top` rebaselines when counters go backwards).
- **Idle interaction:** subscribing is passive observation in the #396
  sense — no activity recording, no leases. A monitor left open all day
  neither blocks idle reclaim nor wakes an un-watched VM.
- PSI pressure rides along as a gauge (`-1` on kernels without
  `CONFIG_PSI`) — the desktop can show a pressure meter OrbStack has no
  equivalent of.

## Pieces

- `stats.proto` + agent `WatchStats` RPC (wire IDs 0x0010/0x1010,
  additive — no protocol version bump)
- agent: platform-neutral `/proc` parsers (whole-disk filtering so
  partitions and dm/loop devices don't double-count I/O) + streaming
  handler mirroring `WatchMemoryPressure`
- core: `StatsHub` (broadcast fan-out, generation-tagged pump lifecycle,
  reconnect backoff) + `agent_client` plumbing for both transports
- api/daemon: `StatsService.Watch` server-streaming RPC (`machine_id`
  reserved for P2 per-machine stats)
- cli: `abctl top` (live refresh; `--once` / `--format json` for
  scripting)
- e2e: `stats_watch` scenario on real VZ asserting the P1 acceptance
  criteria, including the shared-pump and pump-stop lifecycle via the
  daemon-log oracle

Also carries a one-line pre-existing fix: `ArcboxProfile`'s `FromStr`
impl (fleet-agent 0.1.1) allocates its error `String` and broke the
crate's default `no_std` build; it is now gated on the `std` feature.

## Validation

- Parser/hub/CLI unit tests (`arcbox-agent`, `arcbox-core`,
  `arcbox-cli`); workspace clippy clean
- Hardware e2e on real VZ (`stats_watch`): live samples flow and
  progress (CPU ticks, guest clock, PSI all sane), two concurrent
  subscribers share **one** guest stream, the pump stops after the last
  subscriber drops, and a resubscription starts a fresh pump. Note: the
  scenario needs a current dev `arcbox-agent` staged (dev tree / musl
  release / `~/.arcbox/bin`) — a stale agent that predates `WatchStats`
  returns an error frame and the stream never yields, the same
  stale-agent trap the harness already warns about.

## Out of scope (tracked in ABX-115 phases)

- P2: per-container stats via cgroup v2 readers + id↔name enrichment
- P3: desktop Activity Monitor UI + menu bar (ABXD-87's data source)
- P4: K8s pod grouping, adjustable sampling frequency
