### PR TITLE
feat(vz): route config, boot loaders, and generic platform through the shim

### DIFF
--- a/virt/arcbox-vz/Cargo.toml
+++ b/virt/arcbox-vz/Cargo.toml
@@ -23,7 +23,7 @@ include = [
 objc2 = { version = "0.6", features = ["exception"] }
 
 # Async runtime
-tokio = { version = "1", features = ["sync", "rt", "io-util", "net", "time"] }
+tokio = { version = "1", features = ["sync", "rt", "io-util", "net", "time", "macros"] }
 
 # Error handling
 thiserror = "2"

--- a/virt/arcbox-vz/shim/Sources/ArcBoxVZShim/Config.swift
+++ b/virt/arcbox-vz/shim/Sources/ArcBoxVZShim/Config.swift
@@ -1,0 +1,90 @@
+// VM configuration, boot loaders, and the generic platform
+// (mirrors src/configuration/{vm_config,boot_loader,platform}.rs).
+//
+// Configuration objects are queue-free: VZ only requires queue affinity for
+// a live VZVirtualMachine, so these run on the caller's (Rust) thread.
+
+import Virtualization
+
+func configNew() -> UnsafeMutableRawPointer {
+    abxRetainedHandle(VZVirtualMachineConfiguration())
+}
+
+func configSetCPUCount(_ config: UnsafeMutableRawPointer, _ count: UInt64) {
+    abxBorrow(config, as: VZVirtualMachineConfiguration.self).cpuCount = Int(count)
+}
+
+func configCPUCount(_ config: UnsafeMutableRawPointer) -> UInt64 {
+    UInt64(abxBorrow(config, as: VZVirtualMachineConfiguration.self).cpuCount)
+}
+
+func configSetMemorySize(_ config: UnsafeMutableRawPointer, _ bytes: UInt64) {
+    abxBorrow(config, as: VZVirtualMachineConfiguration.self).memorySize = bytes
+}
+
+func configMemorySize(_ config: UnsafeMutableRawPointer) -> UInt64 {
+    abxBorrow(config, as: VZVirtualMachineConfiguration.self).memorySize
+}
+
+func configSetBootLoader(_ config: UnsafeMutableRawPointer, _ bootLoader: UnsafeMutableRawPointer) {
+    abxBorrow(config, as: VZVirtualMachineConfiguration.self).bootLoader =
+        abxBorrow(bootLoader, as: VZBootLoader.self)
+}
+
+func configSetPlatform(_ config: UnsafeMutableRawPointer, _ platform: UnsafeMutableRawPointer) {
+    abxBorrow(config, as: VZVirtualMachineConfiguration.self).platform =
+        abxBorrow(platform, as: VZPlatformConfiguration.self)
+}
+
+func configValidate(
+    _ config: UnsafeMutableRawPointer,
+    _ errorOut: UnsafeMutablePointer<UnsafeMutablePointer<CChar>?>?
+) -> Bool {
+    do {
+        try abxBorrow(config, as: VZVirtualMachineConfiguration.self).validate()
+        return true
+    } catch {
+        errorOut?.pointee = abxErrorString(error)
+        return false
+    }
+}
+
+func bootLoaderLinuxNew(_ kernelPath: UnsafePointer<CChar>) -> UnsafeMutableRawPointer {
+    let url = URL(fileURLWithPath: String(cString: kernelPath))
+    return abxRetainedHandle(VZLinuxBootLoader(kernelURL: url))
+}
+
+func bootLoaderLinuxSetInitrd(
+    _ bootLoader: UnsafeMutableRawPointer, _ path: UnsafePointer<CChar>
+) {
+    let url = URL(fileURLWithPath: String(cString: path))
+    abxBorrow(bootLoader, as: VZLinuxBootLoader.self).initialRamdiskURL = url
+}
+
+func bootLoaderLinuxSetCmdline(
+    _ bootLoader: UnsafeMutableRawPointer, _ cmdline: UnsafePointer<CChar>
+) {
+    abxBorrow(bootLoader, as: VZLinuxBootLoader.self).commandLine = String(cString: cmdline)
+}
+
+func bootLoaderMacOSNew() -> UnsafeMutableRawPointer {
+    abxRetainedHandle(VZMacOSBootLoader())
+}
+
+func platformGenericNew() -> UnsafeMutableRawPointer {
+    abxRetainedHandle(VZGenericPlatformConfiguration())
+}
+
+func platformGenericNestedSupported() -> Bool {
+    if #available(macOS 15.0, *) {
+        return VZGenericPlatformConfiguration.isNestedVirtualizationSupported
+    }
+    return false
+}
+
+func platformGenericSetNested(_ platform: UnsafeMutableRawPointer, _ enabled: Bool) {
+    if #available(macOS 15.0, *) {
+        abxBorrow(platform, as: VZGenericPlatformConfiguration.self)
+            .isNestedVirtualizationEnabled = enabled
+    }
+}

--- a/virt/arcbox-vz/shim/Sources/ArcBoxVZShim/Exports.swift
+++ b/virt/arcbox-vz/shim/Sources/ArcBoxVZShim/Exports.swift
@@ -55,3 +55,95 @@ public func abxVzMinMemorySize() -> UInt64 {
 public func abxVzMaxMemorySize() -> UInt64 {
     vzMaxMemorySize()
 }
+
+// MARK: - Configuration
+
+@_cdecl("abx_config_new")
+public func abxConfigNew() -> UnsafeMutableRawPointer {
+    configNew()
+}
+
+@_cdecl("abx_config_set_cpu_count")
+public func abxConfigSetCPUCount(_ config: UnsafeMutableRawPointer, _ count: UInt64) {
+    configSetCPUCount(config, count)
+}
+
+@_cdecl("abx_config_cpu_count")
+public func abxConfigCPUCount(_ config: UnsafeMutableRawPointer) -> UInt64 {
+    configCPUCount(config)
+}
+
+@_cdecl("abx_config_set_memory_size")
+public func abxConfigSetMemorySize(_ config: UnsafeMutableRawPointer, _ bytes: UInt64) {
+    configSetMemorySize(config, bytes)
+}
+
+@_cdecl("abx_config_memory_size")
+public func abxConfigMemorySize(_ config: UnsafeMutableRawPointer) -> UInt64 {
+    configMemorySize(config)
+}
+
+@_cdecl("abx_config_set_boot_loader")
+public func abxConfigSetBootLoader(
+    _ config: UnsafeMutableRawPointer, _ bootLoader: UnsafeMutableRawPointer
+) {
+    configSetBootLoader(config, bootLoader)
+}
+
+@_cdecl("abx_config_set_platform")
+public func abxConfigSetPlatform(
+    _ config: UnsafeMutableRawPointer, _ platform: UnsafeMutableRawPointer
+) {
+    configSetPlatform(config, platform)
+}
+
+@_cdecl("abx_config_validate")
+public func abxConfigValidate(
+    _ config: UnsafeMutableRawPointer,
+    _ errorOut: UnsafeMutablePointer<UnsafeMutablePointer<CChar>?>?
+) -> Bool {
+    configValidate(config, errorOut)
+}
+
+// MARK: - Boot loaders
+
+@_cdecl("abx_bootloader_linux_new")
+public func abxBootLoaderLinuxNew(_ kernelPath: UnsafePointer<CChar>) -> UnsafeMutableRawPointer {
+    bootLoaderLinuxNew(kernelPath)
+}
+
+@_cdecl("abx_bootloader_linux_set_initrd")
+public func abxBootLoaderLinuxSetInitrd(
+    _ bootLoader: UnsafeMutableRawPointer, _ path: UnsafePointer<CChar>
+) {
+    bootLoaderLinuxSetInitrd(bootLoader, path)
+}
+
+@_cdecl("abx_bootloader_linux_set_cmdline")
+public func abxBootLoaderLinuxSetCmdline(
+    _ bootLoader: UnsafeMutableRawPointer, _ cmdline: UnsafePointer<CChar>
+) {
+    bootLoaderLinuxSetCmdline(bootLoader, cmdline)
+}
+
+@_cdecl("abx_bootloader_macos_new")
+public func abxBootLoaderMacOSNew() -> UnsafeMutableRawPointer {
+    bootLoaderMacOSNew()
+}
+
+// MARK: - Platforms (generic; MacPlatform arrives with the identity types)
+
+@_cdecl("abx_platform_generic_new")
+public func abxPlatformGenericNew() -> UnsafeMutableRawPointer {
+    platformGenericNew()
+}
+
+@_cdecl("abx_platform_generic_nested_supported")
+public func abxPlatformGenericNestedSupported() -> Bool {
+    platformGenericNestedSupported()
+}
+
+@_cdecl("abx_platform_generic_set_nested")
+public func abxPlatformGenericSetNested(_ platform: UnsafeMutableRawPointer, _ enabled: Bool) {
+    platformGenericSetNested(platform, enabled)
+}

--- a/virt/arcbox-vz/src/configuration/boot_loader.rs
+++ b/virt/arcbox-vz/src/configuration/boot_loader.rs
@@ -1,10 +1,17 @@
 //! Boot loader configurations.
 
 use crate::error::{VZError, VZResult};
-use crate::ffi::{get_class, nsurl_file_path, release};
-use crate::{msg_send, msg_send_void};
+use crate::shim_ffi;
 use objc2::runtime::AnyObject;
+use std::ffi::CString;
 use std::path::Path;
+
+/// Converts a path to a `CString`, rejecting interior NUL bytes.
+fn path_cstring(path: &Path) -> VZResult<CString> {
+    CString::new(path.to_string_lossy().as_bytes()).map_err(|_| {
+        VZError::InvalidConfiguration(format!("path contains NUL: {}", path.display()))
+    })
+}
 
 /// Trait for boot loader configurations.
 pub trait BootLoader {
@@ -40,26 +47,13 @@ impl LinuxBootLoader {
             return Err(VZError::NotFound(path.display().to_string()));
         }
 
-        let path_str = path.to_string_lossy();
-
-        // SAFETY: ObjC alloc/init pattern on valid VZLinuxBootLoader class. Result is checked non-null.
-        unsafe {
-            let cls = get_class("VZLinuxBootLoader").ok_or_else(|| VZError::Internal {
-                code: -1,
-                message: "VZLinuxBootLoader class not found".into(),
-            })?;
-            let kernel_url = nsurl_file_path(&path_str);
-            let alloc = msg_send!(cls, alloc);
-            let obj = msg_send!(alloc, initWithKernelURL: kernel_url);
-
-            if obj.is_null() {
-                return Err(VZError::InvalidConfiguration(format!(
-                    "Failed to create boot loader for kernel: {path_str}"
-                )));
-            }
-
-            Ok(Self { inner: obj })
-        }
+        let c_path = path_cstring(path)?;
+        // SAFETY: c_path is a valid NUL-terminated string; the shim returns
+        // a +1 VZLinuxBootLoader handle, released by Drop.
+        let obj = unsafe { shim_ffi::abx_bootloader_linux_new(c_path.as_ptr()) };
+        Ok(Self {
+            inner: obj as *mut AnyObject,
+        })
     }
 
     /// Sets the initial ramdisk (initrd) path.
@@ -69,12 +63,12 @@ impl LinuxBootLoader {
     /// * `path` - Path to the initrd/initramfs image
     pub fn set_initial_ramdisk(&mut self, path: impl AsRef<Path>) -> &mut Self {
         let path = path.as_ref();
-        if path.exists() {
-            let path_str = path.to_string_lossy();
-            // SAFETY: self.inner is a valid VZLinuxBootLoader. NSURL is created from a validated path.
+        if path.exists()
+            && let Ok(c_path) = path_cstring(path)
+        {
+            // SAFETY: valid handle and NUL-terminated path string.
             unsafe {
-                let url = nsurl_file_path(&path_str);
-                msg_send_void!(self.inner, setInitialRamdiskURL: url);
+                shim_ffi::abx_bootloader_linux_set_initrd(self.inner.cast(), c_path.as_ptr());
             }
         }
         self
@@ -86,10 +80,11 @@ impl LinuxBootLoader {
     ///
     /// * `cmdline` - Kernel command line string (e.g., "console=hvc0 root=/dev/vda")
     pub fn set_command_line(&mut self, cmdline: &str) -> &mut Self {
-        // SAFETY: self.inner is a valid VZLinuxBootLoader. NSString is created from a valid Rust str.
-        unsafe {
-            let s = crate::ffi::nsstring(cmdline);
-            msg_send_void!(self.inner, setCommandLine: s);
+        if let Ok(c_cmdline) = CString::new(cmdline) {
+            // SAFETY: valid handle and NUL-terminated command-line string.
+            unsafe {
+                shim_ffi::abx_bootloader_linux_set_cmdline(self.inner.cast(), c_cmdline.as_ptr());
+            }
         }
         self
     }
@@ -104,7 +99,8 @@ impl BootLoader for LinuxBootLoader {
 impl Drop for LinuxBootLoader {
     fn drop(&mut self) {
         if !self.inner.is_null() {
-            release(self.inner);
+            // SAFETY: releasing the +1 handle returned by the shim.
+            unsafe { shim_ffi::abx_object_release(self.inner.cast()) };
         }
     }
 }
@@ -129,24 +125,13 @@ impl MacOSBootLoader {
     /// Returns an error if `VZMacOSBootLoader` is unavailable (non-Apple-Silicon hosts
     /// or macOS versions without macOS-guest support) or cannot be created.
     pub fn new() -> VZResult<Self> {
-        // SAFETY: ObjC alloc/init pattern on the VZMacOSBootLoader class. Result checked non-null.
-        unsafe {
-            let cls = get_class("VZMacOSBootLoader").ok_or_else(|| VZError::Internal {
-                code: -1,
-                message: "VZMacOSBootLoader class not found".into(),
-            })?;
-            let alloc = msg_send!(cls, alloc);
-            let obj = msg_send!(alloc, init);
-
-            if obj.is_null() {
-                return Err(VZError::Internal {
-                    code: -1,
-                    message: "Failed to create VZMacOSBootLoader".into(),
-                });
-            }
-
-            Ok(Self { inner: obj })
-        }
+        // SAFETY: the shim returns a +1 VZMacOSBootLoader handle, released by
+        // Drop. Construction cannot fail; guest support is checked by
+        // configuration validation.
+        let obj = unsafe { shim_ffi::abx_bootloader_macos_new() };
+        Ok(Self {
+            inner: obj as *mut AnyObject,
+        })
     }
 }
 
@@ -159,7 +144,8 @@ impl BootLoader for MacOSBootLoader {
 impl Drop for MacOSBootLoader {
     fn drop(&mut self) {
         if !self.inner.is_null() {
-            release(self.inner);
+            // SAFETY: releasing the +1 handle returned by the shim.
+            unsafe { shim_ffi::abx_object_release(self.inner.cast()) };
         }
     }
 }

--- a/virt/arcbox-vz/src/configuration/platform.rs
+++ b/virt/arcbox-vz/src/configuration/platform.rs
@@ -2,8 +2,8 @@
 
 use crate::error::{VZError, VZResult};
 use crate::ffi::{get_class, release};
-use crate::{msg_send, msg_send_bool, msg_send_void, msg_send_void_bool};
-use objc2::runtime::{AnyObject, Bool};
+use crate::{msg_send, msg_send_void};
+use objc2::runtime::AnyObject;
 
 use super::mac::{MacAuxiliaryStorage, MacHardwareModel, MacMachineIdentifier};
 
@@ -26,64 +26,32 @@ unsafe impl Send for GenericPlatform {}
 impl GenericPlatform {
     /// Creates a new generic platform configuration.
     pub fn new() -> VZResult<Self> {
-        // SAFETY: ObjC alloc/init pattern on valid VZGenericPlatformConfiguration class. Result is checked non-null. retain prevents autorelease.
-        unsafe {
-            let cls =
-                get_class("VZGenericPlatformConfiguration").ok_or_else(|| VZError::Internal {
-                    code: -1,
-                    message: "VZGenericPlatformConfiguration class not found".into(),
-                })?;
-            let obj = msg_send!(cls, new);
-
-            if obj.is_null() {
-                return Err(VZError::Internal {
-                    code: -1,
-                    message: "Failed to create generic platform".into(),
-                });
-            }
-
-            // Retain to prevent autorelease
-            let _: *mut AnyObject = msg_send!(obj, retain);
-
-            Ok(Self { inner: obj })
-        }
+        // SAFETY: the shim returns a +1 VZGenericPlatformConfiguration
+        // handle, released by Drop.
+        let obj = unsafe { crate::shim_ffi::abx_platform_generic_new() };
+        Ok(Self {
+            inner: obj as *mut AnyObject,
+        })
     }
 
     /// Returns whether the hardware supports nested virtualization.
     ///
-    /// Requires macOS 15+ and Apple M3 or later. On older systems, the
-    /// selector does not exist and this returns `false`.
+    /// Requires macOS 15+ and Apple M3 or later; the shim's `#available`
+    /// guard returns `false` on older systems.
     pub fn is_nested_virt_supported() -> bool {
-        let Some(cls) = get_class("VZGenericPlatformConfiguration") else {
-            return false;
-        };
-        // `isNestedVirtualizationSupported` is a *class* method.
-        // `AnyClass::responds_to` checks instance methods, so use
-        // `class_method` which queries the metaclass instead.
-        let sel = objc2::sel!(isNestedVirtualizationSupported);
-        if cls.class_method(sel).is_none() {
-            return false;
-        }
-        // SAFETY: Selector existence is checked above via class_method. Sending to a valid class pointer.
-        unsafe { msg_send_bool!(cls, isNestedVirtualizationSupported).as_bool() }
+        // SAFETY: class-property read behind an availability guard.
+        unsafe { crate::shim_ffi::abx_platform_generic_nested_supported() }
     }
 
     /// Enables or disables nested virtualization for this platform config.
     ///
-    /// Only has effect when [`Self::is_nested_virt_supported()`] returns `true`.
+    /// Only has effect when [`Self::is_nested_virt_supported()`] returns
+    /// `true`; on older systems the shim's `#available` guard makes this a
+    /// no-op.
     pub fn set_nested_virt_enabled(&self, enabled: bool) {
-        // Guard: the setter selector only exists on macOS 15+.
-        let sel = objc2::sel!(setNestedVirtualizationEnabled:);
-        // SAFETY: self.inner is a valid ObjC object pointer; casting to &AnyObject to query its class.
-        if !unsafe { &*(self.inner as *const AnyObject) }
-            .class()
-            .responds_to(sel)
-        {
-            return;
-        }
-        // SAFETY: Selector existence is checked above via responds_to. self.inner is a valid VZGenericPlatformConfiguration.
+        // SAFETY: self.inner is a valid platform handle.
         unsafe {
-            msg_send_void_bool!(self.inner, setNestedVirtualizationEnabled: Bool::new(enabled));
+            crate::shim_ffi::abx_platform_generic_set_nested(self.inner.cast(), enabled);
         }
     }
 }
@@ -103,7 +71,8 @@ impl Platform for GenericPlatform {
 impl Drop for GenericPlatform {
     fn drop(&mut self) {
         if !self.inner.is_null() {
-            release(self.inner);
+            // SAFETY: releasing the +1 handle returned by the shim.
+            unsafe { crate::shim_ffi::abx_object_release(self.inner.cast()) };
         }
     }
 }

--- a/virt/arcbox-vz/src/configuration/vm_config.rs
+++ b/virt/arcbox-vz/src/configuration/vm_config.rs
@@ -8,7 +8,7 @@ use crate::device::{
 use crate::error::{VZError, VZResult};
 use crate::ffi::{DispatchQueue, get_class, nsarray, release};
 use crate::vm::VirtualMachine;
-use crate::{msg_send, msg_send_bool, msg_send_u64, msg_send_void, msg_send_void_u64};
+use crate::{msg_send, msg_send_void};
 use objc2::runtime::AnyObject;
 use std::ptr;
 
@@ -36,35 +36,20 @@ unsafe impl Send for VirtualMachineConfiguration {}
 impl VirtualMachineConfiguration {
     /// Creates a new VM configuration with default settings.
     pub fn new() -> VZResult<Self> {
-        // SAFETY: ObjC alloc/init pattern on valid VZVirtualMachineConfiguration class. Result is checked non-null.
-        unsafe {
-            let cls =
-                get_class("VZVirtualMachineConfiguration").ok_or_else(|| VZError::Internal {
-                    code: -1,
-                    message: "VZVirtualMachineConfiguration class not found".into(),
-                })?;
-            let alloc = msg_send!(cls, alloc);
-            let obj = msg_send!(alloc, init);
-
-            if obj.is_null() {
-                return Err(VZError::Internal {
-                    code: -1,
-                    message: "Failed to create VZVirtualMachineConfiguration".into(),
-                });
-            }
-
-            Ok(Self {
-                inner: obj,
-                storage_devices: Vec::new(),
-                network_devices: Vec::new(),
-                serial_ports: Vec::new(),
-                socket_devices: Vec::new(),
-                entropy_devices: Vec::new(),
-                directory_sharing_devices: Vec::new(),
-                memory_balloon_devices: Vec::new(),
-                graphics_devices: Vec::new(),
-            })
-        }
+        // SAFETY: shim allocates a VZVirtualMachineConfiguration and returns
+        // it at +1; released by Drop.
+        let obj = unsafe { crate::shim_ffi::abx_config_new() };
+        Ok(Self {
+            inner: obj as *mut AnyObject,
+            storage_devices: Vec::new(),
+            network_devices: Vec::new(),
+            serial_ports: Vec::new(),
+            socket_devices: Vec::new(),
+            entropy_devices: Vec::new(),
+            directory_sharing_devices: Vec::new(),
+            memory_balloon_devices: Vec::new(),
+            graphics_devices: Vec::new(),
+        })
     }
 
     /// Sets the number of CPUs for the VM.
@@ -75,17 +60,17 @@ impl VirtualMachineConfiguration {
     /// Use `arcbox_vz::min_cpu_count()` and `arcbox_vz::max_cpu_count()`
     /// to get the valid range.
     pub fn set_cpu_count(&mut self, count: usize) -> &mut Self {
-        // SAFETY: self.inner is a valid VZVirtualMachineConfiguration. The selector matches the expected argument type.
+        // SAFETY: self.inner is a valid configuration handle.
         unsafe {
-            msg_send_void_u64!(self.inner, setCPUCount: count as u64);
+            crate::shim_ffi::abx_config_set_cpu_count(self.inner.cast(), count as u64);
         }
         self
     }
 
     /// Gets the configured CPU count.
     pub fn cpu_count(&self) -> u64 {
-        // SAFETY: self.inner is a valid VZVirtualMachineConfiguration. The selector matches the expected argument type.
-        unsafe { msg_send_u64!(self.inner, CPUCount) }
+        // SAFETY: self.inner is a valid configuration handle.
+        unsafe { crate::shim_ffi::abx_config_cpu_count(self.inner.cast()) }
     }
 
     /// Sets the memory size in bytes.
@@ -96,33 +81,38 @@ impl VirtualMachineConfiguration {
     /// Use `arcbox_vz::min_memory_size()` and `arcbox_vz::max_memory_size()`
     /// to get the valid range.
     pub fn set_memory_size(&mut self, bytes: u64) -> &mut Self {
-        // SAFETY: self.inner is a valid VZVirtualMachineConfiguration. The selector matches the expected argument type.
+        // SAFETY: self.inner is a valid configuration handle.
         unsafe {
-            msg_send_void_u64!(self.inner, setMemorySize: bytes);
+            crate::shim_ffi::abx_config_set_memory_size(self.inner.cast(), bytes);
         }
         self
     }
 
     /// Gets the configured memory size in bytes.
     pub fn memory_size(&self) -> u64 {
-        // SAFETY: self.inner is a valid VZVirtualMachineConfiguration. The selector matches the expected argument type.
-        unsafe { msg_send_u64!(self.inner, memorySize) }
+        // SAFETY: self.inner is a valid configuration handle.
+        unsafe { crate::shim_ffi::abx_config_memory_size(self.inner.cast()) }
     }
 
     /// Sets the boot loader for the VM.
     pub fn set_boot_loader(&mut self, boot_loader: impl BootLoader) -> &mut Self {
-        // SAFETY: self.inner is a valid VZVirtualMachineConfiguration. The selector matches the expected argument type.
+        // SAFETY: both arguments are valid handles; the config retains the
+        // boot loader (strong property), so dropping `boot_loader` is fine.
         unsafe {
-            msg_send_void!(self.inner, setBootLoader: boot_loader.as_ptr());
+            crate::shim_ffi::abx_config_set_boot_loader(
+                self.inner.cast(),
+                boot_loader.as_ptr().cast(),
+            );
         }
         self
     }
 
     /// Sets the platform configuration.
     pub fn set_platform(&mut self, platform: impl Platform) -> &mut Self {
-        // SAFETY: self.inner is a valid VZVirtualMachineConfiguration. The selector matches the expected argument type.
+        // SAFETY: both arguments are valid handles; the config retains the
+        // platform (strong property), so dropping `platform` is fine.
         unsafe {
-            msg_send_void!(self.inner, setPlatform: platform.as_ptr());
+            crate::shim_ffi::abx_config_set_platform(self.inner.cast(), platform.as_ptr().cast());
         }
         self
     }
@@ -196,14 +186,16 @@ impl VirtualMachineConfiguration {
     /// This is called automatically by `build()`, but can be called
     /// manually to check for configuration errors early.
     pub fn validate(&self) -> VZResult<()> {
-        // SAFETY: self.inner is a valid VZVirtualMachineConfiguration. validateWithError: writes to the error out-parameter only on failure.
+        // SAFETY: self.inner is a valid configuration handle; on failure the
+        // shim writes a strdup'd message that take_error_string frees.
         unsafe {
-            let mut error: *mut AnyObject = ptr::null_mut();
-            let valid = msg_send_bool!(self.inner, validateWithError: &mut error);
-            if valid.as_bool() {
+            let mut error: *mut std::ffi::c_char = ptr::null_mut();
+            if crate::shim_ffi::abx_config_validate(self.inner.cast(), &mut error) {
                 Ok(())
             } else {
-                Err(crate::ffi::extract_nserror(error))
+                Err(VZError::InvalidConfiguration(
+                    crate::shim_ffi::take_error_string(error),
+                ))
             }
         }
     }

--- a/virt/arcbox-vz/src/shim_ffi.rs
+++ b/virt/arcbox-vz/src/shim_ffi.rs
@@ -55,6 +55,45 @@ unsafe extern "C" {
     pub fn abx_vz_max_cpu_count() -> u64;
     pub fn abx_vz_min_memory_size() -> u64;
     pub fn abx_vz_max_memory_size() -> u64;
+
+    // Configuration
+    pub fn abx_config_new() -> *mut c_void;
+    pub fn abx_config_set_cpu_count(config: *mut c_void, count: u64);
+    pub fn abx_config_cpu_count(config: *mut c_void) -> u64;
+    pub fn abx_config_set_memory_size(config: *mut c_void, bytes: u64);
+    pub fn abx_config_memory_size(config: *mut c_void) -> u64;
+    pub fn abx_config_set_boot_loader(config: *mut c_void, boot_loader: *mut c_void);
+    pub fn abx_config_set_platform(config: *mut c_void, platform: *mut c_void);
+    pub fn abx_config_validate(config: *mut c_void, error_out: *mut *mut c_char) -> bool;
+
+    // Boot loaders
+    pub fn abx_bootloader_linux_new(kernel_path: *const c_char) -> *mut c_void;
+    pub fn abx_bootloader_linux_set_initrd(boot_loader: *mut c_void, path: *const c_char);
+    pub fn abx_bootloader_linux_set_cmdline(boot_loader: *mut c_void, cmdline: *const c_char);
+    pub fn abx_bootloader_macos_new() -> *mut c_void;
+
+    // Platforms (generic; MacPlatform arrives with the identity types)
+    pub fn abx_platform_generic_new() -> *mut c_void;
+    pub fn abx_platform_generic_nested_supported() -> bool;
+    pub fn abx_platform_generic_set_nested(platform: *mut c_void, enabled: bool);
+}
+
+/// Takes ownership of a shim-returned error string and frees it.
+///
+/// # Safety
+///
+/// `err` must be null or a string allocated by the shim (strdup'd) that has
+/// not been freed yet.
+pub unsafe fn take_error_string(err: *mut c_char) -> String {
+    if err.is_null() {
+        return "unknown error".to_string();
+    }
+    // SAFETY: per contract, `err` is a valid NUL-terminated C string owned by us.
+    unsafe {
+        let message = std::ffi::CStr::from_ptr(err).to_string_lossy().into_owned();
+        abx_string_free(err);
+        message
+    }
 }
 
 #[cfg(test)]
@@ -75,11 +114,26 @@ mod tests {
         abx_vz_max_cpu_count as *const (),
         abx_vz_min_memory_size as *const (),
         abx_vz_max_memory_size as *const (),
+        abx_config_new as *const (),
+        abx_config_set_cpu_count as *const (),
+        abx_config_cpu_count as *const (),
+        abx_config_set_memory_size as *const (),
+        abx_config_memory_size as *const (),
+        abx_config_set_boot_loader as *const (),
+        abx_config_set_platform as *const (),
+        abx_config_validate as *const (),
+        abx_bootloader_linux_new as *const (),
+        abx_bootloader_linux_set_initrd as *const (),
+        abx_bootloader_linux_set_cmdline as *const (),
+        abx_bootloader_macos_new as *const (),
+        abx_platform_generic_new as *const (),
+        abx_platform_generic_nested_supported as *const (),
+        abx_platform_generic_set_nested as *const (),
     ];
 
     /// Update when symbols are added; a mismatch means Exports.swift and this
     /// file have drifted.
-    const EXPECTED_SYMBOL_COUNT: usize = 9;
+    const EXPECTED_SYMBOL_COUNT: usize = 24;
 
     #[test]
     fn link_coverage() {
@@ -103,6 +157,49 @@ mod tests {
             abx_string_free(ptr::null_mut());
             abx_bytes_free(ptr::null_mut());
             abx_object_release(ptr::null_mut());
+        }
+    }
+
+    #[test]
+    fn config_create_free_roundtrip() {
+        // SAFETY: configuration objects are plain allocations — the
+        // virtualization entitlement is enforced at VM init, not here.
+        unsafe {
+            let cfg = abx_config_new();
+            assert!(!cfg.is_null());
+            abx_config_set_cpu_count(cfg, 2);
+            assert_eq!(abx_config_cpu_count(cfg), 2);
+            abx_config_set_memory_size(cfg, 512 * 1024 * 1024);
+            assert_eq!(abx_config_memory_size(cfg), 512 * 1024 * 1024);
+
+            let platform = abx_platform_generic_new();
+            assert!(!platform.is_null());
+            abx_config_set_platform(cfg, platform);
+            // Reading the class support flag must not crash regardless of host.
+            let _ = abx_platform_generic_nested_supported();
+
+            abx_object_release(platform);
+            abx_object_release(cfg);
+        }
+    }
+
+    #[test]
+    fn linux_boot_loader_roundtrip() {
+        let dir = std::env::temp_dir().join("abx-shim-ffi-test");
+        std::fs::create_dir_all(&dir).unwrap();
+        let kernel = dir.join("fake-kernel");
+        std::fs::write(&kernel, b"not a kernel").unwrap();
+        let c_path = std::ffi::CString::new(kernel.to_str().unwrap()).unwrap();
+        let c_cmdline = std::ffi::CString::new("console=hvc0").unwrap();
+
+        // SAFETY: boot-loader objects are plain allocations; the paths are
+        // valid NUL-terminated strings for the duration of the calls.
+        unsafe {
+            let bl = abx_bootloader_linux_new(c_path.as_ptr());
+            assert!(!bl.is_null());
+            abx_bootloader_linux_set_initrd(bl, c_path.as_ptr());
+            abx_bootloader_linux_set_cmdline(bl, c_cmdline.as_ptr());
+            abx_object_release(bl);
         }
     }
 


### PR DESCRIPTION
## Summary

PR 3/11 of the ArcBoxVZShim migration (stacked on #414). The configuration-building surface moves to Swift: `VZVirtualMachineConfiguration` creation, CPU/memory setters+getters, `bootLoader`/`platform` assignment, and `validate()`; `LinuxBootLoader` (kernel/initrd/cmdline), `MacOSBootLoader`, and `GenericPlatform` (incl. nested-virt probe/toggle). `build()` and the device arrays stay on the old path until the lifecycle PR.

Notable behavior changes:
- Nested-virt probing switches from `responds_to` selector sniffing to the shim's `#available(macOS 15)` guard.
- `validate()` failures now surface as `VZError::InvalidConfiguration(framework message)` instead of `Internal{code}` — both consumers only display the message (`#[from]` in core, `to_string()` in arcbox-hypervisor).
- Adds the tokio `macros` feature that restore.rs's `select!` had been silently borrowing from workspace feature unification (surfaced by the first standalone `cargo build -p arcbox-vz`).

## Validation

- `cargo test -p arcbox-vz` (21 + 10 doctests, incl. config/boot-loader round-trips), workspace clippy `-D warnings`, fmt, swift-format strict — green
- e2e `boot_assets` VZ: full Docker lifecycle with the config path built by Swift, 184s