### PR TITLE
feat(fleet): windows capability via WSL interop

### DIFF
--- a/fleet/arcbox-fleet-agent/src/attach.rs
+++ b/fleet/arcbox-fleet-agent/src/attach.rs
@@ -124,6 +124,7 @@ pub fn spawn_supervisor(
     config: &AgentConfig,
     docker: Option<docker::DockerRunner>,
     vm: Option<crate::vm::VmRunner>,
+    interop: Option<crate::interop::InteropRunner>,
     capabilities: Vec<Capability>,
     state: AgentState,
 ) -> (RunnerSupervisor, mpsc::Receiver<AttachRequest>) {
@@ -133,6 +134,7 @@ pub fn spawn_supervisor(
         config.runner_script.clone(),
         docker,
         vm,
+        interop,
         capabilities,
         state,
     );
@@ -687,7 +689,7 @@ mod tests {
             machine_token: "flt_revoked".to_owned(),
         };
         let (supervisor, egress_rx) =
-            spawn_supervisor(&config, None, None, Vec::new(), state.clone());
+            spawn_supervisor(&config, None, None, None, Vec::new(), state.clone());
         let shutdown = CancellationToken::new();
         let run = tokio::spawn(run(
             config,
@@ -817,6 +819,7 @@ mod tests {
             None,
             None,
             None,
+            None,
             Vec::new(),
             AgentState::new(&seed()),
         );
@@ -869,6 +872,7 @@ mod tests {
         let (events, _rx) = mpsc::channel(1);
         let supervisor = RunnerSupervisor::new(
             events,
+            None,
             None,
             None,
             None,
@@ -925,6 +929,7 @@ mod tests {
         let (events, _rx) = mpsc::channel(1);
         let supervisor = RunnerSupervisor::new(
             events,
+            None,
             None,
             None,
             None,

--- a/fleet/arcbox-fleet-agent/src/attach.rs
+++ b/fleet/arcbox-fleet-agent/src/attach.rs
@@ -602,6 +602,7 @@ mod tests {
             gateway: "https://fleet.arcbox.dev".to_owned(),
             docker_mode: DockerMode::Disabled,
             runner_script: None,
+            windows_runner_script: None,
             participate: true,
             vm_mode: crate::config::VmMode::Auto,
             macos_runner_image: "tahoe-base".to_owned(),
@@ -666,6 +667,7 @@ mod tests {
         let config = AgentConfig {
             gateway,
             runner_script: None,
+            windows_runner_script: None,
             load_ceiling: 0.9,
             mem_floor_mib: 2048,
             data_dir: std::env::temp_dir(),
@@ -887,6 +889,7 @@ mod tests {
         AgentConfig {
             gateway: "http://127.0.0.1:1".to_owned(),
             runner_script: None,
+            windows_runner_script: None,
             load_ceiling: 0.9,
             mem_floor_mib: 2048,
             data_dir: std::env::temp_dir(),

--- a/fleet/arcbox-fleet-agent/src/config.rs
+++ b/fleet/arcbox-fleet-agent/src/config.rs
@@ -17,6 +17,7 @@ pub const DEFAULT_GATEWAY: &str = "https://gateway.fleet.arcbox.dev";
 
 const ENV_GATEWAY: &str = "ARCBOX_FLEET_GATEWAY";
 const ENV_RUNNER_SCRIPT: &str = "ARCBOX_FLEET_RUNNER_SCRIPT";
+const ENV_WINDOWS_RUNNER_SCRIPT: &str = "ARCBOX_FLEET_WINDOWS_RUNNER_SCRIPT";
 const ENV_LOAD_CEILING: &str = "ARCBOX_FLEET_LOAD_CEILING";
 const ENV_MEM_FLOOR_MIB: &str = "ARCBOX_FLEET_MEM_FLOOR_MIB";
 const ENV_DATA_DIR: &str = "ARCBOX_FLEET_DATA_DIR";
@@ -101,6 +102,11 @@ pub struct AgentConfig {
     /// (`run.sh`) — not its containing directory. `None` until set; required
     /// only by the `quick run` command.
     pub runner_script: Option<PathBuf>,
+    /// Windows-style path to the Windows runner entry point (e.g.
+    /// `C:\actions-runner\run.cmd`), executed across the WSL interop
+    /// boundary. Only meaningful on a Linux agent inside WSL2; the interop
+    /// probe at startup decides whether windows jobs are actually advertised.
+    pub windows_runner_script: Option<String>,
     /// Reject an offer when 1-minute load average per core exceeds this.
     pub load_ceiling: f64,
     /// Reject an offer when available memory (MiB) is below this.
@@ -121,6 +127,7 @@ impl AgentConfig {
         let gateway = std::env::var(ENV_GATEWAY).unwrap_or_else(|_| DEFAULT_GATEWAY.to_string());
 
         let runner_script = std::env::var_os(ENV_RUNNER_SCRIPT).map(PathBuf::from);
+        let windows_runner_script = std::env::var(ENV_WINDOWS_RUNNER_SCRIPT).ok();
 
         let load_ceiling = match std::env::var(ENV_LOAD_CEILING) {
             Ok(v) => parse_load_ceiling(&v)?,
@@ -185,6 +192,7 @@ impl AgentConfig {
         Ok(Self {
             gateway,
             runner_script,
+            windows_runner_script,
             load_ceiling,
             mem_floor_mib,
             data_dir,

--- a/fleet/arcbox-fleet-agent/src/control/image.rs
+++ b/fleet/arcbox-fleet-agent/src/control/image.rs
@@ -199,6 +199,7 @@ mod tests {
             gateway: "https://fleet.arcbox.dev".to_owned(),
             docker_mode: DockerMode::Disabled,
             runner_script: None,
+            windows_runner_script: None,
             participate: true,
             vm_mode: crate::config::VmMode::Auto,
             macos_runner_image: "tahoe-base".to_owned(),

--- a/fleet/arcbox-fleet-agent/src/control/lifecycle.rs
+++ b/fleet/arcbox-fleet-agent/src/control/lifecycle.rs
@@ -40,6 +40,11 @@ impl FleetLifecycleService for LifecycleService {
             // jobs (see crate::vm).
             features.push("vm-backend".to_owned());
         }
+        if self.supervisor.interop_active() {
+            // Windows jobs run on the WSL host across the interop boundary
+            // (see crate::interop).
+            features.push("wsl-interop".to_owned());
+        }
         Ok(Response::new(GetAgentInfoResponse {
             agent_version: env!("CARGO_PKG_VERSION").to_owned(),
             api_version: API_VERSION,

--- a/fleet/arcbox-fleet-agent/src/control/mod.rs
+++ b/fleet/arcbox-fleet-agent/src/control/mod.rs
@@ -321,6 +321,13 @@ impl AgentSupervisor {
         self.vm.clone()
     }
 
+    /// Whether the WSL interop backend for windows jobs is active — the
+    /// startup probe passed. Reported as a `GetAgentInfo` feature, same
+    /// rationale as [`Self::vm_active`]; restart-scoped like every backend.
+    pub fn interop_active(&self) -> bool {
+        self.interop.is_some()
+    }
+
     /// Spawn the attach task for `credential` and build its [`Attachment`].
     /// `credential_gateway` is the store key the credential is persisted
     /// under (see [`Attachment::credential_gateway`]).

--- a/fleet/arcbox-fleet-agent/src/control/mod.rs
+++ b/fleet/arcbox-fleet-agent/src/control/mod.rs
@@ -729,6 +729,7 @@ mod tests {
             gateway: "http://127.0.0.1:1".to_owned(),
             docker_mode: DockerMode::Disabled,
             runner_script: None,
+            windows_runner_script: None,
             participate: true,
             vm_mode: crate::config::VmMode::Auto,
             macos_runner_image: "tahoe-base".to_owned(),
@@ -739,6 +740,7 @@ mod tests {
         AgentConfig {
             gateway: "http://127.0.0.1:1".to_owned(),
             runner_script: None,
+            windows_runner_script: None,
             load_ceiling: 0.9,
             mem_floor_mib: 2048,
             data_dir,

--- a/fleet/arcbox-fleet-agent/src/control/mod.rs
+++ b/fleet/arcbox-fleet-agent/src/control/mod.rs
@@ -230,6 +230,7 @@ pub struct AgentSupervisor {
     config: AgentConfig,
     docker: Option<DockerRunner>,
     vm: Option<crate::vm::VmRunner>,
+    interop: Option<crate::interop::InteropRunner>,
     capabilities: Vec<Capability>,
     /// Cancelled on process shutdown (SIGTERM/Ctrl-C); every attachment's
     /// `shutdown` is a child of this token.
@@ -247,10 +248,17 @@ pub struct AgentSupervisor {
 impl AgentSupervisor {
     /// Build the supervisor, immediately attaching if a credential is
     /// already persisted — the existing headless/farm behavior.
+    #[expect(
+        clippy::too_many_arguments,
+        reason = "construction genuinely needs the config, all three optional job backends \
+                  (docker/vm/interop), the advertised capabilities, and the three process-wide \
+                  handles; same shape as attach::run"
+    )]
     pub async fn new(
         config: AgentConfig,
         docker: Option<DockerRunner>,
         vm: Option<crate::vm::VmRunner>,
+        interop: Option<crate::interop::InteropRunner>,
         capabilities: Vec<Capability>,
         process_shutdown: CancellationToken,
         agent_state: AgentState,
@@ -260,6 +268,7 @@ impl AgentSupervisor {
             config,
             docker,
             vm,
+            interop,
             capabilities,
             process_shutdown,
             state: Mutex::new(State::Unenrolled),
@@ -329,6 +338,7 @@ impl AgentSupervisor {
             &self.config,
             self.docker.clone(),
             self.vm.clone(),
+            self.interop.clone(),
             self.capabilities.clone(),
             self.agent_state.clone(),
         );
@@ -767,6 +777,7 @@ mod tests {
                 test_config(dir.to_path_buf()),
                 None,
                 None,
+                None,
                 Vec::new(),
                 CancellationToken::new(),
                 agent_state,
@@ -839,6 +850,7 @@ mod tests {
         let (events, _events_rx) = tokio::sync::mpsc::channel(1);
         let runner = crate::runner::RunnerSupervisor::new(
             events,
+            None,
             None,
             None,
             None,
@@ -936,6 +948,7 @@ mod tests {
             config,
             None,
             None,
+            None,
             Vec::new(),
             CancellationToken::new(),
             agent_state.clone(),
@@ -970,6 +983,7 @@ mod tests {
                 test_config(dir.clone()),
                 None,
                 None,
+                None,
                 Vec::new(),
                 CancellationToken::new(),
                 agent_state.clone(),
@@ -989,8 +1003,15 @@ mod tests {
             Ok(())
         });
         let (events, _events_rx) = tokio::sync::mpsc::channel(1);
-        let runner =
-            crate::runner::RunnerSupervisor::new(events, None, None, None, Vec::new(), agent_state);
+        let runner = crate::runner::RunnerSupervisor::new(
+            events,
+            None,
+            None,
+            None,
+            None,
+            Vec::new(),
+            agent_state,
+        );
         // A persisted credential, so the completed unenroll can prove the
         // local clear happens even though this gateway is unreachable (the
         // server-side call is best-effort).

--- a/fleet/arcbox-fleet-agent/src/control/settings.rs
+++ b/fleet/arcbox-fleet-agent/src/control/settings.rs
@@ -84,6 +84,9 @@ impl FleetSettingsServiceTrait for SettingsService {
             let path = (!v.is_empty()).then_some(Path::new(v));
             self.state.set_runner_script_target(path);
         }
+        if let Some(v) = &req.windows_runner_script {
+            self.state.set_windows_runner_script_target(v);
+        }
         // Target only — the supervisor's participation reconciler performs
         // the detach/reattach and flips `current` when it completes.
         if let Some(v) = req.participate {
@@ -157,6 +160,21 @@ fn validate(req: &UpdateSettingsRequest, state: &AgentState) -> Result<(), Strin
             return Err("macos_runner_image must not be empty".to_owned());
         }
     }
+    // Deliberately absent from the servability cross-field check below:
+    // like an Auto mode, the windows capability is probe-dependent (WSL
+    // interop must resolve at startup), so it is never a guarantee.
+    if let Some(script) = &req.windows_runner_script
+        && !script.is_empty()
+    {
+        let unix_view = crate::interop::windows_path_to_unix(script)
+            .map_err(|e| format!("windows_runner_script: {e:#}"))?;
+        if !unix_view.is_file() {
+            return Err(format!(
+                "windows_runner_script {script} does not exist (checked {})",
+                unix_view.display()
+            ));
+        }
+    }
     if let Some(vm_mode) = req.vm_mode
         && vm_mode_from_wire(vm_mode) == VmMode::Enabled
         && std::env::consts::OS != "macos"
@@ -221,6 +239,7 @@ mod tests {
             gateway: "https://fleet.arcbox.dev".to_owned(),
             docker_mode: DockerMode::Auto,
             runner_script: None,
+            windows_runner_script: None,
             participate: true,
             vm_mode: crate::config::VmMode::Auto,
             macos_runner_image: "tahoe-base".to_owned(),
@@ -238,6 +257,7 @@ mod tests {
             participate: None,
             macos_runner_image: None,
             vm_mode: None,
+            windows_runner_script: None,
         }
     }
 
@@ -346,6 +366,27 @@ mod tests {
             ..request()
         };
         assert!(validate(&req, &state).is_err());
+    }
+
+    /// The Windows-path shape check fires before `wslpath` is consulted, so
+    /// this rejection is host-independent; clearing (empty string) never
+    /// touches `wslpath` at all. A real WSL translation is exercised by the
+    /// interop module's live test instead — it needs a Windows host below.
+    #[test]
+    fn windows_runner_script_rejects_non_windows_paths_and_accepts_clear() {
+        let state = AgentState::new(&seed());
+        let req = UpdateSettingsRequest {
+            windows_runner_script: Some("/opt/actions-runner/run.sh".to_owned()),
+            ..request()
+        };
+        let err = validate(&req, &state).expect_err("unix path must be rejected");
+        assert!(err.contains("not an absolute Windows path"), "{err}");
+
+        let clear = UpdateSettingsRequest {
+            windows_runner_script: Some(String::new()),
+            ..request()
+        };
+        assert!(validate(&clear, &state).is_ok());
     }
 
     #[test]

--- a/fleet/arcbox-fleet-agent/src/host.rs
+++ b/fleet/arcbox-fleet-agent/src/host.rs
@@ -90,10 +90,17 @@ pub fn telemetry() -> HostTelemetry {
 ///   pre-installed runner, backed by `host_runner`. Omitted when no runner
 ///   script is configured, or when the native pair is already served by
 ///   Docker (a Linux host) or by the VM backend (above).
+/// - **Windows-via-interop capability.** `interop_active` means this Linux
+///   agent runs inside WSL2 and the interop probe passed (see
+///   `crate::interop`); `windows` on the native arch (WSL always matches the
+///   Windows host's arch) is then served across the interop boundary.
+///   Additive and host_runner-backed on the wire — it IS the host's
+///   pre-installed Windows runner.
 pub fn capabilities(
     runner_script_present: bool,
     docker_arches: &[String],
     vm_active: bool,
+    interop_active: bool,
 ) -> Vec<Capability> {
     build_capabilities(
         &host_os(),
@@ -101,6 +108,7 @@ pub fn capabilities(
         runner_script_present,
         docker_arches,
         vm_active,
+        interop_active,
     )
 }
 
@@ -112,6 +120,7 @@ fn build_capabilities(
     runner_script_present: bool,
     docker_arches: &[String],
     vm_active: bool,
+    interop_active: bool,
 ) -> Vec<Capability> {
     let mut caps = Vec::new();
 
@@ -120,6 +129,14 @@ fn build_capabilities(
             os: "linux".to_owned(),
             arch: arch.clone(),
             backed_by: Backend::Docker as i32,
+        });
+    }
+
+    if interop_active {
+        caps.push(Capability {
+            os: "windows".to_owned(),
+            arch: native_arch.to_owned(),
+            backed_by: Backend::HostRunner as i32,
         });
     }
 
@@ -162,7 +179,7 @@ mod tests {
 
     #[test]
     fn host_only_without_docker() {
-        let caps = build_capabilities("darwin", "arm64", true, &[], false);
+        let caps = build_capabilities("darwin", "arm64", true, &[], false, false);
         assert_eq!(caps.len(), 1);
         assert_eq!(
             triple(&caps[0]),
@@ -173,7 +190,7 @@ mod tests {
     #[test]
     fn macos_adds_docker_linux_capabilities() {
         let arches = vec!["arm64".to_owned(), "amd64".to_owned()];
-        let caps = build_capabilities("darwin", "arm64", true, &arches, false);
+        let caps = build_capabilities("darwin", "arm64", true, &arches, false, false);
         // Two docker linux capabilities plus the darwin host-runner one.
         assert_eq!(caps.len(), 3);
         assert_eq!(triple(&caps[0]), ("linux", "arm64", Backend::Docker as i32));
@@ -188,7 +205,7 @@ mod tests {
     fn linux_host_capability_is_docker_served() {
         // On a Linux host with Docker the native capability IS the docker linux
         // one — no separate host-runner capability is added.
-        let caps = build_capabilities("linux", "amd64", true, &["amd64".to_owned()], false);
+        let caps = build_capabilities("linux", "amd64", true, &["amd64".to_owned()], false, false);
         assert_eq!(caps.len(), 1);
         assert_eq!(triple(&caps[0]), ("linux", "amd64", Backend::Docker as i32));
     }
@@ -196,7 +213,14 @@ mod tests {
     #[test]
     fn omits_host_capability_without_runner_script() {
         // Docker-only macOS: no runner script means no darwin capability.
-        let caps = build_capabilities("darwin", "arm64", false, &["arm64".to_owned()], false);
+        let caps = build_capabilities(
+            "darwin",
+            "arm64",
+            false,
+            &["arm64".to_owned()],
+            false,
+            false,
+        );
         assert_eq!(caps.len(), 1);
         assert_eq!(triple(&caps[0]), ("linux", "arm64", Backend::Docker as i32));
     }
@@ -205,15 +229,41 @@ mod tests {
     fn vm_backend_serves_the_native_pair_and_wins_over_host_runner() {
         // With the VM backend active, darwin/arm64 is VM-served even though a
         // runner script is configured — isolation wins.
-        let caps = build_capabilities("darwin", "arm64", true, &["arm64".to_owned()], true);
+        let caps = build_capabilities("darwin", "arm64", true, &["arm64".to_owned()], true, false);
         assert_eq!(caps.len(), 2);
         assert_eq!(triple(&caps[0]), ("linux", "arm64", Backend::Docker as i32));
         assert_eq!(triple(&caps[1]), ("darwin", "arm64", Backend::Vm as i32));
     }
 
+    /// The interop windows capability is additive: a WSL Linux host with
+    /// Docker advertises its linux capability as before, plus windows on
+    /// the native arch, host_runner-backed on the wire.
+    #[test]
+    fn interop_adds_a_windows_capability_alongside_docker_linux() {
+        let caps = build_capabilities("linux", "amd64", false, &["amd64".to_owned()], false, true);
+        assert_eq!(caps.len(), 2);
+        assert_eq!(triple(&caps[0]), ("linux", "amd64", Backend::Docker as i32));
+        assert_eq!(
+            triple(&caps[1]),
+            ("windows", "amd64", Backend::HostRunner as i32)
+        );
+    }
+
+    /// Interop alone (no Docker, no runner script) still serves windows —
+    /// the WSL distro exists purely to host the agent.
+    #[test]
+    fn interop_alone_serves_only_windows() {
+        let caps = build_capabilities("linux", "amd64", false, &[], false, true);
+        assert_eq!(caps.len(), 1);
+        assert_eq!(
+            triple(&caps[0]),
+            ("windows", "amd64", Backend::HostRunner as i32)
+        );
+    }
+
     #[test]
     fn vm_backend_without_runner_script_still_serves_darwin() {
-        let caps = build_capabilities("darwin", "arm64", false, &[], true);
+        let caps = build_capabilities("darwin", "arm64", false, &[], true, false);
         assert_eq!(caps.len(), 1);
         assert_eq!(triple(&caps[0]), ("darwin", "arm64", Backend::Vm as i32));
     }

--- a/fleet/arcbox-fleet-agent/src/interop.rs
+++ b/fleet/arcbox-fleet-agent/src/interop.rs
@@ -392,6 +392,23 @@ mod tests {
         path
     }
 
+    /// [`InteropRunner::spawn`], retrying the brief ETXTBSY window: a
+    /// concurrently forking test can hold a just-written stub open for
+    /// writing until its own exec, and executing a file open for writing
+    /// fails with "Text file busy". Test-suite artifact only — production
+    /// spawns long-existing Windows binaries, never freshly written ones.
+    async fn spawn_retrying(runner: &InteropRunner, jit: &str) -> Result<InteropJob> {
+        for _ in 0..100 {
+            match runner.spawn(jit).await {
+                Err(e) if format!("{e:#}").contains("Text file busy") => {
+                    tokio::time::sleep(Duration::from_millis(20)).await;
+                }
+                other => return other,
+            }
+        }
+        panic!("spawn kept hitting ETXTBSY");
+    }
+
     /// The spawn handshake parses `WINPID=` from the wrapper's stdout, and
     /// a normal exit propagates the exit code through `wait`.
     #[tokio::test]
@@ -401,7 +418,9 @@ mod tests {
         let taskkill = stub(dir.path(), "taskkill", "exit 0");
         let runner = InteropRunner::with_paths(powershell, taskkill, r"C:\r\run.cmd");
 
-        let mut job = runner.spawn("dGVzdA==").await.expect("handshake");
+        let mut job = spawn_retrying(&runner, "dGVzdA==")
+            .await
+            .expect("handshake");
         assert_eq!(job.windows_pid(), 4242);
         let status = job.wait().await.expect("wait");
         assert_eq!(status.code(), Some(7));
@@ -420,7 +439,9 @@ mod tests {
         let taskkill = stub(dir.path(), "taskkill", "exit 0");
         let runner = InteropRunner::with_paths(powershell, taskkill, r"C:\r\run.cmd");
 
-        let job = runner.spawn("dGVzdA==").await.expect("handshake");
+        let job = spawn_retrying(&runner, "dGVzdA==")
+            .await
+            .expect("handshake");
         assert_eq!(job.windows_pid(), 7);
     }
 
@@ -433,7 +454,9 @@ mod tests {
         let taskkill = stub(dir.path(), "taskkill", "exit 0");
         let runner = InteropRunner::with_paths(powershell, taskkill, r"C:\r\run.cmd");
 
-        let err = runner.spawn("dGVzdA==").await.expect_err("no handshake");
+        let err = spawn_retrying(&runner, "dGVzdA==")
+            .await
+            .expect_err("no handshake");
         assert!(
             err.to_string().contains("without reporting WINPID"),
             "{err}"
@@ -462,7 +485,9 @@ mod tests {
         );
         let runner = InteropRunner::with_paths(powershell, taskkill, r"C:\r\run.cmd");
 
-        let mut job = runner.spawn("dGVzdA==").await.expect("handshake");
+        let mut job = spawn_retrying(&runner, "dGVzdA==")
+            .await
+            .expect("handshake");
         let pid = job.windows_pid();
         let start = tokio::time::Instant::now();
         job.kill().await;
@@ -474,18 +499,25 @@ mod tests {
         assert_eq!(recorded.trim(), format!("/T /F /PID {pid}"));
     }
 
-    /// Live end-to-end against real interop — requires a WSL2 host with a
-    /// stub `run.cmd` staged on the Windows side, so it is ignored by
-    /// default: `cargo test -p arcbox-fleet-agent -- --ignored interop`.
+    /// Live end-to-end against real interop — requires a WSL2 host, so it
+    /// is ignored by default:
+    /// `cargo test -p arcbox-fleet-agent -- --ignored interop`.
+    /// Stages a stub `run.cmd` in the Windows user's `%TEMP%` (resolved
+    /// across the same interop boundary under test).
     #[tokio::test]
     #[ignore = "requires a WSL2 host with Windows interop enabled"]
     async fn live_wsl_spawn_and_kill_round_trip() {
-        let staged = PathBuf::from("/mnt/c/Temp/arcbox-interop-test.cmd");
-        std::fs::create_dir_all(staged.parent().unwrap()).unwrap();
+        let cmd_exe = windows_path_to_unix(r"C:\Windows\System32\cmd.exe").expect("wslpath");
+        let output = std::process::Command::new(cmd_exe)
+            .args(["/c", "echo %TEMP%"])
+            .output()
+            .expect("resolving %TEMP% via interop");
+        let temp_win = String::from_utf8_lossy(&output.stdout).trim().to_owned();
+        let script = format!("{temp_win}\\arcbox-interop-test.cmd");
+        let staged = windows_path_to_unix(&script).expect("translate %TEMP%");
         std::fs::write(&staged, "@echo off\r\nping -n 60 127.0.0.1 >NUL\r\n").unwrap();
-        let script = r"C:\Temp\arcbox-interop-test.cmd";
 
-        let runner = InteropRunner::new(script).await.expect("probe");
+        let runner = InteropRunner::new(&script).await.expect("probe");
         let mut job = runner.spawn("dGVzdA==").await.expect("spawn");
         assert!(job.windows_pid() > 0);
 

--- a/fleet/arcbox-fleet-agent/src/interop.rs
+++ b/fleet/arcbox-fleet-agent/src/interop.rs
@@ -1,11 +1,56 @@
 //! WSL Windows-interop support: the bridge that lets the Linux agent, running
 //! inside WSL2, serve `windows` jobs by executing the host's pre-installed
 //! Windows runner across the interop boundary.
+//!
+//! Interop process management is asymmetric, which shapes the whole design
+//! (verified empirically on WSL2):
+//!
+//! - Spawning works like any exec: the Linux-side process is a **relay**
+//!   that pipes stdio and mirrors the Windows process's exit code.
+//! - Killing does not: SIGKILL on the relay **orphans** the Windows process,
+//!   so the Unix process-group teardown the host-runner path uses cannot
+//!   cancel a windows job.
+//!
+//! [`InteropRunner::spawn`] therefore launches the runner through a
+//! PowerShell wrapper that prints the Windows PID (`WINPID=<n>`) before
+//! waiting on the process, and [`InteropJob::kill`] cancels by asking
+//! Windows itself — `taskkill /T /F /PID` across the same interop boundary —
+//! which tears down the whole Windows tree and unblocks the relay's wait.
+//!
+//! Known limitations, accepted by design: admission telemetry measures the
+//! WSL utility VM (not the Windows host the jobs actually burn), and the
+//! composed `cmd.exe` command line is capped at ~8k chars (cmd's limit), so
+//! oversized JIT configs are rejected up front with a clear reason.
 
 use std::path::PathBuf;
-use std::process::Command;
+use std::process::{Command, Stdio};
+use std::time::Duration;
 
-use anyhow::{Context, Result, bail};
+use anyhow::{Context, Result, bail, ensure};
+use tokio::io::{AsyncBufReadExt, BufReader};
+use tracing::{debug, warn};
+
+/// Fixed Windows locations of the interop tools, translated through
+/// `wslpath` at startup so a non-default automount root still resolves.
+/// Windows PowerShell 5.1 ships with every Windows 10/11 install (unlike
+/// `pwsh`), and both paths are identical on x64 and ARM64.
+const POWERSHELL_WINDOWS_PATH: &str = r"C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe";
+const TASKKILL_WINDOWS_PATH: &str = r"C:\Windows\System32\taskkill.exe";
+
+/// Budget for the startup probe (`powershell -Command "exit 0"`): the first
+/// interop spawn after a WSL boot can take a few seconds, a hung one means
+/// interop is unusable.
+const PROBE_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Budget for the `WINPID=` handshake after spawn. Generous: the wrapper
+/// prints it right after `Start-Process` returns, well before the runner
+/// does any work.
+const HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Ceiling for the composed `cmd.exe` command line. cmd refuses lines over
+/// 8191 chars; staying under with margin turns a too-large JIT config into
+/// a clean upfront rejection instead of a cryptic mid-spawn failure.
+const CMD_LINE_BUDGET: usize = 8000;
 
 /// Translate an absolute Windows path (`C:\actions-runner\run.cmd`) to its
 /// WSL mount view (`/mnt/c/actions-runner/run.cmd`) via `wslpath -u`.
@@ -40,8 +85,259 @@ pub fn windows_path_to_unix(windows_path: &str) -> Result<PathBuf> {
     Ok(PathBuf::from(translated.trim_end_matches('\n')))
 }
 
+/// Runs windows jobs on the WSL host via interop. Constructed once at
+/// startup; the runner script is frozen at construction — restart-scoped,
+/// like the host path's `runner_script`.
+#[derive(Clone)]
+pub struct InteropRunner {
+    /// WSL-mount view of Windows PowerShell 5.1, the wrapper interpreter.
+    powershell: PathBuf,
+    /// WSL-mount view of `taskkill.exe`, the cancellation mechanism.
+    taskkill: PathBuf,
+    /// Windows-style path to the runner entry point (`run.cmd`).
+    script: String,
+}
+
+impl InteropRunner {
+    /// Resolve the interop tools and prove interop actually executes:
+    /// translate the fixed tool paths and `script` through `wslpath`
+    /// (fails cleanly outside WSL), require all three to exist under the
+    /// mount view, then run a trivial PowerShell command end-to-end —
+    /// translation alone cannot detect interop disabled via `wsl.conf`.
+    pub async fn new(script: &str) -> Result<Self> {
+        let powershell = windows_path_to_unix(POWERSHELL_WINDOWS_PATH)?;
+        let taskkill = windows_path_to_unix(TASKKILL_WINDOWS_PATH)?;
+        for (name, path) in [("powershell", &powershell), ("taskkill", &taskkill)] {
+            ensure!(
+                path.is_file(),
+                "{name} not found at {} — is the Windows drive mounted?",
+                path.display()
+            );
+        }
+        let script_unix = windows_path_to_unix(script)?;
+        ensure!(
+            script_unix.is_file(),
+            "windows runner script {script} not found (checked {})",
+            script_unix.display()
+        );
+
+        let probe = tokio::process::Command::new(&powershell)
+            .args(["-NoProfile", "-NonInteractive", "-Command", "exit 0"])
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .status();
+        let status = tokio::time::timeout(PROBE_TIMEOUT, probe)
+            .await
+            .context("interop probe timed out — is interop enabled in wsl.conf?")?
+            .context("spawning the interop probe")?;
+        ensure!(status.success(), "interop probe exited with {status}");
+
+        Ok(Self {
+            powershell,
+            taskkill,
+            script: script.to_owned(),
+        })
+    }
+
+    /// Test constructor bypassing `wslpath` and the probe, so the spawn/
+    /// wait/kill contract is exercisable anywhere with stub executables
+    /// standing in for powershell and taskkill.
+    #[cfg(test)]
+    fn with_paths(powershell: PathBuf, taskkill: PathBuf, script: &str) -> Self {
+        Self {
+            powershell,
+            taskkill,
+            script: script.to_owned(),
+        }
+    }
+
+    /// Start the Windows runner for one job and complete the `WINPID=`
+    /// handshake, so the returned job is provably running on the Windows
+    /// side and carries the PID that can cancel it. Any failure past the
+    /// spawn reaps the relay before returning, so an error never leaks a
+    /// process.
+    pub async fn spawn(&self, encoded_jit_config: &str) -> Result<InteropJob> {
+        validate_jit_config(&self.script, encoded_jit_config)?;
+
+        let mut child = tokio::process::Command::new(&self.powershell)
+            .args(["-NoProfile", "-NonInteractive", "-Command"])
+            .arg(wrapper_command(&self.script, encoded_jit_config))
+            .stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .kill_on_drop(true)
+            .spawn()
+            .context("spawning the interop wrapper")?;
+
+        let stdout = child
+            .stdout
+            .take()
+            .context("interop wrapper spawned without a stdout pipe")?;
+        let mut lines = BufReader::new(stdout).lines();
+        let handshake = async {
+            while let Some(line) = lines.next_line().await? {
+                if let Some(pid) = line.strip_prefix("WINPID=") {
+                    return pid
+                        .trim()
+                        .parse::<u32>()
+                        .with_context(|| format!("malformed handshake line {line:?}"));
+                }
+                debug!(line, "interop wrapper output before handshake");
+            }
+            bail!("interop wrapper exited without reporting WINPID");
+        };
+        let windows_pid = match tokio::time::timeout(HANDSHAKE_TIMEOUT, handshake).await {
+            Ok(Ok(pid)) => pid,
+            Ok(Err(e)) => {
+                reap(&mut child).await;
+                return Err(e);
+            }
+            Err(_) => {
+                reap(&mut child).await;
+                bail!("interop wrapper did not report WINPID within {HANDSHAKE_TIMEOUT:?}");
+            }
+        };
+
+        // Keep the pipe drained for the rest of the job — the runner's
+        // output flows through the wrapper's console — so a chatty runner
+        // can never fill the pipe and wedge itself. Ends at EOF when the
+        // relay exits; detaching the handle is deliberate.
+        tokio::spawn(async move {
+            loop {
+                match lines.next_line().await {
+                    Ok(Some(line)) => debug!(line, "windows runner output"),
+                    Ok(None) => break,
+                    Err(e) => {
+                        debug!(error = %e, "windows runner output stream failed");
+                        break;
+                    }
+                }
+            }
+        });
+
+        Ok(InteropJob {
+            windows_pid,
+            child,
+            taskkill: self.taskkill.clone(),
+        })
+    }
+}
+
+/// Kill and reap the relay after a failed handshake. Losing the Windows
+/// process is acceptable here: either it never started (`Start-Process`
+/// failed) or the wrapper is defective — there is no PID to taskkill.
+async fn reap(child: &mut tokio::process::Child) {
+    if let Err(e) = child.kill().await {
+        warn!(error = %e, "killing the interop wrapper failed");
+    }
+}
+
+/// A windows job running on the WSL host: the interop relay (whose exit
+/// mirrors the Windows process's) plus the Windows PID that can kill it.
+#[derive(Debug)]
+pub struct InteropJob {
+    windows_pid: u32,
+    child: tokio::process::Child,
+    taskkill: PathBuf,
+}
+
+impl InteropJob {
+    /// The Windows-side PID, for logs and diagnostics.
+    pub fn windows_pid(&self) -> u32 {
+        self.windows_pid
+    }
+
+    /// Wait for the runner to exit; the relay mirrors its exit status.
+    pub async fn wait(&mut self) -> std::io::Result<std::process::ExitStatus> {
+        self.child.wait().await
+    }
+
+    /// Cancel: `taskkill /T /F` the Windows tree, then reap the relay
+    /// (whose `WaitForExit` returns once the tree is gone). Killing the
+    /// relay instead would orphan the Windows process — see the module doc.
+    /// Falls back to exactly that (with a warning) if taskkill itself
+    /// fails, so the job slot is always released either way.
+    pub async fn kill(&mut self) {
+        let killed = tokio::process::Command::new(&self.taskkill)
+            .args(["/T", "/F", "/PID", &self.windows_pid.to_string()])
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .status()
+            .await;
+        match killed {
+            Ok(status) if status.success() => {}
+            Ok(status) => {
+                warn!(
+                    windows_pid = self.windows_pid,
+                    %status,
+                    "taskkill failed; killing the relay (the Windows tree may be orphaned)"
+                );
+                reap(&mut self.child).await;
+            }
+            Err(e) => {
+                warn!(
+                    windows_pid = self.windows_pid,
+                    error = %e,
+                    "spawning taskkill failed; killing the relay (the Windows tree may be orphaned)"
+                );
+                reap(&mut self.child).await;
+            }
+        }
+        if let Err(e) = self.child.wait().await {
+            warn!(error = %e, "reaping the interop relay failed");
+        }
+    }
+}
+
+/// Compose the PowerShell wrapper: start the runner via `cmd.exe`, report
+/// its Windows PID, then block until it exits and mirror its exit code.
+/// `-NoNewWindow` keeps the runner's output on the wrapper's console, which
+/// the relay pipes back to us.
+///
+/// Quoting: the script path is embedded in a PowerShell single-quoted
+/// string (only `'` is special, doubled) *and* wrapped in `"` for the
+/// cmd.exe layer (`"` cannot occur in a Windows path); the JIT config's
+/// charset is pre-validated, so it needs no quoting at either layer.
+fn wrapper_command(script: &str, encoded_jit_config: &str) -> String {
+    let script_ps = script.replace('\'', "''");
+    format!(
+        "$p = Start-Process -FilePath 'cmd.exe' \
+         -ArgumentList '/c','\"{script_ps}\"','--jitconfig','{encoded_jit_config}' \
+         -PassThru -NoNewWindow; \
+         Write-Output \"WINPID=$($p.Id)\"; \
+         $p.WaitForExit(); \
+         exit $p.ExitCode"
+    )
+}
+
+/// Boundary validation before anything is spawned: the JIT config must be
+/// base64-shaped (GitHub's encoded JIT config always is), so it can be
+/// embedded without quoting hazards, and the composed `cmd.exe` line must
+/// fit cmd's length limit.
+fn validate_jit_config(script: &str, encoded_jit_config: &str) -> Result<()> {
+    ensure!(
+        !encoded_jit_config.is_empty(),
+        "encoded JIT config is empty"
+    );
+    ensure!(
+        encoded_jit_config
+            .bytes()
+            .all(|b| b.is_ascii_alphanumeric() || matches!(b, b'+' | b'/' | b'=' | b'-' | b'_')),
+        "encoded JIT config contains non-base64 characters"
+    );
+    // `cmd.exe /c "<script>" --jitconfig <blob>` plus slack for quotes.
+    let composed = "cmd.exe /c \"\" --jitconfig ".len() + script.len() + encoded_jit_config.len();
+    ensure!(
+        composed <= CMD_LINE_BUDGET,
+        "composed command line ({composed} chars) exceeds cmd.exe's limit — \
+         the JIT config is too large to pass through cmd"
+    );
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
+    use std::os::unix::fs::PermissionsExt;
+
     use super::*;
 
     /// Shape validation happens before `wslpath` is ever invoked, so these
@@ -62,5 +358,142 @@ mod tests {
                 "{bad}: {err}"
             );
         }
+    }
+
+    #[test]
+    fn wrapper_embeds_script_and_jitconfig_and_doubles_quotes() {
+        let cmd = wrapper_command(r"C:\runners\o'brien\run.cmd", "abc123=");
+        assert!(cmd.contains(r#"'"C:\runners\o''brien\run.cmd"'"#), "{cmd}");
+        assert!(cmd.contains("'--jitconfig','abc123='"), "{cmd}");
+        assert!(cmd.contains("WINPID=$($p.Id)"), "{cmd}");
+        assert!(cmd.contains("exit $p.ExitCode"), "{cmd}");
+    }
+
+    #[test]
+    fn jit_config_validation_rejects_hostile_or_oversized_input() {
+        let script = r"C:\actions-runner\run.cmd";
+        assert!(validate_jit_config(script, "eyJhbGciOi+/=_-c9").is_ok());
+
+        for bad in ["", "abc def", "abc'def", "abc\"def", "abc;rm -rf"] {
+            assert!(validate_jit_config(script, bad).is_err(), "{bad:?}");
+        }
+
+        let oversized = "A".repeat(CMD_LINE_BUDGET);
+        let err = validate_jit_config(script, &oversized).expect_err("oversized");
+        assert!(err.to_string().contains("too large"), "{err}");
+    }
+
+    /// Write an executable stub script for the fake powershell/taskkill.
+    fn stub(dir: &std::path::Path, name: &str, body: &str) -> PathBuf {
+        let path = dir.join(name);
+        std::fs::write(&path, format!("#!/bin/sh\n{body}\n")).unwrap();
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o755)).unwrap();
+        path
+    }
+
+    /// The spawn handshake parses `WINPID=` from the wrapper's stdout, and
+    /// a normal exit propagates the exit code through `wait`.
+    #[tokio::test]
+    async fn spawn_handshakes_winpid_and_wait_mirrors_the_exit_code() {
+        let dir = tempfile::tempdir().unwrap();
+        let powershell = stub(dir.path(), "powershell", "echo 'WINPID=4242'\nexit 7");
+        let taskkill = stub(dir.path(), "taskkill", "exit 0");
+        let runner = InteropRunner::with_paths(powershell, taskkill, r"C:\r\run.cmd");
+
+        let mut job = runner.spawn("dGVzdA==").await.expect("handshake");
+        assert_eq!(job.windows_pid(), 4242);
+        let status = job.wait().await.expect("wait");
+        assert_eq!(status.code(), Some(7));
+    }
+
+    /// Pre-handshake chatter on stdout is tolerated; the handshake scans
+    /// for the `WINPID=` line rather than requiring it first.
+    #[tokio::test]
+    async fn spawn_skips_pre_handshake_output() {
+        let dir = tempfile::tempdir().unwrap();
+        let powershell = stub(
+            dir.path(),
+            "powershell",
+            "echo 'starting up'\necho 'WINPID=7'\nexit 0",
+        );
+        let taskkill = stub(dir.path(), "taskkill", "exit 0");
+        let runner = InteropRunner::with_paths(powershell, taskkill, r"C:\r\run.cmd");
+
+        let job = runner.spawn("dGVzdA==").await.expect("handshake");
+        assert_eq!(job.windows_pid(), 7);
+    }
+
+    /// A wrapper that exits without reporting a PID is a spawn failure —
+    /// the caller rejects the offer instead of accepting a ghost job.
+    #[tokio::test]
+    async fn spawn_fails_when_the_wrapper_never_reports_winpid() {
+        let dir = tempfile::tempdir().unwrap();
+        let powershell = stub(dir.path(), "powershell", "echo 'no pid here'\nexit 1");
+        let taskkill = stub(dir.path(), "taskkill", "exit 0");
+        let runner = InteropRunner::with_paths(powershell, taskkill, r"C:\r\run.cmd");
+
+        let err = runner.spawn("dGVzdA==").await.expect_err("no handshake");
+        assert!(
+            err.to_string().contains("without reporting WINPID"),
+            "{err}"
+        );
+    }
+
+    /// Cancellation goes through taskkill (here a stub that SIGKILLs the
+    /// reported PID — the stub reports its own, standing in for the Windows
+    /// tree), after which the relay's exit is reaped by `kill` itself.
+    #[tokio::test]
+    async fn kill_invokes_taskkill_with_the_windows_pid_and_reaps_the_relay() {
+        let dir = tempfile::tempdir().unwrap();
+        // The fake powershell reports its own PID then parks, exactly like
+        // the real wrapper parks in WaitForExit until the tree dies.
+        let powershell = stub(
+            dir.path(),
+            "powershell",
+            "echo \"WINPID=$$\"\nexec sleep 30",
+        );
+        // The fake taskkill records its arguments, then kills the "tree".
+        let log = dir.path().join("taskkill.log");
+        let taskkill = stub(
+            dir.path(),
+            "taskkill",
+            &format!("echo \"$@\" > {}\nkill -9 \"$4\"", log.display()),
+        );
+        let runner = InteropRunner::with_paths(powershell, taskkill, r"C:\r\run.cmd");
+
+        let mut job = runner.spawn("dGVzdA==").await.expect("handshake");
+        let pid = job.windows_pid();
+        let start = tokio::time::Instant::now();
+        job.kill().await;
+        assert!(
+            start.elapsed() < Duration::from_secs(20),
+            "kill must not wait out the stub's 30s sleep"
+        );
+        let recorded = std::fs::read_to_string(&log).expect("taskkill invoked");
+        assert_eq!(recorded.trim(), format!("/T /F /PID {pid}"));
+    }
+
+    /// Live end-to-end against real interop — requires a WSL2 host with a
+    /// stub `run.cmd` staged on the Windows side, so it is ignored by
+    /// default: `cargo test -p arcbox-fleet-agent -- --ignored interop`.
+    #[tokio::test]
+    #[ignore = "requires a WSL2 host with Windows interop enabled"]
+    async fn live_wsl_spawn_and_kill_round_trip() {
+        let staged = PathBuf::from("/mnt/c/Temp/arcbox-interop-test.cmd");
+        std::fs::create_dir_all(staged.parent().unwrap()).unwrap();
+        std::fs::write(&staged, "@echo off\r\nping -n 60 127.0.0.1 >NUL\r\n").unwrap();
+        let script = r"C:\Temp\arcbox-interop-test.cmd";
+
+        let runner = InteropRunner::new(script).await.expect("probe");
+        let mut job = runner.spawn("dGVzdA==").await.expect("spawn");
+        assert!(job.windows_pid() > 0);
+
+        let start = tokio::time::Instant::now();
+        job.kill().await;
+        assert!(
+            start.elapsed() < Duration::from_secs(30),
+            "taskkill must unblock the relay well before the 60s ping ends"
+        );
+        let _ = std::fs::remove_file(&staged);
     }
 }

--- a/fleet/arcbox-fleet-agent/src/interop.rs
+++ b/fleet/arcbox-fleet-agent/src/interop.rs
@@ -1,0 +1,66 @@
+//! WSL Windows-interop support: the bridge that lets the Linux agent, running
+//! inside WSL2, serve `windows` jobs by executing the host's pre-installed
+//! Windows runner across the interop boundary.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+use anyhow::{Context, Result, bail};
+
+/// Translate an absolute Windows path (`C:\actions-runner\run.cmd`) to its
+/// WSL mount view (`/mnt/c/actions-runner/run.cmd`) via `wslpath -u`.
+///
+/// The shape is validated first because `wslpath -u` passes non-Windows
+/// input through unchanged instead of failing. Translation is textual for
+/// mounted drives — the file itself need not exist — so callers that care
+/// check the returned path. Fails cleanly outside WSL (no `wslpath`) or for
+/// an unmounted drive letter.
+pub fn windows_path_to_unix(windows_path: &str) -> Result<PathBuf> {
+    let mut chars = windows_path.chars();
+    let drive_prefixed = chars.next().is_some_and(|c| c.is_ascii_alphabetic())
+        && chars.next() == Some(':')
+        && chars.next() == Some('\\');
+    if !drive_prefixed {
+        bail!("{windows_path} is not an absolute Windows path (expected e.g. C:\\...)");
+    }
+
+    let output = Command::new("wslpath")
+        .arg("-u")
+        .arg(windows_path)
+        .output()
+        .context("running wslpath (is this a WSL distro?)")?;
+    if !output.status.success() {
+        bail!(
+            "wslpath -u {windows_path} failed ({}): {}",
+            output.status,
+            String::from_utf8_lossy(&output.stderr).trim()
+        );
+    }
+    let translated = String::from_utf8(output.stdout).context("wslpath emitted non-UTF-8")?;
+    Ok(PathBuf::from(translated.trim_end_matches('\n')))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Shape validation happens before `wslpath` is ever invoked, so these
+    /// pass on any host, WSL or not.
+    #[test]
+    fn rejects_paths_that_are_not_absolute_windows_paths() {
+        for bad in [
+            "",
+            "run.cmd",
+            "/mnt/c/actions-runner/run.cmd",
+            "actions-runner\\run.cmd",
+            "C:/actions-runner/run.cmd",
+            ":\\no-drive",
+        ] {
+            let err = windows_path_to_unix(bad).expect_err(bad);
+            assert!(
+                err.to_string().contains("not an absolute Windows path"),
+                "{bad}: {err}"
+            );
+        }
+    }
+}

--- a/fleet/arcbox-fleet-agent/src/interop.rs
+++ b/fleet/arcbox-fleet-agent/src/interop.rs
@@ -141,9 +141,10 @@ impl InteropRunner {
 
     /// Test constructor bypassing `wslpath` and the probe, so the spawn/
     /// wait/kill contract is exercisable anywhere with stub executables
-    /// standing in for powershell and taskkill.
+    /// standing in for powershell and taskkill. Crate-visible for the
+    /// runner's routing tests.
     #[cfg(test)]
-    fn with_paths(powershell: PathBuf, taskkill: PathBuf, script: &str) -> Self {
+    pub(crate) fn with_paths(powershell: PathBuf, taskkill: PathBuf, script: &str) -> Self {
         Self {
             powershell,
             taskkill,

--- a/fleet/arcbox-fleet-agent/src/interop.rs
+++ b/fleet/arcbox-fleet-agent/src/interop.rs
@@ -47,6 +47,11 @@ const PROBE_TIMEOUT: Duration = Duration::from_secs(10);
 /// does any work.
 const HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(30);
 
+/// Budget for each interop-boundary call in the cancel path (`taskkill`,
+/// relay reap). A wedged interop layer must not block the cancel arm in
+/// `run_interop_job` forever — that would leak the in-flight job slot.
+const KILL_TIMEOUT: Duration = Duration::from_secs(10);
+
 /// Ceiling for the composed `cmd.exe` command line. cmd refuses lines over
 /// 8191 chars; staying under with margin turns a too-large JIT config into
 /// a clean upfront rejection instead of a cryptic mid-spawn failure.
@@ -189,11 +194,11 @@ impl InteropRunner {
         let windows_pid = match tokio::time::timeout(HANDSHAKE_TIMEOUT, handshake).await {
             Ok(Ok(pid)) => pid,
             Ok(Err(e)) => {
-                reap(&mut child).await;
+                reap(&mut child, KILL_TIMEOUT).await;
                 return Err(e);
             }
             Err(_) => {
-                reap(&mut child).await;
+                reap(&mut child, KILL_TIMEOUT).await;
                 bail!("interop wrapper did not report WINPID within {HANDSHAKE_TIMEOUT:?}");
             }
         };
@@ -219,16 +224,25 @@ impl InteropRunner {
             windows_pid,
             child,
             taskkill: self.taskkill.clone(),
+            kill_timeout: KILL_TIMEOUT,
         })
     }
 }
 
-/// Kill and reap the relay after a failed handshake. Losing the Windows
-/// process is acceptable here: either it never started (`Start-Process`
-/// failed) or the wrapper is defective — there is no PID to taskkill.
-async fn reap(child: &mut tokio::process::Child) {
-    if let Err(e) = child.kill().await {
-        warn!(error = %e, "killing the interop wrapper failed");
+/// Kill and reap the relay after a failed handshake or a failed/hung
+/// taskkill. Losing the Windows process is acceptable here: either it
+/// never started (`Start-Process` failed), the wrapper is defective, or
+/// the tree teardown already ran. Bounded: if even SIGKILL delivery/reap
+/// wedges (degraded interop), the kill signal is left pending and the
+/// caller proceeds — releasing the job slot outranks reaping the zombie.
+async fn reap(child: &mut tokio::process::Child, timeout: Duration) {
+    match tokio::time::timeout(timeout, child.kill()).await {
+        Ok(Ok(())) => {}
+        Ok(Err(e)) => warn!(error = %e, "killing the interop wrapper failed"),
+        Err(_) => {
+            let _ = child.start_kill();
+            warn!("interop wrapper did not reap within {timeout:?}; leaving the kill pending");
+        }
     }
 }
 
@@ -239,6 +253,10 @@ pub struct InteropJob {
     windows_pid: u32,
     child: tokio::process::Child,
     taskkill: PathBuf,
+    /// Per-call budget for the teardown in [`Self::kill`]. Always
+    /// [`KILL_TIMEOUT`] in production; tests shrink it to exercise the
+    /// hung-taskkill path quickly.
+    kill_timeout: Duration,
 }
 
 impl InteropJob {
@@ -256,35 +274,53 @@ impl InteropJob {
     /// (whose `WaitForExit` returns once the tree is gone). Killing the
     /// relay instead would orphan the Windows process — see the module doc.
     /// Falls back to exactly that (with a warning) if taskkill itself
-    /// fails, so the job slot is always released either way.
+    /// fails or hangs, so the job slot is always released either way:
+    /// every interop-boundary call here is bounded by [`KILL_TIMEOUT`] —
+    /// an unbounded wait would wedge the cancel arm in `run_interop_job`
+    /// and leak the slot.
     pub async fn kill(&mut self) {
-        let killed = tokio::process::Command::new(&self.taskkill)
+        let taskkill = tokio::process::Command::new(&self.taskkill)
             .args(["/T", "/F", "/PID", &self.windows_pid.to_string()])
             .stdin(Stdio::null())
             .stdout(Stdio::null())
-            .status()
-            .await;
-        match killed {
-            Ok(status) if status.success() => {}
-            Ok(status) => {
+            .status();
+        match tokio::time::timeout(self.kill_timeout, taskkill).await {
+            Ok(Ok(status)) if status.success() => {}
+            Ok(Ok(status)) => {
                 warn!(
                     windows_pid = self.windows_pid,
                     %status,
                     "taskkill failed; killing the relay (the Windows tree may be orphaned)"
                 );
-                reap(&mut self.child).await;
+                reap(&mut self.child, self.kill_timeout).await;
             }
-            Err(e) => {
+            Ok(Err(e)) => {
                 warn!(
                     windows_pid = self.windows_pid,
                     error = %e,
                     "spawning taskkill failed; killing the relay (the Windows tree may be orphaned)"
                 );
-                reap(&mut self.child).await;
+                reap(&mut self.child, self.kill_timeout).await;
+            }
+            Err(_) => {
+                warn!(
+                    windows_pid = self.windows_pid,
+                    "taskkill hung past {:?}; killing the relay (the Windows tree may be orphaned)",
+                    self.kill_timeout
+                );
+                reap(&mut self.child, self.kill_timeout).await;
             }
         }
-        if let Err(e) = self.child.wait().await {
-            warn!(error = %e, "reaping the interop relay failed");
+        match tokio::time::timeout(self.kill_timeout, self.child.wait()).await {
+            Ok(Ok(_)) => {}
+            Ok(Err(e)) => warn!(error = %e, "reaping the interop relay failed"),
+            Err(_) => {
+                warn!(
+                    "interop relay did not exit within {:?}; killing it",
+                    self.kill_timeout
+                );
+                reap(&mut self.child, self.kill_timeout).await;
+            }
         }
     }
 }
@@ -497,6 +533,41 @@ mod tests {
         );
         let recorded = std::fs::read_to_string(&log).expect("taskkill invoked");
         assert_eq!(recorded.trim(), format!("/T /F /PID {pid}"));
+    }
+
+    /// A hung taskkill (degraded interop) must not wedge `kill`: the
+    /// per-call [`InteropJob::kill_timeout`] expires, the relay is reaped
+    /// via the fallback, and the caller — the cancel arm in
+    /// `run_interop_job` — gets control back so the job slot is released.
+    #[tokio::test]
+    async fn kill_survives_a_hung_taskkill_and_still_reaps_the_relay() {
+        let dir = tempfile::tempdir().unwrap();
+        let powershell = stub(
+            dir.path(),
+            "powershell",
+            "echo \"WINPID=$$\"\nexec sleep 30",
+        );
+        // A taskkill that never returns and never kills the tree.
+        let taskkill = stub(dir.path(), "taskkill", "exec sleep 30");
+        let runner = InteropRunner::with_paths(powershell, taskkill, r"C:\r\run.cmd");
+
+        let mut job = spawn_retrying(&runner, "dGVzdA==")
+            .await
+            .expect("handshake");
+        job.kill_timeout = Duration::from_millis(300);
+
+        let start = tokio::time::Instant::now();
+        job.kill().await;
+        assert!(
+            start.elapsed() < Duration::from_secs(10),
+            "kill must not wait out the hung taskkill"
+        );
+        // The relay was reaped by the fallback: wait() returns immediately.
+        let status = tokio::time::timeout(Duration::from_secs(5), job.wait())
+            .await
+            .expect("relay already reaped")
+            .expect("wait");
+        assert!(!status.success(), "relay was killed, not exited");
     }
 
     /// Live end-to-end against real interop — requires a WSL2 host, so it

--- a/fleet/arcbox-fleet-agent/src/main.rs
+++ b/fleet/arcbox-fleet-agent/src/main.rs
@@ -259,7 +259,7 @@ async fn run(command: Command, config: AgentConfig) -> Result<()> {
             // The capabilities sent here are an initial hint, replaced wholesale
             // by the first heartbeat once the agent attaches, so we advertise
             // what we know without probing the runtimes.
-            let capabilities = capabilities(seed.runner_script.is_some(), None, None);
+            let capabilities = capabilities(seed.runner_script.is_some(), None, None, None);
             let credential = match enroll::enroll(&config, token, capabilities, &seed.gateway).await
             {
                 Ok(credential) => credential,
@@ -296,8 +296,12 @@ async fn run(command: Command, config: AgentConfig) -> Result<()> {
             )
             .await?;
             let interop = init_interop(seed.windows_runner_script.as_deref()).await;
-            let capabilities =
-                capabilities(seed.runner_script.is_some(), docker.as_ref(), vm.as_ref());
+            let capabilities = capabilities(
+                seed.runner_script.is_some(),
+                docker.as_ref(),
+                vm.as_ref(),
+                interop.as_ref(),
+            );
             let credential = config.credential_store_for(&seed.gateway).load()?.context(
                 "no credential found — run `arcbox-fleet-agent quick enroll --token-file …` first",
             )?;
@@ -352,8 +356,12 @@ async fn run(command: Command, config: AgentConfig) -> Result<()> {
             )
             .await?;
             let interop = init_interop(seed.windows_runner_script.as_deref()).await;
-            let capabilities =
-                capabilities(seed.runner_script.is_some(), docker.as_ref(), vm.as_ref());
+            let capabilities = capabilities(
+                seed.runner_script.is_some(),
+                docker.as_ref(),
+                vm.as_ref(),
+                interop.as_ref(),
+            );
             let socket_path = config.control_socket_path();
 
             // Cascades to every attach task's child token, so runners still
@@ -660,16 +668,23 @@ fn resolve_enrollment_token(token_file: Option<PathBuf>, token: Option<String>) 
 }
 
 /// Build the capabilities this agent advertises: any Docker-served Linux
-/// capabilities, plus the native pair — VM-served when the daemon backend
-/// is active, else the host runner (if a runner script is configured).
-/// Capacity is decided per offer from live telemetry, not here.
+/// capabilities, windows via WSL interop when that probe passed, plus the
+/// native pair — VM-served when the daemon backend is active, else the host
+/// runner (if a runner script is configured). Capacity is decided per offer
+/// from live telemetry, not here.
 fn capabilities(
     runner_script_present: bool,
     docker: Option<&DockerRunner>,
     vm: Option<&VmRunner>,
+    interop: Option<&InteropRunner>,
 ) -> Vec<Capability> {
     let docker_arches = docker.map(DockerRunner::linux_arches).unwrap_or_default();
-    host::capabilities(runner_script_present, &docker_arches, vm.is_some())
+    host::capabilities(
+        runner_script_present,
+        &docker_arches,
+        vm.is_some(),
+        interop.is_some(),
+    )
 }
 
 /// Probe Docker availability according to `mode`.

--- a/fleet/arcbox-fleet-agent/src/main.rs
+++ b/fleet/arcbox-fleet-agent/src/main.rs
@@ -749,7 +749,13 @@ async fn init_vm(
 async fn init_interop(windows_runner_script: Option<&str>) -> Option<InteropRunner> {
     let script = windows_runner_script?;
     match InteropRunner::new(script).await {
-        Ok(runner) => Some(runner),
+        Ok(runner) => {
+            info!(
+                script,
+                "WSL interop available; advertising the windows capability"
+            );
+            Some(runner)
+        }
         Err(e) => {
             warn!(
                 error = format!("{e:#}"),

--- a/fleet/arcbox-fleet-agent/src/main.rs
+++ b/fleet/arcbox-fleet-agent/src/main.rs
@@ -34,6 +34,7 @@ mod docker;
 mod enroll;
 mod fsutil;
 mod host;
+mod interop;
 mod runner;
 #[cfg(target_os = "macos")]
 mod service;
@@ -164,6 +165,11 @@ struct EnrollArgs {
 }
 
 #[derive(Debug, Subcommand)]
+#[expect(
+    clippy::large_enum_variant,
+    reason = "one value, parsed once at startup and consumed immediately — the Set variant's \
+              size is irrelevant, and boxing fights the clap derive"
+)]
 enum SettingsCommand {
     /// Show every setting's current (in-effect) and target (requested) value.
     Get,
@@ -198,6 +204,11 @@ enum SettingsCommand {
         /// "auto" | "enabled" | "disabled".
         #[arg(long)]
         vm_mode: Option<String>,
+        /// Windows-style path to the Windows runner entry point (e.g.
+        /// "C:\actions-runner\run.cmd"), run via WSL interop. Requires a WSL
+        /// host; "" clears. Applies on the next full restart.
+        #[arg(long)]
+        windows_runner_script: Option<String>,
     },
 }
 
@@ -464,6 +475,7 @@ async fn run(command: Command, config: AgentConfig) -> Result<()> {
             participate,
             macos_runner_image,
             vm_mode,
+            windows_runner_script,
         }) => {
             let docker_mode = docker_mode
                 .as_deref()
@@ -488,6 +500,7 @@ async fn run(command: Command, config: AgentConfig) -> Result<()> {
                     participate,
                     macos_runner_image,
                     vm_mode,
+                    windows_runner_script,
                 })
                 .await
                 .context("UpdateSettings RPC failed")?
@@ -828,18 +841,7 @@ fn print_settings(s: control_proto::AgentSettings) {
         );
     }
     if let Some(v) = s.runner_script {
-        let none = "(none)".to_owned();
-        let current = if v.current.is_empty() {
-            &none
-        } else {
-            &v.current
-        };
-        let target = if v.target.is_empty() {
-            &none
-        } else {
-            &v.target
-        };
-        print_setting("runner_script", current, target);
+        print_script_setting("runner_script", &v);
     }
     if let Some(v) = s.macos_runner_image {
         print_setting("macos_runner_image", &v.current, &v.target);
@@ -847,6 +849,22 @@ fn print_settings(s: control_proto::AgentSettings) {
     if let Some(v) = s.vm_mode {
         print_setting("vm_mode", vm_mode_label(v.current), vm_mode_label(v.target));
     }
+    if let Some(v) = s.windows_runner_script {
+        print_script_setting("windows_runner_script", &v);
+    }
+}
+
+/// [`print_setting`] for the script settings, whose empty string encodes
+/// "unset" and prints as `(none)`.
+fn print_script_setting(name: &str, v: &control_proto::StringSetting) {
+    let or_none = |s: &str| {
+        if s.is_empty() {
+            "(none)".to_owned()
+        } else {
+            s.to_owned()
+        }
+    };
+    print_setting(name, &or_none(&v.current), &or_none(&v.target));
 }
 
 #[cfg(test)]

--- a/fleet/arcbox-fleet-agent/src/main.rs
+++ b/fleet/arcbox-fleet-agent/src/main.rs
@@ -59,6 +59,7 @@ use tracing::{info, warn};
 
 use crate::config::{AgentConfig, DockerMode, VmMode};
 use crate::docker::DockerRunner;
+use crate::interop::InteropRunner;
 use crate::settings::{PersistedSettings, SettingsStore};
 use crate::state::AgentState;
 use crate::vm::VmRunner;
@@ -294,6 +295,7 @@ async fn run(command: Command, config: AgentConfig) -> Result<()> {
                 &config.vm.daemon_socket,
             )
             .await?;
+            let interop = init_interop(seed.windows_runner_script.as_deref()).await;
             let capabilities =
                 capabilities(seed.runner_script.is_some(), docker.as_ref(), vm.as_ref());
             let credential = config.credential_store_for(&seed.gateway).load()?.context(
@@ -313,6 +315,7 @@ async fn run(command: Command, config: AgentConfig) -> Result<()> {
                 &config,
                 docker,
                 vm,
+                interop,
                 capabilities.clone(),
                 agent_state.clone(),
             );
@@ -348,6 +351,7 @@ async fn run(command: Command, config: AgentConfig) -> Result<()> {
                 &config.vm.daemon_socket,
             )
             .await?;
+            let interop = init_interop(seed.windows_runner_script.as_deref()).await;
             let capabilities =
                 capabilities(seed.runner_script.is_some(), docker.as_ref(), vm.as_ref());
             let socket_path = config.control_socket_path();
@@ -363,6 +367,7 @@ async fn run(command: Command, config: AgentConfig) -> Result<()> {
                     config,
                     docker,
                     vm,
+                    interop,
                     capabilities,
                     shutdown.clone(),
                     agent_state.clone(),
@@ -717,6 +722,26 @@ async fn init_vm(
                 Ok(None)
             }
         },
+    }
+}
+
+/// Probe the WSL interop backend for windows jobs, Auto semantics only: an
+/// unset `windows_runner_script` means not wanted, and a failed probe (not
+/// WSL, interop disabled, script missing) logs and falls through — the
+/// windows capability is simply not advertised. There is no Enabled mode:
+/// unlike Docker/VM, nothing else can serve windows jobs, so failing
+/// startup would only take the host's other capabilities down with it.
+async fn init_interop(windows_runner_script: Option<&str>) -> Option<InteropRunner> {
+    let script = windows_runner_script?;
+    match InteropRunner::new(script).await {
+        Ok(runner) => Some(runner),
+        Err(e) => {
+            warn!(
+                error = format!("{e:#}"),
+                "WSL interop not available; the windows capability will not be advertised"
+            );
+            None
+        }
     }
 }
 

--- a/fleet/arcbox-fleet-agent/src/runner.rs
+++ b/fleet/arcbox-fleet-agent/src/runner.rs
@@ -753,6 +753,7 @@ mod tests {
             gateway: "https://fleet.arcbox.dev".to_owned(),
             docker_mode: crate::config::DockerMode::Auto,
             runner_script: None,
+            windows_runner_script: None,
             participate: true,
             vm_mode: crate::config::VmMode::Auto,
             macos_runner_image: "tahoe-base".to_owned(),

--- a/fleet/arcbox-fleet-agent/src/runner.rs
+++ b/fleet/arcbox-fleet-agent/src/runner.rs
@@ -917,6 +917,20 @@ mod tests {
         let powershell = interop_stub(dir.path(), "powershell", "echo 'WINPID=4242'\nexit 0");
         let taskkill = interop_stub(dir.path(), "taskkill", "exit 0");
         let interop = InteropRunner::with_paths(powershell, taskkill, r"C:\r\run.cmd");
+
+        // Warm the freshly written stub through the ETXTBSY window (a
+        // concurrently forking test can hold it open for writing until its
+        // own exec) so the spawn inside handle_provision can't hit it.
+        for _ in 0..100 {
+            match interop.spawn("dGVzdA==").await {
+                Ok(mut job) => {
+                    let _ = job.wait().await;
+                    break;
+                }
+                Err(_) => tokio::time::sleep(Duration::from_millis(20)).await,
+            }
+        }
+
         let (sup, mut rx) = windows_supervisor_with_rx(Some(interop));
 
         sup.handle_provision(ProvisionRunner {

--- a/fleet/arcbox-fleet-agent/src/runner.rs
+++ b/fleet/arcbox-fleet-agent/src/runner.rs
@@ -875,6 +875,104 @@ mod tests {
         );
     }
 
+    /// A supervisor advertising windows/amd64 (host_runner-backed, as the
+    /// interop capability is on the wire), with thresholds that can never
+    /// reject — `handle_provision` reads real `host::telemetry()`.
+    fn windows_supervisor_with_rx(
+        interop: Option<InteropRunner>,
+    ) -> (RunnerSupervisor, mpsc::Receiver<AttachRequest>) {
+        let (events, rx) = mpsc::channel(8);
+        let sup = RunnerSupervisor::new(
+            events,
+            None,
+            None,
+            None,
+            interop,
+            vec![capability("windows", "amd64", Backend::HostRunner)],
+            AgentState::new(&crate::settings::PersistedSettings {
+                load_ceiling: f64::MAX,
+                mem_floor_mib: 0,
+                ..seed()
+            }),
+        );
+        (sup, rx)
+    }
+
+    /// Write an executable stub standing in for powershell/taskkill.
+    fn interop_stub(dir: &std::path::Path, name: &str, body: &str) -> PathBuf {
+        use std::os::unix::fs::PermissionsExt;
+        let path = dir.join(name);
+        std::fs::write(&path, format!("#!/bin/sh\n{body}\n")).unwrap();
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o755)).unwrap();
+        path
+    }
+
+    /// Full dispatch for a windows offer: `handle_provision` routes the
+    /// host_runner-backed windows capability to the interop path, which
+    /// accepts only after the WINPID handshake and releases the slot when
+    /// the runner exits.
+    #[tokio::test]
+    async fn windows_offer_runs_through_the_interop_backend() {
+        let dir = tempfile::tempdir().unwrap();
+        let powershell = interop_stub(dir.path(), "powershell", "echo 'WINPID=4242'\nexit 0");
+        let taskkill = interop_stub(dir.path(), "taskkill", "exit 0");
+        let interop = InteropRunner::with_paths(powershell, taskkill, r"C:\r\run.cmd");
+        let (sup, mut rx) = windows_supervisor_with_rx(Some(interop));
+
+        sup.handle_provision(ProvisionRunner {
+            job_id: "rjob_win".to_owned(),
+            os: "windows".to_owned(),
+            arch: "amd64".to_owned(),
+            encoded_jit_config: "dGVzdA==".to_owned(),
+            offer_token: "tok1".to_owned(),
+        });
+
+        let verdict = tokio::time::timeout(Duration::from_secs(5), rx.recv())
+            .await
+            .expect("verdict within the handshake budget")
+            .expect("egress channel open");
+        match verdict.msg {
+            Some(attach_request::Msg::RunnerAccepted(a)) => assert_eq!(a.job_id, "rjob_win"),
+            other => panic!("expected RunnerAccepted, got {other:?}"),
+        }
+
+        // The stub exits immediately, so the slot drains without a cancel.
+        tokio::time::timeout(Duration::from_secs(5), async {
+            while sup.inner.in_flight.contains_key("rjob_win") {
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("slot released once the runner exited");
+    }
+
+    /// The defensive arm: a windows offer admitted while no interop backend
+    /// exists (a broken capability set) must reject, not panic or accept a
+    /// ghost job.
+    #[tokio::test]
+    async fn windows_offer_without_interop_is_rejected() {
+        let (sup, mut rx) = windows_supervisor_with_rx(None);
+
+        sup.handle_provision(ProvisionRunner {
+            job_id: "rjob_win".to_owned(),
+            os: "windows".to_owned(),
+            arch: "amd64".to_owned(),
+            encoded_jit_config: "dGVzdA==".to_owned(),
+            offer_token: "tok1".to_owned(),
+        });
+
+        let verdict = tokio::time::timeout(Duration::from_secs(5), rx.recv())
+            .await
+            .expect("verdict promptly")
+            .expect("egress channel open");
+        match verdict.msg {
+            Some(attach_request::Msg::RunnerRejected(r)) => {
+                assert!(r.reason.contains("not served"), "{}", r.reason);
+            }
+            other => panic!("expected RunnerRejected, got {other:?}"),
+        }
+    }
+
     #[test]
     fn rejects_unservable_os_arch() {
         let sup = supervisor(vec![capability("darwin", "arm64", Backend::HostRunner)]);

--- a/fleet/arcbox-fleet-agent/src/runner.rs
+++ b/fleet/arcbox-fleet-agent/src/runner.rs
@@ -7,7 +7,9 @@
 //! Backend is chosen from the agent's own advertised capabilities: Linux jobs a
 //! Docker capability serves run in a container (isolation); darwin jobs a `vm`
 //! capability serves run in a disposable macOS guest via the local daemon
-//! (isolation); a `host_runner` capability runs via the pre-installed runner.
+//! (isolation); a `host_runner` capability runs via the pre-installed runner —
+//! directly for the native platform, or across the WSL interop boundary for a
+//! windows capability served from inside WSL2.
 //! Capacity is never a number — admission gates on live load and free memory,
 //! so a busy host simply rejects and the platform re-offers elsewhere.
 
@@ -29,6 +31,7 @@ use tracing::{info, warn};
 
 use crate::docker::{DockerRunner, RunSpec};
 use crate::host;
+use crate::interop::InteropRunner;
 use crate::state::AgentState;
 use crate::vm::VmRunner;
 
@@ -87,7 +90,8 @@ struct Inner {
     /// Jobs currently running here, each with its cancellation token — one map
     /// for duplicate detection, cancel delivery, and release. Cancelling a token
     /// makes the job's `run_job` tear down the runner — the whole process group
-    /// (host) or the container (Docker) — awaited, before the entry is released.
+    /// (host), the container (Docker), the guest (VM), or the Windows process
+    /// tree (interop) — awaited, before the entry is released.
     /// The token is level-triggered, so a cancel that lands while the runner is
     /// still starting is observed at the next cancellation point rather than
     /// lost; see [`RunnerSupervisor::handle_cancel`].
@@ -99,6 +103,8 @@ struct Inner {
     docker: Option<DockerRunner>,
     /// macOS VM backend for darwin jobs, if the local daemon serves it.
     vm: Option<VmRunner>,
+    /// WSL interop backend for windows jobs, if the startup probe passed.
+    interop: Option<InteropRunner>,
     /// The backend serving each advertised `(os, arch)` — the routing table.
     backends: HashMap<(String, String), Backend>,
     /// Set once `Drain` is received; no new jobs are accepted.
@@ -142,6 +148,7 @@ impl RunnerSupervisor {
         runner_script: Option<PathBuf>,
         docker: Option<DockerRunner>,
         vm: Option<VmRunner>,
+        interop: Option<InteropRunner>,
         capabilities: Vec<Capability>,
         state: AgentState,
     ) -> Self {
@@ -164,6 +171,7 @@ impl RunnerSupervisor {
                 runner_script,
                 docker,
                 vm,
+                interop,
                 backends,
                 draining: std::sync::atomic::AtomicBool::new(false),
                 draining_for_update: std::sync::atomic::AtomicBool::new(false),
@@ -426,6 +434,13 @@ impl RunnerSupervisor {
         let job_id = order.job_id.clone();
         match backend {
             Backend::Docker => self.run_docker_job(&job_id, &order, &token, cancel).await,
+            // A windows capability is host_runner-backed on the wire (it IS
+            // the host's pre-installed runner, reached across the WSL
+            // interop boundary), but its process management is different
+            // enough to be its own path — see `crate::interop`.
+            Backend::HostRunner if order.os == "windows" => {
+                self.run_interop_job(&job_id, &order, &token, cancel).await;
+            }
             Backend::HostRunner => self.run_host_job(&job_id, &order, &token, cancel).await,
             Backend::Vm => self.run_vm_job(&job_id, &order, &token, cancel).await,
             // Never advertised, so admit() never routes here; reject
@@ -518,6 +533,60 @@ impl RunnerSupervisor {
             // the in-flight slot outlives the guest — never the reverse.
             None => {
                 running.destroy().await;
+                info!(job_id, "runner canceled");
+            }
+        }
+    }
+
+    /// Run a windows job on the WSL host via interop. The offer is accepted
+    /// only after the `WINPID=` handshake proves the Windows process is
+    /// running; cancellation tears down the Windows tree via `taskkill`
+    /// (a Unix process-group kill would only orphan it — see
+    /// [`crate::interop`]), awaited, so the slot outlives the runner.
+    async fn run_interop_job(
+        &self,
+        job_id: &str,
+        order: &ProvisionRunner,
+        token: &str,
+        cancel: CancellationToken,
+    ) {
+        // Invariant: a windows capability is only advertised when the
+        // interop probe passed, so admit() routes here only with `interop`
+        // set; reject defensively rather than panic if that ever breaks.
+        let Some(interop) = &self.inner.interop else {
+            self.reject(job_id, token, "windows jobs are not served by this agent");
+            return;
+        };
+
+        let mut job = match interop.spawn(&order.encoded_jit_config).await {
+            Ok(job) => job,
+            Err(e) => {
+                self.reject(
+                    job_id,
+                    token,
+                    &format!("failed to spawn windows runner: {e:#}"),
+                );
+                return;
+            }
+        };
+
+        self.accept(job_id, token);
+        info!(
+            job_id,
+            windows_pid = job.windows_pid(),
+            "runner started (windows interop)"
+        );
+
+        tokio::select! {
+            result = job.wait() => match result {
+                Ok(status) => info!(job_id, success = status.success(), "runner exited"),
+                Err(e) => warn!(job_id, error = %e, "waiting on runner failed"),
+            },
+            // CancelRunner: taskkill the Windows tree and reap the relay,
+            // awaited. The token is level-triggered, so a cancel that fired
+            // during the spawn handshake is observed here immediately.
+            () = cancel.cancelled() => {
+                job.kill().await;
                 info!(job_id, "runner canceled");
             }
         }
@@ -767,6 +836,7 @@ mod tests {
             Some(PathBuf::from("/nonexistent")),
             None,
             None,
+            None,
             capabilities,
             AgentState::new(&seed()),
         )
@@ -881,6 +951,7 @@ mod tests {
             Some(PathBuf::from("/nonexistent")),
             None,
             None,
+            None,
             vec![capability("darwin", "arm64", Backend::HostRunner)],
             AgentState::new(&seed()),
         );
@@ -898,6 +969,7 @@ mod tests {
         let sup = RunnerSupervisor::new(
             events,
             Some(PathBuf::from("/nonexistent")),
+            None,
             None,
             None,
             vec![capability("darwin", "arm64", Backend::HostRunner)],
@@ -1118,7 +1190,8 @@ mod tests {
     async fn shutdown_does_not_flip_observable_draining_but_drain_does() {
         let drained = AgentState::new(&seed());
         let (events, _rx) = mpsc::channel(1);
-        RunnerSupervisor::new(events, None, None, None, Vec::new(), drained.clone()).handle_drain();
+        RunnerSupervisor::new(events, None, None, None, None, Vec::new(), drained.clone())
+            .handle_drain();
         assert!(
             drained.current().draining,
             "Drain flips the observable flag"
@@ -1126,9 +1199,17 @@ mod tests {
 
         let torn_down = AgentState::new(&seed());
         let (events, _rx) = mpsc::channel(1);
-        RunnerSupervisor::new(events, None, None, None, Vec::new(), torn_down.clone())
-            .shutdown(Duration::from_secs(1))
-            .await;
+        RunnerSupervisor::new(
+            events,
+            None,
+            None,
+            None,
+            None,
+            Vec::new(),
+            torn_down.clone(),
+        )
+        .shutdown(Duration::from_secs(1))
+        .await;
         assert!(
             !torn_down.current().draining,
             "teardown must not flip the observable flag",

--- a/fleet/arcbox-fleet-agent/src/runner.rs
+++ b/fleet/arcbox-fleet-agent/src/runner.rs
@@ -558,9 +558,19 @@ impl RunnerSupervisor {
             return;
         };
 
-        let mut job = match interop.spawn(&order.encoded_jit_config).await {
-            Ok(job) => job,
-            Err(e) => {
+        // The spawn + WINPID handshake can block for up to HANDSHAKE_TIMEOUT
+        // on degraded interop and must not make the agent deaf to
+        // CancelRunner — mirror the VM startup path.
+        let spawned = {
+            let spawn = std::pin::pin!(interop.spawn(&order.encoded_jit_config));
+            tokio::select! {
+                result = spawn => Some(result),
+                () = cancel.cancelled() => None,
+            }
+        };
+        let mut job = match spawned {
+            Some(Ok(job)) => job,
+            Some(Err(e)) => {
                 self.reject(
                     job_id,
                     token,
@@ -568,7 +578,25 @@ impl RunnerSupervisor {
                 );
                 return;
             }
+            None => {
+                // Canceled mid-spawn: no verdict is owed (the platform
+                // already concluded the job). Dropping the spawn future
+                // kills the relay (`kill_on_drop`); without a completed
+                // WINPID handshake there is no Windows tree to taskkill —
+                // the same orphan tolerance as a failed handshake.
+                info!(job_id, "runner canceled during interop spawn");
+                return;
+            }
         };
+
+        // A cancel that landed while the spawn was completing: the platform
+        // already concluded the job, so don't resolve the offer — tear the
+        // job down instead of accepting it just to kill it.
+        if cancel.is_cancelled() {
+            job.kill().await;
+            info!(job_id, "runner canceled during interop spawn");
+            return;
+        }
 
         self.accept(job_id, token);
         info!(
@@ -583,8 +611,7 @@ impl RunnerSupervisor {
                 Err(e) => warn!(job_id, error = %e, "waiting on runner failed"),
             },
             // CancelRunner: taskkill the Windows tree and reap the relay,
-            // awaited. The token is level-triggered, so a cancel that fired
-            // during the spawn handshake is observed here immediately.
+            // awaited, so the slot outlives the teardown.
             () = cancel.cancelled() => {
                 job.kill().await;
                 info!(job_id, "runner canceled");
@@ -958,6 +985,55 @@ mod tests {
         })
         .await
         .expect("slot released once the runner exited");
+    }
+
+    /// A cancel that arrives while the interop spawn is still in the WINPID
+    /// handshake must not resolve the offer: the platform already concluded
+    /// the job, so no `RunnerAccepted` is owed and the slot must drain.
+    #[tokio::test]
+    async fn windows_offer_canceled_mid_spawn_sends_no_accept() {
+        let dir = tempfile::tempdir().unwrap();
+        // The handshake stalls long enough for the cancel to land first.
+        let powershell = interop_stub(
+            dir.path(),
+            "powershell",
+            "sleep 3\necho 'WINPID=4242'\nexit 0",
+        );
+        let taskkill = interop_stub(dir.path(), "taskkill", "exit 0");
+        let interop = InteropRunner::with_paths(powershell, taskkill, r"C:\r\run.cmd");
+
+        let (sup, mut rx) = windows_supervisor_with_rx(Some(interop));
+
+        sup.handle_provision(ProvisionRunner {
+            job_id: "rjob_win".to_owned(),
+            os: "windows".to_owned(),
+            arch: "amd64".to_owned(),
+            encoded_jit_config: "dGVzdA==".to_owned(),
+            offer_token: "tok1".to_owned(),
+        });
+
+        // Cancel while the wrapper is still sleeping pre-handshake.
+        tokio::time::timeout(Duration::from_secs(5), async {
+            while !sup.inner.in_flight.contains_key("rjob_win") {
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("job registered in_flight");
+        sup.handle_cancel("rjob_win");
+
+        // The slot drains without any verdict having been sent.
+        tokio::time::timeout(Duration::from_secs(5), async {
+            while sup.inner.in_flight.contains_key("rjob_win") {
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("slot released after the mid-spawn cancel");
+        assert!(
+            rx.try_recv().is_err(),
+            "no verdict may resolve a canceled offer"
+        );
     }
 
     /// The defensive arm: a windows offer admitted while no interop backend

--- a/fleet/arcbox-fleet-agent/src/settings.rs
+++ b/fleet/arcbox-fleet-agent/src/settings.rs
@@ -36,6 +36,11 @@ pub struct PersistedSettings {
     /// Direct path to the runner entry point (`run.sh`), not its containing
     /// directory.
     pub runner_script: Option<PathBuf>,
+    /// Windows-style path to the Windows runner entry point (e.g.
+    /// `C:\actions-runner\run.cmd`), executed across the WSL interop
+    /// boundary. Meaningful only inside WSL2 with interop enabled.
+    #[serde(default)]
+    pub windows_runner_script: Option<String>,
     /// Whether this machine takes part in the fleet; `false` keeps the
     /// credential but stays detached. Persisted so a launchd restart honors
     /// an operator's detach instead of silently reattaching.
@@ -58,6 +63,7 @@ impl From<&AgentConfig> for PersistedSettings {
             gateway: config.gateway.clone(),
             docker_mode: config.docker.mode,
             runner_script: config.runner_script.clone(),
+            windows_runner_script: config.windows_runner_script.clone(),
             // No env seed: a fresh install participates; only an explicit
             // UpdateSettings opts a machine out.
             participate: true,
@@ -121,6 +127,7 @@ mod tests {
             gateway: "https://fleet.arcbox.dev".to_owned(),
             docker_mode: DockerMode::Auto,
             runner_script: Some(PathBuf::from("/opt/actions-runner/run.sh")),
+            windows_runner_script: Some("C:\\actions-runner\\run.cmd".to_owned()),
             participate: true,
             vm_mode: crate::config::VmMode::Auto,
             macos_runner_image: "tahoe-base".to_owned(),
@@ -154,6 +161,7 @@ mod tests {
         let config = AgentConfig {
             gateway: "https://example.test".to_owned(),
             runner_script: Some(PathBuf::from("/opt/runner/run.sh")),
+            windows_runner_script: Some("C:\\runner\\run.cmd".to_owned()),
             load_ceiling: 0.5,
             mem_floor_mib: 1024,
             data_dir: PathBuf::from("/tmp/does-not-matter"),
@@ -178,10 +186,11 @@ mod tests {
         assert_eq!(seeded.linux_runner_image, config.docker.linux_runner_image);
         assert_eq!(seeded.vm_mode, config.vm.mode);
         assert_eq!(seeded.macos_runner_image, config.vm.macos_runner_image);
+        assert_eq!(seeded.windows_runner_script, config.windows_runner_script);
     }
 
-    /// A settings.json written before the VM-backend fields existed must
-    /// load as if those fields were seeded fresh.
+    /// A settings.json written before the VM-backend and WSL-interop fields
+    /// existed must load as if those fields were seeded fresh.
     #[test]
     fn pre_vm_fields_settings_file_loads_with_defaults() {
         let json = r#"{
@@ -196,5 +205,6 @@ mod tests {
         let settings: PersistedSettings = serde_json::from_str(json).unwrap();
         assert_eq!(settings.vm_mode, crate::config::VmMode::Auto);
         assert_eq!(settings.macos_runner_image, DEFAULT_MACOS_RUNNER_IMAGE);
+        assert_eq!(settings.windows_runner_script, None);
     }
 }

--- a/fleet/arcbox-fleet-agent/src/state.rs
+++ b/fleet/arcbox-fleet-agent/src/state.rs
@@ -101,6 +101,13 @@ fn setting_value_to_path(value: &str) -> Option<PathBuf> {
     (!value.is_empty()).then(|| PathBuf::from(value))
 }
 
+/// Same empty-means-unset encoding as [`setting_value_to_path`], for settings
+/// that are opaque strings rather than local paths (the Windows-style
+/// `windows_runner_script`).
+fn setting_value_to_string(value: &str) -> Option<String> {
+    (!value.is_empty()).then(|| value.to_owned())
+}
+
 /// The always-present settings block. Every accessor goes through these two
 /// helpers so the outer [`SETTINGS_INVARIANT`] assertion is spelled once here
 /// rather than at each of the ~15 call sites (and each new settable field
@@ -129,6 +136,7 @@ impl AgentState {
     /// separately.
     pub fn new(seed: &PersistedSettings) -> Self {
         let runner_script = path_to_setting_value(seed.runner_script.as_deref());
+        let windows_runner_script = seed.windows_runner_script.clone().unwrap_or_default();
         let docker_mode = docker_mode_to_control(seed.docker_mode) as i32;
         let vm_mode = vm_mode_to_control(seed.vm_mode);
         let settings = AgentSettings {
@@ -167,6 +175,10 @@ impl AgentState {
             vm_mode: Some(VmModeSetting {
                 current: vm_mode as i32,
                 target: vm_mode as i32,
+            }),
+            windows_runner_script: Some(StringSetting {
+                current: windows_runner_script.clone(),
+                target: windows_runner_script,
             }),
         };
         let (tx, _) = watch::channel(AgentStateSnapshot {
@@ -221,6 +233,12 @@ impl AgentState {
             ),
             runner_script: setting_value_to_path(
                 &s.runner_script.as_ref().expect(SETTINGS_INVARIANT).target,
+            ),
+            windows_runner_script: setting_value_to_string(
+                &s.windows_runner_script
+                    .as_ref()
+                    .expect(SETTINGS_INVARIANT)
+                    .target,
             ),
             participate: s.participate.as_ref().expect(SETTINGS_INVARIANT).target,
             vm_mode: vm_mode_from_wire(s.vm_mode.as_ref().expect(SETTINGS_INVARIANT).target),
@@ -536,6 +554,19 @@ impl AgentState {
         });
     }
 
+    /// Restart-scoped like `runner_script`: `current` stays what the process
+    /// started with. `script` uses the same empty-means-unset encoding.
+    pub fn set_windows_runner_script_target(&self, script: &str) {
+        let value = script.to_owned();
+        self.tx.send_modify(|s| {
+            settings_mut(s)
+                .windows_runner_script
+                .as_mut()
+                .expect(SETTINGS_INVARIANT)
+                .target = value;
+        });
+    }
+
     pub fn set_participate_target(&self, value: bool) {
         self.tx.send_modify(|s| {
             settings_mut(s)
@@ -574,6 +605,7 @@ mod tests {
             gateway: "https://fleet.arcbox.dev".to_owned(),
             docker_mode: DockerMode::Auto,
             runner_script: None,
+            windows_runner_script: None,
             participate: true,
             vm_mode: crate::config::VmMode::Auto,
             macos_runner_image: "tahoe-base".to_owned(),

--- a/fleet/arcbox-fleet-agent/src/update.rs
+++ b/fleet/arcbox-fleet-agent/src/update.rs
@@ -307,6 +307,7 @@ mod tests {
         AgentConfig {
             gateway: "http://127.0.0.1:1".to_owned(),
             runner_script: None,
+            windows_runner_script: None,
             load_ceiling: 0.9,
             mem_floor_mib: 2048,
             data_dir: data_dir.to_path_buf(),

--- a/fleet/arcbox-fleet-control-proto/proto/arcbox/fleet/control/v1/control.proto
+++ b/fleet/arcbox-fleet-control-proto/proto/arcbox/fleet/control/v1/control.proto
@@ -254,6 +254,12 @@ message UpdateSettingsRequest {
   // FleetImageService.Prepare pulls it through the daemon and promotes.
   optional string macos_runner_image = 8;
   optional VmMode vm_mode = 9;
+  // Windows-style path to the Windows runner entry point (e.g.
+  // `C:\actions-runner\run.cmd`), executed across the WSL interop boundary.
+  // Only meaningful on a Linux agent running inside WSL2 with interop
+  // enabled; rejected elsewhere. Empty string clears. Restart-scoped, like
+  // runner_script.
+  optional string windows_runner_script = 10;
 }
 
 // Reused across every setting regardless of type, so a client's rendering
@@ -301,6 +307,10 @@ message AgentSettings {
   // semantics as linux_runner_image; prepared through the daemon.
   StringSetting macos_runner_image = 8;
   VmModeSetting vm_mode = 9;
+  // Windows-style path to the Windows runner entry point, run via WSL
+  // interop (see UpdateSettingsRequest.windows_runner_script). Empty when
+  // unset.
+  StringSetting windows_runner_script = 10;
 }
 
 // Long-running image preparation, split out of FleetSettingsService so


### PR DESCRIPTION
## Summary

Brings windows job support to the fleet without a native Windows port: a Windows machine joins the fleet by running the existing Linux agent inside WSL2, and the agent executes the host's pre-installed Windows Actions runner across the WSL interop boundary. The control socket, credentials, settings, systemd/self-update story all stay Linux — the new surface is one runner backend.

- **`windows_runner_script` setting** — Windows-style path to the runner entry point (e.g. `C:\actions-runner\run.cmd`), settable via `ARCBOX_FLEET_WINDOWS_RUNNER_SCRIPT`, settings.json, the control API, and `settings set --windows-runner-script`. Restart-scoped like `runner_script`. Validation shape-checks the path, translates it via `wslpath -u`, and requires the file to exist — non-WSL hosts get a clean rejection.
- **`InteropRunner`** (`src/interop.rs`) — startup probe (tool paths via `wslpath`, then a real `powershell -Command "exit 0"` round-trip, since translation alone can't detect interop disabled in `wsl.conf`), Auto semantics only: probe failure warns and skips advertising rather than failing startup.
- **Spawn/cancel contract** — verified empirically on WSL2: killing the Linux-side relay **orphans** the Windows process, so the host path's process-group teardown can't cancel a windows job. The runner is launched through a PowerShell wrapper that reports the Windows PID (`WINPID=` handshake) before waiting; cancel is `taskkill /T /F /PID` across the interop boundary, which tears down the Windows tree and unblocks the relay. Offers are accepted only after the handshake proves the runner started. JIT configs are validated up front (base64 charset + cmd.exe's 8191-char command-line ceiling).
- **Advertisement** — `windows/<native arch>` (WSL's arch always matches the Windows host's), `host_runner`-backed on the wire, so **no gateway proto change is needed**; platform-side triage (`arcbox-windows-x64`), capability registration, and placement already handle windows generically. `GetAgentInfo` reports a `wsl-interop` feature mirroring `vm-backend`.

## Verification

- 94 unit + 1 integration test pass; clippy/fmt clean. Stub-executable tests cover the WINPID handshake, exit-code mirroring, taskkill teardown, missing-handshake rejection, jitconfig validation, capability building, and full `handle_provision` routing (accept-after-handshake, reject-without-backend).
- Live on a WSL2 host: `#[ignore]`d round-trip against real powershell/taskkill (spawn → WINPID → taskkill → relay unblocked <1s); `serve` boot with probe success log; live-socket `settings set` validation (nonexistent path, non-Windows path, clear) and persistence; negative boot (bad script → warn, other capabilities unaffected).

## Notes

- Commit 2 exceeds the 400-line guidance (576 incl. tests): the module, its tests, and the supervisor threading had to land together to keep every commit compiling with zero warnings.
- Known limitations (documented in the module doc): admission telemetry measures the WSL utility VM, not the Windows host; jobs whose composed cmd line exceeds ~8k chars are rejected with a clear reason (fallback if real JIT configs hit this: invoke `Runner.Listener.exe run` directly for the 32k limit).
- Follow-ups (not this PR): operator onboarding docs (WSL keep-alive via a logon scheduled task), and a live gateway round-trip to size real JIT configs.