### PR TITLE
feat(sandbox): fresh-network restore re-addresses the guest (Firecracker 1.16.1)

### DIFF
--- a/docs/sandbox-api.md
+++ b/docs/sandbox-api.md
@@ -171,12 +171,11 @@ Direct-mode (non-jailer) restores of the same snapshot cannot run
 concurrently with each other or the origin sandbox (the vmstate pins the
 origin vsock path); jailer-mode restores have no such constraint.
 
-`network_override` (a fresh TAP/IP for the restored sandbox) relies on
-Firecracker's `network_overrides` snapshot-load field, which the pinned
-Firecracker 1.10.1 predates — it currently fails with an
-`unknown field network_overrides` API error. Restore without
-`network_override` (reusing the recorded NIC) works today; fresh-network
-restore unlocks when the bundled Firecracker is upgraded.
+`network_override` (a fresh TAP/IP for the restored sandbox) uses
+Firecracker's `network_overrides` snapshot-load field (Firecracker ≥ 1.12;
+the bundle ships 1.16.1). With it, a clone restores and runs while the
+origin keeps its NIC. Restore without `network_override` reuses the
+recorded NIC, so the origin must be stopped first.
 
 ## Error model
 

--- a/tests/e2e/src/boot_assets.rs
+++ b/tests/e2e/src/boot_assets.rs
@@ -423,7 +423,19 @@ pub fn stage_dev_boot_assets(root: &Path, data_dir: &Path, version: &str) -> Res
         fs::create_dir_all(&bin_dir)?;
         for entry in fs::read_dir(&seed_dir)? {
             let entry = entry?;
-            copy_file(&entry.path(), &bin_dir.join(entry.file_name()))?;
+            if entry.path().is_dir() {
+                // Subdirectories mirror `install_dir` binaries, which land as
+                // siblings of bin/ (e.g. runtime-bin/kernel/vmlinux →
+                // runtime/kernel/vmlinux).
+                let sibling = data_dir.join("runtime").join(entry.file_name());
+                fs::create_dir_all(&sibling)?;
+                for sub in fs::read_dir(entry.path())? {
+                    let sub = sub?;
+                    copy_file(&sub.path(), &sibling.join(sub.file_name()))?;
+                }
+            } else {
+                copy_file(&entry.path(), &bin_dir.join(entry.file_name()))?;
+            }
         }
         info!(seed = %seed_dir.display(), "pre-seeded runtime binaries");
     }

--- a/tests/e2e/src/sandbox.rs
+++ b/tests/e2e/src/sandbox.rs
@@ -260,12 +260,41 @@ async fn drive_sandboxes(channel: Channel, metrics: &mut RunMetrics) -> Result<(
     );
     info!(%snapshot_id, "checkpoint taken");
 
-    // Stop the origin before restoring: with `network_override: false` the
-    // restored sandbox reuses the recorded NIC (the origin's TAP), so the
-    // origin must release it first. Fresh-network restore (a new TAP while
-    // the origin keeps running) relies on FC's `network_overrides`
-    // snapshot-load field, which the pinned Firecracker 1.10.1 predates —
-    // see docs/sandbox-api.md.
+    // -- Fresh-network restore (origin still running) ----------------------
+    // `network_override: true` gives the clone a new TAP via FC's
+    // `network_overrides` snapshot-load field (Firecracker >= 1.12), so the
+    // origin keeps its NIC and both run side by side.
+    let fresh_net_started = Instant::now();
+    let cloned = snapshots
+        .restore(with_machine(RestoreRequest {
+            id: "smoke3".into(),
+            snapshot_id: snapshot_id.clone(),
+            network_override: true,
+            ..Default::default()
+        }))
+        .await
+        .context("Fresh-network restore failed")?
+        .into_inner();
+    info!(id = %cloned.id, "sandbox restored with fresh network while origin runs");
+    let stdout = run_and_collect(&mut sandboxes, "smoke3", &["/bin/echo", "hello-clone"]).await?;
+    if !stdout.contains("hello-clone") {
+        bail!("fresh-network clone run output missing marker: {stdout:?}");
+    }
+    let origin = inspect(&mut sandboxes, "smoke1").await?;
+    if origin.state != "ready" {
+        bail!(
+            "origin should keep running through a fresh-network restore, state={}",
+            origin.state
+        );
+    }
+    metrics.record(
+        "sandbox_restore_fresh_net",
+        fresh_net_started.elapsed().as_secs_f64(),
+    );
+
+    // Stop the origin before the reuse-NIC restore: with
+    // `network_override: false` the restored sandbox reuses the recorded NIC
+    // (the origin's TAP), so the origin must release it first.
     let restore_started = Instant::now();
     sandboxes
         .stop(with_machine(StopSandboxRequest {
@@ -303,7 +332,7 @@ async fn drive_sandboxes(channel: Channel, metrics: &mut RunMetrics) -> Result<(
 
     // -- Teardown -----------------------------------------------------------
     let teardown_started = Instant::now();
-    for id in ["smoke1", "smoke2"] {
+    for id in ["smoke1", "smoke2", "smoke3"] {
         sandboxes
             .remove(with_machine(RemoveSandboxRequest {
                 id: id.into(),

--- a/tests/e2e/src/sandbox.rs
+++ b/tests/e2e/src/sandbox.rs
@@ -275,11 +275,62 @@ async fn drive_sandboxes(channel: Channel, metrics: &mut RunMetrics) -> Result<(
         .await
         .context("Fresh-network restore failed")?
         .into_inner();
-    info!(id = %cloned.id, "sandbox restored with fresh network while origin runs");
+    info!(id = %cloned.id, ip = %cloned.ip_address, "sandbox restored with fresh network while origin runs");
+    if cloned.ip_address.is_empty() || cloned.ip_address == created.ip_address {
+        bail!(
+            "fresh-network clone must get its own IP (origin {}, clone {:?})",
+            created.ip_address,
+            cloned.ip_address
+        );
+    }
     let stdout = run_and_collect(&mut sandboxes, "smoke3", &["/bin/echo", "hello-clone"]).await?;
     if !stdout.contains("hello-clone") {
         bail!("fresh-network clone run output missing marker: {stdout:?}");
     }
+
+    // The vsock channel working proves nothing about the new TAP. Assert the
+    // guest actually re-addressed eth0 to the fresh allocation…
+    wait_for_state(&mut sandboxes, "smoke3", "ready", Duration::from_secs(30)).await?;
+    let addr = run_and_collect(
+        &mut sandboxes,
+        "smoke3",
+        &["/bin/sh", "-c", "ip addr show eth0"],
+    )
+    .await?;
+    if !addr.contains(&cloned.ip_address) {
+        bail!(
+            "clone eth0 does not carry its allocated IP {} (got: {addr:?})",
+            cloned.ip_address
+        );
+    }
+    if addr.contains(&format!("{}/", created.ip_address)) {
+        bail!(
+            "clone eth0 still carries the origin's IP {} (got: {addr:?})",
+            created.ip_address
+        );
+    }
+
+    // …and that traffic flows through the new TAP: ping the gateway, which
+    // is the local address of the clone's own TAP (sandboxes are isolated
+    // point-to-point links, so peers are deliberately unreachable). Deriving
+    // the gateway from `ip route` also proves the reconfig re-installed the
+    // default route.
+    wait_for_state(&mut sandboxes, "smoke3", "ready", Duration::from_secs(30)).await?;
+    let ping = run_and_collect(
+        &mut sandboxes,
+        "smoke3",
+        &[
+            "/bin/sh",
+            "-c",
+            "gw=$(ip route | sed -n 's/^default via \\([0-9.]*\\).*/\\1/p' | head -1); \
+             echo \"gateway=$gw\"; ping -c 1 -W 2 \"$gw\"",
+        ],
+    )
+    .await?;
+    if !ping.contains(" 0% packet loss") {
+        bail!("clone could not reach its gateway over the new TAP: {ping:?}");
+    }
+
     let origin = inspect(&mut sandboxes, "smoke1").await?;
     if origin.state != "ready" {
         bail!(

--- a/virt/arcbox-vm/src/bin/vm-agent.rs
+++ b/virt/arcbox-vm/src/bin/vm-agent.rs
@@ -337,7 +337,7 @@ mod agent {
             fd: &OwnedFd,
             request: libc::c_ulong,
             arg: *mut libc::c_void,
-        ) -> Result<(), String> {
+        ) -> Result<(), std::io::Error> {
             #[allow(
                 clippy::cast_possible_truncation,
                 clippy::cast_possible_wrap,
@@ -347,7 +347,7 @@ mod agent {
             // SAFETY: fd is a valid socket; arg points at a properly sized,
             // initialized kernel struct owned by the caller.
             if unsafe { libc::ioctl(fd.as_raw_fd(), request, arg) } < 0 {
-                return Err(std::io::Error::last_os_error().to_string());
+                return Err(std::io::Error::last_os_error());
             }
             Ok(())
         }
@@ -370,8 +370,22 @@ mod agent {
             ioctl(&fd, libc::SIOCSIFNETMASK, (&raw mut req).cast())
                 .map_err(|e| format!("SIOCSIFNETMASK: {e}"))?;
 
-            // Changing the address drops routes through the interface; add the
-            // default route back via the new gateway.
+            // The kernel flushes routes through the interface when its
+            // primary address changes, but don't rely on that implicit
+            // behavior: drop any surviving default route first so the add
+            // below never races an EEXIST. ESRCH just means none survived.
+            // SAFETY: rtentry is POD; fields set below, rest zeroed.
+            let mut stale: libc::rtentry = unsafe { std::mem::zeroed() };
+            stale.rt_dst = sockaddr_in(Ipv4Addr::UNSPECIFIED);
+            stale.rt_genmask = sockaddr_in(Ipv4Addr::UNSPECIFIED);
+            stale.rt_flags = libc::RTF_UP;
+            if let Err(e) = ioctl(&fd, libc::SIOCDELRT, (&raw mut stale).cast()) {
+                if e.raw_os_error() != Some(libc::ESRCH) {
+                    eprintln!("agent: net reconfig: SIOCDELRT stale default: {e}");
+                }
+            }
+
+            // Add the default route via the new gateway.
             // SAFETY: rtentry is POD; fields set below, rest zeroed.
             let mut route: libc::rtentry = unsafe { std::mem::zeroed() };
             route.rt_dst = sockaddr_in(Ipv4Addr::UNSPECIFIED);

--- a/virt/arcbox-vm/src/bin/vm-agent.rs
+++ b/virt/arcbox-vm/src/bin/vm-agent.rs
@@ -21,6 +21,8 @@
 //! | 0x02 | Host→Agent  | raw stdin bytes                  |
 //! | 0x03 | Host→Agent  | `[u16 LE width][u16 LE height]`  |
 //! | 0x04 | Host→Agent  | empty — stdin EOF                |
+//! | 0x05 | Host→Agent  | `[i64 LE secs][u32 LE nanos]` — clock sync |
+//! | 0x06 | Host→Agent  | JSON `NetReconfigCommand` — re-address eth0 |
 //! | 0x10 | Agent→Host  | raw stdout bytes                 |
 //! | 0x11 | Agent→Host  | raw stderr bytes                 |
 //! | 0x12 | Agent→Host  | `[i32 LE exit_code]`             |
@@ -56,12 +58,13 @@ mod agent {
     const MSG_RESIZE: u8 = 0x03;
     const MSG_EOF: u8 = 0x04;
     const MSG_CLOCK_SYNC: u8 = 0x05;
+    const MSG_NET_RECONFIG: u8 = 0x06;
     const MSG_STDOUT: u8 = 0x10;
     const MSG_STDERR: u8 = 0x11;
     const MSG_EXIT: u8 = 0x12;
 
     // File I/O channel (vsock:53) — imported from the shared proto module.
-    use arcbox_vm::boot_proto::KernelIpParam;
+    use arcbox_vm::boot_proto::{KernelIpParam, NetReconfigCommand};
     use arcbox_vm::file_io::proto::{
         FILE_ACK, FILE_DATA, FILE_DONE, FILE_ERR, FILE_PORT, FILE_READ_REQ, FILE_WRITE_REQ,
         MAX_FILE_SIZE,
@@ -207,6 +210,7 @@ mod agent {
 
         match msg_type {
             MSG_CLOCK_SYNC => handle_clock_sync(conn, &payload),
+            MSG_NET_RECONFIG => handle_net_reconfig(conn, &payload),
             MSG_START => {
                 let start: StartCommand = match serde_json::from_slice(&payload) {
                     Ok(s) => s,
@@ -256,6 +260,129 @@ mod agent {
             return;
         }
         let _ = write_frame(&mut conn, MSG_EXIT, &0i32.to_le_bytes());
+    }
+
+    fn handle_net_reconfig(mut conn: VsockStream, payload: &[u8]) {
+        let cmd: NetReconfigCommand = match serde_json::from_slice(payload) {
+            Ok(c) => c,
+            Err(e) => {
+                eprintln!("agent: parse NetReconfigCommand: {e}");
+                let _ = write_frame(&mut conn, MSG_EXIT, &(-1i32).to_le_bytes());
+                return;
+            }
+        };
+
+        if let Err(e) = net_reconfig::apply(&cmd) {
+            eprintln!("agent: net reconfig failed: {e}");
+            let _ = write_frame(&mut conn, MSG_EXIT, &(-1i32).to_le_bytes());
+            return;
+        }
+
+        // Repoint DNS at the new gateway, mirroring the boot-time setup_dns.
+        let content = format!("nameserver {}\n", cmd.gateway);
+        if let Err(e) = std::fs::write("/etc/resolv.conf", &content) {
+            eprintln!("agent: net reconfig: failed to write /etc/resolv.conf: {e}");
+        }
+
+        eprintln!(
+            "agent: reconfigured eth0 to {}/{} via {}",
+            cmd.ip, cmd.netmask, cmd.gateway
+        );
+        let _ = write_frame(&mut conn, MSG_EXIT, &0i32.to_le_bytes());
+    }
+
+    /// eth0 re-addressing via raw `ioctl(2)`, self-contained so it works on
+    /// any sandbox rootfs (no dependence on busybox `ip`/`route` applets).
+    mod net_reconfig {
+        use arcbox_vm::boot_proto::NetReconfigCommand;
+        use std::net::Ipv4Addr;
+        use std::os::fd::{AsRawFd, FromRawFd, OwnedFd};
+
+        const IFNAME: &[u8] = b"eth0";
+
+        fn sockaddr_in(ip: Ipv4Addr) -> libc::sockaddr {
+            let sin = libc::sockaddr_in {
+                sin_family: libc::AF_INET as libc::sa_family_t,
+                sin_port: 0,
+                sin_addr: libc::in_addr {
+                    s_addr: u32::from(ip).to_be(),
+                },
+                sin_zero: [0; 8],
+            };
+            // SAFETY: sockaddr_in and sockaddr are layout-compatible for the
+            // kernel ABI; sockaddr is larger or equal, remainder zeroed below.
+            let mut sa: libc::sockaddr = unsafe { std::mem::zeroed() };
+            // SAFETY: copying sizeof(sockaddr_in) <= sizeof(sockaddr) bytes.
+            unsafe {
+                std::ptr::copy_nonoverlapping(
+                    (&raw const sin).cast::<u8>(),
+                    (&raw mut sa).cast::<u8>(),
+                    std::mem::size_of::<libc::sockaddr_in>(),
+                );
+            }
+            sa
+        }
+
+        fn ifreq_with_addr(addr: libc::sockaddr) -> libc::ifreq {
+            // SAFETY: ifreq is POD; fully initialized below.
+            let mut req: libc::ifreq = unsafe { std::mem::zeroed() };
+            for (dst, src) in req.ifr_name.iter_mut().zip(IFNAME) {
+                *dst = *src as libc::c_char;
+            }
+            req.ifr_ifru.ifru_addr = addr;
+            req
+        }
+
+        fn ioctl(
+            fd: &OwnedFd,
+            request: libc::c_ulong,
+            arg: *mut libc::c_void,
+        ) -> Result<(), String> {
+            #[allow(
+                clippy::cast_possible_truncation,
+                clippy::cast_possible_wrap,
+                reason = "SIOC* request numbers fit musl's c_int ioctl request type"
+            )]
+            let request = request as libc::Ioctl;
+            // SAFETY: fd is a valid socket; arg points at a properly sized,
+            // initialized kernel struct owned by the caller.
+            if unsafe { libc::ioctl(fd.as_raw_fd(), request, arg) } < 0 {
+                return Err(std::io::Error::last_os_error().to_string());
+            }
+            Ok(())
+        }
+
+        /// Set eth0's address + netmask and replace the default route.
+        pub fn apply(cmd: &NetReconfigCommand) -> Result<(), String> {
+            // SAFETY: plain socket(2) call; result checked below.
+            let raw = unsafe { libc::socket(libc::AF_INET, libc::SOCK_DGRAM, 0) };
+            if raw < 0 {
+                return Err(format!("socket: {}", std::io::Error::last_os_error()));
+            }
+            // SAFETY: raw is a freshly opened, owned socket fd.
+            let fd = unsafe { OwnedFd::from_raw_fd(raw) };
+
+            let mut req = ifreq_with_addr(sockaddr_in(cmd.ip));
+            ioctl(&fd, libc::SIOCSIFADDR, (&raw mut req).cast())
+                .map_err(|e| format!("SIOCSIFADDR: {e}"))?;
+
+            let mut req = ifreq_with_addr(sockaddr_in(cmd.netmask));
+            ioctl(&fd, libc::SIOCSIFNETMASK, (&raw mut req).cast())
+                .map_err(|e| format!("SIOCSIFNETMASK: {e}"))?;
+
+            // Changing the address drops routes through the interface; add the
+            // default route back via the new gateway.
+            // SAFETY: rtentry is POD; fields set below, rest zeroed.
+            let mut route: libc::rtentry = unsafe { std::mem::zeroed() };
+            route.rt_dst = sockaddr_in(Ipv4Addr::UNSPECIFIED);
+            route.rt_genmask = sockaddr_in(Ipv4Addr::UNSPECIFIED);
+            route.rt_gateway = sockaddr_in(cmd.gateway);
+            route.rt_flags = libc::RTF_UP | libc::RTF_GATEWAY;
+            ioctl(&fd, libc::SIOCADDRT, (&raw mut route).cast())
+                .map_err(|e| format!("SIOCADDRT default via {}: {e}", cmd.gateway))?;
+
+            Ok(())
+        }
     }
 
     // -------------------------------------------------------------------------

--- a/virt/arcbox-vm/src/boot_proto.rs
+++ b/virt/arcbox-vm/src/boot_proto.rs
@@ -78,6 +78,24 @@ impl FromStr for KernelIpParam {
     }
 }
 
+/// Network reconfiguration command sent to `vm-agent` over the exec vsock
+/// channel (`MSG_NET_RECONFIG`) after a fresh-network snapshot restore.
+///
+/// A restored VM still carries the network the kernel configured from the
+/// origin's `ip=` boot parameter; when the restore allocated a new TAP/IP
+/// (`network_override`), the host sends this command so the guest
+/// re-addresses `eth0`, replaces the default route, and repoints DNS at the
+/// new gateway. Serialized as JSON, mirroring `StartCommand`.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct NetReconfigCommand {
+    /// New guest IP address for `eth0`.
+    pub ip: Ipv4Addr,
+    /// Subnet mask (e.g. 255.255.0.0).
+    pub netmask: Ipv4Addr,
+    /// Gateway IP (also serves as the guest DNS nameserver).
+    pub gateway: Ipv4Addr,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/virt/arcbox-vm/src/sandbox/checkpoint.rs
+++ b/virt/arcbox-vm/src/sandbox/checkpoint.rs
@@ -492,6 +492,40 @@ impl SandboxManager {
             Ok(Ok(())) => {}
         }
 
+        // Re-address the guest to the fresh allocation. The restored kernel
+        // still carries the origin's `ip=` boot configuration, so without
+        // this the clone would squat the origin's IP on its new TAP and
+        // never own the address its DNAT/expose mappings target. Unlike the
+        // clock, a fresh-network restore without a working network is the
+        // silent breakage `network_override` exists to prevent — fail the
+        // restore rather than hand back a half-networked sandbox.
+        if let Some(ref net) = net_alloc {
+            let cmd = crate::boot_proto::NetReconfigCommand {
+                ip: net.ip_address,
+                netmask: net.netmask(),
+                gateway: net.gateway,
+            };
+            let reconfig = tokio::time::timeout(
+                std::time::Duration::from_secs(10),
+                vsock::reconfigure_network(&actual_vsock_path, &cmd),
+            )
+            .await
+            .map_err(|_| VmmError::Vsock("net reconfig after restore timed out".into()))
+            .and_then(|r| r);
+            if let Err(e) = reconfig {
+                kill_and_reap_fc(&mut process).await;
+                cleanup_pending_restore(
+                    &self.cow_manager,
+                    &self.network,
+                    pending_cow.take(),
+                    net_alloc.as_ref(),
+                    pending_origin_dir.as_deref(),
+                )
+                .await;
+                return Err(e);
+            }
+        }
+
         // Populate the reserved instance in place, then commit the reservation
         // so it survives (the placeholder inserted by reserve_id is otherwise
         // removed on drop). All resources are now tracked on the instance and

--- a/virt/arcbox-vm/src/vsock.rs
+++ b/virt/arcbox-vm/src/vsock.rs
@@ -52,6 +52,9 @@ const MSG_EOF: u8 = 0x04;
 /// Synchronise the guest clock to the host after snapshot restore.
 /// Payload: `[i64 LE unix_seconds][u32 LE nanos]` (12 bytes).
 pub(crate) const MSG_CLOCK_SYNC: u8 = 0x05;
+/// Re-address the guest network after a fresh-network snapshot restore.
+/// Payload: JSON [`NetReconfigCommand`](crate::boot_proto::NetReconfigCommand).
+pub(crate) const MSG_NET_RECONFIG: u8 = 0x06;
 
 // Frame type constants — Agent → Host (exec channel).
 const MSG_STDOUT: u8 = 0x10;
@@ -440,6 +443,60 @@ async fn sync_clock_on_stream<S: tokio::io::AsyncReadExt + tokio::io::AsyncWrite
     Ok(())
 }
 
+/// Re-address the guest network after a fresh-network snapshot restore.
+///
+/// Sends [`MSG_NET_RECONFIG`] to the exec channel (vsock port 52) and waits
+/// for `MSG_EXIT(0)`. A restored kernel still carries the origin's `ip=`
+/// boot configuration, so a restore that allocated a new TAP/IP must
+/// re-address the guest or the clone collides with the running origin.
+pub async fn reconfigure_network(
+    uds_path: &Path,
+    cmd: &crate::boot_proto::NetReconfigCommand,
+) -> Result<()> {
+    let mut stream = connect_to_agent(uds_path).await?;
+    net_reconfig_on_stream(&mut stream, cmd).await
+}
+
+/// Send a net-reconfig frame and validate the agent response.
+///
+/// Extracted from [`reconfigure_network`] so the wire protocol can be tested
+/// with `tokio::io::duplex` without needing a real vsock connection.
+async fn net_reconfig_on_stream<S: tokio::io::AsyncReadExt + tokio::io::AsyncWriteExt + Unpin>(
+    stream: &mut S,
+    cmd: &crate::boot_proto::NetReconfigCommand,
+) -> Result<()> {
+    let payload = serde_json::to_vec(cmd)
+        .map_err(|e| VmmError::Vsock(format!("encode NetReconfigCommand: {e}")))?;
+
+    write_frame(stream, MSG_NET_RECONFIG, &payload)
+        .await
+        .map_err(|e| VmmError::Vsock(format!("write MSG_NET_RECONFIG: {e}")))?;
+
+    let (msg_type, payload) = tokio::time::timeout(Duration::from_secs(5), read_frame(stream))
+        .await
+        .map_err(|_| VmmError::Vsock("net reconfig: timed out waiting for response".into()))?
+        .map_err(|e| VmmError::Vsock(format!("read net reconfig response: {e}")))?;
+
+    if msg_type != MSG_EXIT {
+        return Err(VmmError::Vsock(format!(
+            "net reconfig: unexpected response type 0x{msg_type:02x}"
+        )));
+    }
+    if payload.len() < 4 {
+        return Err(VmmError::Vsock(format!(
+            "net reconfig: payload too short ({} bytes, expected 4)",
+            payload.len()
+        )));
+    }
+    let code = i32::from_le_bytes(payload[..4].try_into().unwrap());
+    if code != 0 {
+        return Err(VmmError::Vsock(format!(
+            "net reconfig: agent returned exit code {code}"
+        )));
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -619,6 +676,61 @@ mod tests {
         let msg = result.unwrap_err().to_string();
         assert!(
             msg.contains("unexpected response type"),
+            "unexpected error: {msg}"
+        );
+        agent_handle.await.unwrap();
+    }
+
+    // -----------------------------------------------------------------
+    // reconfigure_network protocol tests
+    // -----------------------------------------------------------------
+
+    fn reconfig_cmd() -> crate::boot_proto::NetReconfigCommand {
+        crate::boot_proto::NetReconfigCommand {
+            ip: std::net::Ipv4Addr::new(172, 20, 0, 3),
+            netmask: std::net::Ipv4Addr::new(255, 255, 0, 0),
+            gateway: std::net::Ipv4Addr::new(172, 20, 0, 1),
+        }
+    }
+
+    /// Simulate a successful net-reconfig exchange, round-tripping the JSON.
+    #[tokio::test]
+    async fn test_net_reconfig_success() {
+        let (mut agent, mut host) = tokio::io::duplex(1024);
+
+        let agent_handle = tokio::spawn(async move {
+            let (ty, payload) = read_frame(&mut agent).await.unwrap();
+            assert_eq!(ty, MSG_NET_RECONFIG);
+            let cmd: crate::boot_proto::NetReconfigCommand =
+                serde_json::from_slice(&payload).unwrap();
+            assert_eq!(cmd, reconfig_cmd());
+
+            write_frame(&mut agent, MSG_EXIT, &0i32.to_le_bytes())
+                .await
+                .unwrap();
+        });
+
+        let result = net_reconfig_on_stream(&mut host, &reconfig_cmd()).await;
+        assert!(result.is_ok());
+        agent_handle.await.unwrap();
+    }
+
+    /// Agent reports failure to apply the new configuration.
+    #[tokio::test]
+    async fn test_net_reconfig_agent_error() {
+        let (mut agent, mut host) = tokio::io::duplex(1024);
+
+        let agent_handle = tokio::spawn(async move {
+            let _ = read_frame(&mut agent).await.unwrap();
+            write_frame(&mut agent, MSG_EXIT, &(-1i32).to_le_bytes())
+                .await
+                .unwrap();
+        });
+
+        let result = net_reconfig_on_stream(&mut host, &reconfig_cmd()).await;
+        let msg = result.unwrap_err().to_string();
+        assert!(
+            msg.contains("agent returned exit code -1"),
             "unexpected error: {msg}"
         );
         agent_handle.await.unwrap();


### PR DESCRIPTION
## Summary

Pairs with arcboxlabs/boot-assets#36 (FC 1.16.1 + CI kernel 6.1.155, merged;
shipped in boot 0.6.3). Two layers:

**Feature completion — in-guest re-addressing.** A restored kernel keeps the
network the origin's `ip=` boot parameter configured, so a
`network_override` restore swapped the TAP while the clone kept squatting
the origin's IP (DNAT/expose against the clone's recorded IP could never
work). `vm-agent` gains `MSG_NET_RECONFIG` (JSON `NetReconfigCommand` via
`boot_proto`): re-addresses eth0 and re-installs the default route via raw
ioctls (self-contained on any sandbox rootfs), then repoints
`resolv.conf`. The restore path sends it after clock sync whenever a fresh
network was allocated — fatal on failure. Found by enabling the coverage the
Codex review asked for; the guest protocol is additive and sandboxes are
unreleased.

**E2E.** The smoke restores a clone with `network_override: true` while the
origin keeps running, asserts the clone's eth0 carries the allocated IP
(not the origin's), and pings its gateway through the new TAP (gateway
derived from `ip route`, proving the default route too). The reuse-NIC path
stays covered. `docs/sandbox-api.md` updated; `stage_dev_boot_assets` seed
dir mirrors `install_dir` semantics so kernel-class binaries validate
pre-release.

## Validation

Real VZ boot, jailer mode, FC 1.16.1 + guest kernel 6.1.155: full smoke
green including in-guest re-address + gateway ping while the origin runs
(108s). Negative control: the same smoke against the pre-fix agent fails
exactly on the new assertion (`inet 172.20.0.2/16` on a clone allocated
`172.20.0.3`). Wire protocol unit-tested (`net_reconfig_on_stream` duplex
tests, linux-gated).
