### PR TITLE
chore: bump host toolchain to docker 29.6.1 era; fix tool updater for moby's new tags

### DIFF
--- a/assets.lock
+++ b/assets.lock
@@ -14,9 +14,9 @@
 # and the [boot] bump.
 
 [boot]
-version = "0.6.2"
+version = "0.6.3"
 cdn = "https://boot.arcboxcdn.com"
-manifest_sha256 = "f82fa766db54d56c42e86ad831c92ab18cf7df0bc646d054f675f361284793de"
+manifest_sha256 = "80c04d681dcf8384f8e4c76160a3d72b84b1d57a7b5663cf89325382073a5256"
 
 [[tools]]
 name = "docker"

--- a/assets.lock
+++ b/assets.lock
@@ -18,30 +18,30 @@ manifest_sha256 = "f82fa766db54d56c42e86ad831c92ab18cf7df0bc646d054f675f36128479
 [[tools]]
 name = "docker"
 group = "docker"
-version = "29.3.1"
-arch.arm64.sha256 = "7a448b9d948157f4bcf29369755389049746297d1289a0607ea3d0a811d20e75"
-arch.x86_64.sha256 = "e3c8b6b87399e58080263a7294fdd5c7d1fb8cbc1712f99d3f6de20acee949cb"
+version = "29.6.1"
+arch.arm64.sha256 = "2e38a0fc5e90520f32bfa4b951984f4684e46042ef855ed2c6a98f015e4284ba"
+arch.x86_64.sha256 = "4dd10d89a3481de4903a791f6ea84f30fc18b892e9ae8b8035b4d1ddd9351e73"
 
 [[tools]]
 name = "docker-buildx"
 group = "docker"
-version = "0.33.0"
-arch.arm64.sha256 = "35dc3303d2ddb20b9490be4f658eb4b08ee6c9b2a5b5a56797f6c8fb20f5f52b"
-arch.x86_64.sha256 = "b1b5a38f78311cfed70a0e68096df0e9ed7dd1b1fcd09adbb117d74e3bad6f32"
+version = "0.35.0"
+arch.arm64.sha256 = "fedbcbd488dcdb46414c6119920d8186d406531a1157ceede4e857e25af77ff1"
+arch.x86_64.sha256 = "7d53fd11deca2d4caebc5436c9eebece5c81c8bbc6d4b539cf30be5c133c38c7"
 
 [[tools]]
 name = "docker-compose"
 group = "docker"
-version = "5.1.1"
-arch.arm64.sha256 = "7b10566e09366d1c22222eb0726805b8c488b4109e63689fd6c543d0006504e2"
-arch.x86_64.sha256 = "2d1845ad583a08095b469547dc1bee2a985d1db3b62bc478f88361b85c8ff0e9"
+version = "5.3.1"
+arch.arm64.sha256 = "32691ba1196d819fa68cbdc0aad9a5569e730a35ae40c6fdd8458110ecd69488"
+arch.x86_64.sha256 = "56620a2e87e789147b9b1cc5d37eeecec2332e2cdf5c2d58a68f999f2dc416ca"
 
 [[tools]]
 name = "docker-credential-osxkeychain"
 group = "docker"
-version = "0.9.5"
-arch.arm64.sha256 = "bc216761bc10e5a707f52d4e5b4050dd7ee7a2daae63c35a97ed7fed2ea64822"
-arch.x86_64.sha256 = "578294a426d86322a17f998cf814258fe7aa764bf505354fcebee51a7456266c"
+version = "0.9.8"
+arch.arm64.sha256 = "6fae515ffbc74f395af1b51c6f079ddb57895ed9e428e0bea3f6aff64e916b22"
+arch.x86_64.sha256 = "0575a404c4ead8b5135a2482ece4dd142bde3cbd319433697e212bbea0afb100"
 
 [[tools]]
 name = "pstramp"
@@ -53,6 +53,6 @@ arch.x86_64.sha256 = "eb3cc921de1aed02348821f4a653705a33b012b6a1da7466e577673c5c
 [[tools]]
 name = "kubectl"
 group = "kubernetes"
-version = "1.35.3"
-arch.arm64.sha256 = "280651239d84bab214ba83403666bf6976a5fa0dbdb41404f26eb6f276d34963"
-arch.x86_64.sha256 = "2f339b1eae2e1792ec08da281b37afbeee94f70bed6b7398e7efd81ba08f8d37"
+version = "1.36.2"
+arch.arm64.sha256 = "4408c85c83fd3a31adaa555bdf3c7a6c81f74b19449a9060ba31ab91926f023d"
+arch.x86_64.sha256 = "ce6c5e55cd17559e87e4fb5e73ebbbc2511bcf2b695d7a40c1b1461a9817d4b3"

--- a/assets.lock
+++ b/assets.lock
@@ -6,9 +6,12 @@
 #   - group "desktop": host-only binaries embedded in the app bundle
 #     (e.g. pstramp for PTY session isolation).
 #
-# Because both paths read from this single lockfile, the Docker CLI and the
-# guest dockerd are always the same version — there is no CLI/daemon version
-# skew to worry about when upgrading.
+# The guest runtime binaries (dockerd, containerd, …) come from the boot
+# manifest pinned under [boot], NOT from [[tools]]. Keep the "docker" tool
+# below on the same version as the boot bundle's dockerd when bumping either
+# side — the CLI tolerates an older daemon through API negotiation, but the
+# two pins should only diverge for the short window between a bundle release
+# and the [boot] bump.
 
 [boot]
 version = "0.6.2"

--- a/docs/boot-assets.md
+++ b/docs/boot-assets.md
@@ -10,7 +10,7 @@ Each release contains per-architecture artifacts plus a unified multi-target man
 - `kernel` — pre-built Linux kernel (all drivers built-in, `CONFIG_MODULES=n`)
 - `rootfs.erofs` — minimal read-only EROFS rootfs (busybox + mkfs.btrfs + iptables-legacy + ebtables + ethtool + socat + CA certs)
 - `manifest.json` — manifest with SHA256 checksums and kernel cmdline (`schema_version` = major of `asset_version`)
-- Runtime binaries — dockerd, containerd, containerd-shim-runc-v2, runc (from Docker 29.3.1 static package) plus k3s
+- Runtime binaries — dockerd, containerd, containerd-shim-runc-v2, runc, docker-init (from the Docker 29.6.1 static package, shipping containerd 2.2.5) plus k3s, firecracker/jailer, and the microVM vmlinux
 
 No initramfs. The kernel boots directly into the EROFS rootfs (`root=/dev/vda ro rootfstype=erofs`).
 Agent and runtime binaries are distributed via VirtioFS from the host.
@@ -28,7 +28,7 @@ Agent and runtime binaries are distributed via VirtioFS from the host.
 
 1. Build EROFS rootfs from Alpine static binaries
 2. Download pre-built kernels from `arcboxlabs/kernel`
-3. Sync upstream runtime binaries (Docker 29.3.1 static package)
+3. Sync upstream runtime binaries (Docker 29.6.1 static package)
 4. Package tarball + checksum + manifest
 5. Publish to GitHub Releases and Cloudflare R2 CDN
 

--- a/guest/arcbox-agent/src/init.rs
+++ b/guest/arcbox-agent/src/init.rs
@@ -876,6 +876,13 @@ const NOFILE_LIMIT: u64 = 1_048_576;
 /// Extracted as a pure function so the output contract (DNS + default
 /// ulimits + containerd image store) is testable independently of the
 /// filesystem and platform.
+///
+/// `containerd-snapshotter` stays explicitly `true` even though dockerd ≥ 29
+/// defaults to the containerd image store: without the explicit flag, dockerd
+/// falls back to the graphdriver whenever it finds prior graphdriver state on
+/// the data volume (`graphdriver-prior`), which would silently flip a machine
+/// with stale overlay2 remnants back to the legacy store. dockerd 29 logs a
+/// benign "no longer needed" warning for it.
 #[cfg(any(target_os = "linux", test))]
 fn docker_daemon_json() -> String {
     serde_json::json!({

--- a/tests/e2e/src/boot_assets.rs
+++ b/tests/e2e/src/boot_assets.rs
@@ -387,6 +387,24 @@ pub fn stage_dev_boot_assets(root: &Path, data_dir: &Path, version: &str) -> Res
     // downloads anything still missing.
     stage_runtime_binaries(&data_dir.join("runtime/bin"));
 
+    // Then pre-seed runtime binaries staged in boot-assets/dev/runtime-bin
+    // (put there by hand or by `boot-assets sync-binaries` in the sibling
+    // repo), overwriting the installed-app copies where both exist. The
+    // daemon's checksum check treats matching files as cached, so an
+    // unreleased runtime bundle can be validated end-to-end before the CDN
+    // carries it — pair with a matching dev manifest and a blanked
+    // assets.lock manifest pin.
+    let seed_dir = dev_boot_dir.join("runtime-bin");
+    if seed_dir.is_dir() {
+        let bin_dir = data_dir.join("runtime/bin");
+        fs::create_dir_all(&bin_dir)?;
+        for entry in fs::read_dir(&seed_dir)? {
+            let entry = entry?;
+            copy_file(&entry.path(), &bin_dir.join(entry.file_name()))?;
+        }
+        info!(seed = %seed_dir.display(), "pre-seeded runtime binaries");
+    }
+
     info!(dev_boot_dir = %dev_boot_dir.display(), "using development boot assets");
     Ok(())
 }

--- a/xtask/src/commands/release/check_tool_updates.rs
+++ b/xtask/src/commands/release/check_tool_updates.rs
@@ -118,7 +118,7 @@ fn latest_version(client: &Client, tool: &Tool) -> Result<String> {
             .with_context(|| format!("GitHub latest release request failed for {repo}"))?
             .json::<GithubRelease>()
             .with_context(|| format!("decoding latest release for {repo}"))?;
-        Ok(release.tag_name.trim_start_matches('v').to_owned())
+        Ok(version_from_tag(&release.tag_name))
     } else {
         Ok(client
             .get("https://dl.k8s.io/release/stable.txt")
@@ -131,6 +131,16 @@ fn latest_version(client: &Client, tool: &Tool) -> Result<String> {
             .trim()
             .trim_start_matches('v')
             .to_owned())
+    }
+}
+
+/// Extracts the bare version from a release tag by dropping everything up to
+/// the first digit: `v0.35.0` → `0.35.0`, and moby's post-split scheme
+/// `docker-v29.6.1` → `29.6.1`.
+fn version_from_tag(tag: &str) -> String {
+    match tag.find(|c: char| c.is_ascii_digit()) {
+        Some(idx) => tag[idx..].to_owned(),
+        None => tag.to_owned(),
     }
 }
 
@@ -185,4 +195,16 @@ fn update_tool(
     tool["arch"]["arm64"]["sha256"] = value(arm_sha);
     tool["arch"]["x86_64"]["sha256"] = value(x86_sha);
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::version_from_tag;
+
+    #[test]
+    fn version_from_tag_handles_all_upstream_schemes() {
+        assert_eq!(version_from_tag("v0.35.0"), "0.35.0");
+        assert_eq!(version_from_tag("docker-v29.6.1"), "29.6.1");
+        assert_eq!(version_from_tag("29.3.1"), "29.3.1");
+    }
 }


### PR DESCRIPTION
## Summary

Host-side half of the runtime toolchain upgrade
(pairs with arcboxlabs/boot-assets#35):

- **assets.lock host tools to latest upstream**: docker CLI 29.3.1 → 29.6.1
  (same version as the new guest dockerd bundle, restoring the lockfile's
  same-version CLI/daemon promise), buildx 0.33.0 → 0.35.0, compose 5.1.1 →
  5.3.1, docker-credential-osxkeychain 0.9.5 → 0.9.8, kubectl 1.35.3 →
  1.36.2 (pairs with k3s v1.36.2+k3s1 in the bundle).
- **fix(xtask)**: `release check-tool-updates` broke on moby's post-split
  release tags (`docker-v29.6.1` → built a `docker-docker-v29.6.1.tgz` 404
  URL). Version is now extracted from the first digit onward; unit-tested
  against all upstream tag schemes.
- **agent**: document why `daemon.json` keeps `containerd-snapshotter=true`
  now that dockerd ≥ 29 defaults to the containerd store (guards against a
  `graphdriver-prior` flip-back on machines with stale overlay2 state).
- **e2e**: `stage_dev_boot_assets` pre-seeds runtime binaries from
  `boot-assets/dev/runtime-bin`, so an unreleased runtime bundle validates
  end-to-end before the CDN carries it (the workflow used to validate this
  upgrade).

## Validation (real VZ boots)

- Docker bundle 29.6.1: full `boot_assets` e2e lifecycle green in 67s
  (ready 13s, pull/run/logs/exec/stop/rm); executed binaries sha-verified;
  containerd 2.2.5 auto-migrates the agent's `version = 2` config
  (CRI CNI dirs correctly mapped).
- k3s v1.36.2+k3s1 on the shared containerd 2.2.5: node
  `arcbox-vm Ready control-plane 24s`, clean stop.
- `cargo test -p xtask` green; clippy/fmt clean.

## Follow-up (not in this PR)

After boot-assets#35 merges and a boot release ships, `assets.lock [boot]`
gets bumped to the new version + manifest sha. Firecracker 1.10.1 → 1.16.1
is staged separately (snapshot format 5.0.0 invalidates existing sandbox
checkpoints; unlocks `network_overrides` for sandbox clone networking).
