### PR TITLE
fix(net): default the VZ network MTU to 1500 (ABX-423 mitigation)

### DIFF
--- a/common/splicetcp/src/classifier.rs
+++ b/common/splicetcp/src/classifier.rs
@@ -25,12 +25,16 @@ use arcbox_datapath::pool::PacketPool;
 use crate::ethernet::{ArpResponder, ETH_HEADER_LEN};
 
 /// Default Ethernet MTU (excludes Ethernet header).
-/// Used as fallback when VZ `setMaximumTransmissionUnit:` is unavailable.
 #[cfg(test)]
 const DEFAULT_ETHERNET_MTU: usize = 1500;
 
-/// Enhanced MTU for VZ framework with `maximumTransmissionUnit` (macOS 13+).
-/// Reduces frame count by ~2.7x vs 1500.
+/// Enhanced MTU (excludes Ethernet header), ~2.7x fewer frames than 1500.
+///
+/// No longer a negotiated link MTU by default: the VZ device stays at 1500
+/// (ABX-423 — see `arcbox-vz/src/device/network.rs`). The VMMs still pass
+/// this value as the classifier `mtu`, where it only sizes buffers — pure
+/// headroom on a 1500 link — and covers the `ARCBOX_DIAG_NET_MTU_4000`
+/// reproduction mode.
 pub const ENHANCED_ETHERNET_MTU: usize = 4000;
 
 /// Protocol numbers.
@@ -100,8 +104,8 @@ pub struct FrameClassifier {
     arp: ArpResponder,
     /// Pre-allocated packet pool for zero-alloc frame ownership.
     pool: Arc<PacketPool>,
-    /// Negotiated MTU (excludes Ethernet header). Set at construction time
-    /// based on whether the VZ `maximumTransmissionUnit` setter succeeded.
+    /// Buffer-sizing MTU (excludes Ethernet header). At least the device's
+    /// configured MTU; see [`ENHANCED_ETHERNET_MTU`].
     #[allow(dead_code)]
     mtu: usize,
 }
@@ -127,9 +131,9 @@ impl FrameClassifier {
     /// Creates a new classifier with the
     /// [default pool capacity](Self::DEFAULT_POOL_CAPACITY).
     ///
-    /// `mtu` should match the device's configured MTU. Use
-    /// `ENHANCED_ETHERNET_MTU` (4000) when VZ `setMaximumTransmissionUnit:`
-    /// succeeded, or 1500 otherwise.
+    /// `mtu` sizes internal buffers and must be at least the device's
+    /// configured MTU; `ENHANCED_ETHERNET_MTU` (4000) is safe headroom for a
+    /// default 1500 link.
     ///
     /// The gateway MAC (needed to synthesize ARP replies) is set later via
     /// [`set_gateway_mac`](Self::set_gateway_mac), once it is known.

--- a/virt/arcbox-net/src/darwin/datapath_loop/mod.rs
+++ b/virt/arcbox-net/src/darwin/datapath_loop/mod.rs
@@ -78,7 +78,8 @@ pub struct NetworkDatapath {
     pub guest_ip: Ipv4Addr,
     /// Cancellation token for graceful shutdown.
     pub cancel: CancellationToken,
-    /// Negotiated MTU (from VZ `setMaximumTransmissionUnit:` result).
+    /// Buffer-sizing MTU (at least the device's configured MTU; see
+    /// `splicetcp`'s `ENHANCED_ETHERNET_MTU`).
     pub mtu: usize,
     /// Frame sink for host-to-guest RX injection. When set, all frames
     /// destined for the guest go through this sink (to the inject thread)

--- a/virt/arcbox-vmm/src/vmm/darwin.rs
+++ b/virt/arcbox-vmm/src/vmm/darwin.rs
@@ -15,10 +15,10 @@ use tokio_util::sync::CancellationToken;
 ///
 /// Both ends must be sized, not just the VZ side: on macOS a `SOCK_DGRAM` unix
 /// socket rejects any datagram larger than its `SO_SNDBUF` with `EMSGSIZE`. The
-/// host datapath end is the *sender* of guest-inbound frames, so once VZ's
-/// `setMaximumTransmissionUnit:` raises the link to `VZ_NETWORK_MTU` (4000) a
-/// default-sized (~2 KiB) host end would silently drop every frame above the
-/// default 1500 MTU.
+/// host datapath end is the *sender* of guest-inbound frames; the default
+/// (~2 KiB) buffer leaves almost no headroom over a full 1514-byte frame, and
+/// none at all when `ARCBOX_DIAG_NET_MTU_4000` raises the link to the enhanced
+/// MTU (see `arcbox-vz/src/device/network.rs`).
 const NET_SOCKET_BUF_BYTES: libc::c_int = 8 * 1024 * 1024;
 
 impl Vmm {
@@ -372,15 +372,15 @@ impl Vmm {
 
         // 5. Build the datapath and spawn it on the tokio runtime.
 
-        // NOTE(MTU): Hardcoded to 4000 intentionally — our platform target is
-        // macOS 13+ Apple Silicon (P0) where VZ's setMaximumTransmissionUnit:
-        // always succeeds. On macOS <13 the VZ setter is skipped via
-        // respondsToSelector: (see arcbox-vz/device/network.rs), and the VZ
-        // device stays at 1500 while the classifier gets 4000. This mismatch
-        // would cause frames >1500 to be dropped — acceptable since macOS <13
-        // is not a supported target. If macOS <13 support is ever needed,
-        // plumb the actual MTU from NetworkDeviceConfiguration::mtu() through
-        // the hypervisor abstraction layer.
+        // NOTE(MTU): the VZ device stays at the default 1500 (ABX-423 — see
+        // arcbox-vz/src/device/network.rs), but the classifier deliberately
+        // keeps ENHANCED_ETHERNET_MTU (4000). For the datapath this value only
+        // sizes buffers and frame sinks — at a 1500 link it is pure headroom —
+        // and it keeps the ARCBOX_DIAG_NET_MTU_4000 reproduction mode working
+        // without plumbing the negotiated MTU from
+        // NetworkDeviceConfiguration::mtu() through the hypervisor abstraction
+        // layer. Guest-bound TCP segments are bounded by the peer's advertised
+        // MSS (TcpBridge peer_mss), not by this value.
         let net_mtu = arcbox_net::darwin::classifier::ENHANCED_ETHERNET_MTU;
 
         let datapath = NetworkDatapath::new(
@@ -824,7 +824,7 @@ mod tests {
     /// end of the network socketpair must be enlarged or a full enhanced-MTU
     /// frame (4000 + 14-byte Ethernet header) to the guest fails with
     /// `EMSGSIZE` and is silently dropped. Guards the host-side sizing that
-    /// pairs with VZ's `setMaximumTransmissionUnit:`.
+    /// the `ARCBOX_DIAG_NET_MTU_4000` reproduction mode relies on.
     #[test]
     fn enlarged_socket_buffer_accepts_enhanced_mtu_frame() {
         let mut fds = [0 as libc::c_int; 2];

--- a/virt/arcbox-vz/src/device/network.rs
+++ b/virt/arcbox-vz/src/device/network.rs
@@ -6,22 +6,29 @@ use crate::{msg_send, msg_send_void, msg_send_void_u64};
 use objc2::runtime::AnyObject;
 use std::os::unix::io::RawFd;
 
-/// MTU configured on VZ network devices when `setMaximumTransmissionUnit:` is
-/// available (macOS 13+). Exported so the VMM can pass it to the datapath.
+/// MTU a VZ network device uses when `setMaximumTransmissionUnit:` is not
+/// called — Apple's default, and since ABX-423 also ArcBox's default.
+pub const VZ_DEFAULT_MTU: usize = 1500;
+
+/// Enhanced MTU applied only under `ARCBOX_DIAG_NET_MTU_4000`.
 ///
-/// 4000 is chosen based on macOS XNU internals: the kernel has a 4096-byte
-/// internal threshold above which performance degrades for loopback/utun paths.
-/// Surge uses 4000, Shadowrocket/Quantumult X use 4064 (4096 - 32 for headers).
-/// We round to 4000 to stay safely under the threshold.
+/// 4000 was chosen from macOS XNU internals (the kernel has a 4096-byte
+/// threshold above which loopback/utun performance degrades; Surge uses 4000,
+/// Shadowrocket/Quantumult X use 4064) and reduces frame count ~2.7x vs 1500.
 ///
-/// This reduces frame count by ~2.7x vs the default 1500, directly reducing
-/// per-frame overhead through the entire datapath.
-pub const VZ_NETWORK_MTU: u64 = 4000;
+/// It is no longer the default: `VZFileHandleNetworkDeviceAttachment` enters
+/// an intermittent, self-healing whole-device stall under sustained bulk
+/// transfer once the link MTU is raised above 1500 (ABX-423). The stall was
+/// bisected to the VZ device layer, so the only host-side mitigation is to
+/// stay at 1500. Keep this constant and the diagnostic knob for reproducing
+/// the stall (Apple Feedback evidence) and for throughput A/B runs.
+pub const VZ_ENHANCED_MTU: u64 = 4000;
 
 /// Configuration for a `VirtIO` network device.
 pub struct NetworkDeviceConfiguration {
     inner: *mut AnyObject,
-    /// Actual MTU that was configured (4000 if setter succeeded, 1500 otherwise).
+    /// Actual MTU that was configured (1500 by default; 4000 only under
+    /// `ARCBOX_DIAG_NET_MTU_4000` when the setter is available).
     mtu: usize,
 }
 
@@ -102,45 +109,47 @@ impl NetworkDeviceConfiguration {
 
             msg_send_void!(obj, setAttachment: attachment);
 
-            // Set MTU to reduce frame count through the datapath (~2.7x fewer
-            // frames vs default 1500). Available since macOS 13 (Ventura).
-            // On older macOS, the selector doesn't exist — we must check
+            // The MTU stays at Apple's default 1500 (ABX-423 — see
+            // VZ_ENHANCED_MTU). ARCBOX_DIAG_NET_MTU_4000 opts back into the
+            // enhanced MTU for stall reproduction and throughput A/B runs;
+            // it needs setMaximumTransmissionUnit: (macOS 13+), so check
             // respondsToSelector: to avoid an unrecognized-selector crash.
-            // Check if the VZ config class supports the MTU setter (macOS 13+).
-            // msg_send_bool! doesn't support Sel arguments, so we dispatch manually.
-            let mtu_sel = objc2::sel!(setMaximumTransmissionUnit:);
-            let responds: bool = {
-                let check_sel = objc2::sel!(respondsToSelector:);
-                let func: unsafe extern "C" fn(
-                    *const objc2::runtime::AnyObject,
-                    objc2::runtime::Sel,
-                    objc2::runtime::Sel,
-                ) -> objc2::runtime::Bool = std::mem::transmute(
-                    crate::ffi::runtime::objc_msgSend as *const std::ffi::c_void,
-                );
-                func(
-                    attachment as *const _ as *const objc2::runtime::AnyObject,
-                    check_sel,
-                    mtu_sel,
-                )
-                .as_bool()
-            };
-            // ARCBOX_DIAG_NET_MTU_1500 skips the MTU raise — a diagnostic
-            // knob for the ABX-423 freeze bisection (4000-byte frames are an
-            // uncommon VZ configuration and a bisection dimension).
-            let diag_mtu_1500 = std::env::var_os("ARCBOX_DIAG_NET_MTU_1500").is_some();
-            let mtu = if responds && !diag_mtu_1500 {
-                msg_send_void_u64!(attachment, setMaximumTransmissionUnit: VZ_NETWORK_MTU);
-                tracing::info!("VZ network MTU set to {VZ_NETWORK_MTU}");
-                VZ_NETWORK_MTU as usize
-            } else if diag_mtu_1500 {
-                tracing::warn!("VZ network MTU left at 1500 (ARCBOX_DIAG_NET_MTU_1500)");
-                1500
+            let mtu = if std::env::var_os("ARCBOX_DIAG_NET_MTU_4000").is_some() {
+                let mtu_sel = objc2::sel!(setMaximumTransmissionUnit:);
+                // msg_send_bool! doesn't support Sel arguments, so dispatch manually.
+                let responds: bool = {
+                    let check_sel = objc2::sel!(respondsToSelector:);
+                    let func: unsafe extern "C" fn(
+                        *const objc2::runtime::AnyObject,
+                        objc2::runtime::Sel,
+                        objc2::runtime::Sel,
+                    ) -> objc2::runtime::Bool = std::mem::transmute(
+                        crate::ffi::runtime::objc_msgSend as *const std::ffi::c_void,
+                    );
+                    func(
+                        attachment as *const _ as *const objc2::runtime::AnyObject,
+                        check_sel,
+                        mtu_sel,
+                    )
+                    .as_bool()
+                };
+                if responds {
+                    msg_send_void_u64!(attachment, setMaximumTransmissionUnit: VZ_ENHANCED_MTU);
+                    tracing::warn!(
+                        "VZ network MTU raised to {VZ_ENHANCED_MTU} (ARCBOX_DIAG_NET_MTU_4000; \
+                         expect ABX-423 device stalls under sustained bulk transfer)"
+                    );
+                    VZ_ENHANCED_MTU as usize
+                } else {
+                    tracing::warn!(
+                        "ARCBOX_DIAG_NET_MTU_4000 set but the MTU setter is unavailable \
+                         (macOS < 13); MTU stays at {VZ_DEFAULT_MTU}"
+                    );
+                    VZ_DEFAULT_MTU
+                }
             } else {
-                tracing::info!(
-                    "VZ network MTU setter unavailable (macOS < 13), using default 1500"
-                );
-                1500
+                tracing::info!("VZ network MTU at default {VZ_DEFAULT_MTU} (ABX-423 mitigation)");
+                VZ_DEFAULT_MTU
             };
 
             let mac = match mac_address {
@@ -155,7 +164,8 @@ impl NetworkDeviceConfiguration {
         }
     }
 
-    /// Returns the actual MTU that was configured (4000 or 1500).
+    /// Returns the actual MTU that was configured (1500 unless raised via
+    /// `ARCBOX_DIAG_NET_MTU_4000`).
     #[must_use]
     pub fn mtu(&self) -> usize {
         self.mtu


### PR DESCRIPTION
## Why

`VZFileHandleNetworkDeviceAttachment` intermittently goes silent — whole-device, self-healing — under sustained bulk transfer once the link MTU is raised above 1500. The ABX-423 hunt exonerated every controllable host/guest dimension (including a custom no-EVENT_IDX guest kernel) and pinned the stall to the VZ device layer; whether it is ring starvation or a copy-path bug inside the framework is Apple's to dig out with `sample`/`sysdiagnose`. ArcBox has been raising the MTU to 4000 for datapath throughput since #361-era work, which is why we hit it so often.

Reverting to 1500 is the only mitigation supported by the data (39xx is not a sweet spot — the trigger is >1500 itself, not a specific size).

## What

- **arcbox-vz**: stop calling `setMaximumTransmissionUnit:` by default — the device stays at Apple's default **1500**. The old `ARCBOX_DIAG_NET_MTU_1500` bisection knob inverts into opt-in **`ARCBOX_DIAG_NET_MTU_4000`**, kept for reproducing the stall (Apple Feedback: MTU-1500 control + frozen-state counters/sample) and for throughput A/B runs.
- **darwin.rs / splicetcp classifier**: `ENHANCED_ETHERNET_MTU` (4000) stays as the datapath **buffer-sizing** value — pure headroom on a 1500 link — so the diagnostic mode works without plumbing the negotiated MTU through the hypervisor abstraction layer. Guest-bound TCP segments are already bounded by peer MSS (`TcpBridge` `peer_mss`, #378), so a 1460-MSS guest is served correctly either way.
- HV backend is untouched: its guest NIC was already at `NetConfig` default 1500.

## Validation

- `cargo test -p arcbox-vz -p splicetcp -p arcbox-vmm` green; clippy/fmt clean.
- VZ `boot_assets` e2e **green at default 1500** (NFS export read-through, alpine pull, run/logs/exec/stop/rm), daemon log confirms both NICs: `VZ network MTU at default 1500 (ABX-423 mitigation)`.
- A/B: same binaries with `ARCBOX_DIAG_NET_MTU_4000=1` also green (80s vs 87s — noise-level delta on this scenario), knob confirmed active in the daemon log.
- One earlier pull timeout at 1500 was triaged to docker.io reachability variance (layers were downloading; extract reached), not the datapath.