### PR TITLE
feat(stats): per-container resource stats (ABX-115 P2)

### DIFF
--- a/app/arcbox-api/src/grpc/stats.rs
+++ b/app/arcbox-api/src/grpc/stats.rs
@@ -7,13 +7,29 @@
 
 use std::pin::Pin;
 
-use arcbox_core::DEFAULT_MACHINE_NAME;
+use arcbox_core::{DEFAULT_MACHINE_NAME, Runtime};
 use arcbox_grpc::v1::stats_service_server;
 use arcbox_protocol::v1::{MachineStats, StatsWatchRequest};
 use tokio_stream::Stream;
 use tonic::{Request, Response, Status};
 
 use super::{SharedRuntime, SharedRuntimeExt};
+
+/// Fills each container's display name from the runtime's registry,
+/// leaving the ID-only entries untouched when no name is known (the
+/// consumer falls back to the short ID). Skips the registry read entirely
+/// when the frame carries no containers.
+async fn enrich_container_names(runtime: &Runtime, sample: &mut MachineStats) {
+    if sample.containers.is_empty() {
+        return;
+    }
+    let names = runtime.container_names().await;
+    for container in &mut sample.containers {
+        if let Some(name) = names.get(&container.id) {
+            container.name = name.clone();
+        }
+    }
+}
 
 /// Stats service implementation.
 pub struct StatsServiceImpl {
@@ -42,12 +58,15 @@ impl stats_service_server::StatsService for StatsServiceImpl {
                 "per-machine stats are not implemented yet; omit machine_id for the System VM",
             ));
         }
-        let runtime = self.runtime.ready()?;
+        let runtime = std::sync::Arc::clone(self.runtime.ready()?);
         let mut rx = runtime.subscribe_machine_stats();
         let stream = async_stream::stream! {
             loop {
                 match rx.recv().await {
-                    Ok(sample) => yield Ok(sample),
+                    Ok(mut sample) => {
+                        enrich_container_names(&runtime, &mut sample).await;
+                        yield Ok(sample);
+                    }
                     // This subscriber lagged; newer samples follow, which
                     // is exactly what a live monitor wants.
                     Err(tokio::sync::broadcast::error::RecvError::Lagged(_)) => {}

--- a/app/arcbox-cli/src/commands/top.rs
+++ b/app/arcbox-cli/src/commands/top.rs
@@ -180,9 +180,13 @@ impl ComputedStats {
             fmt_bytes(self.net_tx_bytes_per_sec as u64),
         );
         if !self.containers.is_empty() {
+            // Header and rows share the same width spec so columns stay
+            // aligned; the size/rate cells are pre-formatted into "a/b"
+            // strings (worst case ~"1023.9 MiB/1023.9 MiB") and
+            // right-aligned as a whole.
             let _ = writeln!(
                 out,
-                "\n{:<24} {:>7}  {:>10}  {:>18}  {:>18}  {:>5}",
+                "\n{:<24} {:>7} {:>19} {:>21} {:>21} {:>5}",
                 "CONTAINER", "CPU%", "MEM", "DISK R/W/s", "NET ↓/↑/s", "PIDS"
             );
             for c in &self.containers {
@@ -195,16 +199,24 @@ impl ComputedStats {
                         fmt_bytes(c.memory_limit_bytes)
                     )
                 };
+                let disk = format!(
+                    "{}/{}",
+                    fmt_bytes(c.disk_read_bytes_per_sec as u64),
+                    fmt_bytes(c.disk_write_bytes_per_sec as u64)
+                );
+                let net = format!(
+                    "{}/{}",
+                    fmt_bytes(c.net_rx_bytes_per_sec as u64),
+                    fmt_bytes(c.net_tx_bytes_per_sec as u64)
+                );
                 let _ = writeln!(
                     out,
-                    "{:<24} {:>6.1}%  {:>10}  {:>8}/{:<8}  {:>8}/{:<8}  {:>5}",
+                    "{:<24} {:>6.1}% {:>19} {:>21} {:>21} {:>5}",
                     truncate(&c.name, 24),
                     c.cpu_percent,
                     mem,
-                    fmt_bytes(c.disk_read_bytes_per_sec as u64),
-                    fmt_bytes(c.disk_write_bytes_per_sec as u64),
-                    fmt_bytes(c.net_rx_bytes_per_sec as u64),
-                    fmt_bytes(c.net_tx_bytes_per_sec as u64),
+                    disk,
+                    net,
                     c.pids,
                 );
             }

--- a/app/arcbox-cli/src/commands/top.rs
+++ b/app/arcbox-cli/src/commands/top.rs
@@ -112,6 +112,8 @@ struct ComputedContainer {
     memory_limit_bytes: u64,
     disk_read_bytes_per_sec: f64,
     disk_write_bytes_per_sec: f64,
+    net_rx_bytes_per_sec: f64,
+    net_tx_bytes_per_sec: f64,
     pids: u32,
 }
 
@@ -180,8 +182,8 @@ impl ComputedStats {
         if !self.containers.is_empty() {
             let _ = writeln!(
                 out,
-                "\n{:<24} {:>7}  {:>10}  {:>18}  {:>5}",
-                "CONTAINER", "CPU%", "MEM", "DISK R/W/s", "PIDS"
+                "\n{:<24} {:>7}  {:>10}  {:>18}  {:>18}  {:>5}",
+                "CONTAINER", "CPU%", "MEM", "DISK R/W/s", "NET ↓/↑/s", "PIDS"
             );
             for c in &self.containers {
                 let mem = if c.memory_limit_bytes == 0 {
@@ -195,12 +197,14 @@ impl ComputedStats {
                 };
                 let _ = writeln!(
                     out,
-                    "{:<24} {:>6.1}%  {:>10}  {:>8}/{:<8}  {:>5}",
+                    "{:<24} {:>6.1}%  {:>10}  {:>8}/{:<8}  {:>8}/{:<8}  {:>5}",
                     truncate(&c.name, 24),
                     c.cpu_percent,
                     mem,
                     fmt_bytes(c.disk_read_bytes_per_sec as u64),
                     fmt_bytes(c.disk_write_bytes_per_sec as u64),
+                    fmt_bytes(c.net_rx_bytes_per_sec as u64),
+                    fmt_bytes(c.net_tx_bytes_per_sec as u64),
                     c.pids,
                 );
             }
@@ -243,6 +247,8 @@ fn computed_containers(prev: &MachineStats, cur: &MachineStats, dt: f64) -> Vec<
                     c.disk_written_bytes,
                     before.map(|p| p.disk_written_bytes),
                 ),
+                net_rx_bytes_per_sec: rate(c.net_rx_bytes, before.map(|p| p.net_rx_bytes)),
+                net_tx_bytes_per_sec: rate(c.net_tx_bytes, before.map(|p| p.net_tx_bytes)),
                 pids: c.pids,
             }
         })
@@ -314,6 +320,8 @@ mod tests {
             disk_read_bytes: 0,
             disk_written_bytes: 0,
             pids: 3,
+            net_rx_bytes: 0,
+            net_tx_bytes: 0,
         }
     }
 
@@ -362,6 +370,24 @@ mod tests {
         assert_eq!(c.containers[0].name, "busy");
         assert!((c.containers[0].cpu_percent - 50.0).abs() < 0.01);
         assert!((c.containers[1].cpu_percent - 0.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn container_network_rate_from_deltas() {
+        let mut prev = sample(10_000, 100, 1000);
+        let mut cur = sample(12_000, 150, 1200); // +2s
+        let mut p = container("net", 0, 100);
+        p.net_rx_bytes = 1000;
+        p.net_tx_bytes = 2000;
+        prev.containers = vec![p];
+        let mut n = container("net", 0, 100);
+        n.net_rx_bytes = 1000 + 4096; // +2 KiB/s
+        n.net_tx_bytes = 2000 + 1024; // +512 B/s
+        cur.containers = vec![n];
+
+        let c = ComputedStats::from_delta(&prev, &cur).unwrap();
+        assert!((c.containers[0].net_rx_bytes_per_sec - 2048.0).abs() < 0.001);
+        assert!((c.containers[0].net_tx_bytes_per_sec - 512.0).abs() < 0.001);
     }
 
     #[test]

--- a/app/arcbox-cli/src/commands/top.rs
+++ b/app/arcbox-cli/src/commands/top.rs
@@ -186,7 +186,7 @@ impl ComputedStats {
             // right-aligned as a whole.
             let _ = writeln!(
                 out,
-                "\n{:<24} {:>7} {:>19} {:>21} {:>21} {:>5}",
+                "\n{:<24} {:>7} {:>21} {:>21} {:>21} {:>5}",
                 "CONTAINER", "CPU%", "MEM", "DISK R/W/s", "NET ↓/↑/s", "PIDS"
             );
             for c in &self.containers {
@@ -211,7 +211,7 @@ impl ComputedStats {
                 );
                 let _ = writeln!(
                     out,
-                    "{:<24} {:>6.1}% {:>19} {:>21} {:>21} {:>5}",
+                    "{:<24} {:>6.1}% {:>21} {:>21} {:>21} {:>5}",
                     truncate(&c.name, 24),
                     c.cpu_percent,
                     mem,

--- a/app/arcbox-cli/src/commands/top.rs
+++ b/app/arcbox-cli/src/commands/top.rs
@@ -5,9 +5,12 @@
 //! between consecutive samples over the guest's monotonic clock, so a
 //! stalled stream never fabricates activity.
 
+use std::collections::HashMap;
+use std::fmt::Write as _;
+
 use anyhow::{Context, Result, bail};
 use arcbox_grpc::v1::stats_service_client::StatsServiceClient;
-use arcbox_protocol::v1::{MachineStats, StatsWatchRequest};
+use arcbox_protocol::v1::{ContainerStats, MachineStats, StatsWatchRequest};
 use clap::Args;
 use tonic::transport::Endpoint;
 
@@ -49,11 +52,16 @@ pub async fn execute(args: TopArgs, format: OutputFormat) -> Result<()> {
             Some(sample) => sample,
             None => bail!("stats stream ended (daemon shutting down?)"),
         };
-        let Some(prev) = previous.replace(sample) else {
-            continue; // baseline for the first delta
-        };
-        let Some(computed) = ComputedStats::from_delta(&prev, &sample) else {
-            continue; // counters reset (guest rebooted): rebaseline
+        // Compute against the prior sample (if any) before it becomes the
+        // new baseline. A first sample or a counter reset yields None and
+        // simply rebaselines. `MachineStats` owns a container Vec, so this
+        // borrows rather than copies.
+        let computed = previous
+            .as_ref()
+            .and_then(|prev| ComputedStats::from_delta(prev, &sample));
+        previous = Some(sample);
+        let Some(computed) = computed else {
+            continue;
         };
 
         match format {
@@ -89,6 +97,22 @@ struct ComputedStats {
     disk_write_bytes_per_sec: f64,
     net_rx_bytes_per_sec: f64,
     net_tx_bytes_per_sec: f64,
+    containers: Vec<ComputedContainer>,
+}
+
+/// Per-container rates and gauges, derived from the same two samples.
+#[derive(Debug, serde::Serialize)]
+struct ComputedContainer {
+    name: String,
+    /// Percent of one core (may exceed 100 for a multi-threaded container),
+    /// matching `docker stats`.
+    cpu_percent: f64,
+    memory_current_bytes: u64,
+    /// 0 means unlimited.
+    memory_limit_bytes: u64,
+    disk_read_bytes_per_sec: f64,
+    disk_write_bytes_per_sec: f64,
+    pids: u32,
 }
 
 impl ComputedStats {
@@ -124,6 +148,7 @@ impl ComputedStats {
             disk_write_bytes_per_sec: rate(cur.disk_written_bytes, prev.disk_written_bytes),
             net_rx_bytes_per_sec: rate(cur.net_rx_bytes, prev.net_rx_bytes),
             net_tx_bytes_per_sec: rate(cur.net_tx_bytes, prev.net_tx_bytes),
+            containers: computed_containers(prev, cur, dt),
         })
     }
 
@@ -133,7 +158,7 @@ impl ComputedStats {
         } else {
             format!("{:.2}%", self.memory_psi_full_avg10)
         };
-        format!(
+        let mut out = format!(
             "ArcBox System VM\n\
              \n\
              CPU     {:>6.1}%  of {} cpus   load {:.2}\n\
@@ -151,7 +176,93 @@ impl ComputedStats {
             fmt_bytes(self.disk_write_bytes_per_sec as u64),
             fmt_bytes(self.net_rx_bytes_per_sec as u64),
             fmt_bytes(self.net_tx_bytes_per_sec as u64),
-        )
+        );
+        if !self.containers.is_empty() {
+            let _ = writeln!(
+                out,
+                "\n{:<24} {:>7}  {:>10}  {:>18}  {:>5}",
+                "CONTAINER", "CPU%", "MEM", "DISK R/W/s", "PIDS"
+            );
+            for c in &self.containers {
+                let mem = if c.memory_limit_bytes == 0 {
+                    fmt_bytes(c.memory_current_bytes)
+                } else {
+                    format!(
+                        "{}/{}",
+                        fmt_bytes(c.memory_current_bytes),
+                        fmt_bytes(c.memory_limit_bytes)
+                    )
+                };
+                let _ = writeln!(
+                    out,
+                    "{:<24} {:>6.1}%  {:>10}  {:>8}/{:<8}  {:>5}",
+                    truncate(&c.name, 24),
+                    c.cpu_percent,
+                    mem,
+                    fmt_bytes(c.disk_read_bytes_per_sec as u64),
+                    fmt_bytes(c.disk_write_bytes_per_sec as u64),
+                    c.pids,
+                );
+            }
+        }
+        out
+    }
+}
+
+/// Joins each current container with its previous sample by ID, computes
+/// per-container rates, and sorts by CPU descending (top-style). A
+/// container with no prior sample (just started) reports 0% CPU until the
+/// next frame gives it a baseline.
+fn computed_containers(prev: &MachineStats, cur: &MachineStats, dt: f64) -> Vec<ComputedContainer> {
+    let previous: HashMap<&str, &ContainerStats> =
+        prev.containers.iter().map(|c| (c.id.as_str(), c)).collect();
+    let mut computed: Vec<ComputedContainer> = cur
+        .containers
+        .iter()
+        .map(|c| {
+            let before = previous.get(c.id.as_str());
+            let cpu_percent = before
+                .filter(|p| c.cpu_usage_usec > p.cpu_usage_usec)
+                .map_or(0.0, |p| {
+                    (c.cpu_usage_usec - p.cpu_usage_usec) as f64 / (dt * 1_000_000.0) * 100.0
+                });
+            let rate = |cur_b: u64, prev_b: Option<u64>| {
+                prev_b.map_or(0.0, |pb| cur_b.saturating_sub(pb) as f64 / dt)
+            };
+            ComputedContainer {
+                name: if c.name.is_empty() {
+                    short_id(&c.id)
+                } else {
+                    c.name.clone()
+                },
+                cpu_percent,
+                memory_current_bytes: c.memory_current_bytes,
+                memory_limit_bytes: c.memory_limit_bytes,
+                disk_read_bytes_per_sec: rate(c.disk_read_bytes, before.map(|p| p.disk_read_bytes)),
+                disk_write_bytes_per_sec: rate(
+                    c.disk_written_bytes,
+                    before.map(|p| p.disk_written_bytes),
+                ),
+                pids: c.pids,
+            }
+        })
+        .collect();
+    computed.sort_by(|a, b| b.cpu_percent.total_cmp(&a.cpu_percent));
+    computed
+}
+
+/// Docker-style 12-character short ID.
+fn short_id(id: &str) -> String {
+    id.chars().take(12).collect()
+}
+
+/// Truncates a display string to `width` columns, ellipsizing when longer.
+fn truncate(s: &str, width: usize) -> String {
+    if s.chars().count() <= width {
+        s.to_owned()
+    } else {
+        let kept: String = s.chars().take(width.saturating_sub(1)).collect();
+        format!("{kept}…")
     }
 }
 
@@ -189,6 +300,20 @@ mod tests {
             disk_written_bytes: 2000,
             net_rx_bytes: 3000,
             net_tx_bytes: 4000,
+            containers: vec![],
+        }
+    }
+
+    fn container(id: &str, cpu_usec: u64, mem: u64) -> ContainerStats {
+        ContainerStats {
+            id: id.to_owned(),
+            name: String::new(),
+            cpu_usage_usec: cpu_usec,
+            memory_current_bytes: mem,
+            memory_limit_bytes: 0,
+            disk_read_bytes: 0,
+            disk_written_bytes: 0,
+            pids: 3,
         }
     }
 
@@ -219,5 +344,47 @@ mod tests {
         assert_eq!(fmt_bytes(512), "512 B");
         assert_eq!(fmt_bytes(2048), "2.0 KiB");
         assert_eq!(fmt_bytes(3 * 1024 * 1024 * 1024), "3.0 GiB");
+    }
+
+    #[test]
+    fn container_cpu_from_usec_delta_and_sorted_desc() {
+        let mut prev = sample(10_000, 100, 1000);
+        let mut cur = sample(12_000, 150, 1200); // +2s
+        // busy: 1s of CPU over 2s = 50% of one core.
+        prev.containers = vec![container("busy", 0, 100), container("idle", 0, 50)];
+        cur.containers = vec![
+            container("idle", 0, 50),          // no CPU movement
+            container("busy", 1_000_000, 100), // +1s cpu
+        ];
+
+        let c = ComputedStats::from_delta(&prev, &cur).unwrap();
+        // Sorted CPU-descending: the busy one leads.
+        assert_eq!(c.containers[0].name, "busy");
+        assert!((c.containers[0].cpu_percent - 50.0).abs() < 0.01);
+        assert!((c.containers[1].cpu_percent - 0.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn newly_started_container_reports_zero_cpu_until_baseline() {
+        let prev = sample(10_000, 100, 1000);
+        let mut cur = sample(12_000, 150, 1200);
+        cur.containers = vec![container("fresh", 5_000_000, 128)];
+
+        let c = ComputedStats::from_delta(&prev, &cur).unwrap();
+        // No prior sample for "fresh": CPU% is 0, not a huge spike.
+        assert_eq!(c.containers.len(), 1);
+        assert!((c.containers[0].cpu_percent - 0.0).abs() < f64::EPSILON);
+        assert_eq!(c.containers[0].name, "fresh");
+    }
+
+    #[test]
+    fn empty_name_falls_back_to_short_id() {
+        let id = "0a1b2c3d4e5f00112233445566778899aabbccddeeff00112233445566778899";
+        let prev = sample(10_000, 100, 1000);
+        let mut cur = sample(12_000, 150, 1200);
+        cur.containers = vec![container(id, 0, 64)];
+
+        let c = ComputedStats::from_delta(&prev, &cur).unwrap();
+        assert_eq!(c.containers[0].name, "0a1b2c3d4e5f");
     }
 }

--- a/app/arcbox-core/src/runtime.rs
+++ b/app/arcbox-core/src/runtime.rs
@@ -1111,7 +1111,7 @@ impl Runtime {
                 .entry(id.clone())
                 .and_modify(|existing| {
                     if name.len() < existing.len() {
-                        *existing = name.clone();
+                        existing.clone_from(name);
                     }
                 })
                 .or_insert_with(|| name.clone());

--- a/app/arcbox-core/src/runtime.rs
+++ b/app/arcbox-core/src/runtime.rs
@@ -1099,6 +1099,26 @@ impl Runtime {
         );
     }
 
+    /// Maps canonical container ID → display name, inverting the registered
+    /// name aliases. Used to enrich per-container stats so a monitor can
+    /// show names instead of bare IDs. When a container has several
+    /// registered names, the shortest wins (the primary Docker name is
+    /// shorter than the alias set it accretes).
+    pub async fn container_names(&self) -> HashMap<String, String> {
+        let mut names: HashMap<String, String> = HashMap::new();
+        for (name, id) in self.container_aliases.read().await.iter() {
+            names
+                .entry(id.clone())
+                .and_modify(|existing| {
+                    if name.len() < existing.len() {
+                        *existing = name.clone();
+                    }
+                })
+                .or_insert_with(|| name.clone());
+        }
+        names
+    }
+
     /// Records a container's unique name so later lifecycle calls can resolve
     /// it to the canonical ID without a guest round-trip.
     pub async fn register_container_alias(&self, name: &str, container_id: &str) {

--- a/app/arcbox-core/src/runtime/tests.rs
+++ b/app/arcbox-core/src/runtime/tests.rs
@@ -154,6 +154,23 @@ async fn resolve_registered_container_rejects_ambiguous_prefix() {
 }
 
 #[tokio::test]
+async fn container_names_invert_aliases_and_prefer_the_shortest() {
+    let (runtime, _tmp) = networking_test_runtime();
+    let id = "0a1b2c3d4e5f00112233445566778899";
+    // A container accreting two names: the short primary and a longer alias.
+    runtime.register_container_alias("db", id).await;
+    runtime.register_container_alias("arcbox-postgres-1", id).await;
+    // A second container with a single name.
+    runtime.register_container_alias("cache", "beef5678").await;
+
+    let names = runtime.container_names().await;
+    assert_eq!(names.get(id).map(String::as_str), Some("db"));
+    assert_eq!(names.get("beef5678").map(String::as_str), Some("cache"));
+    // Unknown IDs have no name (the consumer falls back to the short ID).
+    assert!(names.get("unknown").is_none());
+}
+
+#[tokio::test]
 async fn deregister_dns_clears_aliases_even_without_dns_entry() {
     let (runtime, _tmp) = networking_test_runtime();
     // Alias registered without any DNS entry (e.g. port forwarding only).

--- a/app/arcbox-core/src/runtime/tests.rs
+++ b/app/arcbox-core/src/runtime/tests.rs
@@ -159,7 +159,9 @@ async fn container_names_invert_aliases_and_prefer_the_shortest() {
     let id = "0a1b2c3d4e5f00112233445566778899";
     // A container accreting two names: the short primary and a longer alias.
     runtime.register_container_alias("db", id).await;
-    runtime.register_container_alias("arcbox-postgres-1", id).await;
+    runtime
+        .register_container_alias("arcbox-postgres-1", id)
+        .await;
     // A second container with a single name.
     runtime.register_container_alias("cache", "beef5678").await;
 
@@ -167,7 +169,7 @@ async fn container_names_invert_aliases_and_prefer_the_shortest() {
     assert_eq!(names.get(id).map(String::as_str), Some("db"));
     assert_eq!(names.get("beef5678").map(String::as_str), Some("cache"));
     // Unknown IDs have no name (the consumer falls back to the short ID).
-    assert!(names.get("unknown").is_none());
+    assert!(!names.contains_key("unknown"));
 }
 
 #[tokio::test]

--- a/guest/arcbox-agent/src/agent/linux/stats.rs
+++ b/guest/arcbox-agent/src/agent/linux/stats.rs
@@ -17,8 +17,8 @@ use arcbox_protocol::agent::{ContainerStats, MachineStats, WatchStatsRequest};
 use crate::rpc::{MessageType, write_message};
 use crate::stats::{
     is_container_id, parse_cgroup_cpu_usage_usec, parse_cgroup_io_bytes, parse_cgroup_memory_max,
-    parse_cpu_ticks, parse_diskstats, parse_loadavg1, parse_meminfo, parse_net_dev,
-    parse_psi_full_avg10, parse_u64_file, parse_uptime_ms,
+    parse_cpu_ticks, parse_diskstats, parse_first_pid, parse_loadavg1, parse_meminfo,
+    parse_net_dev, parse_psi_full_avg10, parse_u64_file, parse_uptime_ms,
 };
 
 /// cgroup v2 parent that Docker (cgroupfs driver) places one child cgroup
@@ -156,6 +156,7 @@ fn read_container_stats() -> Vec<ContainerStats> {
         let dir = entry.path();
         let read = |leaf: &str| std::fs::read_to_string(dir.join(leaf)).unwrap_or_default();
         let (disk_read_bytes, disk_written_bytes) = parse_cgroup_io_bytes(&read("io.stat"));
+        let (net_rx_bytes, net_tx_bytes) = container_network(&read("cgroup.procs"));
         containers.push(ContainerStats {
             id: name,
             name: String::new(),
@@ -165,7 +166,42 @@ fn read_container_stats() -> Vec<ContainerStats> {
             disk_read_bytes,
             disk_written_bytes,
             pids: parse_u64_file(&read("pids.current")).unwrap_or(0) as u32,
+            net_rx_bytes,
+            net_tx_bytes,
         });
     }
     containers
+}
+
+/// Cumulative `(rx, tx)` bytes for a container, read from `/proc/<pid>/net/dev`
+/// of a process in the container's network namespace.
+///
+/// Returns `(0, 0)` when the container has no readable process, or when it
+/// shares the agent's network namespace (host networking) — its traffic is
+/// the machine's, already counted in the machine-level totals, so counting
+/// it again per-container would double it.
+fn container_network(cgroup_procs: &str) -> (u64, u64) {
+    let Some(pid) = parse_first_pid(cgroup_procs) else {
+        return (0, 0);
+    };
+    if shares_agent_netns(pid) {
+        return (0, 0);
+    }
+    match std::fs::read_to_string(format!("/proc/{pid}/net/dev")) {
+        Ok(net_dev) => parse_net_dev(&net_dev),
+        // The process may have exited between listing and reading; treat a
+        // vanished container as no traffic rather than an error.
+        Err(_) => (0, 0),
+    }
+}
+
+/// Whether `pid` is in the same network namespace as the agent — i.e. a
+/// host-networked container. Compares the `net:[inode]` targets of the two
+/// `ns/net` links; on any read failure, assumes distinct (report the
+/// container's own counters) rather than silently zeroing.
+fn shares_agent_netns(pid: u32) -> bool {
+    let Ok(agent_ns) = std::fs::read_link("/proc/self/ns/net") else {
+        return false;
+    };
+    std::fs::read_link(format!("/proc/{pid}/ns/net")).is_ok_and(|ns| ns == agent_ns)
 }

--- a/guest/arcbox-agent/src/agent/linux/stats.rs
+++ b/guest/arcbox-agent/src/agent/linux/stats.rs
@@ -12,13 +12,18 @@ use anyhow::Result;
 use prost::Message as _;
 use tokio::io::AsyncWrite;
 
-use arcbox_protocol::agent::{MachineStats, WatchStatsRequest};
+use arcbox_protocol::agent::{ContainerStats, MachineStats, WatchStatsRequest};
 
 use crate::rpc::{MessageType, write_message};
 use crate::stats::{
+    is_container_id, parse_cgroup_cpu_usage_usec, parse_cgroup_io_bytes, parse_cgroup_memory_max,
     parse_cpu_ticks, parse_diskstats, parse_loadavg1, parse_meminfo, parse_net_dev,
-    parse_psi_full_avg10, parse_uptime_ms,
+    parse_psi_full_avg10, parse_u64_file, parse_uptime_ms,
 };
+
+/// cgroup v2 parent that Docker (cgroupfs driver) places one child cgroup
+/// per container under, named by the full container ID.
+const DOCKER_CGROUP_ROOT: &str = "/sys/fs/cgroup/docker";
 
 /// Default watch window when the request leaves `timeout_ms` at 0.
 const DEFAULT_WINDOW: Duration = Duration::from_secs(300);
@@ -127,5 +132,40 @@ fn read_machine_stats() -> Option<MachineStats> {
         disk_written_bytes,
         net_rx_bytes,
         net_tx_bytes,
+        containers: read_container_stats(),
     })
+}
+
+/// Reads one [`ContainerStats`] per Docker container cgroup.
+///
+/// Returns an empty vec when no containers run or the cgroup tree is
+/// absent — never an error, since machine stats must still flow. The
+/// `name` field is left empty for the daemon to fill from its registry.
+fn read_container_stats() -> Vec<ContainerStats> {
+    let Ok(entries) = std::fs::read_dir(DOCKER_CGROUP_ROOT) else {
+        return Vec::new();
+    };
+    let mut containers = Vec::new();
+    for entry in entries.flatten() {
+        let Ok(name) = entry.file_name().into_string() else {
+            continue;
+        };
+        if !is_container_id(&name) {
+            continue;
+        }
+        let dir = entry.path();
+        let read = |leaf: &str| std::fs::read_to_string(dir.join(leaf)).unwrap_or_default();
+        let (disk_read_bytes, disk_written_bytes) = parse_cgroup_io_bytes(&read("io.stat"));
+        containers.push(ContainerStats {
+            id: name,
+            name: String::new(),
+            cpu_usage_usec: parse_cgroup_cpu_usage_usec(&read("cpu.stat")).unwrap_or(0),
+            memory_current_bytes: parse_u64_file(&read("memory.current")).unwrap_or(0),
+            memory_limit_bytes: parse_cgroup_memory_max(&read("memory.max")),
+            disk_read_bytes,
+            disk_written_bytes,
+            pids: parse_u64_file(&read("pids.current")).unwrap_or(0) as u32,
+        });
+    }
+    containers
 }

--- a/guest/arcbox-agent/src/stats.rs
+++ b/guest/arcbox-agent/src/stats.rs
@@ -165,6 +165,62 @@ fn is_physical_nic(name: &str) -> bool {
     name.starts_with("eth") || name.starts_with("en")
 }
 
+/// Cumulative CPU time in microseconds from a cgroup v2 `cpu.stat`
+/// (`usage_usec` line).
+#[must_use]
+pub fn parse_cgroup_cpu_usage_usec(cpu_stat: &str) -> Option<u64> {
+    cpu_stat
+        .lines()
+        .find_map(|l| l.strip_prefix("usage_usec "))?
+        .trim()
+        .parse()
+        .ok()
+}
+
+/// A cgroup v2 memory limit from `memory.max`: `"max"` (unlimited) maps to
+/// 0, any other value parses as a byte count.
+#[must_use]
+pub fn parse_cgroup_memory_max(memory_max: &str) -> u64 {
+    let trimmed = memory_max.trim();
+    if trimmed == "max" {
+        0
+    } else {
+        trimmed.parse().unwrap_or(0)
+    }
+}
+
+/// A bare unsigned integer file (`memory.current`, `pids.current`).
+#[must_use]
+pub fn parse_u64_file(content: &str) -> Option<u64> {
+    content.trim().parse().ok()
+}
+
+/// Cumulative `(read, written)` bytes summed across every device line in a
+/// cgroup v2 `io.stat` (`MAJ:MIN rbytes=… wbytes=… …`).
+#[must_use]
+pub fn parse_cgroup_io_bytes(io_stat: &str) -> (u64, u64) {
+    let mut read = 0u64;
+    let mut written = 0u64;
+    for line in io_stat.lines() {
+        for field in line.split_ascii_whitespace() {
+            if let Some(v) = field.strip_prefix("rbytes=") {
+                read = read.saturating_add(v.parse().unwrap_or(0));
+            } else if let Some(v) = field.strip_prefix("wbytes=") {
+                written = written.saturating_add(v.parse().unwrap_or(0));
+            }
+        }
+    }
+    (read, written)
+}
+
+/// Whether a name under `/sys/fs/cgroup/docker` is a container cgroup: a
+/// full 64-character lowercase-hex container ID. Filters out the parent's
+/// own control files and any non-container entries.
+#[must_use]
+pub fn is_container_id(name: &str) -> bool {
+    name.len() == 64 && name.bytes().all(|b| b.is_ascii_hexdigit() && !b.is_ascii_uppercase())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -283,5 +339,39 @@ veth1a2b3c: 8000     80    0    0    0     0          0         0  8000     80  
         ] {
             assert!(!is_physical_nic(virt), "{virt}");
         }
+    }
+
+    #[test]
+    fn cgroup_cpu_reads_usage_usec() {
+        let cpu_stat = "usage_usec 123456789\nuser_usec 80000000\nsystem_usec 40000000\n\
+                        nr_periods 0\nnr_throttled 0\n";
+        assert_eq!(parse_cgroup_cpu_usage_usec(cpu_stat), Some(123_456_789));
+        assert!(parse_cgroup_cpu_usage_usec("user_usec 5\n").is_none());
+    }
+
+    #[test]
+    fn cgroup_memory_max_treats_max_as_unlimited() {
+        assert_eq!(parse_cgroup_memory_max("max\n"), 0);
+        assert_eq!(parse_cgroup_memory_max("2147483648\n"), 2_147_483_648);
+        assert_eq!(parse_u64_file("536870912\n"), Some(536_870_912));
+        assert_eq!(parse_u64_file("42\n"), Some(42));
+    }
+
+    #[test]
+    fn cgroup_io_sums_bytes_across_devices() {
+        let io_stat = "254:0 rbytes=1000 wbytes=2000 rios=10 wios=20 dbytes=0 dios=0\n\
+                       254:16 rbytes=500 wbytes=700 rios=5 wios=7 dbytes=0 dios=0\n";
+        assert_eq!(parse_cgroup_io_bytes(io_stat), (1500, 2700));
+        assert_eq!(parse_cgroup_io_bytes(""), (0, 0));
+    }
+
+    #[test]
+    fn container_id_matches_full_hex_only() {
+        let id = "e8b0e6ed2660238f9cb327d7b8b2ab3b7ff088920b9fa9efe0118c6ec1fa6474";
+        assert!(is_container_id(id));
+        assert!(!is_container_id("cgroup.procs"));
+        assert!(!is_container_id("buildkit"));
+        assert!(!is_container_id(&id[..12])); // short id is not a cgroup dir
+        assert!(!is_container_id(&id.to_uppercase()));
     }
 }

--- a/guest/arcbox-agent/src/stats.rs
+++ b/guest/arcbox-agent/src/stats.rs
@@ -218,7 +218,18 @@ pub fn parse_cgroup_io_bytes(io_stat: &str) -> (u64, u64) {
 /// own control files and any non-container entries.
 #[must_use]
 pub fn is_container_id(name: &str) -> bool {
-    name.len() == 64 && name.bytes().all(|b| b.is_ascii_hexdigit() && !b.is_ascii_uppercase())
+    name.len() == 64
+        && name
+            .bytes()
+            .all(|b| b.is_ascii_hexdigit() && !b.is_ascii_uppercase())
+}
+
+/// The first PID listed in a cgroup v2 `cgroup.procs` (one PID per line).
+/// A container's network stats are read through any of its processes'
+/// network namespace, so the first live PID suffices.
+#[must_use]
+pub fn parse_first_pid(cgroup_procs: &str) -> Option<u32> {
+    cgroup_procs.lines().next()?.trim().parse().ok()
 }
 
 #[cfg(test)]
@@ -373,5 +384,13 @@ veth1a2b3c: 8000     80    0    0    0     0          0         0  8000     80  
         assert!(!is_container_id("buildkit"));
         assert!(!is_container_id(&id[..12])); // short id is not a cgroup dir
         assert!(!is_container_id(&id.to_uppercase()));
+    }
+
+    #[test]
+    fn first_pid_reads_leading_line() {
+        assert_eq!(parse_first_pid("4242\n4243\n4244\n"), Some(4242));
+        assert_eq!(parse_first_pid("777"), Some(777));
+        assert_eq!(parse_first_pid(""), None); // empty cgroup: no process
+        assert_eq!(parse_first_pid("notapid\n"), None);
     }
 }

--- a/rpc/arcbox-protocol/proto/agent.proto
+++ b/rpc/arcbox-protocol/proto/agent.proto
@@ -257,10 +257,11 @@ message MachineStats {
 
 // One container's cgroup v2 resource sample.
 //
-// Sourced from the container's cgroup (cpu.stat, memory.current,
-// memory.max, io.stat, pids.current). CPU and disk fields are cumulative;
-// memory and pids are gauges. Per-container network is not a cgroup
-// counter (it lives in the network namespace) and is not reported here.
+// CPU, disk, and network fields are cumulative; memory and pids are
+// gauges. CPU/memory/disk/pids come from the container's cgroup
+// (cpu.stat, memory.current, memory.max, io.stat, pids.current). Network
+// is not a cgroup counter — it lives in the container's network
+// namespace, read via /proc/<pid>/net/dev for a process in the container.
 message ContainerStats {
     // Full container ID (the cgroup directory name).
     string id = 1;
@@ -280,6 +281,12 @@ message ContainerStats {
     uint64 disk_written_bytes = 7;
     // Current process/thread count (pids.current).
     uint32 pids = 8;
+    // Cumulative bytes across the container's non-loopback interfaces,
+    // from /proc/<pid>/net/dev in its network namespace. Zero for a
+    // host-networked container (its traffic is the machine's, already
+    // counted in MachineStats) or when no process is readable.
+    uint64 net_rx_bytes = 9;
+    uint64 net_tx_bytes = 10;
 }
 
 // Runtime status report.

--- a/rpc/arcbox-protocol/proto/agent.proto
+++ b/rpc/arcbox-protocol/proto/agent.proto
@@ -249,6 +249,37 @@ message MachineStats {
     // traffic is not counted once per internal hop).
     uint64 net_rx_bytes = 11;
     uint64 net_tx_bytes = 12;
+    // Per-container samples, one per running Docker container (cgroup v2
+    // tree under /sys/fs/cgroup/docker). Empty when no containers run or
+    // the subscriber did not request them.
+    repeated ContainerStats containers = 13;
+}
+
+// One container's cgroup v2 resource sample.
+//
+// Sourced from the container's cgroup (cpu.stat, memory.current,
+// memory.max, io.stat, pids.current). CPU and disk fields are cumulative;
+// memory and pids are gauges. Per-container network is not a cgroup
+// counter (it lives in the network namespace) and is not reported here.
+message ContainerStats {
+    // Full container ID (the cgroup directory name).
+    string id = 1;
+    // Human-readable name, filled by the daemon from its container
+    // registry. Empty on the guest→host hop and when the daemon has no
+    // name for the ID (the consumer falls back to the short ID).
+    string name = 2;
+    // Cumulative CPU time in microseconds (cpu.stat usage_usec).
+    uint64 cpu_usage_usec = 3;
+    // Current memory charge in bytes (memory.current).
+    uint64 memory_current_bytes = 4;
+    // Memory limit in bytes (memory.max); 0 means unlimited ("max").
+    uint64 memory_limit_bytes = 5;
+    // Cumulative block I/O bytes summed across devices (io.stat
+    // rbytes/wbytes).
+    uint64 disk_read_bytes = 6;
+    uint64 disk_written_bytes = 7;
+    // Current process/thread count (pids.current).
+    uint32 pids = 8;
 }
 
 // Runtime status report.

--- a/rpc/arcbox-protocol/src/generated/arcbox.v1.rs
+++ b/rpc/arcbox-protocol/src/generated/arcbox.v1.rs
@@ -2003,10 +2003,11 @@ pub struct MachineStats {
 }
 /// One container's cgroup v2 resource sample.
 ///
-/// Sourced from the container's cgroup (cpu.stat, memory.current,
-/// memory.max, io.stat, pids.current). CPU and disk fields are cumulative;
-/// memory and pids are gauges. Per-container network is not a cgroup
-/// counter (it lives in the network namespace) and is not reported here.
+/// CPU, disk, and network fields are cumulative; memory and pids are
+/// gauges. CPU/memory/disk/pids come from the container's cgroup
+/// (cpu.stat, memory.current, memory.max, io.stat, pids.current). Network
+/// is not a cgroup counter — it lives in the container's network
+/// namespace, read via /proc/<pid>/net/dev for a process in the container.
 #[derive(serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -2037,6 +2038,14 @@ pub struct ContainerStats {
     /// Current process/thread count (pids.current).
     #[prost(uint32, tag = "8")]
     pub pids: u32,
+    /// Cumulative bytes across the container's non-loopback interfaces,
+    /// from /proc/<pid>/net/dev in its network namespace. Zero for a
+    /// host-networked container (its traffic is the machine's, already
+    /// counted in MachineStats) or when no process is readable.
+    #[prost(uint64, tag = "9")]
+    pub net_rx_bytes: u64,
+    #[prost(uint64, tag = "10")]
+    pub net_tx_bytes: u64,
 }
 /// Runtime status report.
 #[derive(serde::Serialize, serde::Deserialize)]

--- a/rpc/arcbox-protocol/src/generated/arcbox.v1.rs
+++ b/rpc/arcbox-protocol/src/generated/arcbox.v1.rs
@@ -1954,7 +1954,7 @@ pub struct WatchStatsRequest {
 /// and stream restarts.
 #[derive(serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[derive(Clone, Copy, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct MachineStats {
     /// Guest monotonic clock at sample time (from /proc/uptime), in
     /// milliseconds. Rate denominators come from deltas of this field, not
@@ -1995,6 +1995,48 @@ pub struct MachineStats {
     pub net_rx_bytes: u64,
     #[prost(uint64, tag = "12")]
     pub net_tx_bytes: u64,
+    /// Per-container samples, one per running Docker container (cgroup v2
+    /// tree under /sys/fs/cgroup/docker). Empty when no containers run or
+    /// the subscriber did not request them.
+    #[prost(message, repeated, tag = "13")]
+    pub containers: ::prost::alloc::vec::Vec<ContainerStats>,
+}
+/// One container's cgroup v2 resource sample.
+///
+/// Sourced from the container's cgroup (cpu.stat, memory.current,
+/// memory.max, io.stat, pids.current). CPU and disk fields are cumulative;
+/// memory and pids are gauges. Per-container network is not a cgroup
+/// counter (it lives in the network namespace) and is not reported here.
+#[derive(serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ContainerStats {
+    /// Full container ID (the cgroup directory name).
+    #[prost(string, tag = "1")]
+    pub id: ::prost::alloc::string::String,
+    /// Human-readable name, filled by the daemon from its container
+    /// registry. Empty on the guest→host hop and when the daemon has no
+    /// name for the ID (the consumer falls back to the short ID).
+    #[prost(string, tag = "2")]
+    pub name: ::prost::alloc::string::String,
+    /// Cumulative CPU time in microseconds (cpu.stat usage_usec).
+    #[prost(uint64, tag = "3")]
+    pub cpu_usage_usec: u64,
+    /// Current memory charge in bytes (memory.current).
+    #[prost(uint64, tag = "4")]
+    pub memory_current_bytes: u64,
+    /// Memory limit in bytes (memory.max); 0 means unlimited ("max").
+    #[prost(uint64, tag = "5")]
+    pub memory_limit_bytes: u64,
+    /// Cumulative block I/O bytes summed across devices (io.stat
+    /// rbytes/wbytes).
+    #[prost(uint64, tag = "6")]
+    pub disk_read_bytes: u64,
+    #[prost(uint64, tag = "7")]
+    pub disk_written_bytes: u64,
+    /// Current process/thread count (pids.current).
+    #[prost(uint32, tag = "8")]
+    pub pids: u32,
 }
 /// Runtime status report.
 #[derive(serde::Serialize, serde::Deserialize)]

--- a/rpc/arcbox-protocol/src/lib.rs
+++ b/rpc/arcbox-protocol/src/lib.rs
@@ -93,7 +93,7 @@ pub mod image {
 /// Re-exports all agent-related types for backward compatibility.
 pub mod agent {
     pub use super::v1::{
-        AgentPingRequest, AgentPingResponse, DiskTrimRequest, DiskTrimResponse,
+        AgentPingRequest, AgentPingResponse, ContainerStats, DiskTrimRequest, DiskTrimResponse,
         KubernetesDeleteRequest, KubernetesDeleteResponse, KubernetesKubeconfigRequest,
         KubernetesKubeconfigResponse, KubernetesStartRequest, KubernetesStartResponse,
         KubernetesStatusRequest, KubernetesStatusResponse, KubernetesStopRequest,

--- a/tests/e2e/tests/stats_watch.rs
+++ b/tests/e2e/tests/stats_watch.rs
@@ -5,7 +5,8 @@
 //! sane values, concurrent subscribers share a single guest stream (the
 //! daemon log is the oracle for pump lifecycle, as with the idle-balloon
 //! scenario), and a later subscriber gets a fresh pump after the first
-//! generation wound down.
+//! generation wound down. It also runs one container and asserts its
+//! per-container cgroup stats appear in the frames, name-enriched (P2).
 
 use std::path::Path;
 use std::sync::Once;
@@ -14,6 +15,7 @@ use std::time::Duration;
 use anyhow::{Context, Result, bail};
 use arcbox_e2e::boot_assets::{resolve_boot_version, stage_dev_boot_assets};
 use arcbox_e2e::daemon::{DaemonConfig, DaemonHandle, connect_unix};
+use arcbox_e2e::docker::{docker_output, ensure_image};
 use arcbox_e2e::metrics::RunMetrics;
 use arcbox_grpc::v1::stats_service_client::StatsServiceClient;
 use arcbox_protocol::v1::{MachineStats, StatsWatchRequest};
@@ -27,6 +29,10 @@ const SAMPLE_BUDGET: Duration = Duration::from_secs(10);
 /// Budget for the first pump to stop after its subscribers disconnect
 /// (the pump notices within its frame patience).
 const PUMP_STOP_BUDGET: Duration = Duration::from_secs(15);
+/// Ceiling for one docker CLI invocation.
+const DOCKER_ATTEMPT: Duration = Duration::from_secs(30);
+/// Name of the probe container whose per-container stats we assert.
+const PROBE_NAME: &str = "stats-probe";
 
 fn init_tracing() {
     TRACING.call_once(|| {
@@ -97,12 +103,35 @@ fn scenario(daemon: &mut DaemonHandle, data_dir: &Path, metrics: &mut RunMetrics
     metrics.time("daemon_ready", || daemon.wait_ready_blocking(READY_TIMEOUT))?;
     let socket = daemon.grpc_socket();
 
+    // A running container so the per-container assertions have a subject.
+    // It touches memory (a tmpfs write) so memory.current is non-trivial.
+    let image = std::env::var("ARCBOX_E2E_IMAGE").unwrap_or_else(|_| "alpine:latest".to_owned());
+    metrics.time("docker_pull", || ensure_image(data_dir, &image))?;
+    metrics.time("probe_start", || {
+        docker_output(
+            data_dir,
+            &[
+                "run",
+                "-d",
+                "--name",
+                PROBE_NAME,
+                &image,
+                "sh",
+                "-c",
+                "dd if=/dev/zero of=/tmp/hold bs=1M count=32; sleep 600",
+            ],
+            DOCKER_ATTEMPT,
+        )
+        .context("starting probe container")
+    })?;
+
     let runtime = tokio::runtime::Builder::new_current_thread()
         .enable_all()
         .build()
         .context("building tokio runtime")?;
 
-    // Phase 1 — two concurrent subscribers, sane and progressing samples.
+    // Phase 1 — two concurrent subscribers, sane and progressing samples,
+    // and the probe container's per-container stats.
     runtime.block_on(async {
         let channel = connect_unix(&socket).await?;
         let mut client = StatsServiceClient::new(channel);
@@ -138,7 +167,11 @@ fn scenario(daemon: &mut DaemonHandle, data_dir: &Path, metrics: &mut RunMetrics
             psi = second.memory_psi_full_avg10,
             "samples flow and progress"
         );
-        Ok::<_, anyhow::Error>(())
+
+        // The probe container's cgroup stats must appear (discovery is
+        // per-tick, so it may take a frame or two), name-enriched by the
+        // daemon from its registry.
+        assert_probe_container(&mut stream_a).await
     })?;
     if count_log_matches(data_dir, "stats pump started")? != 1 {
         bail!("concurrent subscribers did not share a single stats pump");
@@ -173,7 +206,40 @@ fn scenario(daemon: &mut DaemonHandle, data_dir: &Path, metrics: &mut RunMetrics
         bail!("resubscription did not start a fresh stats pump");
     }
 
+    docker_output(data_dir, &["rm", "-f", PROBE_NAME], DOCKER_ATTEMPT).ok();
     Ok(())
+}
+
+/// Consumes frames until the probe container appears, then asserts its
+/// cgroup stats are sane and the daemon enriched its name. Bounded by a
+/// few sample budgets so a never-appearing container fails instead of
+/// hanging.
+async fn assert_probe_container(stream: &mut Streaming<MachineStats>) -> Result<()> {
+    for _ in 0..5 {
+        let sample = next_sample(stream)
+            .await
+            .context("frame while awaiting probe")?;
+        let Some(probe) = sample.containers.iter().find(|c| c.name == PROBE_NAME) else {
+            continue;
+        };
+        if probe.id.len() != 64 {
+            bail!("probe container id is not a full cgroup id: {:?}", probe.id);
+        }
+        if probe.memory_current_bytes == 0 {
+            bail!("probe container reports zero memory");
+        }
+        if probe.pids == 0 {
+            bail!("probe container reports zero pids");
+        }
+        tracing::info!(
+            id = %probe.id,
+            memory = probe.memory_current_bytes,
+            pids = probe.pids,
+            "probe container stats present and enriched"
+        );
+        return Ok(());
+    }
+    bail!("probe container never appeared in the stats stream");
 }
 
 async fn watch(

--- a/tests/e2e/tests/stats_watch.rs
+++ b/tests/e2e/tests/stats_watch.rs
@@ -231,10 +231,18 @@ async fn assert_probe_container(stream: &mut Streaming<MachineStats>) -> Result<
         if probe.pids == 0 {
             bail!("probe container reports zero pids");
         }
+        // A bridged container's eth0 always accrues setup/DHCP traffic, so
+        // its netns-read counters must be non-zero — proving per-container
+        // network (P4) is wired, not just the cgroup metrics.
+        if probe.net_rx_bytes == 0 {
+            bail!("probe container reports zero network rx (netns read failed?)");
+        }
         tracing::info!(
             id = %probe.id,
             memory = probe.memory_current_bytes,
             pids = probe.pids,
+            net_rx = probe.net_rx_bytes,
+            net_tx = probe.net_tx_bytes,
             "probe container stats present and enriched"
         );
         return Ok(());


### PR DESCRIPTION
Phase P2 of ABX-115: per-container resource stats. **Stacked on #397
(P1)** — review/merge #397 first; this PR targets `feat/stats-watch` and
its diff is just the four P2 commits.

## What it adds

Per-container CPU / memory / disk / pids, carried on the same
`WatchStats` frame as the machine totals (one guest pass, still a single
sampler), name-enriched by the daemon.

- **Agent** walks `/sys/fs/cgroup/docker/<id>` each tick (cgroupfs driver,
  cgroup v2 — verified on the live guest) and reads each container's
  `cpu.stat` (cumulative `usage_usec`), `memory.current` / `memory.max`,
  `io.stat` (cumulative read/write bytes), and `pids.current` into a
  `ContainerStats` entry. Discovery filters on a full 64-hex cgroup name,
  so the parent's control files and non-container entries are skipped.
  Absent tree / unreadable leaves degrade to empty/zero — machine stats
  always flow.
- **Daemon** fills each container's display name from
  `Runtime::container_names` (the inverted name-alias registry, shortest
  name wins), so a monitor shows `arcbox-postgres-1`, not a 64-char hash.
  Unknown IDs keep an empty name and the consumer falls back to the short
  ID. The registry read is skipped for container-free frames.
- **`abctl top`** grows a per-container table under the machine summary:
  CPU% (per-core, like `docker stats`), memory used/limit, disk R/W rate,
  pids — sorted CPU-descending, matched by ID across frames so a
  just-started container shows 0% until its baseline rather than a spike.

## Scope boundary

Per-container **network** is deliberately omitted: cgroup v2 has no
network controller, so per-container rx/tx needs the container's network
namespace (`/proc/<pid>/net/dev` or nsenter), not the cgroup. That's a
follow-up; machine-level network is already in P1.

## Validation

- Unit tests: cgroup parsers (cpu.stat / memory.max / io.stat / id
  filter), the name-inversion registry method, and `abctl top`'s
  per-container delta math (CPU from usec deltas, fresh-container zero,
  short-ID fallback).
- Hardware e2e on real VZ (`stats_watch`, extended): a named container
  writing ~32 MiB to tmpfs surfaces in the stream with a full cgroup ID,
  non-zero `memory.current` (~33 MiB observed), non-zero pids, and its
  enriched name. Also folds the pull-once image cache into the shared
  e2e docker helper.
- Workspace clippy clean.

## Remaining (ABX-115)

- P3: desktop Activity Monitor UI + menu bar (unblocks ABXD-87)
- P4: K8s pod grouping, adjustable sampling frequency; per-container
  network via netns
