### PR TITLE
fix(net): lossless guest-frame backpressure and direct gateway egress

### DIFF
--- a/common/splicetcp/src/egress.rs
+++ b/common/splicetcp/src/egress.rs
@@ -99,6 +99,14 @@ impl DefaultEgress {
         dst_port: u16,
         domain: Option<&str>,
     ) -> Option<(String, String, u16, &'static str)> {
+        // The gateway IP means "the host itself" (`host.docker.internal`):
+        // it is translated to loopback at connect time and must never be
+        // tunnelled through a proxy — the proxy would dial a virtual
+        // address that exists only inside the datapath.
+        if dst_ip == self.gateway_ip {
+            return None;
+        }
+
         let env = self.proxy_env.as_ref()?;
 
         // No proxy configured → always direct.
@@ -260,6 +268,19 @@ mod tests {
         let eg = egress(Some(env(true, true, true)));
         let got = eg.resolve_proxy_target(Ipv4Addr::new(1, 2, 3, 4), 443, None);
         assert_eq!(got.unwrap().3, "socks5");
+    }
+
+    // Regression: the gateway IP (`host.docker.internal`) is translated to
+    // loopback at connect time and must stay direct even when a system proxy
+    // is configured — tunnelling it would make the proxy dial a virtual
+    // address that exists only inside the datapath.
+    #[test]
+    fn gateway_dst_is_direct_despite_proxy() {
+        let eg = egress(Some(env(true, true, true)));
+        assert_eq!(
+            eg.resolve_proxy_target(Ipv4Addr::new(10, 0, 0, 1), 8080, None),
+            None,
+        );
     }
 
     // No usable proxy → direct, regardless of domain.

--- a/tests/e2e/src/daemon.rs
+++ b/tests/e2e/src/daemon.rs
@@ -109,6 +109,12 @@ impl DaemonHandle {
         })
     }
 
+    /// The daemon's process ID (for external diagnostics such as `sample`).
+    #[must_use]
+    pub fn pid(&self) -> u32 {
+        self.child.id()
+    }
+
     /// The Docker API socket under the handle's data directory.
     pub fn docker_socket(&self) -> PathBuf {
         self.data_dir.join("run/docker.sock")

--- a/tests/e2e/src/docker.rs
+++ b/tests/e2e/src/docker.rs
@@ -95,6 +95,51 @@ pub fn docker_ignore(data_dir: &Path, args: &[String]) {
         .status();
 }
 
+/// Makes `image` available in the daemon under test.
+///
+/// Avoids depending on registry reachability more than once per machine:
+/// the first successful pull is cached as a tarball under `target/`, and
+/// later runs `docker load` it (guest registry access is
+/// environment-dependent; pulls here have been observed to black-hole
+/// intermittently).
+pub fn ensure_image(data_dir: &Path, image: &str) -> Result<()> {
+    let cache_dir = crate::repo_root().join("target/e2e-image-cache");
+    let tar = cache_dir.join(format!(
+        "{}.tar",
+        image.replace(['/', ':'], "_").replace('.', "-")
+    ));
+    if tar.exists() {
+        docker_output(
+            data_dir,
+            &["load", "-i", &tar.display().to_string()],
+            Duration::from_secs(60),
+        )
+        .context("docker load from cache")?;
+        return Ok(());
+    }
+
+    let mut last_err = None;
+    for attempt in 1..=3 {
+        match docker_output(data_dir, &["pull", image], Duration::from_secs(90)) {
+            Ok(_) => {
+                std::fs::create_dir_all(&cache_dir)?;
+                docker_output(
+                    data_dir,
+                    &["save", "-o", &tar.display().to_string(), image],
+                    Duration::from_secs(60),
+                )
+                .context("docker save to cache")?;
+                return Ok(());
+            }
+            Err(e) => {
+                tracing::warn!(attempt, "docker pull failed: {e:#}");
+                last_err = Some(e);
+            }
+        }
+    }
+    Err(last_err.expect("loop ran at least once")).context("docker pull (3 attempts)")
+}
+
 /// Runs a command, killing it once `timeout` passes.
 pub fn run_with_timeout(command: &mut Command, timeout: Duration) -> Result<std::process::Output> {
     let mut child = command

--- a/tests/e2e/tests/egress_throughput.rs
+++ b/tests/e2e/tests/egress_throughput.rs
@@ -176,6 +176,41 @@ fn scenario(daemon: &mut DaemonHandle, data_dir: &Path, metrics: &mut RunMetrics
     let url = format!("http://{GUEST_GATEWAY_IP}:{port}/blob");
     tracing::info!(%url, blob_mb = BLOB_BYTES / (1024 * 1024), "blob server up");
 
+    // ABX-423 experiment (ARCBOX_E2E_GUEST_SAMPLER): a persistent in-guest
+    // 1 Hz sampler recording eth0 packet counters and virtio interrupt
+    // counts for the whole scenario. Its timeline across a freeze is the
+    // guest-side vs device-side discriminator: frozen tx_packets = the
+    // guest driver stopped transmitting (NAPI/interrupt wedge in the
+    // guest); advancing tx_packets with a silent host datapath = frames
+    // vanish on the device side. Read back with `docker logs` (vsock,
+    // unaffected by the freeze).
+    let sampler = std::env::var_os("ARCBOX_E2E_GUEST_SAMPLER").is_some();
+    if sampler {
+        let script = r#"while true; do
+  echo "t=$(date +%s) tx=$(cat /sys/class/net/eth0/statistics/tx_packets) rx=$(cat /sys/class/net/eth0/statistics/rx_packets)"
+  grep virtio /proc/interrupts | awk '{s=0; for(i=2;i<=NF;i++) if ($i+0==$i) s+=$i; printf "  irq %s %s\n", $1, s}'
+  sleep 1
+done"#;
+        docker_output(
+            data_dir,
+            &[
+                "run",
+                "-d",
+                "--name",
+                "abx423-sampler",
+                "--net=host",
+                "--privileged",
+                &image,
+                "sh",
+                "-c",
+                script,
+            ],
+            Duration::from_secs(30),
+        )
+        .context("starting guest sampler")?;
+        tracing::info!("guest sampler started (1 Hz eth0 + virtio irq counters)");
+    }
+
     // ABX-423 experiment (ARCBOX_E2E_CANARY_PING): a 1 Hz gateway pinger
     // running for the whole scenario forces a guest virtio-net TX kick every
     // second. If a guest-side kick revives the frozen device, stalls shrink
@@ -206,6 +241,12 @@ fn scenario(daemon: &mut DaemonHandle, data_dir: &Path, metrics: &mut RunMetrics
         arcbox_e2e::docker::docker_ignore(
             data_dir,
             &["rm".into(), "-f".into(), "abx423-canary".into()],
+        );
+    }
+    if sampler {
+        arcbox_e2e::docker::docker_ignore(
+            data_dir,
+            &["rm".into(), "-f".into(), "abx423-sampler".into()],
         );
     }
     downloads?;
@@ -315,6 +356,19 @@ fn sample_daemon(data_dir: &Path, pid: u32) {
 /// interface addresses, and small-transfer probes that distinguish a total
 /// datapath freeze from a per-connection loss.
 fn capture_guest_forensics(data_dir: &Path, image: &str) {
+    // Dump the in-guest sampler's timeline first — it covers the freeze
+    // onset retroactively, so it has no live-window race at all.
+    if std::env::var_os("ARCBOX_E2E_GUEST_SAMPLER").is_some() {
+        match docker_output(
+            data_dir,
+            &["logs", "--tail", "400", "abx423-sampler"],
+            Duration::from_secs(30),
+        ) {
+            Ok(out) => tracing::info!("guest sampler timeline:\n{}", out.trim_end()),
+            Err(error) => tracing::warn!("guest sampler read failed: {error:#}"),
+        }
+    }
+
     // ABX-423 mitigation experiment (ARCBOX_E2E_TRY_LINK_BOUNCE): FIRST in
     // the sequence — the freeze often ends ~30 s after onset, and the other
     // probes would eat the remaining live window. Tries guest-side recovery

--- a/tests/e2e/tests/egress_throughput.rs
+++ b/tests/e2e/tests/egress_throughput.rs
@@ -1,0 +1,201 @@
+//! Sustained-egress regression e2e (container→external download black hole).
+//!
+//! The incident: multi-MB container downloads from fast CDNs stalled
+//! permanently mid-transfer (~40-100% of attempts), while the same URL
+//! downloaded fine on the host. Root cause: the TCP shim terminates guest
+//! connections and re-injects host→guest data over the VZ socketpair with
+//! no retransmission; under sustained throughput the socketpair overflowed
+//! (macOS `ENOBUFS`) and frames were dropped — a permanent sequence gap.
+//!
+//! This scenario reproduces the shape without external network dependence:
+//! a host-local HTTP server serves large blobs, and a container downloads
+//! them through the full egress datapath (guest eth0 → classifier →
+//! TcpBridge fast path → host socket). Loopback burst rates exceed any CDN,
+//! so the backpressure path is exercised harder than the original repro.
+//! Every download must complete; a stall means frames were lost.
+
+use std::io::{Read, Write};
+use std::net::TcpListener;
+use std::path::Path;
+use std::sync::Once;
+use std::time::Duration;
+
+use anyhow::{Context, Result};
+use arcbox_e2e::boot_assets::{resolve_boot_version, stage_dev_boot_assets};
+use arcbox_e2e::daemon::{DaemonConfig, DaemonHandle};
+use arcbox_e2e::docker::{docker_output, ensure_image};
+use arcbox_e2e::metrics::RunMetrics;
+
+static TRACING: Once = Once::new();
+
+const READY_TIMEOUT: Duration = Duration::from_secs(180);
+/// Blob size per download. Large enough to sustain a multi-second transfer
+/// (the original stalls hit within the first ~64 KB..few MB).
+const BLOB_BYTES: usize = 64 * 1024 * 1024;
+/// Number of sequential downloads. The pre-fix stall rate was ~40-100% per
+/// attempt, so several consecutive successes give strong signal.
+const DOWNLOADS: usize = 6;
+/// Ceiling for one in-container download (loopback moves 64 MB in seconds;
+/// generous slack for slow CI hosts).
+const DOWNLOAD_TIMEOUT: Duration = Duration::from_secs(120);
+/// Gateway IP the guest sees on its primary (userspace-netstack) NIC.
+/// TcpBridge translates connections targeting it to host `127.0.0.1`
+/// (the `host.docker.internal` mechanism), which is exactly the datapath
+/// under test.
+const GUEST_GATEWAY_IP: &str = "10.0.2.1";
+
+fn init_tracing() {
+    TRACING.call_once(|| {
+        let _ = tracing_subscriber::fmt()
+            .with_env_filter(
+                tracing_subscriber::EnvFilter::try_from_default_env()
+                    .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info")),
+            )
+            .try_init();
+    });
+}
+
+/// Serves `BLOB_BYTES` of zeroes for any HTTP request, one thread per
+/// connection, until the process exits. Returns the bound port.
+fn spawn_blob_server() -> Result<u16> {
+    let listener = TcpListener::bind("127.0.0.1:0").context("binding blob server")?;
+    let port = listener.local_addr()?.port();
+    std::thread::spawn(move || {
+        for stream in listener.incoming() {
+            let Ok(mut stream) = stream else { continue };
+            std::thread::spawn(move || {
+                // Read the request until the header terminator (or EOF).
+                let mut buf = [0u8; 4096];
+                let mut request = Vec::new();
+                loop {
+                    match stream.read(&mut buf) {
+                        Ok(0) => return,
+                        Ok(n) => {
+                            request.extend_from_slice(&buf[..n]);
+                            if request.windows(4).any(|w| w == b"\r\n\r\n") {
+                                break;
+                            }
+                        }
+                        Err(_) => return,
+                    }
+                }
+                let header = format!(
+                    "HTTP/1.1 200 OK\r\nContent-Length: {BLOB_BYTES}\r\nConnection: close\r\n\r\n"
+                );
+                if stream.write_all(header.as_bytes()).is_err() {
+                    return;
+                }
+                let chunk = vec![0u8; 64 * 1024];
+                let mut remaining = BLOB_BYTES;
+                while remaining > 0 {
+                    let n = remaining.min(chunk.len());
+                    if stream.write_all(&chunk[..n]).is_err() {
+                        return;
+                    }
+                    remaining -= n;
+                }
+            });
+        }
+    });
+    Ok(port)
+}
+
+#[test]
+#[ignore = "boots a VZ System VM through a real daemon and drives sustained egress downloads"]
+fn sustained_egress_downloads_do_not_stall() -> Result<()> {
+    init_tracing();
+
+    let root = arcbox_e2e::repo_root();
+    if !arcbox_e2e::env_flag("SKIP_BUILD") {
+        let shell = xshell::Shell::new()?;
+        shell.change_dir(&root);
+        xshell::cmd!(shell, "cargo build --release -p arcbox-daemon").run()?;
+    }
+
+    let version = resolve_boot_version(&root)?;
+    let data_dir = tempfile::Builder::new()
+        .prefix("arcbox-egress-throughput-")
+        .tempdir()?;
+    stage_dev_boot_assets(&root, data_dir.path(), &version)?;
+
+    let mut daemon = DaemonHandle::spawn(DaemonConfig {
+        binary: root.join("target/release/arcbox-daemon"),
+        data_dir: data_dir.path().to_owned(),
+        args: vec![],
+        env: vec![
+            ("ARCBOX_BOOT_ASSET_VERSION".to_owned(), version),
+            ("ARCBOX_VM_BACKEND".to_owned(), "vz".to_owned()),
+            // Avoid the host DNS service port (5553) so this test daemon can
+            // run alongside a developer's live daemon.
+            ("ARCBOX_DNS_PORT".to_owned(), "15553".to_owned()),
+        ],
+    })?;
+
+    let mut metrics = RunMetrics::new("egress_throughput", Some("vz"));
+    let result = scenario(&mut daemon, data_dir.path(), &mut metrics);
+    metrics.passed = result.is_ok();
+    if let Err(error) = metrics.write(Some(data_dir.path())) {
+        tracing::warn!("writing run metrics failed: {error:#}");
+    }
+    if result.is_err() {
+        let kept = data_dir.keep();
+        tracing::warn!(path = %kept.display(), "preserving test directory");
+    }
+    result
+}
+
+fn scenario(daemon: &mut DaemonHandle, data_dir: &Path, metrics: &mut RunMetrics) -> Result<()> {
+    metrics.time("daemon_ready", || daemon.wait_ready_blocking(READY_TIMEOUT))?;
+
+    let image = std::env::var("ARCBOX_E2E_IMAGE").unwrap_or_else(|_| "alpine:latest".to_owned());
+    metrics.time("docker_pull", || ensure_image(data_dir, &image))?;
+
+    let port = spawn_blob_server()?;
+    let url = format!("http://{GUEST_GATEWAY_IP}:{port}/blob");
+    tracing::info!(%url, blob_mb = BLOB_BYTES / (1024 * 1024), "blob server up");
+
+    run_downloads(data_dir, metrics, &image, &url, "download")?;
+
+    // Optional second phase: a real external URL (e.g. a fast CDN, possibly
+    // through a host VPN). Environment-dependent, so never run in CI — set
+    // ARCBOX_E2E_EGRESS_URL to enable during manual validation.
+    if let Ok(external) = std::env::var("ARCBOX_E2E_EGRESS_URL") {
+        tracing::info!(url = %external, "external egress phase");
+        run_downloads(data_dir, metrics, &image, &external, "external_download")?;
+    }
+
+    Ok(())
+}
+
+fn run_downloads(
+    data_dir: &Path,
+    metrics: &mut RunMetrics,
+    image: &str,
+    url: &str,
+    label_prefix: &str,
+) -> Result<()> {
+    for attempt in 1..=DOWNLOADS {
+        let label = format!("{label_prefix}_{attempt}");
+        metrics.time(&label, || {
+            docker_output(
+                data_dir,
+                &[
+                    "run",
+                    "--rm",
+                    image,
+                    "wget",
+                    "-q",
+                    "-O",
+                    "/dev/null",
+                    "-T",
+                    "60",
+                    url,
+                ],
+                DOWNLOAD_TIMEOUT,
+            )
+            .with_context(|| format!("{label_prefix} {attempt}/{DOWNLOADS} stalled or failed"))
+        })?;
+        tracing::info!(attempt, label_prefix, "download completed");
+    }
+    Ok(())
+}

--- a/tests/e2e/tests/egress_throughput.rs
+++ b/tests/e2e/tests/egress_throughput.rs
@@ -315,6 +315,52 @@ fn sample_daemon(data_dir: &Path, pid: u32) {
 /// interface addresses, and small-transfer probes that distinguish a total
 /// datapath freeze from a per-connection loss.
 fn capture_guest_forensics(data_dir: &Path, image: &str) {
+    // ABX-423 mitigation experiment (ARCBOX_E2E_TRY_LINK_BOUNCE): FIRST in
+    // the sequence — the freeze often ends ~30 s after onset, and the other
+    // probes would eat the remaining live window. Tries guest-side recovery
+    // actions in escalating order — a link bounce (NAPI/queue re-enable)
+    // and a virtio driver unbind/rebind (full device reset + feature
+    // renegotiation), statically reconfiguring eth0 after each. If either
+    // revives the datapath in seconds, an agent-side watchdog becomes a
+    // shippable mitigation.
+    if std::env::var_os("ARCBOX_E2E_TRY_LINK_BOUNCE").is_some() {
+        let script = r#"
+probe() { wget -q -O /dev/null -T 3 http://10.0.2.1:9/ 2>&1 | grep -q "timed out" && echo "$1: FROZEN" || echo "$1: alive"; }
+restore() { ip link set eth0 up; ip addr replace 10.0.2.2/24 dev eth0; ip route replace default via 10.0.2.1 dev eth0; }
+echo "t=$(date +%s)"
+if ! probe baseline | tee /dev/stderr | grep -q FROZEN; then
+  echo "freeze already over; skipping recovery actions"
+  exit 0
+fi
+ip link set eth0 down; restore; sleep 1
+echo "t=$(date +%s)"; probe after-link-bounce
+d=$(basename $(dirname $(dirname $(ls -d /sys/bus/virtio/devices/*/net/eth0 2>/dev/null | head -1))))
+if [ -n "$d" ]; then
+  echo "$d" > /sys/bus/virtio/drivers/virtio_net/unbind; sleep 1
+  echo "$d" > /sys/bus/virtio/drivers/virtio_net/bind; sleep 1
+  restore
+  echo "t=$(date +%s)"; probe after-driver-rebind
+fi
+"#;
+        match docker_output(
+            data_dir,
+            &[
+                "run",
+                "--rm",
+                "--net=host",
+                "--privileged",
+                image,
+                "sh",
+                "-c",
+                script,
+            ],
+            Duration::from_secs(60),
+        ) {
+            Ok(out) => tracing::info!("link-bounce experiment:\n{}", out.trim_end()),
+            Err(error) => tracing::warn!("link-bounce experiment failed: {error:#}"),
+        }
+    }
+
     // Two eth0 counter samples 2 s apart: tx_packets advancing while the
     // datapath sees nothing means the guest transmits into a black hole
     // (VZ consuming and dropping); frozen tx_packets means the guest-side

--- a/tests/e2e/tests/egress_throughput.rs
+++ b/tests/e2e/tests/egress_throughput.rs
@@ -1,18 +1,27 @@
 //! Sustained-egress regression e2e (container→external download black hole).
 //!
 //! The incident: multi-MB container downloads from fast CDNs stalled
-//! permanently mid-transfer (~40-100% of attempts), while the same URL
-//! downloaded fine on the host. Root cause: the TCP shim terminates guest
-//! connections and re-injects host→guest data over the VZ socketpair with
-//! no retransmission; under sustained throughput the socketpair overflowed
-//! (macOS `ENOBUFS`) and frames were dropped — a permanent sequence gap.
+//! permanently (~40-100% of attempts), while the same URL downloaded fine
+//! on the host. Two distinct defects produced the shape:
 //!
-//! This scenario reproduces the shape without external network dependence:
-//! a host-local HTTP server serves large blobs, and a container downloads
-//! them through the full egress datapath (guest eth0 → classifier →
-//! TcpBridge fast path → host socket). Loopback burst rates exceed any CDN,
-//! so the backpressure path is exercised harder than the original repro.
-//! Every download must complete; a stall means frames were lost.
+//! 1. **Frame drops under backpressure** (fixed): the TCP shim terminates
+//!    guest connections and never retransmits, and the socketpair write
+//!    path dropped frames on `ENOBUFS`/queue-cap — a permanent sequence
+//!    gap. Covered by the `GuestTx` lossless contract; the delivery
+//!    counters in the daemon log must stay at zero drops during this test.
+//! 2. **VZ virtio-net freeze** (open, ABX-420): the device stops moving
+//!    frames in both directions for ~60-75 s and self-heals — during the
+//!    freeze the socketpair is empty, guest routing is intact, and no
+//!    guest kernel errors appear. Reproduces here on roughly 1 in 5
+//!    downloads, so this scenario currently FAILS intermittently; the
+//!    forensics it captures (eth0 counter deltas, recovery-time probe,
+//!    delivery counters) are the post-mortem record for the hunt.
+//!
+//! The scenario needs no external network: a host-local HTTP server serves
+//! large blobs and a container downloads them through the full egress
+//! datapath (guest eth0 → classifier → TcpBridge fast path → host socket)
+//! via the gateway-IP→loopback translation, which also regression-tests
+//! `host.docker.internal` staying direct under a configured system proxy.
 
 use std::io::{Read, Write};
 use std::net::TcpListener;
@@ -128,6 +137,12 @@ fn sustained_egress_downloads_do_not_stall() -> Result<()> {
             // Avoid the host DNS service port (5553) so this test daemon can
             // run alongside a developer's live daemon.
             ("ARCBOX_DNS_PORT".to_owned(), "15553".to_owned()),
+            // Per-SYN datapath tracing: stall forensics need the gated-SYN,
+            // handshake-retransmit, and RST decisions, which log at debug.
+            (
+                "RUST_LOG".to_owned(),
+                "info,arcbox_net=debug,splicetcp=debug".to_owned(),
+            ),
         ],
     })?;
 
@@ -167,6 +182,9 @@ fn scenario(daemon: &mut DaemonHandle, data_dir: &Path, metrics: &mut RunMetrics
     Ok(())
 }
 
+/// Runs all `DOWNLOADS` attempts (not aborting on the first stall, so the
+/// failure pattern is visible), captures guest-side forensics after any
+/// failure, and errors if any attempt stalled.
 fn run_downloads(
     data_dir: &Path,
     metrics: &mut RunMetrics,
@@ -174,9 +192,10 @@ fn run_downloads(
     url: &str,
     label_prefix: &str,
 ) -> Result<()> {
+    let mut failures = Vec::new();
     for attempt in 1..=DOWNLOADS {
         let label = format!("{label_prefix}_{attempt}");
-        metrics.time(&label, || {
+        let result = metrics.time(&label, || {
             docker_output(
                 data_dir,
                 &[
@@ -193,9 +212,121 @@ fn run_downloads(
                 ],
                 DOWNLOAD_TIMEOUT,
             )
-            .with_context(|| format!("{label_prefix} {attempt}/{DOWNLOADS} stalled or failed"))
-        })?;
-        tracing::info!(attempt, label_prefix, "download completed");
+        });
+        match result {
+            Ok(_) => tracing::info!(attempt, label_prefix, "download completed"),
+            Err(error) => {
+                tracing::warn!(attempt, label_prefix, "download stalled: {error:#}");
+                if failures.is_empty() {
+                    capture_guest_forensics(data_dir, image);
+                }
+                failures.push(attempt);
+            }
+        }
     }
-    Ok(())
+    if failures.is_empty() {
+        Ok(())
+    } else {
+        anyhow::bail!("{label_prefix}: attempts {failures:?} of {DOWNLOADS} stalled")
+    }
+}
+
+/// Captures guest network state right after a stall: routing table,
+/// interface addresses, and small-transfer probes that distinguish a total
+/// datapath freeze from a per-connection loss.
+fn capture_guest_forensics(data_dir: &Path, image: &str) {
+    // Two eth0 counter samples 2 s apart: tx_packets advancing while the
+    // datapath sees nothing means the guest transmits into a black hole
+    // (VZ consuming and dropping); frozen tx_packets means the guest-side
+    // virtio TX queue is wedged (VZ not consuming the ring).
+    let eth0_stats = "for f in tx_packets rx_packets tx_dropped rx_dropped; do \
+         echo \"$f=$(cat /sys/class/net/eth0/statistics/$f)\"; done; \
+         sleep 2; echo ---; \
+         for f in tx_packets rx_packets tx_dropped rx_dropped; do \
+         echo \"$f=$(cat /sys/class/net/eth0/statistics/$f)\"; done";
+    let probes: [(&str, &[&str]); 4] = [
+        (
+            "ip route",
+            &["run", "--rm", "--net=host", image, "ip", "route"],
+        ),
+        (
+            "eth0 stats (2 samples, 2s apart)",
+            &["run", "--rm", "--net=host", image, "sh", "-c", eth0_stats],
+        ),
+        (
+            "ping gateway",
+            &[
+                "run",
+                "--rm",
+                image,
+                "ping",
+                "-c",
+                "2",
+                "-W",
+                "3",
+                GUEST_GATEWAY_IP,
+            ],
+        ),
+        (
+            "small http probe",
+            &[
+                "run",
+                "--rm",
+                image,
+                "wget",
+                "-q",
+                "-O",
+                "/dev/null",
+                "-T",
+                "5",
+                "http://10.0.2.1:80/",
+            ],
+        ),
+    ];
+    for (name, args) in probes {
+        match docker_output(data_dir, args, Duration::from_secs(30)) {
+            Ok(out) => tracing::info!(probe = name, "forensics:\n{}", out.trim_end()),
+            Err(error) => tracing::warn!(probe = name, "forensics probe failed: {error:#}"),
+        }
+    }
+
+    // Measure the freeze duration: retry a tiny gateway probe until the
+    // datapath answers again (connection refused counts as alive — an RST
+    // made the round trip).
+    let started = std::time::Instant::now();
+    for _ in 0..30 {
+        let alive = match docker_output(
+            data_dir,
+            &[
+                "run",
+                "--rm",
+                image,
+                "wget",
+                "-q",
+                "-O",
+                "/dev/null",
+                "-T",
+                "3",
+                "http://10.0.2.1:9/",
+            ],
+            Duration::from_secs(20),
+        ) {
+            Ok(_) => true,
+            Err(error) => {
+                let msg = format!("{error:#}");
+                !msg.contains("timed out") && !msg.contains("timeout")
+            }
+        };
+        if alive {
+            tracing::info!(
+                elapsed_secs = started.elapsed().as_secs(),
+                "datapath recovered (probe answered)"
+            );
+            return;
+        }
+    }
+    tracing::warn!(
+        elapsed_secs = started.elapsed().as_secs(),
+        "datapath still frozen after probe window"
+    );
 }

--- a/tests/e2e/tests/egress_throughput.rs
+++ b/tests/e2e/tests/egress_throughput.rs
@@ -127,6 +127,15 @@ fn sustained_egress_downloads_do_not_stall() -> Result<()> {
         .tempdir()?;
     stage_dev_boot_assets(&root, data_dir.path(), &version)?;
 
+    // Probe a free port for the daemon's host DNS service so this test can
+    // run alongside a developer's live daemon (fixed 5553) and parallel
+    // test runs. The bind is dropped before the daemon starts — a benign
+    // TOCTOU for a test harness.
+    let dns_port = std::net::UdpSocket::bind("127.0.0.1:0")
+        .and_then(|s| s.local_addr())
+        .context("probing a free DNS port")?
+        .port();
+
     let mut daemon = DaemonHandle::spawn(DaemonConfig {
         binary: root.join("target/release/arcbox-daemon"),
         data_dir: data_dir.path().to_owned(),
@@ -134,9 +143,7 @@ fn sustained_egress_downloads_do_not_stall() -> Result<()> {
         env: vec![
             ("ARCBOX_BOOT_ASSET_VERSION".to_owned(), version),
             ("ARCBOX_VM_BACKEND".to_owned(), "vz".to_owned()),
-            // Avoid the host DNS service port (5553) so this test daemon can
-            // run alongside a developer's live daemon.
-            ("ARCBOX_DNS_PORT".to_owned(), "15553".to_owned()),
+            ("ARCBOX_DNS_PORT".to_owned(), dns_port.to_string()),
             // Per-SYN datapath tracing: stall forensics need the gated-SYN,
             // handshake-retransmit, and RST decisions, which log at debug.
             (
@@ -169,14 +176,53 @@ fn scenario(daemon: &mut DaemonHandle, data_dir: &Path, metrics: &mut RunMetrics
     let url = format!("http://{GUEST_GATEWAY_IP}:{port}/blob");
     tracing::info!(%url, blob_mb = BLOB_BYTES / (1024 * 1024), "blob server up");
 
-    run_downloads(data_dir, metrics, &image, &url, "download")?;
+    // ABX-423 experiment (ARCBOX_E2E_CANARY_PING): a 1 Hz gateway pinger
+    // running for the whole scenario forces a guest virtio-net TX kick every
+    // second. If a guest-side kick revives the frozen device, stalls shrink
+    // from ~60-75 s to ~1-2 s and downloads stop failing.
+    let canary = std::env::var_os("ARCBOX_E2E_CANARY_PING").is_some();
+    if canary {
+        docker_output(
+            data_dir,
+            &[
+                "run",
+                "-d",
+                "--name",
+                "abx423-canary",
+                &image,
+                "ping",
+                "-i",
+                "1",
+                GUEST_GATEWAY_IP,
+            ],
+            Duration::from_secs(30),
+        )
+        .context("starting canary pinger")?;
+        tracing::info!("canary pinger started (1 Hz guest TX kicks)");
+    }
+
+    let downloads = run_downloads(data_dir, metrics, &image, &url, "download", daemon.pid());
+    if canary {
+        arcbox_e2e::docker::docker_ignore(
+            data_dir,
+            &["rm".into(), "-f".into(), "abx423-canary".into()],
+        );
+    }
+    downloads?;
 
     // Optional second phase: a real external URL (e.g. a fast CDN, possibly
     // through a host VPN). Environment-dependent, so never run in CI — set
     // ARCBOX_E2E_EGRESS_URL to enable during manual validation.
     if let Ok(external) = std::env::var("ARCBOX_E2E_EGRESS_URL") {
         tracing::info!(url = %external, "external egress phase");
-        run_downloads(data_dir, metrics, &image, &external, "external_download")?;
+        run_downloads(
+            data_dir,
+            metrics,
+            &image,
+            &external,
+            "external_download",
+            daemon.pid(),
+        )?;
     }
 
     Ok(())
@@ -191,7 +237,16 @@ fn run_downloads(
     image: &str,
     url: &str,
     label_prefix: &str,
+    daemon_pid: u32,
 ) -> Result<()> {
+    // Default 60 s tolerates slow CI. The ABX-423 hunt sets a short timeout
+    // (e.g. 15 s) so a stall is detected while the ~60-75 s freeze is still
+    // live and the forensics below observe it, not its aftermath.
+    let wget_timeout = std::env::var("ARCBOX_E2E_WGET_TIMEOUT_SECS")
+        .ok()
+        .and_then(|v| v.parse::<u32>().ok())
+        .unwrap_or(60)
+        .to_string();
     let mut failures = Vec::new();
     for attempt in 1..=DOWNLOADS {
         let label = format!("{label_prefix}_{attempt}");
@@ -207,7 +262,7 @@ fn run_downloads(
                     "-O",
                     "/dev/null",
                     "-T",
-                    "60",
+                    &wget_timeout,
                     url,
                 ],
                 DOWNLOAD_TIMEOUT,
@@ -218,6 +273,10 @@ fn run_downloads(
             Err(error) => {
                 tracing::warn!(attempt, label_prefix, "download stalled: {error:#}");
                 if failures.is_empty() {
+                    // Thread census FIRST — the freeze may end within seconds
+                    // of the wget timeout, and the VZ-internal thread states
+                    // are the most perishable evidence.
+                    sample_daemon(data_dir, daemon_pid);
                     capture_guest_forensics(data_dir, image);
                 }
                 failures.push(attempt);
@@ -228,6 +287,27 @@ fn run_downloads(
         Ok(())
     } else {
         anyhow::bail!("{label_prefix}: attempts {failures:?} of {DOWNLOADS} stalled")
+    }
+}
+
+/// Samples the daemon's threads (Virtualization.framework internals
+/// included) into `<data_dir>/freeze-sample.txt` — the ABX-423 hunt's view
+/// into where Apple's file-handle device threads are parked during a
+/// freeze.
+fn sample_daemon(data_dir: &Path, pid: u32) {
+    let out = data_dir.join("freeze-sample.txt");
+    match std::process::Command::new("sample")
+        .args([&pid.to_string(), "2", "-file", &out.display().to_string()])
+        .output()
+    {
+        Ok(o) if o.status.success() => {
+            tracing::info!(path = %out.display(), "daemon thread sample captured");
+        }
+        Ok(o) => tracing::warn!(
+            "sample failed: {}",
+            String::from_utf8_lossy(&o.stderr).trim_end()
+        ),
+        Err(e) => tracing::warn!("sample not available: {e}"),
     }
 }
 

--- a/tests/e2e/tests/idle_balloon.rs
+++ b/tests/e2e/tests/idle_balloon.rs
@@ -27,7 +27,7 @@ use std::time::{Duration, Instant};
 use anyhow::{Context, Result, bail};
 use arcbox_e2e::boot_assets::{resolve_boot_version, stage_dev_boot_assets};
 use arcbox_e2e::daemon::{DaemonConfig, DaemonHandle};
-use arcbox_e2e::docker::{docker_output, docker_stream};
+use arcbox_e2e::docker::{docker_output, docker_stream, ensure_image};
 use arcbox_e2e::metrics::RunMetrics;
 
 static TRACING: Once = Once::new();
@@ -236,49 +236,6 @@ fn scenario(daemon: &mut DaemonHandle, data_dir: &Path, metrics: &mut RunMetrics
 
     docker_output(data_dir, &["rm", "-f", "ballast"], DOCKER_ATTEMPT).ok();
     Ok(())
-}
-
-/// Makes `image` available in the daemon under test, without depending on
-/// registry reachability more than once per machine: the first successful
-/// pull is cached as a tarball under `target/`, and later runs `docker load`
-/// it (guest registry access is environment-dependent; pulls here have been
-/// observed to black-hole intermittently).
-fn ensure_image(data_dir: &Path, image: &str) -> Result<()> {
-    let cache_dir = arcbox_e2e::repo_root().join("target/e2e-image-cache");
-    let tar = cache_dir.join(format!(
-        "{}.tar",
-        image.replace(['/', ':'], "_").replace('.', "-")
-    ));
-    if tar.exists() {
-        docker_output(
-            data_dir,
-            &["load", "-i", &tar.display().to_string()],
-            Duration::from_secs(60),
-        )
-        .context("docker load from cache")?;
-        return Ok(());
-    }
-
-    let mut last_err = None;
-    for attempt in 1..=3 {
-        match docker_output(data_dir, &["pull", image], Duration::from_secs(90)) {
-            Ok(_) => {
-                std::fs::create_dir_all(&cache_dir)?;
-                docker_output(
-                    data_dir,
-                    &["save", "-o", &tar.display().to_string(), image],
-                    Duration::from_secs(60),
-                )
-                .context("docker save to cache")?;
-                return Ok(());
-            }
-            Err(e) => {
-                tracing::warn!(attempt, "docker pull failed: {e:#}");
-                last_err = Some(e);
-            }
-        }
-    }
-    Err(last_err.unwrap()).context("docker pull (3 attempts)")
 }
 
 /// The daemon's own rotating log (structured JSON lines).

--- a/virt/arcbox-net/src/darwin/datapath_loop/guest_tx.rs
+++ b/virt/arcbox-net/src/darwin/datapath_loop/guest_tx.rs
@@ -108,6 +108,8 @@ pub(super) struct GuestTxStats {
     pub gated_polls: u64,
     /// High-water mark of the pending queue.
     pub queue_high_water: usize,
+    /// Frames successfully written to the guest FD (or inject sink).
+    pub tx_frames: u64,
 }
 
 /// Outcome of a single non-blocking write attempt.
@@ -179,7 +181,9 @@ impl GuestTx {
             // Inject-thread path (HV): bounded channel, drop-on-full.
             // TODO(ABX-420): reliable frames need the lossless contract on
             // this path too; count failures so post-mortems can see them.
-            if !sink.send(frame.to_vec()) {
+            if sink.send(frame.to_vec()) {
+                self.stats.tx_frames += 1;
+            } else {
                 self.stats.sink_send_failures += 1;
                 tracing::debug!("Guest frame sink full, frame dropped ({class:?})");
             }
@@ -227,7 +231,10 @@ impl GuestTx {
     /// Attempts one non-blocking write of `frame` to `guest_fd`.
     fn try_write(&mut self, guest_fd: RawFd, frame: &[u8]) -> WriteOutcome {
         match fd_write(guest_fd, frame) {
-            Ok(n) if n >= frame.len() => WriteOutcome::Consumed,
+            Ok(n) if n >= frame.len() => {
+                self.stats.tx_frames += 1;
+                WriteOutcome::Consumed
+            }
             Ok(n) => {
                 // SOCK_DGRAM delivers whole datagrams or fails — a short
                 // write indicates a broken invariant. The partial frame is
@@ -264,12 +271,17 @@ impl GuestTx {
 
     /// Logs a delivery-counter snapshot. Called from the maintenance tick;
     /// a backlog that persists across consecutive reports indicates a
-    /// wedged drain (post-mortem signal, see ABX-420).
-    pub(super) fn log_stats(&self) {
+    /// wedged drain, and `tx_frames` advancing while a connection is
+    /// stalled means frames vanish beyond the socketpair (post-mortem
+    /// signals, see ABX-420). `rx_frames` counts guest→host frames read by
+    /// the loop, to spot one-directional freezes.
+    pub(super) fn log_stats(&self, rx_frames: u64) {
         let s = &self.stats;
         tracing::info!(
             queue_len = self.queue.len(),
             blocked = ?self.blocked,
+            tx_frames = s.tx_frames,
+            rx_frames,
             enobufs = s.enobufs_events,
             would_block = s.would_block_events,
             lossy_dropped = s.lossy_dropped,

--- a/virt/arcbox-net/src/darwin/datapath_loop/guest_tx.rs
+++ b/virt/arcbox-net/src/darwin/datapath_loop/guest_tx.rs
@@ -45,9 +45,15 @@ use super::intercept::process_inbound_cmd;
 
 /// Cap on queued [`DeliveryClass::Lossy`] frames. Datagram replies are small
 /// and loss-recoverable; bounding them keeps a stalled guest FD from growing
-/// the queue without bound. Reliable frames are not capped — their producers
-/// are gated on [`GuestTx::has_backlog`], which bounds the backlog to one
-/// event-loop iteration of bulk production.
+/// the queue without bound. Reliable frames are not capped: the bulk
+/// producer (fast-path host-socket reads) is gated on
+/// [`GuestTx::has_backlog`], bounding it to one event-loop iteration, while
+/// the remaining reliable producers (ACKs, handshake frames, RSTs) are
+/// reactive — they only emit in response to guest activity, which itself
+/// stops when the guest FD is wedged. This is a deliberate
+/// memory-vs-correctness tradeoff: a dropped TCP-shim frame is a permanent
+/// connection stall, and `queue_high_water` records how close the practical
+/// bound comes.
 pub(super) const LOSSY_QUEUE_CAP: usize = 1024;
 
 /// Retry interval for a queue blocked on `ENOBUFS`. The VZ reader drains the

--- a/virt/arcbox-net/src/darwin/datapath_loop/guest_tx.rs
+++ b/virt/arcbox-net/src/darwin/datapath_loop/guest_tx.rs
@@ -153,14 +153,19 @@ impl GuestTx {
         !self.queue.is_empty()
     }
 
-    /// True when draining should resume on `AsyncFd::writable()`.
+    /// True when draining can additionally resume on `AsyncFd::writable()`
+    /// (`EAGAIN`-blocked). The retry timer remains armed as a fallback —
+    /// kqueue write-readiness has not proven trustworthy for a datagram
+    /// socketpair, and a missed edge here would wedge all guest-bound
+    /// traffic permanently.
     pub(super) fn awaits_writable(&self) -> bool {
         self.has_backlog() && self.blocked == Some(WriteBlock::WouldBlock)
     }
 
-    /// True when draining should resume on the [`NOBUFS_RETRY_DELAY`] timer.
+    /// True when the [`NOBUFS_RETRY_DELAY`] timer should drive drain
+    /// attempts: any pending backlog, regardless of which errno blocked it.
     pub(super) fn awaits_retry(&self) -> bool {
-        self.has_backlog() && self.blocked == Some(WriteBlock::NoBufs)
+        self.has_backlog()
     }
 
     /// Sends one frame to the guest.
@@ -255,6 +260,26 @@ impl GuestTx {
     fn push(&mut self, frame: &[u8]) {
         self.queue.push_back(FrameBuf::from(frame.to_vec()));
         self.stats.queue_high_water = self.stats.queue_high_water.max(self.queue.len());
+    }
+
+    /// Logs a delivery-counter snapshot. Called from the maintenance tick;
+    /// a backlog that persists across consecutive reports indicates a
+    /// wedged drain (post-mortem signal, see ABX-420).
+    pub(super) fn log_stats(&self) {
+        let s = &self.stats;
+        tracing::info!(
+            queue_len = self.queue.len(),
+            blocked = ?self.blocked,
+            enobufs = s.enobufs_events,
+            would_block = s.would_block_events,
+            lossy_dropped = s.lossy_dropped,
+            short_writes = s.short_writes,
+            io_errors = s.io_errors,
+            sink_send_failures = s.sink_send_failures,
+            gated_polls = s.gated_polls,
+            queue_high_water = s.queue_high_water,
+            "guest-tx delivery counters"
+        );
     }
 }
 

--- a/virt/arcbox-net/src/darwin/datapath_loop/guest_tx.rs
+++ b/virt/arcbox-net/src/darwin/datapath_loop/guest_tx.rs
@@ -1,23 +1,59 @@
+//! Guest-bound frame sink for the datapath loop.
+//!
+//! All frames destined for the guest go through [`GuestTx`], classified by
+//! delivery semantics:
+//!
+//! - [`DeliveryClass::Reliable`] — TCP-shim frames (handshake, data, ACK,
+//!   FIN, RST). The shim terminates TCP and never retransmits payload, so a
+//!   dropped frame is a permanent sequence gap: the guest dup-ACKs forever
+//!   and the connection stalls. These frames are **never dropped** — when
+//!   the socketpair is full they queue, and the event loop gates bulk
+//!   production ([`GuestTx::has_backlog`]) so host sockets stop being read,
+//!   which propagates backpressure to the remote sender through the host
+//!   kernel's TCP receive window.
+//! - [`DeliveryClass::Lossy`] — datagram-semantics frames (ARP, DHCP, DNS,
+//!   UDP, ICMP replies). The protocol above recovers from loss; bounded
+//!   queue overflow drops them.
+//!
+//! # macOS socketpair overflow semantics
+//!
+//! When the VZ side of the `SOCK_DGRAM` socketpair stops draining (guest RX
+//! ring full, VM paused), `write(2)` fails with `ENOBUFS` — not `EAGAIN` —
+//! because AF_UNIX datagram sends append directly to the peer's receive
+//! buffer. kqueue write-readiness does not reliably signal the transition
+//! back to writable in that state, so an ENOBUFS-blocked queue is drained by
+//! a short retry timer ([`NOBUFS_RETRY_DELAY`]) instead of
+//! `AsyncFd::writable()`; an `EAGAIN`-blocked queue uses write-readiness.
+
 use std::collections::VecDeque;
 use std::io;
 use std::net::Ipv4Addr;
-use std::os::fd::AsRawFd;
+use std::os::fd::RawFd;
+use std::sync::Arc;
+use std::time::Duration;
 
-use tokio::io::unix::AsyncFd;
 use tokio::sync::mpsc;
 
 use crate::darwin::egress::HostEgress;
 use crate::darwin::inbound_relay::InboundCommand;
 use crate::darwin::tcp_bridge::TcpBridge;
 use crate::datapath::FrameBuf;
+use crate::direct_rx::FrameSink;
 
-use super::fd::{FdWrapper, fd_write};
+use super::fd::fd_write;
 use super::intercept::process_inbound_cmd;
 
-/// Hard cap on write_queue depth. Frames beyond this are dropped to prevent
-/// unbounded memory growth when the guest FD is blocked (VM paused, VZ socket
-/// buffer full). Increased from 2048 to 8192 to match 8 MB socket buffers.
-const WRITE_QUEUE_HARD_CAP: usize = 8192;
+/// Cap on queued [`DeliveryClass::Lossy`] frames. Datagram replies are small
+/// and loss-recoverable; bounding them keeps a stalled guest FD from growing
+/// the queue without bound. Reliable frames are not capped — their producers
+/// are gated on [`GuestTx::has_backlog`], which bounds the backlog to one
+/// event-loop iteration of bulk production.
+pub(super) const LOSSY_QUEUE_CAP: usize = 1024;
+
+/// Retry interval for a queue blocked on `ENOBUFS`. The VZ reader drains the
+/// socketpair continuously, so capacity typically returns within
+/// microseconds; 1 ms bounds the added latency without spinning the loop.
+pub(super) const NOBUFS_RETRY_DELAY: Duration = Duration::from_millis(1);
 
 /// Maximum number of reply frames to drain per call, preventing a single
 /// drain from starving other `select!` branches under high traffic.
@@ -29,6 +65,199 @@ const DRAIN_REPLY_BATCH: usize = 64;
 /// still guaranteeing forward progress when `cmd_rx.recv()` is starved.
 const DRAIN_CMD_BATCH: usize = 64;
 
+/// Delivery semantics of a guest-bound frame. See the module docs.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum DeliveryClass {
+    /// TCP-shim frame: must never be dropped (no retransmitter exists).
+    Reliable,
+    /// Datagram-semantics frame: may be dropped under overload.
+    Lossy,
+}
+
+/// Why the guest FD rejected the last write, and therefore which event
+/// resumes draining.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum WriteBlock {
+    /// `EAGAIN` — resume on `AsyncFd::writable()`.
+    WouldBlock,
+    /// `ENOBUFS` — resume on the [`NOBUFS_RETRY_DELAY`] timer.
+    NoBufs,
+}
+
+/// Counters for guest-bound frame delivery. Reliable frames have no drop
+/// path by construction; everything that can go wrong is counted here.
+#[derive(Debug, Default)]
+pub(super) struct GuestTxStats {
+    /// Lossy frames dropped at [`LOSSY_QUEUE_CAP`].
+    pub lossy_dropped: u64,
+    /// `ENOBUFS` write failures (frame queued, not dropped).
+    pub enobufs_events: u64,
+    /// `EAGAIN` write failures (frame queued, not dropped).
+    pub would_block_events: u64,
+    /// Short datagram writes — a `SOCK_DGRAM` invariant violation; the
+    /// frame is dropped because a partial L2 frame is unrecoverable.
+    pub short_writes: u64,
+    /// Write failures with unexpected errnos (frame dropped; the link is
+    /// assumed dead, e.g. `EPIPE` during shutdown).
+    pub io_errors: u64,
+    /// `FrameSink::send` rejections on the inject-thread path (frame
+    /// dropped). TODO(ABX-420): give the HV inject path the same lossless
+    /// contract as the socketpair path.
+    pub sink_send_failures: u64,
+    /// Bulk-production passes skipped because a backlog was pending.
+    pub gated_polls: u64,
+    /// High-water mark of the pending queue.
+    pub queue_high_water: usize,
+}
+
+/// Outcome of a single non-blocking write attempt.
+enum WriteOutcome {
+    /// Frame fully written, or unrecoverably consumed (short write / fatal
+    /// errno — both counted in [`GuestTxStats`]).
+    Consumed,
+    /// FD full; the frame must be preserved and retried.
+    Blocked(WriteBlock),
+}
+
+/// Sink for all guest-bound frames: owns the pending queue, the optional
+/// inject-thread [`FrameSink`], and the blocked-state machine that decides
+/// how draining resumes (write-readiness vs. retry timer).
+pub(super) struct GuestTx {
+    /// Inject-thread sink (HV backend). When set, frames bypass the
+    /// socketpair entirely.
+    frame_sink: Option<Arc<dyn FrameSink>>,
+    /// Frames awaiting socketpair capacity, in delivery order.
+    queue: VecDeque<FrameBuf>,
+    /// Why the last write failed, if a backlog is pending.
+    blocked: Option<WriteBlock>,
+    /// Delivery counters.
+    pub(super) stats: GuestTxStats,
+}
+
+impl GuestTx {
+    /// Creates a sink. `frame_sink` routes frames to the RX inject thread
+    /// when present (HV backend); otherwise frames go to the socketpair.
+    pub(super) fn new(frame_sink: Option<Arc<dyn FrameSink>>) -> Self {
+        Self {
+            frame_sink,
+            queue: VecDeque::new(),
+            blocked: None,
+            stats: GuestTxStats::default(),
+        }
+    }
+
+    /// True when frames are queued waiting for socketpair capacity. Bulk
+    /// producers (fast-path host-socket reads) must be gated on this so the
+    /// backlog stays bounded and backpressure reaches the remote sender.
+    pub(super) fn has_backlog(&self) -> bool {
+        !self.queue.is_empty()
+    }
+
+    /// True when draining should resume on `AsyncFd::writable()`.
+    pub(super) fn awaits_writable(&self) -> bool {
+        self.has_backlog() && self.blocked == Some(WriteBlock::WouldBlock)
+    }
+
+    /// True when draining should resume on the [`NOBUFS_RETRY_DELAY`] timer.
+    pub(super) fn awaits_retry(&self) -> bool {
+        self.has_backlog() && self.blocked == Some(WriteBlock::NoBufs)
+    }
+
+    /// Sends one frame to the guest.
+    ///
+    /// Reliable frames always reach the guest FD eventually: they are
+    /// written directly when the queue is empty and queued otherwise. Lossy
+    /// frames follow the same path but are dropped (and counted) once
+    /// [`LOSSY_QUEUE_CAP`] frames are pending.
+    pub(super) fn send(&mut self, guest_fd: RawFd, frame: &[u8], class: DeliveryClass) {
+        if let Some(sink) = &self.frame_sink {
+            // Inject-thread path (HV): bounded channel, drop-on-full.
+            // TODO(ABX-420): reliable frames need the lossless contract on
+            // this path too; count failures so post-mortems can see them.
+            if !sink.send(frame.to_vec()) {
+                self.stats.sink_send_failures += 1;
+                tracing::debug!("Guest frame sink full, frame dropped ({class:?})");
+            }
+            return;
+        }
+
+        if self.queue.is_empty() {
+            match self.try_write(guest_fd, frame) {
+                WriteOutcome::Consumed => {}
+                WriteOutcome::Blocked(block) => {
+                    self.blocked = Some(block);
+                    self.push(frame);
+                }
+            }
+            return;
+        }
+
+        // Backlog pending: append to preserve per-flow frame order.
+        if class == DeliveryClass::Lossy && self.queue.len() >= LOSSY_QUEUE_CAP {
+            self.stats.lossy_dropped += 1;
+            tracing::debug!("Lossy queue cap ({LOSSY_QUEUE_CAP}) reached, dropping frame");
+            return;
+        }
+        self.push(frame);
+    }
+
+    /// Drains the pending queue until it empties or the FD blocks again,
+    /// updating the blocked state accordingly.
+    pub(super) fn drain(&mut self, guest_fd: RawFd) {
+        self.blocked = None;
+        // Pop before writing (`try_write` needs `&mut self` for counters);
+        // a blocked frame is pushed back to the front, preserving order.
+        while let Some(frame) = self.queue.pop_front() {
+            match self.try_write(guest_fd, &frame) {
+                WriteOutcome::Consumed => {}
+                WriteOutcome::Blocked(block) => {
+                    self.blocked = Some(block);
+                    self.queue.push_front(frame);
+                    break;
+                }
+            }
+        }
+    }
+
+    /// Attempts one non-blocking write of `frame` to `guest_fd`.
+    fn try_write(&mut self, guest_fd: RawFd, frame: &[u8]) -> WriteOutcome {
+        match fd_write(guest_fd, frame) {
+            Ok(n) if n >= frame.len() => WriteOutcome::Consumed,
+            Ok(n) => {
+                // SOCK_DGRAM delivers whole datagrams or fails — a short
+                // write indicates a broken invariant. The partial frame is
+                // unrecoverable; drop it rather than corrupt L2 boundaries.
+                self.stats.short_writes += 1;
+                tracing::error!(
+                    "Guest write: short datagram ({n}/{} bytes), dropping frame",
+                    frame.len(),
+                );
+                WriteOutcome::Consumed
+            }
+            Err(e) if e.kind() == io::ErrorKind::WouldBlock => {
+                self.stats.would_block_events += 1;
+                WriteOutcome::Blocked(WriteBlock::WouldBlock)
+            }
+            Err(e) if e.raw_os_error() == Some(libc::ENOBUFS) => {
+                // Peer receive buffer full (VZ not draining). Backpressure,
+                // not loss — the frame stays queued.
+                self.stats.enobufs_events += 1;
+                WriteOutcome::Blocked(WriteBlock::NoBufs)
+            }
+            Err(e) => {
+                self.stats.io_errors += 1;
+                tracing::warn!("Guest write error: {e}");
+                WriteOutcome::Consumed
+            }
+        }
+    }
+
+    fn push(&mut self, frame: &[u8]) {
+        self.queue.push_back(FrameBuf::from(frame.to_vec()));
+        self.stats.queue_high_water = self.stats.queue_high_water.max(self.queue.len());
+    }
+}
+
 /// Non-blocking drain of the reply channel. Delivers pending proxy
 /// responses (DNS, UDP, ICMP) to the guest without blocking the event loop.
 ///
@@ -36,14 +265,13 @@ const DRAIN_CMD_BATCH: usize = 64;
 /// `select!` branches.
 pub(super) fn drain_reply_rx(
     reply_rx: &mut mpsc::Receiver<Vec<u8>>,
-    frame_sink: Option<&std::sync::Arc<dyn crate::direct_rx::FrameSink>>,
-    guest_async: &AsyncFd<FdWrapper>,
-    write_queue: &mut VecDeque<FrameBuf>,
+    guest_tx: &mut GuestTx,
+    guest_fd: RawFd,
 ) {
     for _ in 0..DRAIN_REPLY_BATCH {
         match reply_rx.try_recv() {
             Ok(reply_frame) => {
-                send_to_guest(frame_sink, guest_async, &reply_frame, write_queue);
+                guest_tx.send(guest_fd, &reply_frame, DeliveryClass::Lossy);
             }
             Err(_) => break,
         }
@@ -68,67 +296,6 @@ pub(super) fn drain_cmd_rx(
                 process_inbound_cmd(cmd, tcp_bridge, egress, guest_ip, gateway_ip, guest_mac);
             }
             Err(_) => break,
-        }
-    }
-}
-
-/// Sends a frame to the guest via the frame sink (if present) or falls
-/// back to the socketpair write path.
-///
-/// When `frame_sink` is `Some`, the frame is sent through the crossbeam
-/// channel to the RX injection thread, bypassing the socketpair entirely.
-/// When `None`, falls back to `enqueue_or_write` for VZ-backend or
-/// early-boot compatibility.
-pub(super) fn send_to_guest(
-    frame_sink: Option<&std::sync::Arc<dyn crate::direct_rx::FrameSink>>,
-    guest_async: &AsyncFd<FdWrapper>,
-    frame_data: &[u8],
-    write_queue: &mut VecDeque<FrameBuf>,
-) {
-    if let Some(sink) = frame_sink {
-        let _ = sink.send(frame_data.to_vec());
-        return;
-    }
-    // Fallback: socketpair (VZ backend or during early boot).
-    enqueue_or_write(
-        guest_async,
-        FrameBuf::from(frame_data.to_vec()),
-        write_queue,
-    );
-}
-
-/// Attempts a direct non-blocking write; queues the frame on `WouldBlock`.
-///
-/// If the write queue is non-empty, the frame is appended directly to
-/// preserve ordering.
-pub(super) fn enqueue_or_write(
-    guest_async: &AsyncFd<FdWrapper>,
-    frame: FrameBuf,
-    write_queue: &mut VecDeque<FrameBuf>,
-) {
-    if !write_queue.is_empty() {
-        if write_queue.len() < WRITE_QUEUE_HARD_CAP {
-            write_queue.push_back(frame);
-        } else {
-            tracing::debug!("Write queue full ({WRITE_QUEUE_HARD_CAP}), dropping frame");
-        }
-        return;
-    }
-    let fd = guest_async.get_ref().as_raw_fd();
-    match fd_write(fd, &frame) {
-        Ok(n) if n >= frame.len() => {}
-        Ok(n) => {
-            // SOCK_DGRAM: short write should never happen — invariant violation.
-            tracing::error!(
-                "Guest write: short datagram ({n}/{} bytes), dropping frame",
-                frame.len(),
-            );
-        }
-        Err(e) if e.kind() == io::ErrorKind::WouldBlock => {
-            write_queue.push_back(frame);
-        }
-        Err(e) => {
-            tracing::warn!("Guest write error: {}", e);
         }
     }
 }

--- a/virt/arcbox-net/src/darwin/datapath_loop/intercept.rs
+++ b/virt/arcbox-net/src/darwin/datapath_loop/intercept.rs
@@ -1,7 +1,7 @@
 use std::net::{Ipv4Addr, SocketAddr};
+use std::os::fd::RawFd;
 use std::time::Duration;
 
-use tokio::io::unix::AsyncFd;
 use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
 
@@ -13,18 +13,14 @@ use crate::dhcp::DhcpServer;
 use crate::dns::DnsForwarder;
 use crate::ethernet::{ETH_HEADER_LEN, build_udp_ip_ethernet};
 
-use super::fd::FdWrapper;
-use super::guest_tx::send_to_guest;
-use crate::datapath::FrameBuf;
-use std::collections::VecDeque;
+use super::guest_tx::{DeliveryClass, GuestTx};
 
 /// Dispatches an intercepted frame to the appropriate handler.
 #[allow(clippy::too_many_arguments)]
 pub(super) fn handle_intercepted_frame(
     intercepted: &crate::darwin::classifier::InterceptedFrame,
-    frame_sink: Option<&std::sync::Arc<dyn crate::direct_rx::FrameSink>>,
-    guest_async: &AsyncFd<FdWrapper>,
-    write_queue: &mut VecDeque<FrameBuf>,
+    guest_tx: &mut GuestTx,
+    guest_fd: RawFd,
     egress: &mut HostEgress,
     dhcp_server: &mut DhcpServer,
     dns_forwarder: &DnsForwarder,
@@ -40,9 +36,8 @@ pub(super) fn handle_intercepted_frame(
         InterceptedKind::Dhcp => {
             handle_dhcp(
                 frame,
-                frame_sink,
-                guest_async,
-                write_queue,
+                guest_tx,
+                guest_fd,
                 dhcp_server,
                 gateway_ip,
                 gateway_mac,
@@ -98,12 +93,10 @@ pub(super) fn process_inbound_cmd(
 }
 
 /// Handles a DHCP packet from the guest.
-#[allow(clippy::too_many_arguments)]
 fn handle_dhcp(
     frame: &[u8],
-    frame_sink: Option<&std::sync::Arc<dyn crate::direct_rx::FrameSink>>,
-    guest_async: &AsyncFd<FdWrapper>,
-    write_queue: &mut VecDeque<FrameBuf>,
+    guest_tx: &mut GuestTx,
+    guest_fd: RawFd,
     dhcp_server: &mut DhcpServer,
     gateway_ip: Ipv4Addr,
     gateway_mac: [u8; 6],
@@ -132,7 +125,7 @@ fn handle_dhcp(
                 guest_mac,
             );
             tracing::info!("Sending DHCP reply frame: {} bytes", reply_frame.len());
-            send_to_guest(frame_sink, guest_async, &reply_frame, write_queue);
+            guest_tx.send(guest_fd, &reply_frame, DeliveryClass::Lossy);
         }
         Ok(None) => {
             tracing::info!("DHCP: no response needed");

--- a/virt/arcbox-net/src/darwin/datapath_loop/mod.rs
+++ b/virt/arcbox-net/src/darwin/datapath_loop/mod.rs
@@ -21,7 +21,6 @@
 //! by the in-shim `TcpBridge`; data frames flow via the fast path or the
 //! zero-copy inline inject thread.
 
-use std::collections::VecDeque;
 use std::io;
 use std::net::Ipv4Addr;
 use std::os::fd::{AsRawFd, OwnedFd};
@@ -37,7 +36,6 @@ use crate::darwin::classifier::FrameClassifier;
 use crate::darwin::egress::HostEgress;
 use crate::darwin::inbound_relay::InboundCommand;
 use crate::darwin::tcp_bridge::TcpBridge;
-use crate::datapath::FrameBuf;
 use crate::dhcp::DhcpServer;
 use crate::dns::DnsForwarder;
 
@@ -47,8 +45,8 @@ mod intercept;
 #[cfg(test)]
 mod tests;
 
-use fd::{FdWrapper, fd_write, set_nonblocking};
-use guest_tx::{drain_cmd_rx, drain_reply_rx, send_to_guest};
+use fd::{FdWrapper, set_nonblocking};
+use guest_tx::{DeliveryClass, GuestTx, NOBUFS_RETRY_DELAY, drain_cmd_rx, drain_reply_rx};
 use intercept::{handle_intercepted_frame, process_inbound_cmd};
 
 /// Async network datapath bridging guest ↔ host via `FrameClassifier`
@@ -219,9 +217,16 @@ impl NetworkDatapath {
 
         let mut guest_mac: Option<[u8; 6]> = None;
 
-        // Write queue: buffers frames that couldn't be written to the guest FD
-        // due to EWOULDBLOCK. Drained when the FD becomes writable again.
-        let mut write_queue: VecDeque<FrameBuf> = VecDeque::new();
+        // Guest-bound frame sink: owns the pending queue and the lossless
+        // backpressure state machine (see the guest_tx module docs).
+        let mut guest_tx = GuestTx::new(frame_sink);
+
+        // Retry driver for an ENOBUFS-blocked backlog. A persistent interval
+        // (rather than a per-iteration `sleep`) survives other select! arms
+        // firing more often than the retry period — a fresh sleep would be
+        // reset every iteration and never complete under load.
+        let mut nobufs_retry = tokio::time::interval(NOBUFS_RETRY_DELAY);
+        nobufs_retry.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
 
         // Unified timer wheel for flow timeout management (1s tick).
         // Replaces per-flow tokio::time::timeout() objects with a single
@@ -238,7 +243,8 @@ impl NetworkDatapath {
         tracing::info!("Network datapath started (TCP shim + socket proxy mode)");
 
         loop {
-            let has_pending = !write_queue.is_empty();
+            let awaits_writable = guest_tx.awaits_writable();
+            let awaits_retry = guest_tx.awaits_retry();
 
             tokio::select! {
                 biased;
@@ -248,31 +254,23 @@ impl NetworkDatapath {
                     break;
                 }
 
-                // Drain pending writes when the guest FD becomes writable.
-                writable = guest_async.writable(), if has_pending => {
+                // Drain an EAGAIN-blocked backlog when the guest FD becomes
+                // writable. An ENOBUFS-blocked backlog is timer-driven below:
+                // write-readiness is not a reliable signal for a full peer
+                // receive buffer on a macOS AF_UNIX datagram socket.
+                writable = guest_async.writable(), if awaits_writable => {
                     let mut guard = writable?;
-                    while let Some(frame) = write_queue.front() {
-                        match guard.try_io(|inner| fd_write(inner.get_ref().as_raw_fd(), frame)) {
-                            Ok(Ok(n)) if n >= frame.len() => { write_queue.pop_front(); }
-                            Ok(Ok(n)) => {
-                                // SOCK_DGRAM delivers whole frames or fails — a short
-                                // write should never happen and indicates a broken
-                                // invariant. Drop the frame to avoid corrupting L2
-                                // boundaries.
-                                tracing::error!(
-                                    "Guest write: short datagram ({n}/{} bytes), dropping frame",
-                                    frame.len(),
-                                );
-                                write_queue.pop_front();
-                            }
-                            Ok(Err(e)) if e.kind() == io::ErrorKind::WouldBlock => break,
-                            Ok(Err(e)) => {
-                                tracing::warn!("Guest write error: {}", e);
-                                write_queue.pop_front();
-                            }
-                            Err(_) => break,
-                        }
+                    guest_tx.drain(guest_raw_fd);
+                    if guest_tx.awaits_writable() {
+                        // Still blocked: clear readiness so the next poll
+                        // waits for a fresh writability edge.
+                        guard.clear_ready();
                     }
+                }
+
+                // Retry an ENOBUFS-blocked backlog after a short delay.
+                _ = nobufs_retry.tick(), if awaits_retry => {
+                    guest_tx.drain(guest_raw_fd);
                 }
 
                 // Guest → Host: read frames, classify, and dispatch.
@@ -301,7 +299,7 @@ impl NetworkDatapath {
                         tcp_bridge.try_fast_path_intercept(frame_data)
                     });
                     for ack in fast_acks {
-                        send_to_guest(frame_sink.as_ref(), &guest_async, &ack, &mut write_queue);
+                        guest_tx.send(guest_raw_fd, &ack, DeliveryClass::Reliable);
                     }
 
                     // Handshake intercept: complete in-progress shim handshakes
@@ -312,12 +310,12 @@ impl NetworkDatapath {
                         tcp_bridge.try_complete_handshake(frame_data)
                     });
                     for reply in hs_replies {
-                        send_to_guest(frame_sink.as_ref(), &guest_async, &reply, &mut write_queue);
+                        guest_tx.send(guest_raw_fd, &reply, DeliveryClass::Reliable);
                     }
 
                     // Flush ARP replies produced inline by the classifier.
                     for reply in device.take_arp_replies() {
-                        send_to_guest(frame_sink.as_ref(), &guest_async, &reply, &mut write_queue);
+                        guest_tx.send(guest_raw_fd, &reply, DeliveryClass::Lossy);
                     }
 
                     // Discard any TCP frames left in the rx queue that didn't
@@ -330,9 +328,8 @@ impl NetworkDatapath {
                     for intercepted_frame in &intercepted {
                         handle_intercepted_frame(
                             intercepted_frame,
-                            frame_sink.as_ref(),
-                            &guest_async,
-                            &mut write_queue,
+                            &mut guest_tx,
+                            guest_raw_fd,
                             &mut egress,
                             &mut dhcp_server,
                             &dns_forwarder,
@@ -353,7 +350,7 @@ impl NetworkDatapath {
                     let gmac = guest_mac.unwrap_or([0xFF; 6]);
                     for syn in &gated_syns {
                         if let Some(rst) = tcp_bridge.handle_outbound_syn(&syn.frame, gateway_mac, gmac) {
-                            send_to_guest(frame_sink.as_ref(), &guest_async, &rst, &mut write_queue);
+                            guest_tx.send(guest_raw_fd, &rst, DeliveryClass::Reliable);
                         }
                     }
 
@@ -361,9 +358,9 @@ impl NetworkDatapath {
 
                 // Proxy → Guest: relay reply frames from socket proxy.
                 // Always poll — the bounded channel (256) provides natural backpressure
-                // to spawned tasks. Gating on write_queue depth starved DNS replies.
+                // to spawned tasks. Gating on backlog depth starved DNS replies.
                 Some(reply_frame) = reply_rx.recv() => {
-                    send_to_guest(frame_sink.as_ref(), &guest_async, &reply_frame, &mut write_queue);
+                    guest_tx.send(guest_raw_fd, &reply_frame, DeliveryClass::Lossy);
                 }
 
                 // Inbound commands from InboundListenerManager.
@@ -419,7 +416,7 @@ impl NetworkDatapath {
             //    active-open (ActiveOpen), and retransmits under loss.
             let hs_frames = tcp_bridge.poll_handshakes();
             for frame in hs_frames {
-                send_to_guest(frame_sink.as_ref(), &guest_async, &frame, &mut write_queue);
+                guest_tx.send(guest_raw_fd, &frame, DeliveryClass::Reliable);
             }
 
             // 1.5. Drain inbound listener commands so `cmd_rx.recv()` cannot be
@@ -434,17 +431,22 @@ impl NetworkDatapath {
             );
 
             // 2. Poll fast-path host streams for inbound data and inject
-            //    constructed frames directly to guest.
-            for frame in tcp_bridge.poll_fast_path() {
-                send_to_guest(frame_sink.as_ref(), &guest_async, &frame, &mut write_queue);
+            //    constructed frames directly to guest — but only when no
+            //    backlog is pending. Skipping the poll leaves host-socket
+            //    data in the host kernel's receive buffer, closing the
+            //    host-side TCP window so the remote sender throttles instead
+            //    of the datapath dropping frames (lossless backpressure; the
+            //    shim has no retransmission, so a dropped data frame would
+            //    stall the connection permanently).
+            if guest_tx.has_backlog() {
+                guest_tx.stats.gated_polls += 1;
+            } else {
+                for frame in tcp_bridge.poll_fast_path() {
+                    guest_tx.send(guest_raw_fd, &frame, DeliveryClass::Reliable);
+                }
             }
 
-            drain_reply_rx(
-                &mut reply_rx,
-                frame_sink.as_ref(),
-                &guest_async,
-                &mut write_queue,
-            );
+            drain_reply_rx(&mut reply_rx, &mut guest_tx, guest_raw_fd);
 
             // Yield to the tokio runtime so spawned tasks (e.g. host relay
             // read/write) get a chance to run on this worker thread. Without

--- a/virt/arcbox-net/src/darwin/datapath_loop/mod.rs
+++ b/virt/arcbox-net/src/darwin/datapath_loop/mod.rs
@@ -268,7 +268,10 @@ impl NetworkDatapath {
                     }
                 }
 
-                // Retry an ENOBUFS-blocked backlog after a short delay.
+                // Timer-driven drain for any pending backlog. This is the
+                // sole resume path for ENOBUFS and the safety net for
+                // EAGAIN, where a missed writability edge would otherwise
+                // wedge all guest-bound traffic permanently.
                 _ = nobufs_retry.tick(), if awaits_retry => {
                     guest_tx.drain(guest_raw_fd);
                 }
@@ -404,6 +407,7 @@ impl NetworkDatapath {
 
                 _ = maintenance.tick() => {
                     egress.maintenance();
+                    guest_tx.log_stats();
                 }
             }
 

--- a/virt/arcbox-net/src/darwin/datapath_loop/mod.rs
+++ b/virt/arcbox-net/src/darwin/datapath_loop/mod.rs
@@ -217,6 +217,9 @@ impl NetworkDatapath {
 
         let mut guest_mac: Option<[u8; 6]> = None;
 
+        // Guest→host frame counter (diagnostics; see GuestTx::log_stats).
+        let mut rx_frames: u64 = 0;
+
         // Guest-bound frame sink: owns the pending queue and the lossless
         // backpressure state machine (see the guest_tx module docs).
         let mut guest_tx = GuestTx::new(frame_sink);
@@ -283,7 +286,10 @@ impl NetworkDatapath {
                     // Drain all available frames from the source, classifying each.
                     // This is the FdFrameSource + classify_frame composition that
                     // replaced the classifier's old fd-owning drain_guest_fd.
-                    source.drain(|frame| device.classify_frame(frame, &mut guest_mac));
+                    source.drain(|frame| {
+                        rx_frames += 1;
+                        device.classify_frame(frame, &mut guest_mac);
+                    });
                     // We drained until WouldBlock; clear readiness to avoid
                     // spinning on the biased readable arm.
                     guard.clear_ready();
@@ -407,7 +413,7 @@ impl NetworkDatapath {
 
                 _ = maintenance.tick() => {
                     egress.maintenance();
-                    guest_tx.log_stats();
+                    guest_tx.log_stats(rx_frames);
                 }
             }
 

--- a/virt/arcbox-net/src/darwin/datapath_loop/tests.rs
+++ b/virt/arcbox-net/src/darwin/datapath_loop/tests.rs
@@ -153,11 +153,9 @@ fn guest_tx_reliable_survives_socketpair_overflow() {
         }
     }
     assert!(tx.has_backlog(), "socketpair never overflowed");
-    // Exactly one resume mechanism must be armed for the blocked state.
-    assert!(
-        tx.awaits_writable() ^ tx.awaits_retry(),
-        "blocked backlog must arm exactly one resume mechanism"
-    );
+    // The retry timer must always be armed for a pending backlog — it is
+    // the safety net against unreliable datagram writability signals.
+    assert!(tx.awaits_retry(), "backlog must arm the retry timer");
     // Keep producing while blocked — everything must queue.
     for _ in 0..16 {
         tx.send(

--- a/virt/arcbox-net/src/darwin/datapath_loop/tests.rs
+++ b/virt/arcbox-net/src/darwin/datapath_loop/tests.rs
@@ -1,8 +1,8 @@
 use super::fd::{fd_read, fd_write, set_nonblocking, write_to_guest};
-use super::guest_tx::enqueue_or_write;
+use super::guest_tx::{DeliveryClass, GuestTx, LOSSY_QUEUE_CAP};
 use super::intercept::build_dns_servfail_response;
 use super::*;
-use std::os::fd::FromRawFd;
+use std::os::fd::{FromRawFd, RawFd};
 
 /// Creates a SOCK_DGRAM socketpair, returning (fd_a, fd_b) as OwnedFds.
 fn socketpair() -> (OwnedFd, OwnedFd) {
@@ -12,6 +12,38 @@ fn socketpair() -> (OwnedFd, OwnedFd) {
     assert_eq!(ret, 0, "socketpair() failed");
     // SAFETY: fds are valid file descriptors from socketpair.
     unsafe { (OwnedFd::from_raw_fd(fds[0]), OwnedFd::from_raw_fd(fds[1])) }
+}
+
+/// Shrinks a socket's send/receive buffers so overflow is reached quickly.
+fn shrink_socket_buffers(fd: RawFd) {
+    let size: libc::c_int = 8192;
+    for opt in [libc::SO_SNDBUF, libc::SO_RCVBUF] {
+        // SAFETY: setsockopt on a valid fd with a valid c_int payload.
+        let ret = unsafe {
+            libc::setsockopt(
+                fd,
+                libc::SOL_SOCKET,
+                opt,
+                (&raw const size).cast(),
+                std::mem::size_of::<libc::c_int>() as libc::socklen_t,
+            )
+        };
+        assert_eq!(ret, 0, "setsockopt failed");
+    }
+}
+
+/// Sends reliable frames until the socketpair overflows and a backlog forms.
+/// Returns the number of frames sent. Panics if overflow is never reached.
+fn send_until_backlog(tx: &mut GuestTx, fd: RawFd, frame: &[u8]) -> usize {
+    let mut sent = 0usize;
+    for _ in 0..10_000 {
+        tx.send(fd, frame, DeliveryClass::Reliable);
+        sent += 1;
+        if tx.has_backlog() {
+            return sent;
+        }
+    }
+    panic!("socketpair never overflowed; cannot exercise backpressure");
 }
 
 #[test]
@@ -68,44 +100,138 @@ fn test_fd_write_roundtrip() {
     assert_eq!(&buf[..n], data);
 }
 
-#[tokio::test]
-async fn test_enqueue_or_write_direct() {
+#[test]
+fn guest_tx_direct_write_when_unblocked() {
     let (a, b) = socketpair();
     set_nonblocking(a.as_raw_fd()).unwrap();
-    let guest_async = AsyncFd::new(FdWrapper(a)).unwrap();
 
-    let mut queue = VecDeque::new();
+    let mut tx = GuestTx::new(None);
     let frame_data = b"direct write frame";
-    enqueue_or_write(
-        &guest_async,
-        FrameBuf::from(frame_data.to_vec()),
-        &mut queue,
-    );
+    tx.send(a.as_raw_fd(), frame_data, DeliveryClass::Reliable);
 
-    assert!(queue.is_empty(), "Queue should be empty after direct write");
+    assert!(
+        !tx.has_backlog(),
+        "queue should be empty after direct write"
+    );
 
     let mut buf = [0u8; 128];
     let n = fd_read(b.as_raw_fd(), &mut buf).unwrap();
     assert_eq!(&buf[..n], frame_data.as_slice());
 }
 
-#[tokio::test]
-async fn test_enqueue_or_write_queues_when_nonempty() {
-    let (a, _b) = socketpair();
+/// Regression test for the container-egress black hole: when the socketpair
+/// overflows (macOS returns `ENOBUFS`, not `EAGAIN`), reliable frames must
+/// be queued — never dropped — and delivered in order once the peer drains.
+/// The shim has no retransmission, so a single lost frame stalls its TCP
+/// connection permanently.
+#[test]
+fn guest_tx_reliable_survives_socketpair_overflow() {
+    let (a, b) = socketpair();
     set_nonblocking(a.as_raw_fd()).unwrap();
-    let guest_async = AsyncFd::new(FdWrapper(a)).unwrap();
+    set_nonblocking(b.as_raw_fd()).unwrap();
+    shrink_socket_buffers(a.as_raw_fd());
+    shrink_socket_buffers(b.as_raw_fd());
 
-    let mut queue: VecDeque<FrameBuf> = VecDeque::new();
-    queue.push_back(FrameBuf::from(b"already queued".to_vec()));
+    let mut tx = GuestTx::new(None);
+    // Each frame carries its sequence number so ordering is verifiable.
+    let make_frame = |seq: u32| {
+        let mut f = vec![0xAB_u8; 2048];
+        f[..4].copy_from_slice(&seq.to_be_bytes());
+        f
+    };
 
-    enqueue_or_write(
-        &guest_async,
-        FrameBuf::from(b"new frame".to_vec()),
-        &mut queue,
+    let mut sent = 0usize;
+    for _ in 0..10_000 {
+        tx.send(
+            a.as_raw_fd(),
+            &make_frame(sent as u32),
+            DeliveryClass::Reliable,
+        );
+        sent += 1;
+        if tx.has_backlog() {
+            break;
+        }
+    }
+    assert!(tx.has_backlog(), "socketpair never overflowed");
+    // Exactly one resume mechanism must be armed for the blocked state.
+    assert!(
+        tx.awaits_writable() ^ tx.awaits_retry(),
+        "blocked backlog must arm exactly one resume mechanism"
+    );
+    // Keep producing while blocked — everything must queue.
+    for _ in 0..16 {
+        tx.send(
+            a.as_raw_fd(),
+            &make_frame(sent as u32),
+            DeliveryClass::Reliable,
+        );
+        sent += 1;
+    }
+
+    // Alternately drain the peer and retry until everything is delivered.
+    let mut buf = vec![0u8; 4096];
+    let mut received = 0usize;
+    let mut idle_rounds = 0;
+    while received < sent && idle_rounds < 1_000 {
+        let mut progressed = false;
+        while let Ok(n) = fd_read(b.as_raw_fd(), &mut buf) {
+            if n == 0 {
+                break;
+            }
+            assert_eq!(
+                u32::from_be_bytes([buf[0], buf[1], buf[2], buf[3]]),
+                received as u32,
+                "frames must arrive in send order"
+            );
+            received += 1;
+            progressed = true;
+        }
+        tx.drain(a.as_raw_fd());
+        if !progressed {
+            idle_rounds += 1;
+        }
+    }
+
+    assert_eq!(received, sent, "reliable frames were lost across overflow");
+    assert!(!tx.has_backlog(), "queue must fully drain");
+    assert!(
+        tx.stats.enobufs_events + tx.stats.would_block_events >= 1,
+        "the overflow path was never exercised"
+    );
+    assert_eq!(tx.stats.lossy_dropped, 0);
+    assert_eq!(tx.stats.io_errors, 0);
+    assert_eq!(tx.stats.short_writes, 0);
+}
+
+/// Lossy frames are bounded at `LOSSY_QUEUE_CAP` and dropped beyond it;
+/// reliable frames are still accepted past the cap.
+#[test]
+fn guest_tx_lossy_capped_reliable_uncapped() {
+    let (a, b) = socketpair();
+    set_nonblocking(a.as_raw_fd()).unwrap();
+    set_nonblocking(b.as_raw_fd()).unwrap();
+    shrink_socket_buffers(a.as_raw_fd());
+    shrink_socket_buffers(b.as_raw_fd());
+
+    let mut tx = GuestTx::new(None);
+    let frame = vec![0xCD_u8; 2048];
+    send_until_backlog(&mut tx, a.as_raw_fd(), &frame);
+
+    for _ in 0..(LOSSY_QUEUE_CAP + 100) {
+        tx.send(a.as_raw_fd(), &frame, DeliveryClass::Lossy);
+    }
+    assert!(
+        tx.stats.lossy_dropped >= 100,
+        "lossy frames must drop at the cap (dropped: {})",
+        tx.stats.lossy_dropped
     );
 
-    assert_eq!(queue.len(), 2);
-    assert_eq!(&queue[1][..], b"new frame");
+    let hwm_before = tx.stats.queue_high_water;
+    tx.send(a.as_raw_fd(), &frame, DeliveryClass::Reliable);
+    assert!(
+        tx.stats.queue_high_water > hwm_before,
+        "reliable frames must still be accepted past the lossy cap"
+    );
 }
 
 #[test]

--- a/virt/arcbox-vmm/src/vmm/darwin.rs
+++ b/virt/arcbox-vmm/src/vmm/darwin.rs
@@ -107,7 +107,15 @@ impl Vmm {
         //
         // Without: use VZNATNetworkDeviceAttachment (Apple creates bridge100,
         // requiring FDB scanning to discover it).
-        if self.config.networking {
+        //
+        // ARCBOX_DIAG_DISABLE_BRIDGE_NIC skips the second NIC entirely — a
+        // diagnostic knob for the ABX-423 freeze bisection (host→container
+        // inbound routing is lost while set).
+        let diag_disable_bridge = std::env::var_os("ARCBOX_DIAG_DISABLE_BRIDGE_NIC").is_some();
+        if diag_disable_bridge {
+            tracing::warn!("bridge NIC disabled via ARCBOX_DIAG_DISABLE_BRIDGE_NIC (diagnostic)");
+        }
+        if self.config.networking && !diag_disable_bridge {
             #[cfg(feature = "vmnet")]
             {
                 match self.create_vmnet_bridge_nic() {
@@ -245,7 +253,19 @@ impl Vmm {
     /// buffers, only with less headroom (see `NET_SOCKET_BUF_BYTES` for why the
     /// host end in particular must be sized once the enhanced MTU is active).
     fn set_socket_buffers(fd: libc::c_int) {
-        let size = NET_SOCKET_BUF_BYTES;
+        // ABX-423 bisection knobs: ARCBOX_DIAG_NET_BUF_DEFAULT skips the
+        // enlargement entirely; ARCBOX_DIAG_NET_BUF_BYTES overrides the size
+        // (buffer sizing is the first dimension found to change the freeze
+        // incidence).
+        if std::env::var_os("ARCBOX_DIAG_NET_BUF_DEFAULT").is_some() {
+            tracing::warn!("socket buffers left at defaults (ARCBOX_DIAG_NET_BUF_DEFAULT)");
+            return;
+        }
+        let size = std::env::var("ARCBOX_DIAG_NET_BUF_BYTES")
+            .ok()
+            .and_then(|v| v.parse::<libc::c_int>().ok())
+            .inspect(|v| tracing::warn!("socket buffers overridden to {v} (diagnostic)"))
+            .unwrap_or(NET_SOCKET_BUF_BYTES);
         // SAFETY: setsockopt on a valid fd with a correctly-sized `c_int` value.
         unsafe {
             for (opt, name) in [

--- a/virt/arcbox-vz/src/device/network.rs
+++ b/virt/arcbox-vz/src/device/network.rs
@@ -125,10 +125,17 @@ impl NetworkDeviceConfiguration {
                 )
                 .as_bool()
             };
-            let mtu = if responds {
+            // ARCBOX_DIAG_NET_MTU_1500 skips the MTU raise — a diagnostic
+            // knob for the ABX-423 freeze bisection (4000-byte frames are an
+            // uncommon VZ configuration and a bisection dimension).
+            let diag_mtu_1500 = std::env::var_os("ARCBOX_DIAG_NET_MTU_1500").is_some();
+            let mtu = if responds && !diag_mtu_1500 {
                 msg_send_void_u64!(attachment, setMaximumTransmissionUnit: VZ_NETWORK_MTU);
                 tracing::info!("VZ network MTU set to {VZ_NETWORK_MTU}");
                 VZ_NETWORK_MTU as usize
+            } else if diag_mtu_1500 {
+                tracing::warn!("VZ network MTU left at 1500 (ARCBOX_DIAG_NET_MTU_1500)");
+                1500
             } else {
                 tracing::info!(
                     "VZ network MTU setter unavailable (macOS < 13), using default 1500"

--- a/xtask/src/commands/e2e.rs
+++ b/xtask/src/commands/e2e.rs
@@ -153,6 +153,11 @@ fn prebuild(root: &std::path::Path, test: &str) -> Result<bool> {
             .run()?;
             Ok(true)
         }
+        // Must match tests/e2e/tests/egress_throughput.rs's own build.
+        "egress_throughput" => {
+            xshell::cmd!(shell, "cargo build --release -p arcbox-daemon").run()?;
+            Ok(true)
+        }
         // Must match tests/e2e/src/sandbox.rs::build_binaries exactly
         // (packages AND profiles), or SKIP_BUILD runs stale binaries.
         "sandbox" => {


### PR DESCRIPTION
## Problem

Container→external large downloads stalled permanently and intermittently (40-100% of attempts on a fast CDN), while the same URL downloaded fine on the host. Reported initially as a container-subnet routing problem; the routing theory was disproven (the 172.16/12 route only serves host→container inbound — egress never touches it).

Two real defects were found and are fixed here; a third, deeper one is now precisely characterized with a reproducer (left open as the true ABX-420).

## Fix 1: lossless backpressure for guest-bound frames

The TCP shim terminates guest connections and never retransmits (`tcp_bridge/mod.rs:10`), so **any** dropped host→guest frame is a permanent sequence gap that stalls the connection forever. The VZ socketpair write path had three drop sites: `ENOBUFS` (macOS unix-dgram overflow — mishandled as a fatal error; 24,582 hits observed in a production daemon log), the 8192-frame queue hard cap, and short writes.

`GuestTx` now classifies guest-bound frames:
- **Reliable** (TCP shim: handshake/data/ACK/FIN/RST) — no drop code path exists. `ENOBUFS` and `EAGAIN` both queue; draining resumes via a persistent 1 ms retry interval (kqueue write-readiness is not trustworthy for a full datagram peer buffer) with writability as an accelerator. Fast-path host-socket polls are gated while a backlog is pending, so backpressure propagates to the remote sender through the host kernel's TCP receive window — lossless, no retransmit buffer needed.
- **Lossy** (ARP/DHCP/DNS/UDP/ICMP replies) — bounded queue, drop + count at the cap.

Delivery counters (tx/rx frames, ENOBUFS/EAGAIN events, drops, queue high-water, gated polls) are reported from the maintenance tick, replacing previously invisible or DEBUG-only drop logs.

## Fix 2: gateway-destined egress must stay direct under a system proxy

`DefaultEgress::resolve` translates the gateway IP to loopback (`host.docker.internal`), but proxy resolution ran **first** and tunnelled the flow through any configured system proxy, which then dialed a virtual address that exists only inside the datapath. With a VPN/proxy app running (e.g. Surge), every container connection to `host.docker.internal` hung until timeout. Gateway-destined flows now short-circuit to direct.

## New e2e: `egress_throughput`

Host-local blob server (64 MB × 6) downloaded by a container through the full egress datapath via the gateway-IP→loopback translation — no external network, and loopback burst rates exceed the original CDN repro. Optional `ARCBOX_E2E_EGRESS_URL` phase for manual through-VPN validation. Includes in-freeze forensics: guest routing/eth0 counter deltas, liveness probes, recovery-time measurement (probes run over vsock, which survives the freeze).

**Known failure rate: ~1 in 5 downloads currently trips the open VZ freeze below, so this `#[ignore]`-gated scenario fails intermittently by design — it is the reproducer and post-mortem recorder for that bug.**

## What remains open (true ABX-420)

With the drops fixed, the counters prove the residual stall is **not** in the datapath: for ~60-75 s the VZ virtio-net device stops moving frames in both directions (socketpair empty, tx idle, zero ENOBUFS, guest routing intact, no guest kernel errors, ICMP+TCP equally dead), then self-heals — timing consistent with the guest's TCP retransmission backoff generating a fresh virtio kick. Evidence points at a lost kick/notification race in the VZ file-handle device or guest driver, i.e. the same class as the EVENT_IDX races fixed on the HV backend, but on Apple's side of the fence. Tracked in ABX-420 with next steps (VZNAT A/B, guest EVENT_IDX experiment).

Also out of scope, tracked separately: the HV inject path (`ChannelFrameSink`) keeps its drop-on-full behavior (counter + TODO), and `abctl doctor`'s container-route check false-positives by probing the network base address instead of a real container IP.

## Validation

- 147 unit/integration tests green across `splicetcp`, `arcbox-net`; clippy/fmt clean on all touched crates.
- New regression unit test drives real `ENOBUFS` on a shrunken socketpair and asserts zero loss + ordering.
- e2e: downloads that dodge the VZ freeze complete at ~21 MB/s with all delivery counters at zero anomalies; `host.docker.internal` works with Surge active (was: 100% hang).