### PR TITLE
fix(net): IPv4-fragment guest-bound UDP datagrams above the link MTU (ABX-428)

### DIFF
--- a/common/arcbox-packet/src/ethernet/mod.rs
+++ b/common/arcbox-packet/src/ethernet/mod.rs
@@ -19,7 +19,7 @@ pub use tcp::{
     build_tcp_rst_frame, build_tcp_syn_ack_frame, build_tcp_syn_frame, parse_tcp_syn_options,
     tcp_pseudo_header_checksum,
 };
-pub use udp::build_udp_ip_ethernet;
+pub use udp::{MAX_UDP_PAYLOAD, build_udp_ip_ethernet};
 
 use std::net::Ipv4Addr;
 

--- a/common/arcbox-packet/src/ethernet/tests.rs
+++ b/common/arcbox-packet/src/ethernet/tests.rs
@@ -125,10 +125,13 @@ fn test_build_udp_ip_ethernet_checksum() {
     let dst_mac = [0x02, 0x00, 0x00, 0x00, 0x00, 0x02];
     let payload = b"hello";
 
-    let frame = build_udp_ip_ethernet(src_ip, dst_ip, 1234, 5678, payload, src_mac, dst_mac);
+    let frames = build_udp_ip_ethernet(src_ip, dst_ip, 1234, 5678, payload, src_mac, dst_mac, 1500);
+    let [frame] = frames.as_slice() else {
+        panic!("small payload must yield exactly one frame");
+    };
 
     // Verify Ethernet header
-    let hdr = EthernetHeader::parse(&frame).unwrap();
+    let hdr = EthernetHeader::parse(frame).unwrap();
     assert_eq!(hdr.ethertype, EtherType::Ipv4);
 
     // Verify IP header
@@ -159,6 +162,166 @@ fn test_build_udp_ip_ethernet_checksum() {
     // Verify UDP checksum is non-zero
     let udp_cksum = u16::from_be_bytes([udp[6], udp[7]]);
     assert_ne!(udp_cksum, 0);
+}
+
+/// Reassembles IPv4 fragments back into the original IP payload, checking
+/// per-fragment invariants (MTU bound, shared IP ID, MF flag, byte offsets,
+/// header checksum) along the way.
+fn reassemble_fragments(frames: &[Vec<u8>], mtu: usize) -> Vec<u8> {
+    let first_ip = &frames[0][ETH_HEADER_LEN..];
+    let id = u16::from_be_bytes([first_ip[4], first_ip[5]]);
+    let mut out = Vec::new();
+    for (i, frame) in frames.iter().enumerate() {
+        assert!(
+            frame.len() <= ETH_HEADER_LEN + mtu,
+            "fragment {i} exceeds the link MTU"
+        );
+        let ip = &frame[ETH_HEADER_LEN..];
+        assert_eq!(ip[0], 0x45);
+        assert_eq!(ip[9], 17);
+        assert_eq!(
+            u16::from_be_bytes([ip[4], ip[5]]),
+            id,
+            "fragment {i} carries a different IP ID"
+        );
+        let mut sum: u32 = 0;
+        for j in (0..20).step_by(2) {
+            sum += u32::from(u16::from_be_bytes([ip[j], ip[j + 1]]));
+        }
+        while sum > 0xFFFF {
+            sum = (sum & 0xFFFF) + (sum >> 16);
+        }
+        assert_eq!(sum as u16, 0xFFFF, "fragment {i} IP header checksum");
+        let flags_frag = u16::from_be_bytes([ip[6], ip[7]]);
+        assert_eq!(
+            flags_frag & 0x2000 != 0,
+            i + 1 < frames.len(),
+            "fragment {i} MF flag"
+        );
+        assert_eq!(
+            usize::from(flags_frag & 0x1FFF) * 8,
+            out.len(),
+            "fragment {i} offset"
+        );
+        let ip_total = u16::from_be_bytes([ip[2], ip[3]]) as usize;
+        assert_eq!(ip_total, frame.len() - ETH_HEADER_LEN);
+        out.extend_from_slice(&ip[20..ip_total]);
+    }
+    out
+}
+
+/// Asserts `datagram` is a valid UDP datagram for `payload` with a correct
+/// checksum.
+fn assert_udp_datagram(datagram: &[u8], src_ip: Ipv4Addr, dst_ip: Ipv4Addr, payload: &[u8]) {
+    assert_eq!(datagram.len(), 8 + payload.len());
+    assert_eq!(
+        u16::from_be_bytes([datagram[4], datagram[5]]) as usize,
+        datagram.len()
+    );
+    assert_eq!(&datagram[8..], payload);
+    let stored = u16::from_be_bytes([datagram[6], datagram[7]]);
+    let mut zeroed = datagram.to_vec();
+    zeroed[6..8].fill(0);
+    assert_eq!(
+        stored,
+        super::checksum::udp_checksum(src_ip, dst_ip, &zeroed),
+        "UDP checksum over the reassembled datagram"
+    );
+}
+
+#[test]
+fn oversized_udp_datagram_fragments_and_reassembles() {
+    let src_ip = Ipv4Addr::new(10, 0, 2, 1);
+    let dst_ip = Ipv4Addr::new(10, 0, 2, 2);
+    let payload: Vec<u8> = (0..3000u32).map(|i| (i % 251) as u8).collect();
+
+    let frames = build_udp_ip_ethernet(src_ip, dst_ip, 53, 40000, &payload, [1; 6], [2; 6], 1500);
+
+    // 3008-byte datagram at 1480 bytes per fragment: 1480 + 1480 + 48.
+    assert_eq!(frames.len(), 3);
+    let datagram = reassemble_fragments(&frames, 1500);
+    assert_udp_datagram(&datagram, src_ip, dst_ip, &payload);
+}
+
+#[test]
+fn tail_fragment_can_be_a_single_byte() {
+    let src_ip = Ipv4Addr::new(10, 0, 2, 1);
+    let dst_ip = Ipv4Addr::new(10, 0, 2, 2);
+    // 1473-byte payload → 1481-byte datagram → 1480 + 1.
+    let payload = vec![0xA5u8; 1473];
+
+    let frames = build_udp_ip_ethernet(src_ip, dst_ip, 53, 40000, &payload, [1; 6], [2; 6], 1500);
+
+    assert_eq!(frames.len(), 2);
+    assert_eq!(frames[1].len(), ETH_HEADER_LEN + 20 + 1);
+    let datagram = reassemble_fragments(&frames, 1500);
+    assert_udp_datagram(&datagram, src_ip, dst_ip, &payload);
+}
+
+#[test]
+fn max_udp_payload_fragments_and_reassembles() {
+    let src_ip = Ipv4Addr::new(10, 0, 2, 1);
+    let dst_ip = Ipv4Addr::new(10, 0, 2, 2);
+    let payload = vec![0x5Au8; MAX_UDP_PAYLOAD];
+
+    let frames = build_udp_ip_ethernet(src_ip, dst_ip, 53, 40000, &payload, [1; 6], [2; 6], 1500);
+
+    // 65515-byte datagram at 1480 per fragment = ceil → 45 frames.
+    assert_eq!(frames.len(), 45);
+    let datagram = reassemble_fragments(&frames, 1500);
+    assert_udp_datagram(&datagram, src_ip, dst_ip, &payload);
+}
+
+#[test]
+fn payload_above_max_yields_no_frames() {
+    let payload = vec![0u8; MAX_UDP_PAYLOAD + 1];
+    let frames = build_udp_ip_ethernet(
+        Ipv4Addr::new(10, 0, 2, 1),
+        Ipv4Addr::new(10, 0, 2, 2),
+        53,
+        40000,
+        &payload,
+        [1; 6],
+        [2; 6],
+        1500,
+    );
+    assert!(frames.is_empty());
+}
+
+#[test]
+fn consecutive_datagrams_carry_distinct_ip_ids() {
+    let build = || {
+        build_udp_ip_ethernet(
+            Ipv4Addr::new(10, 0, 2, 1),
+            Ipv4Addr::new(10, 0, 2, 2),
+            53,
+            40000,
+            b"x",
+            [1; 6],
+            [2; 6],
+            1500,
+        )
+    };
+    let a = build();
+    let b = build();
+    let id =
+        |f: &[Vec<u8>]| u16::from_be_bytes([f[0][ETH_HEADER_LEN + 4], f[0][ETH_HEADER_LEN + 5]]);
+    assert_ne!(id(&a), id(&b));
+}
+
+#[test]
+#[should_panic(expected = "cannot carry an IPv4 fragment")]
+fn tiny_mtu_panics() {
+    let _ = build_udp_ip_ethernet(
+        Ipv4Addr::new(10, 0, 2, 1),
+        Ipv4Addr::new(10, 0, 2, 2),
+        53,
+        40000,
+        b"x",
+        [1; 6],
+        [2; 6],
+        35,
+    );
 }
 
 fn make_tcp_params(

--- a/common/arcbox-packet/src/ethernet/udp.rs
+++ b/common/arcbox-packet/src/ethernet/udp.rs
@@ -1,15 +1,38 @@
 use std::net::Ipv4Addr;
+use std::sync::atomic::{AtomicU16, Ordering};
 
 use super::{
     ETH_HEADER_LEN,
     checksum::{ipv4_header_checksum, udp_checksum},
 };
 
-/// Builds a complete Ethernet frame containing a UDP/IPv4 packet.
+/// Largest UDP payload an IPv4 datagram can carry: the 16-bit IP total-length
+/// field (65535) minus the IPv4 header (20) and the UDP header (8).
+pub const MAX_UDP_PAYLOAD: usize = 65_507;
+
+/// IP identification counter shared by every frame built here, so the
+/// fragments of one datagram carry one ID while consecutive datagrams differ.
+static NEXT_IP_ID: AtomicU16 = AtomicU16::new(1);
+
+/// Builds a guest-bound UDP/IPv4 datagram as one or more Ethernet frames.
 ///
-/// Used to construct DHCP and DNS responses that are injected directly
-/// into the guest FD.
+/// A datagram that fits `mtu` yields exactly one frame. A larger one is split
+/// into standard IPv4 fragments (offsets in 8-byte units, MF set on all but
+/// the last) for the receiver to reassemble — the link never sees a frame
+/// above `mtu` + 14 bytes. Returns no frames for a payload above
+/// [`MAX_UDP_PAYLOAD`], which cannot be expressed in the UDP length field.
+///
+/// `mtu` is the link MTU excluding the Ethernet header.
+///
+/// Used to construct DHCP / DNS responses and relayed UDP datagrams that are
+/// injected directly into the guest FD.
+///
+/// # Panics
+///
+/// Panics if `mtu < 36` (an IPv4 header plus one 8-byte fragment unit) —
+/// a host misconfiguration, not a runtime input.
 #[must_use]
+#[allow(clippy::too_many_arguments)] // all parameters are required header fields
 pub fn build_udp_ip_ethernet(
     src_ip: Ipv4Addr,
     dst_ip: Ipv4Addr,
@@ -18,11 +41,62 @@ pub fn build_udp_ip_ethernet(
     payload: &[u8],
     src_mac: [u8; 6],
     dst_mac: [u8; 6],
-) -> Vec<u8> {
+    mtu: usize,
+) -> Vec<Vec<u8>> {
+    assert!(mtu >= 36, "mtu {mtu} cannot carry an IPv4 fragment");
+    if payload.len() > MAX_UDP_PAYLOAD {
+        return Vec::new();
+    }
+
+    // The IP payload: UDP header + payload, checksummed as one datagram
+    // (the checksum lands in the first fragment with the UDP header).
     let udp_len = 8 + payload.len();
-    let ip_total_len = 20 + udp_len;
-    let frame_len = ETH_HEADER_LEN + ip_total_len;
-    let mut frame = vec![0u8; frame_len];
+    let mut datagram = vec![0u8; udp_len];
+    datagram[0..2].copy_from_slice(&src_port.to_be_bytes());
+    datagram[2..4].copy_from_slice(&dst_port.to_be_bytes());
+    datagram[4..6].copy_from_slice(&(udp_len as u16).to_be_bytes());
+    // Checksum field stays 0 while the checksum is computed.
+    datagram[8..].copy_from_slice(payload);
+    let udp_cksum = udp_checksum(src_ip, dst_ip, &datagram);
+    datagram[6..8].copy_from_slice(&udp_cksum.to_be_bytes());
+
+    let ip_id = NEXT_IP_ID.fetch_add(1, Ordering::Relaxed);
+
+    if 20 + udp_len <= mtu {
+        return vec![build_frame(
+            src_ip, dst_ip, ip_id, 0, false, &datagram, src_mac, dst_mac,
+        )];
+    }
+
+    // Per-fragment IP payload: what fits under the MTU, rounded down to the
+    // 8-byte fragment-offset unit.
+    let chunk = (mtu - 20) & !7;
+    datagram
+        .chunks(chunk)
+        .enumerate()
+        .map(|(i, part)| {
+            let offset = i * chunk;
+            let more = offset + part.len() < udp_len;
+            build_frame(src_ip, dst_ip, ip_id, offset, more, part, src_mac, dst_mac)
+        })
+        .collect()
+}
+
+/// Builds one Ethernet + IPv4 frame carrying `ip_payload` at
+/// `frag_offset_bytes` of the enclosing datagram.
+#[allow(clippy::too_many_arguments)] // all parameters are required header fields
+fn build_frame(
+    src_ip: Ipv4Addr,
+    dst_ip: Ipv4Addr,
+    ip_id: u16,
+    frag_offset_bytes: usize,
+    more_fragments: bool,
+    ip_payload: &[u8],
+    src_mac: [u8; 6],
+    dst_mac: [u8; 6],
+) -> Vec<u8> {
+    let ip_total_len = 20 + ip_payload.len();
+    let mut frame = vec![0u8; ETH_HEADER_LEN + ip_total_len];
 
     // -- Ethernet header --
     frame[0..6].copy_from_slice(&dst_mac);
@@ -33,29 +107,18 @@ pub fn build_udp_ip_ethernet(
     let ip = &mut frame[ETH_HEADER_LEN..];
     ip[0] = 0x45; // Version 4, IHL 5
     ip[2..4].copy_from_slice(&(ip_total_len as u16).to_be_bytes());
+    ip[4..6].copy_from_slice(&ip_id.to_be_bytes());
+    // Flags (bit 13 = MF) + fragment offset in 8-byte units.
+    let flags_frag = (u16::from(more_fragments) << 13) | ((frag_offset_bytes / 8) as u16);
+    ip[6..8].copy_from_slice(&flags_frag.to_be_bytes());
     ip[8] = 64; // TTL
     ip[9] = 17; // Protocol: UDP
     ip[12..16].copy_from_slice(&src_ip.octets());
     ip[16..20].copy_from_slice(&dst_ip.octets());
 
-    // IP header checksum
     let ip_cksum = ipv4_header_checksum(&ip[..20]);
     ip[10..12].copy_from_slice(&ip_cksum.to_be_bytes());
 
-    // -- UDP header --
-    let udp_start = ETH_HEADER_LEN + 20;
-    frame[udp_start..udp_start + 2].copy_from_slice(&src_port.to_be_bytes());
-    frame[udp_start + 2..udp_start + 4].copy_from_slice(&dst_port.to_be_bytes());
-    frame[udp_start + 4..udp_start + 6].copy_from_slice(&(udp_len as u16).to_be_bytes());
-    // UDP checksum = 0 (optional for IPv4)
-    frame[udp_start + 6..udp_start + 8].copy_from_slice(&[0, 0]);
-
-    // -- Payload --
-    frame[udp_start + 8..].copy_from_slice(payload);
-
-    // Compute UDP checksum over pseudo-header + UDP header + payload.
-    let udp_cksum = udp_checksum(src_ip, dst_ip, &frame[udp_start..]);
-    frame[udp_start + 6..udp_start + 8].copy_from_slice(&udp_cksum.to_be_bytes());
-
+    frame[ETH_HEADER_LEN + 20..].copy_from_slice(ip_payload);
     frame
 }

--- a/common/arcbox-proxy/src/egress/mod.rs
+++ b/common/arcbox-proxy/src/egress/mod.rs
@@ -46,7 +46,8 @@ impl HostEgress {
     /// Creates a new host-socket egress.
     ///
     /// `reply_tx` is used by all sub-proxies to send L2 frames back to the
-    /// datapath for writing to the guest FD.
+    /// datapath for writing to the guest FD. `mtu` is the guest link MTU;
+    /// guest-bound UDP datagrams above it are IPv4-fragmented.
     #[must_use]
     pub fn new(
         gateway_ip: Ipv4Addr,
@@ -54,16 +55,18 @@ impl HostEgress {
         guest_ip: Ipv4Addr,
         reply_tx: mpsc::Sender<Vec<u8>>,
         cancel: CancellationToken,
+        mtu: usize,
     ) -> Self {
         let inbound = super::inbound_relay::InboundRelay::new(
             reply_tx.clone(),
             gateway_mac,
             gateway_ip,
             guest_ip,
+            mtu,
         );
         Self {
             icmp: IcmpProxy::new(reply_tx.clone(), gateway_mac),
-            udp: UdpProxy::new(reply_tx.clone(), gateway_mac, gateway_ip),
+            udp: UdpProxy::new(reply_tx.clone(), gateway_mac, gateway_ip, mtu),
             inbound,
             reply_tx,
             cancel,
@@ -163,7 +166,7 @@ mod tests {
         let gw_ip = Ipv4Addr::new(192, 168, 64, 1);
         let gw_mac = [0x02, 0xAB, 0xCD, 0x00, 0x00, 0x01];
         let guest_ip = Ipv4Addr::new(192, 168, 64, 2);
-        let _egress = HostEgress::new(gw_ip, gw_mac, guest_ip, tx, CancellationToken::new());
+        let _egress = HostEgress::new(gw_ip, gw_mac, guest_ip, tx, CancellationToken::new(), 1500);
     }
 
     #[test]
@@ -172,7 +175,8 @@ mod tests {
         let gw_ip = Ipv4Addr::new(192, 168, 64, 1);
         let gw_mac = [0x02, 0xAB, 0xCD, 0x00, 0x00, 0x01];
         let guest_ip = Ipv4Addr::new(192, 168, 64, 2);
-        let mut egress = HostEgress::new(gw_ip, gw_mac, guest_ip, tx, CancellationToken::new());
+        let mut egress =
+            HostEgress::new(gw_ip, gw_mac, guest_ip, tx, CancellationToken::new(), 1500);
 
         // Build a minimal Ethernet + IPv4 frame with protocol=50 (ESP).
         let mut frame = vec![0u8; ETH_HEADER_LEN + 20];
@@ -193,7 +197,8 @@ mod tests {
         let gw_ip = Ipv4Addr::new(192, 168, 64, 1);
         let gw_mac = [0x02, 0xAB, 0xCD, 0x00, 0x00, 0x01];
         let guest_ip = Ipv4Addr::new(192, 168, 64, 2);
-        let mut egress = HostEgress::new(gw_ip, gw_mac, guest_ip, tx, CancellationToken::new());
+        let mut egress =
+            HostEgress::new(gw_ip, gw_mac, guest_ip, tx, CancellationToken::new(), 1500);
 
         let guest_mac = [0x02, 0x00, 0x00, 0x00, 0x00, 0x99];
         // Frame shorter than Ethernet + IP minimum.
@@ -216,6 +221,6 @@ mod tests {
 
         // Verify the egress creates correctly with the same tx.
         let guest_ip = Ipv4Addr::new(192, 168, 64, 2);
-        let _egress = HostEgress::new(gw_ip, gw_mac, guest_ip, tx, CancellationToken::new());
+        let _egress = HostEgress::new(gw_ip, gw_mac, guest_ip, tx, CancellationToken::new(), 1500);
     }
 }

--- a/common/arcbox-proxy/src/egress/udp.rs
+++ b/common/arcbox-proxy/src/egress/udp.rs
@@ -107,6 +107,8 @@ pub(super) struct UdpProxy {
     /// Gateway IP — connections to this IP are translated to loopback
     /// so they reach host services (host.docker.internal support).
     gateway_ip: Ipv4Addr,
+    /// Guest link MTU; replies above it are IPv4-fragmented.
+    mtu: usize,
     /// Shared fake-IP → domain log; reverses a fake-IP destination before the
     /// proxy decision so UDP routes by domain like TCP. `None` = no reversal.
     pub(super) dns_log: Option<DnsResolutionLog>,
@@ -120,12 +122,14 @@ impl UdpProxy {
         reply_tx: mpsc::Sender<Vec<u8>>,
         gateway_mac: [u8; 6],
         gateway_ip: Ipv4Addr,
+        mtu: usize,
     ) -> Self {
         Self {
             flows: HashMap::new(),
             reply_tx,
             gateway_mac,
             gateway_ip,
+            mtu,
             dns_log: None,
             proxy_env: None,
         }
@@ -198,6 +202,7 @@ impl UdpProxy {
 
         let reply_tx = self.reply_tx.clone();
         let gateway_mac = self.gateway_mac;
+        let mtu = self.mtu;
         // Translate gateway IP to loopback so host services are reachable.
         let connect_ip = if dst_ip == self.gateway_ip {
             Ipv4Addr::LOCALHOST
@@ -260,7 +265,7 @@ impl UdpProxy {
                             transport.recv(&mut buf),
                         ) => match recv {
                             Ok(Ok(Some(n))) => {
-                                let reply_frame = build_udp_ip_ethernet(
+                                let reply_frames = build_udp_ip_ethernet(
                                     dst_ip,
                                     src_ip,
                                     dst_port,
@@ -268,9 +273,12 @@ impl UdpProxy {
                                     &buf[..n],
                                     gateway_mac,
                                     guest_mac,
+                                    mtu,
                                 );
-                                if reply_tx.send(reply_frame).await.is_err() {
-                                    return;
+                                for frame in reply_frames {
+                                    if reply_tx.send(frame).await.is_err() {
+                                        return;
+                                    }
                                 }
                             }
                             // A fragmented / malformed relay datagram: skip it (the
@@ -339,7 +347,7 @@ mod tests {
         let (tx, _rx) = mpsc::channel(16);
         let gw_ip = Ipv4Addr::new(192, 168, 64, 1);
         let gw_mac = [0x02, 0xAB, 0xCD, 0x00, 0x00, 0x01];
-        let mut proxy = UdpProxy::new(tx, gw_mac, gw_ip);
+        let mut proxy = UdpProxy::new(tx, gw_mac, gw_ip, 1500);
 
         // Insert a flow that is already expired.
         let key = (
@@ -370,7 +378,7 @@ mod tests {
         let (reply_tx, _reply_rx) = mpsc::channel(64);
         let gw_ip = Ipv4Addr::new(10, 0, 2, 1);
         let gw_mac = [0x02, 0x00, 0x00, 0x00, 0x00, 0x01];
-        let mut proxy = UdpProxy::new(reply_tx, gw_mac, gw_ip);
+        let mut proxy = UdpProxy::new(reply_tx, gw_mac, gw_ip, 1500);
 
         // Bind a UDP listener on loopback.
         let listener = tokio::net::UdpSocket::bind("127.0.0.1:0").await.unwrap();
@@ -439,7 +447,7 @@ mod tests {
         let (reply_tx, mut reply_rx) = mpsc::channel(16);
         let gw_ip = Ipv4Addr::new(10, 0, 2, 1);
         let gw_mac = [0x02, 0x00, 0x00, 0x00, 0x00, 0x01];
-        let mut proxy = UdpProxy::new(reply_tx, gw_mac, gw_ip);
+        let mut proxy = UdpProxy::new(reply_tx, gw_mac, gw_ip, 1500);
         let (phost, pport) = (proxy_addr.ip().to_string(), proxy_addr.port());
         proxy.proxy_env = Some(ProxyEnvironment {
             socks_proxy: Some(arcbox_fakeip::proxy_detect::ProxyConfig {

--- a/common/arcbox-proxy/src/inbound_relay.rs
+++ b/common/arcbox-proxy/src/inbound_relay.rs
@@ -136,6 +136,8 @@ pub(crate) struct InboundRelay {
     gateway_mac: [u8; 6],
     gateway_ip: Ipv4Addr,
     guest_ip: Ipv4Addr,
+    /// Guest link MTU; injected datagrams above it are IPv4-fragmented.
+    mtu: usize,
     ephemeral_ports: EphemeralPorts,
 }
 
@@ -145,6 +147,7 @@ impl InboundRelay {
         gateway_mac: [u8; 6],
         gateway_ip: Ipv4Addr,
         guest_ip: Ipv4Addr,
+        mtu: usize,
     ) -> Self {
         Self {
             udp_flows: HashMap::new(),
@@ -152,6 +155,7 @@ impl InboundRelay {
             gateway_mac,
             gateway_ip,
             guest_ip,
+            mtu,
             ephemeral_ports: EphemeralPorts::new(),
         }
     }
@@ -251,7 +255,7 @@ impl InboundRelay {
             },
         );
 
-        let frame = build_udp_ip_ethernet(
+        let frames = build_udp_ip_ethernet(
             self.gateway_ip,
             self.guest_ip,
             ephemeral_port,
@@ -259,9 +263,15 @@ impl InboundRelay {
             data,
             self.gateway_mac,
             guest_mac,
+            self.mtu,
         );
 
-        let _ = self.reply_tx.try_send(frame);
+        for frame in frames {
+            if self.reply_tx.try_send(frame).is_err() {
+                // Dropping a fragment kills the whole datagram; stop early.
+                break;
+            }
+        }
 
         tracing::debug!(
             "Inbound UDP: injected {} bytes  gw:{} → guest:{}",
@@ -561,7 +571,7 @@ mod tests {
     #[test]
     fn inbound_relay_rejects_non_ephemeral() {
         let (tx, _rx) = mpsc::channel(16);
-        let mut relay = InboundRelay::new(tx, GW_MAC, GW_IP, GUEST_IP);
+        let mut relay = InboundRelay::new(tx, GW_MAC, GW_IP, GUEST_IP, 1500);
 
         // Build a minimal TCP frame with dst_port=80 (not in ephemeral range).
         let mut frame = vec![0u8; ETH_HEADER_LEN + 40];
@@ -583,7 +593,7 @@ mod tests {
     #[tokio::test]
     async fn inject_udp_sends_frame_and_tracks_flow() {
         let (tx, mut rx) = mpsc::channel(16);
-        let mut relay = InboundRelay::new(tx, GW_MAC, GW_IP, GUEST_IP);
+        let mut relay = InboundRelay::new(tx, GW_MAC, GW_IP, GUEST_IP, 1500);
 
         let (client_tx, _client_rx) = mpsc::channel(16);
         relay.inject_udp(53, b"dns query", client_tx, GUEST_MAC);
@@ -610,7 +620,7 @@ mod tests {
     #[test]
     fn cleanup_removes_expired_udp_flows() {
         let (tx, _rx) = mpsc::channel(16);
-        let mut relay = InboundRelay::new(tx, GW_MAC, GW_IP, GUEST_IP);
+        let mut relay = InboundRelay::new(tx, GW_MAC, GW_IP, GUEST_IP, 1500);
 
         let (client_tx, _client_rx) = mpsc::channel(16);
         let key = (GW_IP, 61000, GUEST_IP, 53);

--- a/virt/arcbox-hypervisor/src/darwin/mod.rs
+++ b/virt/arcbox-hypervisor/src/darwin/mod.rs
@@ -26,6 +26,10 @@ pub use memory::DarwinMemory;
 pub use vcpu::DarwinVcpu;
 pub use vm::DarwinVm;
 
+/// The MTU the VZ network device will be configured with — the VMM sizes its
+/// datapath from this before the device exists (see `arcbox-vz`).
+pub use arcbox_vz::desired_network_mtu;
+
 /// Checks if virtualization is supported on this system.
 ///
 /// Uses `arcbox-vz` to query the Virtualization.framework.

--- a/virt/arcbox-net/examples/tun_proxy.rs
+++ b/virt/arcbox-net/examples/tun_proxy.rs
@@ -173,6 +173,7 @@ mod macos {
             guest_ip,
             reply_tx.clone(),
             cancel.clone(),
+            UTUN_MTU as usize,
         );
 
         let async_fd = AsyncFd::new(RawFdWrapper(fd)).context("register utun with reactor")?;
@@ -316,7 +317,7 @@ mod macos {
                 tracing::debug!(%domain, ?ips, "recorded DNS resolution");
                 log.record(&domain, &ips);
             }
-            let reply_frame = build_udp_ip_ethernet(
+            let reply_frames = build_udp_ip_ethernet(
                 gateway_ip,
                 src_ip,
                 53,
@@ -324,8 +325,13 @@ mod macos {
                 response,
                 GATEWAY_MAC,
                 guest_mac,
+                UTUN_MTU as usize,
             );
-            let _ = reply_tx.send(reply_frame).await;
+            for reply_frame in reply_frames {
+                if reply_tx.send(reply_frame).await.is_err() {
+                    return;
+                }
+            }
         });
     }
 

--- a/virt/arcbox-net/src/darwin/datapath_loop/intercept.rs
+++ b/virt/arcbox-net/src/darwin/datapath_loop/intercept.rs
@@ -30,6 +30,7 @@ pub(super) fn handle_intercepted_frame(
     gateway_ip: Ipv4Addr,
     gateway_mac: [u8; 6],
     guest_mac: [u8; 6],
+    mtu: usize,
 ) {
     let frame = &intercepted.frame;
     match intercepted.kind {
@@ -42,6 +43,7 @@ pub(super) fn handle_intercepted_frame(
                 gateway_ip,
                 gateway_mac,
                 guest_mac,
+                mtu,
             );
         }
         InterceptedKind::Dns => {
@@ -54,6 +56,7 @@ pub(super) fn handle_intercepted_frame(
                 gateway_ip,
                 gateway_mac,
                 guest_mac,
+                mtu,
             );
         }
         InterceptedKind::Udp | InterceptedKind::Icmp => {
@@ -93,6 +96,7 @@ pub(super) fn process_inbound_cmd(
 }
 
 /// Handles a DHCP packet from the guest.
+#[allow(clippy::too_many_arguments)] // all parameters are required context for DHCP frame handling
 fn handle_dhcp(
     frame: &[u8],
     guest_tx: &mut GuestTx,
@@ -101,6 +105,7 @@ fn handle_dhcp(
     gateway_ip: Ipv4Addr,
     gateway_mac: [u8; 6],
     guest_mac: [u8; 6],
+    mtu: usize,
 ) {
     let ip_start = ETH_HEADER_LEN;
     let ihl = ((frame[ip_start] & 0x0F) as usize) * 4;
@@ -115,7 +120,7 @@ fn handle_dhcp(
 
     match dhcp_server.handle_packet(dhcp_data) {
         Ok(Some(response)) => {
-            let reply_frame = build_udp_ip_ethernet(
+            let reply_frames = build_udp_ip_ethernet(
                 gateway_ip,
                 Ipv4Addr::BROADCAST,
                 67,
@@ -123,9 +128,12 @@ fn handle_dhcp(
                 &response,
                 gateway_mac,
                 guest_mac,
+                mtu,
             );
-            tracing::info!("Sending DHCP reply frame: {} bytes", reply_frame.len());
-            guest_tx.send(guest_fd, &reply_frame, DeliveryClass::Lossy);
+            for reply_frame in reply_frames {
+                tracing::info!("Sending DHCP reply frame: {} bytes", reply_frame.len());
+                guest_tx.send(guest_fd, &reply_frame, DeliveryClass::Lossy);
+            }
         }
         Ok(None) => {
             tracing::info!("DHCP: no response needed");
@@ -153,6 +161,7 @@ fn handle_dns(
     gateway_ip: Ipv4Addr,
     gateway_mac: [u8; 6],
     guest_mac: [u8; 6],
+    mtu: usize,
 ) {
     let ip_start = ETH_HEADER_LEN;
     let ihl = ((frame[ip_start] & 0x0F) as usize) * 4;
@@ -173,7 +182,7 @@ fn handle_dns(
 
     // Fast path: resolve from local host mappings (no I/O).
     if let Some(response) = dns_forwarder.try_resolve_locally(dns_data) {
-        let reply_frame = build_udp_ip_ethernet(
+        let reply_frames = build_udp_ip_ethernet(
             gateway_ip,
             src_ip,
             53,
@@ -181,11 +190,15 @@ fn handle_dns(
             &response,
             gateway_mac,
             guest_mac,
+            mtu,
         );
         let tx = dns_reply_tx.clone();
         tokio::spawn(async move {
-            if tx.send(reply_frame).await.is_err() {
-                tracing::debug!("DNS reply channel closed");
+            for reply_frame in reply_frames {
+                if tx.send(reply_frame).await.is_err() {
+                    tracing::debug!("DNS reply channel closed");
+                    return;
+                }
             }
         });
         tracing::debug!("Queued local DNS response to guest");
@@ -220,7 +233,7 @@ fn handle_dns(
                     log.record(&domain, &ips);
                 }
 
-                let reply_frame = build_udp_ip_ethernet(
+                let reply_frames = build_udp_ip_ethernet(
                     gateway_ip,
                     src_ip,
                     53,
@@ -228,16 +241,20 @@ fn handle_dns(
                     &response,
                     gateway_mac,
                     guest_mac,
+                    mtu,
                 );
-                if tx.send(reply_frame).await.is_err() {
-                    tracing::debug!("DNS reply channel closed");
+                for reply_frame in reply_frames {
+                    if tx.send(reply_frame).await.is_err() {
+                        tracing::debug!("DNS reply channel closed");
+                        return;
+                    }
                 }
                 tracing::debug!("Sent forwarded DNS response to guest");
             }
             Err(e) => {
                 tracing::warn!("DNS forwarding failed: {e}");
                 if let Some(servfail) = build_dns_servfail_response(&data) {
-                    let reply_frame = build_udp_ip_ethernet(
+                    let reply_frames = build_udp_ip_ethernet(
                         gateway_ip,
                         src_ip,
                         53,
@@ -245,9 +262,13 @@ fn handle_dns(
                         &servfail,
                         gateway_mac,
                         guest_mac,
+                        mtu,
                     );
-                    if tx.send(reply_frame).await.is_err() {
-                        tracing::debug!("DNS reply channel closed");
+                    for reply_frame in reply_frames {
+                        if tx.send(reply_frame).await.is_err() {
+                            tracing::debug!("DNS reply channel closed");
+                            return;
+                        }
                     }
                 }
             }

--- a/virt/arcbox-net/src/darwin/datapath_loop/mod.rs
+++ b/virt/arcbox-net/src/darwin/datapath_loop/mod.rs
@@ -78,8 +78,8 @@ pub struct NetworkDatapath {
     pub guest_ip: Ipv4Addr,
     /// Cancellation token for graceful shutdown.
     pub cancel: CancellationToken,
-    /// Buffer-sizing MTU (at least the device's configured MTU; see
-    /// `splicetcp`'s `ENHANCED_ETHERNET_MTU`).
+    /// Guest link MTU. Guest-bound UDP datagrams above it are IPv4-fragmented
+    /// so no injected frame exceeds what the NIC delivers (ABX-428).
     pub mtu: usize,
     /// Frame sink for host-to-guest RX injection. When set, all frames
     /// destined for the guest go through this sink (to the inject thread)
@@ -349,6 +349,7 @@ impl NetworkDatapath {
                             gateway_ip,
                             gateway_mac,
                             guest_mac.unwrap_or([0xFF; 6]),
+                            mtu,
                         );
                     }
 

--- a/virt/arcbox-net/tests/datapath_test.rs
+++ b/virt/arcbox-net/tests/datapath_test.rs
@@ -48,7 +48,14 @@ fn create_test_datapath() -> (NetworkDatapath, std::os::fd::OwnedFd, Cancellatio
     let (reply_tx, reply_rx) = mpsc::channel(256);
     let (_cmd_tx, cmd_rx) = mpsc::channel(64);
 
-    let egress = HostEgress::new(GATEWAY_IP, GATEWAY_MAC, GUEST_IP, reply_tx, cancel.clone());
+    let egress = HostEgress::new(
+        GATEWAY_IP,
+        GATEWAY_MAC,
+        GUEST_IP,
+        reply_tx,
+        cancel.clone(),
+        1500,
+    );
 
     let dhcp_config = DhcpConfig::new(GATEWAY_IP, Ipv4Addr::new(255, 255, 255, 0));
     let dhcp_server = arcbox_dhcp::DhcpServer::new(dhcp_config);

--- a/virt/arcbox-vmm/src/device/tests.rs
+++ b/virt/arcbox-vmm/src/device/tests.rs
@@ -90,7 +90,11 @@ fn test_finalize_virtio_net_checksum_repairs_ipv4_udp_frame() {
     let payload = b"hello dns";
     let src_mac = [0x52, 0x54, 0xAB, 0xFA, 0x2A, 0x70];
     let dst_mac = [0x02, 0xAB, 0xCD, 0x00, 0x00, 0x01];
-    let mut frame = build_udp_ip_ethernet(src_ip, dst_ip, 49152, 53, payload, src_mac, dst_mac);
+    let frames = build_udp_ip_ethernet(src_ip, dst_ip, 49152, 53, payload, src_mac, dst_mac, 1500);
+    let mut frame = frames
+        .into_iter()
+        .next()
+        .expect("small payload yields one frame");
     let udp_start = 14 + 20;
     frame[udp_start + 6..udp_start + 8].fill(0);
 

--- a/virt/arcbox-vmm/src/vmm/darwin.rs
+++ b/virt/arcbox-vmm/src/vmm/darwin.rs
@@ -343,10 +343,24 @@ impl Vmm {
         let cancel = CancellationToken::new();
         self.net_cancel = Some(cancel.clone());
 
+        // NOTE(MTU): the MTU the VZ device will negotiate (1500 by default,
+        // ABX-423; 4000 under ARCBOX_DIAG_NET_MTU_4000 — see
+        // arcbox-vz/src/device/network.rs). The datapath fragments guest-bound
+        // UDP datagrams to it (ABX-428); guest-bound TCP segments are bounded
+        // by the peer's advertised MSS (TcpBridge peer_mss).
+        let net_mtu = arcbox_hypervisor::darwin::desired_network_mtu();
+
         // 3. Create the socket proxy, reply channel, and inbound command channel.
         let (reply_tx, reply_rx) = tokio::sync::mpsc::channel::<Vec<u8>>(1024);
         let (cmd_tx, cmd_rx) = tokio::sync::mpsc::channel(256);
-        let egress = HostEgress::new(gateway_ip, gateway_mac, guest_ip, reply_tx, cancel.clone());
+        let egress = HostEgress::new(
+            gateway_ip,
+            gateway_mac,
+            guest_ip,
+            reply_tx,
+            cancel.clone(),
+            net_mtu,
+        );
 
         // Create the inbound listener manager for port forwarding.
         self.inbound_listener_manager = Some(InboundListenerManager::new(cmd_tx));
@@ -371,18 +385,6 @@ impl Vmm {
         };
 
         // 5. Build the datapath and spawn it on the tokio runtime.
-
-        // NOTE(MTU): the VZ device stays at the default 1500 (ABX-423 — see
-        // arcbox-vz/src/device/network.rs), but the classifier deliberately
-        // keeps ENHANCED_ETHERNET_MTU (4000). For the datapath this value only
-        // sizes buffers and frame sinks — at a 1500 link it is pure headroom —
-        // and it keeps the ARCBOX_DIAG_NET_MTU_4000 reproduction mode working
-        // without plumbing the negotiated MTU from
-        // NetworkDeviceConfiguration::mtu() through the hypervisor abstraction
-        // layer. Guest-bound TCP segments are bounded by the peer's advertised
-        // MSS (TcpBridge peer_mss), not by this value.
-        let net_mtu = arcbox_net::darwin::classifier::ENHANCED_ETHERNET_MTU;
-
         let datapath = NetworkDatapath::new(
             host_fd,
             egress,

--- a/virt/arcbox-vmm/src/vmm/darwin_hv/network.rs
+++ b/virt/arcbox-vmm/src/vmm/darwin_hv/network.rs
@@ -140,10 +140,22 @@ impl Vmm {
         let cancel = tokio_util::sync::CancellationToken::new();
         self.net_cancel = Some(cancel.clone());
 
+        // The HV virtio-net NIC advertises the NetConfig default MTU (1500,
+        // setup.rs constructs `NetConfig { .. Default::default() }`); the
+        // datapath fragments guest-bound UDP datagrams to it (ABX-428).
+        let net_mtu = arcbox_virtio::net::NetConfig::default().mtu as usize;
+
         // 3. Create socket proxy and channels.
         let (reply_tx, reply_rx) = tokio::sync::mpsc::channel::<Vec<u8>>(1024);
         let (cmd_tx, cmd_rx) = tokio::sync::mpsc::channel(256);
-        let egress = HostEgress::new(gateway_ip, gateway_mac, guest_ip, reply_tx, cancel.clone());
+        let egress = HostEgress::new(
+            gateway_ip,
+            gateway_mac,
+            guest_ip,
+            reply_tx,
+            cancel.clone(),
+            net_mtu,
+        );
 
         self.inbound_listener_manager = Some(InboundListenerManager::new(cmd_tx));
 
@@ -161,7 +173,6 @@ impl Vmm {
         };
 
         // 5. Build and spawn the datapath.
-        let net_mtu = arcbox_net::darwin::classifier::ENHANCED_ETHERNET_MTU;
         let mut datapath = NetworkDatapath::new(
             host_fd,
             egress,

--- a/virt/arcbox-vz/src/device/mod.rs
+++ b/virt/arcbox-vz/src/device/mod.rs
@@ -20,7 +20,7 @@ pub use filesystem::{
     SharedDirectory, SingleDirectoryShare, VirtioFileSystemDeviceConfiguration,
 };
 pub use graphics::MacGraphicsDeviceConfiguration;
-pub use network::NetworkDeviceConfiguration;
+pub use network::{NetworkDeviceConfiguration, desired_network_mtu};
 pub use serial::SerialPortConfiguration;
 pub use socket::SocketDeviceConfiguration;
 pub use storage::StorageDeviceConfiguration;

--- a/virt/arcbox-vz/src/device/network.rs
+++ b/virt/arcbox-vz/src/device/network.rs
@@ -24,6 +24,24 @@ pub const VZ_DEFAULT_MTU: usize = 1500;
 /// the stall (Apple Feedback evidence) and for throughput A/B runs.
 pub const VZ_ENHANCED_MTU: u64 = 4000;
 
+/// The MTU a VZ network device is configured with: [`VZ_DEFAULT_MTU`] unless
+/// `ARCBOX_DIAG_NET_MTU_4000` opts into [`VZ_ENHANCED_MTU`].
+///
+/// This is the policy half of the decision — the VMM sizes its datapath from
+/// it before the device exists. The mechanism half (the
+/// `setMaximumTransmissionUnit:` availability probe and the actual setter
+/// call) stays in [`NetworkDeviceConfiguration`]; on macOS < 13 with the knob
+/// set the device falls back to 1500 while the datapath assumes 4000, an
+/// accepted mismatch on that unsupported, diagnostic-only configuration.
+#[must_use]
+pub fn desired_network_mtu() -> usize {
+    if std::env::var_os("ARCBOX_DIAG_NET_MTU_4000").is_some() {
+        VZ_ENHANCED_MTU as usize
+    } else {
+        VZ_DEFAULT_MTU
+    }
+}
+
 /// Configuration for a `VirtIO` network device.
 pub struct NetworkDeviceConfiguration {
     inner: *mut AnyObject,
@@ -110,11 +128,12 @@ impl NetworkDeviceConfiguration {
             msg_send_void!(obj, setAttachment: attachment);
 
             // The MTU stays at Apple's default 1500 (ABX-423 — see
-            // VZ_ENHANCED_MTU). ARCBOX_DIAG_NET_MTU_4000 opts back into the
-            // enhanced MTU for stall reproduction and throughput A/B runs;
-            // it needs setMaximumTransmissionUnit: (macOS 13+), so check
-            // respondsToSelector: to avoid an unrecognized-selector crash.
-            let mtu = if std::env::var_os("ARCBOX_DIAG_NET_MTU_4000").is_some() {
+            // VZ_ENHANCED_MTU). desired_network_mtu() reads the
+            // ARCBOX_DIAG_NET_MTU_4000 opt-in for stall reproduction and
+            // throughput A/B runs; raising needs setMaximumTransmissionUnit:
+            // (macOS 13+), so check respondsToSelector: to avoid an
+            // unrecognized-selector crash.
+            let mtu = if desired_network_mtu() > VZ_DEFAULT_MTU {
                 let mtu_sel = objc2::sel!(setMaximumTransmissionUnit:);
                 // msg_send_bool! doesn't support Sel arguments, so dispatch manually.
                 let responds: bool = {

--- a/virt/arcbox-vz/src/lib.rs
+++ b/virt/arcbox-vz/src/lib.rs
@@ -82,7 +82,7 @@ pub use device::{
     MacGraphicsDeviceConfiguration, MemoryBalloonDevice, MemoryBalloonDeviceConfiguration,
     MultipleDirectoryShare, NetworkDeviceConfiguration, RosettaAvailability,
     SerialPortConfiguration, SharedDirectory, SingleDirectoryShare, SocketDeviceConfiguration,
-    StorageDeviceConfiguration, VirtioFileSystemDeviceConfiguration,
+    StorageDeviceConfiguration, VirtioFileSystemDeviceConfiguration, desired_network_mtu,
 };
 
 pub use socket::{VirtioSocketConnection, VirtioSocketDevice, VirtioSocketListener};


### PR DESCRIPTION
Fixes ABX-428 (found by Codex review on #410, probe-confirmed there: a 3000-byte guest-bound UDP reply arrives as **0 bytes** at the 1500 default).

## What

- **`arcbox-packet`**: `build_udp_ip_ethernet` now takes the link MTU and returns one frame or standard IPv4 fragments (shared IP ID from a global counter, MF + 8-byte-unit offsets, per-fragment header checksums, UDP checksum over the whole datagram) that the guest kernel reassembles — no injected frame ever exceeds MTU+14. Payloads above `MAX_UDP_PAYLOAD` (65507) yield no frames instead of silently truncating the 16-bit UDP length field (pre-existing latent bug).
- **Wire MTU reaches every guest-bound UDP build site**: egress `UdpProxy` replies, `InboundRelay` injected datagrams (published UDP ports), and the DHCP/DNS intercept handlers — via `HostEgress::new` and `NetworkDatapath.mtu`.
- **`NetworkDatapath.mtu` is the actual guest link MTU again**: the VZ VMM reads it from the new `arcbox_vz::desired_network_mtu()` (single source for the `ARCBOX_DIAG_NET_MTU_4000` policy, re-exported through `arcbox-hypervisor`); the HV VMM reads the `NetConfig` default its NICs advertise. `ENHANCED_ETHERNET_MTU` is no longer wired into any datapath. This also fixes the same oversized-UDP drop on the HV backend, which has always been at 1500.
- `tun_proxy` host harness updated (arcbox-proxy stays VM-free; MTU is a plain parameter).

## Validation

- Unit: fragment math + reassembly-equivalence + checksum tests in `arcbox-packet` (3-fragment 3000B, 1-byte tail fragment, 45-fragment `MAX_UDP_PAYLOAD`, distinct IP IDs, oversize→no frames, tiny-MTU panic). All touched crates' suites green; workspace clippy clean.
- End-to-end probe (host UDP echo → alpine container, real VZ daemon):

  | link MTU | 1200 B reply | 3000 B reply |
  |---|---|---|
  | 1500 default, **before** | delivered | **dropped (0 bytes)** |
  | 1500 default, **after** | delivered | **delivered (3000)** |
  | 4000 knob, after | delivered | delivered |

- VZ `boot_assets` e2e green over the changed DHCP/DNS paths (NFS export, image pull, full container lifecycle, 84.9s).