### PR TITLE
fix(daemon): gate docker.sock self-setup on the profile-default data dir

### DIFF
--- a/app/arcbox-cli/src/commands/install.rs
+++ b/app/arcbox-cli/src/commands/install.rs
@@ -219,6 +219,8 @@ fn register_daemon_service() -> Result<()> {
     // Daemon manages its own log files via tracing-appender, so we no
     // longer set StandardOutPath / StandardErrorPath. Stdout/stderr are
     // discarded to avoid launchd writing duplicate output.
+    let data_dir_env = arcbox_constants::env::DATA_DIR;
+    let data_dir_str = data_dir.display();
     let plist_content = format!(
         r#"<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
@@ -232,8 +234,19 @@ fn register_daemon_service() -> Result<()> {
         <string>--profile</string>
         <string>{profile}</string>
         <string>--data-dir</string>
-        <string>{}</string>
+        <string>{data_dir_str}</string>
     </array>
+    <!--
+      Mirror the data dir into the daemon environment: recovery's host-global
+      self-setup treats {data_dir_env} as the machine-wide canonical layout,
+      so a relocated install keeps ownership of /var/run/docker.sock (the
+      argv flag alone reads as a scoped per-instance override there).
+    -->
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>{data_dir_env}</key>
+        <string>{data_dir_str}</string>
+    </dict>
     <key>RunAtLoad</key>
     <true/>
     <key>KeepAlive</key>
@@ -247,8 +260,7 @@ fn register_daemon_service() -> Result<()> {
     <integer>45</integer>
 </dict>
 </plist>
-"#,
-        data_dir.display()
+"#
     );
 
     std::fs::write(&plist_path, plist_content)

--- a/app/arcbox-daemon/src/recovery.rs
+++ b/app/arcbox-daemon/src/recovery.rs
@@ -4,6 +4,7 @@
 use std::path::Path;
 use std::sync::Arc;
 
+use arcbox_constants::paths::HostLayout;
 use arcbox_core::Runtime;
 use tracing::info;
 
@@ -78,9 +79,23 @@ pub async fn run(ctx: &DaemonContext, runtime: &Arc<Runtime>) {
             "non-default DNS port; skipping /etc/resolver self-setup"
         );
     }
-    let socket_task = self_setup::DockerSocket {
+    // The `/var/run/docker.sock` symlink likewise belongs to the daemon
+    // running its profile's canonical data dir: the link target embeds the
+    // data dir, so a daemon on an overridden one (an e2e harness daemon on
+    // a temp dir, an ad-hoc dev run) would re-point the host-global Docker
+    // socket at a path that dies with it. `ARCBOX_DATA_DIR` counts as
+    // canonical — it relocates the machine-wide installation, not one
+    // daemon instance.
+    let default_data_dir = HostLayout::resolve_for_profile_from_env(ctx.profile, None).data_dir;
+    let socket_task = (ctx.layout.data_dir == default_data_dir).then(|| self_setup::DockerSocket {
         target: ctx.layout.docker_socket.clone(),
-    };
+    });
+    if socket_task.is_none() {
+        tracing::debug!(
+            data_dir = %ctx.layout.data_dir.display(),
+            "non-default data dir; skipping /var/run/docker.sock self-setup"
+        );
+    }
 
     // Create /usr/local/bin/ symlinks for Docker CLI tools if running from
     // bundle with docker integration enabled.
@@ -101,18 +116,28 @@ pub async fn run(ctx: &DaemonContext, runtime: &Arc<Runtime>) {
 
     let setup_state_self = Arc::clone(&ctx.setup_state);
     tokio::spawn(async move {
-        let mut tasks: Vec<&dyn self_setup::SetupTask> = vec![&socket_task];
+        let mut tasks: Vec<&dyn self_setup::SetupTask> = Vec::new();
         if let Some(dns) = &dns_task {
-            tasks.insert(0, dns);
+            tasks.push(dns);
+        }
+        if let Some(socket) = &socket_task {
+            tasks.push(socket);
         }
         for t in &cli_tasks {
             tasks.push(t.as_ref());
+        }
+        if tasks.is_empty() {
+            // Nothing to configure — don't launchd-activate the helper
+            // just to hang up (the common case for harness daemons).
+            return;
         }
         self_setup::run(&tasks).await;
         if let Some(dns) = &dns_task {
             setup_state_self.set_dns_installed(dns.is_satisfied());
         }
-        setup_state_self.set_docker_socket_linked(socket_task.is_satisfied());
+        if let Some(socket) = &socket_task {
+            setup_state_self.set_docker_socket_linked(socket.is_satisfied());
+        }
     });
 
     // Docker CLI tools installation (non-blocking, best-effort).

--- a/app/arcbox-daemon/src/recovery.rs
+++ b/app/arcbox-daemon/src/recovery.rs
@@ -85,7 +85,9 @@ pub async fn run(ctx: &DaemonContext, runtime: &Arc<Runtime>) {
     // a temp dir, an ad-hoc dev run) would re-point the host-global Docker
     // socket at a path that dies with it. `ARCBOX_DATA_DIR` counts as
     // canonical — it relocates the machine-wide installation, not one
-    // daemon instance.
+    // daemon instance; the installer persists it into the launchd plist's
+    // EnvironmentVariables so a relocated install still satisfies this
+    // check (its plist also passes the same path as `--data-dir`).
     let default_data_dir = HostLayout::resolve_for_profile_from_env(ctx.profile, None).data_dir;
     let socket_task = (ctx.layout.data_dir == default_data_dir).then(|| self_setup::DockerSocket {
         target: ctx.layout.docker_socket.clone(),


### PR DESCRIPTION
## Problem

On a helper-enabled host, `recovery::run` unconditionally included the `DockerSocket` self-setup task: `is_satisfied` compares the `/var/run/docker.sock` symlink target against `ctx.layout.docker_socket`, and `apply` asks arcbox-helper to re-link it. Any daemon with an overridden `--data-dir` — an e2e harness daemon on a temp dir, an ad-hoc dev run — therefore saw the installed symlink as unsatisfied and hijacked the host-global Docker socket to its own (soon-to-be-deleted) data dir, violating the tests/e2e AGENTS.md host-globals rule.

Same class as the `/etc/resolver` finding fixed on #396, which gated the resolver task on the canonical DNS port. Flagged in the #396 review thread as "tracking separately".

## Fix

The symlink target embeds the data dir, so ownership follows the data dir: the `DockerSocket` task now runs only when `ctx.layout.data_dir` equals the profile's canonical resolution (`HostLayout::resolve_for_profile_from_env(profile, None)`).

- Explicit `--data-dir` override ⇒ scoped daemon ⇒ skip (debug log), mirroring the DNS gate's shape.
- `ARCBOX_DATA_DIR` counts as canonical — it relocates the machine-wide installation, not one daemon instance, and the comparison sees it on both sides.

Bonus: with both host-global tasks gated, a harness daemon (ephemeral DNS port + temp data dir, no `--docker-integration`) ends up with an empty task list and no longer launchd-activates the helper at all.