### PR TITLE
fix(ci): discover release PRs via REST list, not search-backed gh pr list

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -41,7 +41,7 @@ jobs:
         run: |
           git config --global user.name "arcbox-labs[bot]"
           git config --global user.email "254083426+arcbox-labs[bot]@users.noreply.github.com"
-          gh api "repos/${GITHUB_REPOSITORY}/pulls?base=${GITHUB_REF_NAME}&state=open&per_page=100" |
+          gh api --paginate "repos/${GITHUB_REPOSITORY}/pulls?base=${GITHUB_REF_NAME}&state=open&per_page=100" |
           jq -c '.[]
             | select(any(.labels[]; .name == "autorelease: pending"))
             | {number, headRefName: .head.ref}' |

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -30,21 +30,21 @@ jobs:
 
       # Regenerate Cargo.lock on every open release PR so its release tag
       # can build with --locked. The release-please `prs` output only
-      # includes PRs created or updated during the current run.
+      # includes PRs created or updated during the current run. Discovery
+      # must use the REST list endpoint with client-side label filtering:
+      # a label-filtered `gh pr list` routes through the eventually
+      # consistent search API and misses PRs release-please created
+      # seconds earlier in this same run.
       - name: Update Cargo.lock on release PRs
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           git config --global user.name "arcbox-labs[bot]"
           git config --global user.email "254083426+arcbox-labs[bot]@users.noreply.github.com"
-          gh pr list \
-            --repo "$GITHUB_REPOSITORY" \
-            --base "$GITHUB_REF_NAME" \
-            --state open \
-            --label "autorelease: pending" \
-            --limit 100 \
-            --json headRefName,number |
-          jq -c '.[]' |
+          gh api "repos/${GITHUB_REPOSITORY}/pulls?base=${GITHUB_REF_NAME}&state=open&per_page=100" |
+          jq -c '.[]
+            | select(any(.labels[]; .name == "autorelease: pending"))
+            | {number, headRefName: .head.ref}' |
           while read -r pr; do
             PR_BRANCH=$(jq -r '.headRefName' <<< "$pr")
             PR_NUMBER=$(jq -r '.number' <<< "$pr")


### PR DESCRIPTION
## Problem

The "Update Cargo.lock on release PRs" step in `release-please.yml` discovers release PRs with `gh pr list --label "autorelease: pending"`. A label filter makes `gh` route the query through GitHub's **search API**, which is eventually consistent.

In run [29481150093](https://github.com/arcboxlabs/arcbox/actions/runs/29481150093), release-please created #400 at 07:48:13Z and the list query ran at ~07:48:15Z — before the search index caught up. The step only processed #394, leaving #400 with `Cargo.toml` at 0.1.2 but `Cargo.lock` still pinning 0.1.1, so the `fleet-agent-v0.1.2` tag would not build with `--locked`.

## Fix

List open PRs via the REST pulls endpoint (primary-backed, immediately consistent) and filter the `autorelease: pending` label client-side with `jq`:

```bash
gh api "repos/${GITHUB_REPOSITORY}/pulls?base=${GITHUB_REF_NAME}&state=open&per_page=100" |
jq -c '.[] | select(any(.labels[]; .name == "autorelease: pending")) | {number, headRefName: .head.ref}'
```

The loop body is unchanged (same `number`/`headRefName` shape).

## Verification

- `actionlint` passes with no findings.
- Dry run of the exact pipeline against the live repo finds both open release PRs, including #400 which the old query missed.

## Note

Merging this also self-heals #400: the push to master triggers a release-please run that reprocesses all open release PRs and pushes the `Cargo.lock` refresh. Merge this before #400.