### PR TITLE
fix(agent): reap rpc.mountd and skip zombies in the respawn guard

### DIFF
--- a/guest/arcbox-agent/src/nfs.rs
+++ b/guest/arcbox-agent/src/nfs.rs
@@ -237,6 +237,11 @@ local      tpi_cots_ord  -     loopback  -       -       -
         );
         std::thread::spawn(move || match child.wait() {
             Ok(status) => tracing::warn!(%status, "nfs export: rpc.mountd exited"),
+            // On the legacy PID-1 path the supervisor's global waitpid(-1)
+            // reaper can win the race; its own log line carries the status.
+            Err(e) if e.raw_os_error() == Some(libc::ECHILD) => {
+                tracing::debug!("nfs export: rpc.mountd reaped by the global reaper");
+            }
             Err(e) => tracing::warn!(error = %e, "nfs export: rpc.mountd wait failed"),
         });
         // Let the listener bind before returning so a repeat setup pass sees

--- a/guest/arcbox-agent/src/nfs.rs
+++ b/guest/arcbox-agent/src/nfs.rs
@@ -214,9 +214,15 @@ local      tpi_cots_ord  -     loopback  -       -       -
     /// no client contacts it, but the kernel still calls it to authorize
     /// export access. Registration with a portmapper is not needed (and there
     /// is no `rpcbind`); the listener is created directly.
+    ///
+    /// A watcher thread reaps the child and logs its exit: a dead mountd
+    /// leaves every kernel export upcall unanswered, which wedges the host's
+    /// `mount_nfs` in uninterruptible sleep with zero diagnostics. Reaping
+    /// also keeps the zombie from satisfying the [`mountd_running`] respawn
+    /// guard forever.
     fn spawn_mountd(cfg: &ExportConfig<'_>) -> Result<(), String> {
         let port = cfg.mountd_port.to_string();
-        let child = Command::new("/sbin/rpc.mountd")
+        let mut child = Command::new("/sbin/rpc.mountd")
             .args(["-F", "-p", &port])
             .env("PATH", "/usr/sbin:/usr/bin:/sbin:/bin")
             .stdin(Stdio::null())
@@ -229,6 +235,10 @@ local      tpi_cots_ord  -     loopback  -       -       -
             port = cfg.mountd_port,
             "nfs export: rpc.mountd spawned"
         );
+        std::thread::spawn(move || match child.wait() {
+            Ok(status) => tracing::warn!(%status, "nfs export: rpc.mountd exited"),
+            Err(e) => tracing::warn!(error = %e, "nfs export: rpc.mountd wait failed"),
+        });
         // Let the listener bind before returning so a repeat setup pass sees
         // the port taken and does not spawn a second, conflicting mountd.
         for _ in 0..20 {
@@ -305,6 +315,9 @@ local      tpi_cots_ord  -     loopback  -       -       -
         process_named("rpc.mountd")
     }
 
+    /// True when a live (non-zombie) process with this comm exists. Zombies
+    /// keep their comm until reaped, and a zombie mountd must not satisfy the
+    /// respawn guard — that is exactly the state that wedges the host mount.
     fn process_named(name: &str) -> bool {
         let Ok(entries) = fs::read_dir("/proc") else {
             return false;
@@ -321,7 +334,18 @@ local      tpi_cots_ord  -     loopback  -       -       -
             let Ok(comm) = fs::read_to_string(entry.path().join("comm")) else {
                 continue;
             };
-            if comm.trim() == name {
+            if comm.trim() != name {
+                continue;
+            }
+            let is_zombie = fs::read_to_string(entry.path().join("stat"))
+                .ok()
+                .and_then(|stat| {
+                    // State is the first field after the parenthesized comm.
+                    let after = stat.rsplit_once(')')?.1.trim_start();
+                    after.chars().next()
+                })
+                .is_some_and(|state| state == 'Z');
+            if !is_zombie {
                 return true;
             }
         }


### PR DESCRIPTION
## Problem

If `rpc.mountd` dies for any reason, the guest ends up wedged with zero diagnostics:

1. The agent spawns mountd via `Command` and drops the `Child` — nobody ever `wait()`s, so the corpse stays a **zombie forever**.
2. `process_named()` matches on `/proc/<pid>/comm`, which a zombie keeps until reaped — so the `mountd_running()` guard in `ensure_docker_export` keeps answering *true* and never respawns.
3. With no upcall reader, kernel nfsd defers every export-authorization upcall indefinitely → the host's `mount_nfs` hangs in **uninterruptible sleep**, and nothing anywhere says why.

Found during the ABX-424 live-container-export spike, where a `crossmnt`-triggered mountd SIGSEGV (nfs-utils 2.6.4) produced exactly this wedge and cost most of a day to localize — the missing exit-status log was the difference between "host mount mysteriously hangs" and "mountd exited: signal 11".

## Fix

- `spawn_mountd` now hands the child to a watcher thread that `wait()`s and logs the exit status (reaps the zombie, surfaces the death).
- `process_named` skips processes in state `Z`, so a later ensure pass can actually respawn over a corpse.

No behavior change while mountd is healthy.

## Validation

- `cargo clippy -p arcbox-agent --target aarch64-unknown-linux-musl`: no new warnings on changed lines; fmt clean.
- boot_assets e2e (VZ): NFS chain green — `host NFS mount is populated` + `nfs export file read-through OK` (the run later hit the known flaky `docker pull` 90s registry timeout, unrelated to this path).
- The ABX-424 spike probe exercised the same hardening through full green runs, including the exit-status log firing on a real mountd crash.