### PR TITLE
feat(vz): route device configuration constructors through the shim

### DIFF
--- a/virt/arcbox-vz/shim/Sources/ArcBoxVZShim/Devices.swift
+++ b/virt/arcbox-vz/shim/Sources/ArcBoxVZShim/Devices.swift
@@ -1,0 +1,94 @@
+// Device configuration constructors (mirrors src/device/*.rs).
+//
+// Policy knobs stay on the Rust side (e.g. the ARCBOX_DIAG_NET_MTU_4000 MTU
+// override is read and logged there); this file only performs the VZ calls.
+
+import Virtualization
+
+func storageDiskImageNew(
+    _ path: UnsafePointer<CChar>,
+    _ readOnly: Bool,
+    _ errorOut: UnsafeMutablePointer<UnsafeMutablePointer<CChar>?>?
+) -> UnsafeMutableRawPointer? {
+    let url = URL(fileURLWithPath: String(cString: path))
+    do {
+        let attachment = try VZDiskImageStorageDeviceAttachment(url: url, readOnly: readOnly)
+        return abxRetainedHandle(VZVirtioBlockDeviceConfiguration(attachment: attachment))
+    } catch {
+        errorOut?.pointee = abxErrorString(error)
+        return nil
+    }
+}
+
+/// Shared tail for the network constructors: MAC assignment + optional MTU.
+private func networkConfig(
+    attachment: VZNetworkDeviceAttachment,
+    mac: UnsafePointer<CChar>?,
+    mtu: UInt64,
+    errorOut: UnsafeMutablePointer<UnsafeMutablePointer<CChar>?>?
+) -> UnsafeMutableRawPointer? {
+    if mtu > 0, let fileHandleAttachment = attachment as? VZFileHandleNetworkDeviceAttachment {
+        fileHandleAttachment.maximumTransmissionUnit = Int(mtu)
+    }
+    let config = VZVirtioNetworkDeviceConfiguration()
+    config.attachment = attachment
+    if let mac {
+        guard let address = VZMACAddress(string: String(cString: mac)) else {
+            errorOut?.pointee = abxStrdup("invalid MAC address: \(String(cString: mac))")
+            return nil
+        }
+        config.macAddress = address
+    } else {
+        config.macAddress = VZMACAddress.randomLocallyAdministered()
+    }
+    return abxRetainedHandle(config)
+}
+
+func networkNATNew(
+    _ mac: UnsafePointer<CChar>?,
+    _ mtu: UInt64,
+    _ errorOut: UnsafeMutablePointer<UnsafeMutablePointer<CChar>?>?
+) -> UnsafeMutableRawPointer? {
+    networkConfig(
+        attachment: VZNATNetworkDeviceAttachment(), mac: mac, mtu: mtu, errorOut: errorOut)
+}
+
+func networkFileHandleNew(
+    _ fd: Int32,
+    _ mac: UnsafePointer<CChar>?,
+    _ mtu: UInt64,
+    _ errorOut: UnsafeMutablePointer<UnsafeMutablePointer<CChar>?>?
+) -> UnsafeMutableRawPointer? {
+    let handle = FileHandle(fileDescriptor: fd, closeOnDealloc: false)
+    let attachment = VZFileHandleNetworkDeviceAttachment(fileHandle: handle)
+    return networkConfig(attachment: attachment, mac: mac, mtu: mtu, errorOut: errorOut)
+}
+
+func serialConsoleNew(_ readFd: Int32, _ writeFd: Int32) -> UnsafeMutableRawPointer {
+    let attachment = VZFileHandleSerialPortAttachment(
+        fileHandleForReading: FileHandle(fileDescriptor: readFd, closeOnDealloc: false),
+        fileHandleForWriting: FileHandle(fileDescriptor: writeFd, closeOnDealloc: false))
+    let config = VZVirtioConsoleDeviceSerialPortConfiguration()
+    config.attachment = attachment
+    return abxRetainedHandle(config)
+}
+
+func socketDeviceConfigNew() -> UnsafeMutableRawPointer {
+    abxRetainedHandle(VZVirtioSocketDeviceConfiguration())
+}
+
+func entropyNew() -> UnsafeMutableRawPointer {
+    abxRetainedHandle(VZVirtioEntropyDeviceConfiguration())
+}
+
+func balloonConfigNew() -> UnsafeMutableRawPointer {
+    abxRetainedHandle(VZVirtioTraditionalMemoryBalloonDeviceConfiguration())
+}
+
+func graphicsMacNew(_ width: Int64, _ height: Int64, _ ppi: Int64) -> UnsafeMutableRawPointer {
+    let display = VZMacGraphicsDisplayConfiguration(
+        widthInPixels: Int(width), heightInPixels: Int(height), pixelsPerInch: Int(ppi))
+    let device = VZMacGraphicsDeviceConfiguration()
+    device.displays = [display]
+    return abxRetainedHandle(device)
+}

--- a/virt/arcbox-vz/shim/Sources/ArcBoxVZShim/Exports.swift
+++ b/virt/arcbox-vz/shim/Sources/ArcBoxVZShim/Exports.swift
@@ -147,3 +147,60 @@ public func abxPlatformGenericNestedSupported() -> Bool {
 public func abxPlatformGenericSetNested(_ platform: UnsafeMutableRawPointer, _ enabled: Bool) {
     platformGenericSetNested(platform, enabled)
 }
+
+// MARK: - Device configurations
+
+@_cdecl("abx_storage_disk_image_new")
+public func abxStorageDiskImageNew(
+    _ path: UnsafePointer<CChar>,
+    _ readOnly: Bool,
+    _ errorOut: UnsafeMutablePointer<UnsafeMutablePointer<CChar>?>?
+) -> UnsafeMutableRawPointer? {
+    storageDiskImageNew(path, readOnly, errorOut)
+}
+
+@_cdecl("abx_network_nat_new")
+public func abxNetworkNATNew(
+    _ mac: UnsafePointer<CChar>?,
+    _ mtu: UInt64,
+    _ errorOut: UnsafeMutablePointer<UnsafeMutablePointer<CChar>?>?
+) -> UnsafeMutableRawPointer? {
+    networkNATNew(mac, mtu, errorOut)
+}
+
+@_cdecl("abx_network_file_handle_new")
+public func abxNetworkFileHandleNew(
+    _ fd: Int32,
+    _ mac: UnsafePointer<CChar>?,
+    _ mtu: UInt64,
+    _ errorOut: UnsafeMutablePointer<UnsafeMutablePointer<CChar>?>?
+) -> UnsafeMutableRawPointer? {
+    networkFileHandleNew(fd, mac, mtu, errorOut)
+}
+
+@_cdecl("abx_serial_console_new")
+public func abxSerialConsoleNew(_ readFd: Int32, _ writeFd: Int32) -> UnsafeMutableRawPointer {
+    serialConsoleNew(readFd, writeFd)
+}
+
+@_cdecl("abx_socket_device_config_new")
+public func abxSocketDeviceConfigNew() -> UnsafeMutableRawPointer {
+    socketDeviceConfigNew()
+}
+
+@_cdecl("abx_entropy_new")
+public func abxEntropyNew() -> UnsafeMutableRawPointer {
+    entropyNew()
+}
+
+@_cdecl("abx_balloon_config_new")
+public func abxBalloonConfigNew() -> UnsafeMutableRawPointer {
+    balloonConfigNew()
+}
+
+@_cdecl("abx_graphics_mac_new")
+public func abxGraphicsMacNew(
+    _ width: Int64, _ height: Int64, _ ppi: Int64
+) -> UnsafeMutableRawPointer {
+    graphicsMacNew(width, height, ppi)
+}

--- a/virt/arcbox-vz/src/device/balloon.rs
+++ b/virt/arcbox-vz/src/device/balloon.rs
@@ -4,8 +4,7 @@
 //! by "inflating" the balloon (reducing guest memory) or "deflating" it
 //! (returning memory to the guest).
 
-use crate::error::{VZError, VZResult};
-use crate::ffi::get_class;
+use crate::error::VZResult;
 use crate::{msg_send, msg_send_u64, msg_send_void_u64};
 use objc2::runtime::AnyObject;
 
@@ -28,33 +27,16 @@ unsafe impl Send for MemoryBalloonDeviceConfiguration {}
 impl MemoryBalloonDeviceConfiguration {
     /// Creates a new memory balloon device configuration.
     pub fn new() -> VZResult<Self> {
-        // SAFETY: ObjC new on valid VZVirtioTraditionalMemoryBalloonDeviceConfiguration class. retain prevents autorelease.
-        unsafe {
-            let cls = get_class("VZVirtioTraditionalMemoryBalloonDeviceConfiguration").ok_or_else(
-                || VZError::Internal {
-                    code: -1,
-                    message: "VZVirtioTraditionalMemoryBalloonDeviceConfiguration not found".into(),
-                },
-            )?;
-            let obj = msg_send!(cls, new);
-
-            if obj.is_null() {
-                return Err(VZError::Internal {
-                    code: -1,
-                    message: "Failed to create balloon device configuration".into(),
-                });
-            }
-
-            // Retain to prevent autorelease
-            let _: *mut AnyObject = msg_send!(obj, retain);
-
-            Ok(Self { inner: obj })
-        }
+        // SAFETY: the shim returns a +1 handle, released by Drop.
+        let obj = unsafe { crate::shim_ffi::abx_balloon_config_new() };
+        Ok(Self {
+            inner: obj as *mut AnyObject,
+        })
     }
 
     /// Consumes the configuration and returns the raw pointer.
     #[must_use]
-    pub fn into_ptr(self) -> *mut AnyObject {
+    pub(crate) fn into_ptr(self) -> *mut AnyObject {
         let ptr = self.inner;
         std::mem::forget(self);
         ptr
@@ -70,7 +52,8 @@ impl Default for MemoryBalloonDeviceConfiguration {
 impl Drop for MemoryBalloonDeviceConfiguration {
     fn drop(&mut self) {
         if !self.inner.is_null() {
-            crate::ffi::release(self.inner);
+            // SAFETY: releasing the +1 handle returned by the shim.
+            unsafe { crate::shim_ffi::abx_object_release(self.inner.cast()) };
         }
     }
 }

--- a/virt/arcbox-vz/src/device/entropy.rs
+++ b/virt/arcbox-vz/src/device/entropy.rs
@@ -1,8 +1,7 @@
 //! Entropy device configuration.
 
-use crate::error::{VZError, VZResult};
-use crate::ffi::get_class;
-use crate::msg_send;
+use crate::error::VZResult;
+use crate::shim_ffi;
 use objc2::runtime::AnyObject;
 
 /// Configuration for a `VirtIO` entropy device.
@@ -12,39 +11,23 @@ pub struct EntropyDeviceConfiguration {
     inner: *mut AnyObject,
 }
 
-// SAFETY: Inner ObjC pointer is only used via msg_send! which dispatches to the ObjC runtime.
+// SAFETY: The inner pointer is an ObjC configuration object created by the
+// shim; it is not mutated concurrently.
 unsafe impl Send for EntropyDeviceConfiguration {}
 
 impl EntropyDeviceConfiguration {
     /// Creates a new entropy device configuration.
     pub fn new() -> VZResult<Self> {
-        // SAFETY: ObjC new on valid VZVirtioEntropyDeviceConfiguration class. Result is checked non-null. retain prevents autorelease.
-        unsafe {
-            let cls = get_class("VZVirtioEntropyDeviceConfiguration").ok_or_else(|| {
-                VZError::Internal {
-                    code: -1,
-                    message: "VZVirtioEntropyDeviceConfiguration class not found".into(),
-                }
-            })?;
-            let obj = msg_send!(cls, new);
-
-            if obj.is_null() {
-                return Err(VZError::Internal {
-                    code: -1,
-                    message: "Failed to create entropy device".into(),
-                });
-            }
-
-            // Retain
-            let _: *mut AnyObject = msg_send!(obj, retain);
-
-            Ok(Self { inner: obj })
-        }
+        // SAFETY: the shim returns a +1 handle, released by Drop.
+        let obj = unsafe { shim_ffi::abx_entropy_new() };
+        Ok(Self {
+            inner: obj as *mut AnyObject,
+        })
     }
 
     /// Consumes the configuration and returns the raw pointer.
     #[must_use]
-    pub fn into_ptr(self) -> *mut AnyObject {
+    pub(crate) fn into_ptr(self) -> *mut AnyObject {
         let ptr = self.inner;
         std::mem::forget(self);
         ptr
@@ -60,7 +43,8 @@ impl Default for EntropyDeviceConfiguration {
 impl Drop for EntropyDeviceConfiguration {
     fn drop(&mut self) {
         if !self.inner.is_null() {
-            crate::ffi::release(self.inner);
+            // SAFETY: releasing the +1 handle returned by the shim.
+            unsafe { shim_ffi::abx_object_release(self.inner.cast()) };
         }
     }
 }

--- a/virt/arcbox-vz/src/device/graphics.rs
+++ b/virt/arcbox-vz/src/device/graphics.rs
@@ -1,10 +1,8 @@
 //! macOS graphics device configuration.
 
-use crate::error::{VZError, VZResult};
-use crate::ffi::{get_class, nsarray, release};
-use crate::{msg_send, msg_send_void};
+use crate::error::VZResult;
+use crate::shim_ffi;
 use objc2::runtime::AnyObject;
-use std::ffi::c_void;
 
 /// Configuration for a macOS graphics device with a single display.
 ///
@@ -14,7 +12,8 @@ pub struct MacGraphicsDeviceConfiguration {
     inner: *mut AnyObject,
 }
 
-// SAFETY: Inner ObjC pointer is only used via msg_send! which dispatches to the ObjC runtime.
+// SAFETY: The inner pointer is an ObjC configuration object created by the
+// shim; it is not mutated concurrently.
 unsafe impl Send for MacGraphicsDeviceConfiguration {}
 
 impl MacGraphicsDeviceConfiguration {
@@ -23,77 +22,28 @@ impl MacGraphicsDeviceConfiguration {
     ///
     /// # Errors
     ///
-    /// Returns an error if the graphics/display class is unavailable or cannot be
-    /// created.
+    /// Currently infallible (kept as `VZResult` for API stability).
     pub fn new(
         width_in_pixels: isize,
         height_in_pixels: isize,
         pixels_per_inch: isize,
     ) -> VZResult<Self> {
-        // SAFETY: alloc/init on VZMacGraphicsDisplayConfiguration (3 NSInteger args)
-        // and VZMacGraphicsDeviceConfiguration; setDisplays: takes an NSArray. The
-        // device's `displays` is a copy property, so the temporary display is
-        // released after it is set.
-        unsafe {
-            let display_cls = get_class("VZMacGraphicsDisplayConfiguration").ok_or_else(|| {
-                VZError::Internal {
-                    code: -1,
-                    message: "VZMacGraphicsDisplayConfiguration class not found".into(),
-                }
-            })?;
-            let display_alloc = msg_send!(display_cls, alloc);
-            let init_sel = objc2::sel!(initWithWidthInPixels:heightInPixels:pixelsPerInch:);
-            let init_fn: unsafe extern "C" fn(
-                *mut AnyObject,
-                objc2::runtime::Sel,
-                isize,
-                isize,
-                isize,
-            ) -> *mut AnyObject =
-                std::mem::transmute(crate::ffi::runtime::objc_msgSend as *const c_void);
-            let display = init_fn(
-                display_alloc,
-                init_sel,
-                width_in_pixels,
-                height_in_pixels,
-                pixels_per_inch,
-            );
-            if display.is_null() {
-                return Err(VZError::InvalidConfiguration(
-                    "failed to create macOS graphics display".into(),
-                ));
-            }
-
-            let device_cls = match get_class("VZMacGraphicsDeviceConfiguration") {
-                Some(cls) => cls,
-                None => {
-                    release(display);
-                    return Err(VZError::Internal {
-                        code: -1,
-                        message: "VZMacGraphicsDeviceConfiguration class not found".into(),
-                    });
-                }
-            };
-            let device = msg_send!(msg_send!(device_cls, alloc), init);
-            if device.is_null() {
-                release(display);
-                return Err(VZError::Internal {
-                    code: -1,
-                    message: "Failed to create macOS graphics device".into(),
-                });
-            }
-
-            let displays = nsarray(&[display]);
-            msg_send_void!(device, setDisplays: displays);
-            release(display);
-
-            Ok(Self { inner: device })
-        }
+        // SAFETY: the shim returns a +1 handle, released by Drop.
+        let obj = unsafe {
+            shim_ffi::abx_graphics_mac_new(
+                width_in_pixels as i64,
+                height_in_pixels as i64,
+                pixels_per_inch as i64,
+            )
+        };
+        Ok(Self {
+            inner: obj as *mut AnyObject,
+        })
     }
 
     /// Consumes the configuration and returns the raw pointer.
     #[must_use]
-    pub fn into_ptr(self) -> *mut AnyObject {
+    pub(crate) fn into_ptr(self) -> *mut AnyObject {
         let ptr = self.inner;
         std::mem::forget(self);
         ptr
@@ -103,7 +53,8 @@ impl MacGraphicsDeviceConfiguration {
 impl Drop for MacGraphicsDeviceConfiguration {
     fn drop(&mut self) {
         if !self.inner.is_null() {
-            release(self.inner);
+            // SAFETY: releasing the +1 handle returned by the shim.
+            unsafe { shim_ffi::abx_object_release(self.inner.cast()) };
         }
     }
 }

--- a/virt/arcbox-vz/src/device/network.rs
+++ b/virt/arcbox-vz/src/device/network.rs
@@ -1,10 +1,11 @@
 //! Network device configuration.
 
 use crate::error::{VZError, VZResult};
-use crate::ffi::{file_handle_for_fd, get_class, nsstring, release};
-use crate::{msg_send, msg_send_void, msg_send_void_u64};
+use crate::shim_ffi;
 use objc2::runtime::AnyObject;
+use std::ffi::CString;
 use std::os::unix::io::RawFd;
+use std::ptr;
 
 /// MTU a VZ network device uses when `setMaximumTransmissionUnit:` is not
 /// called — Apple's default, and since ABX-423 also ArcBox's default.
@@ -29,10 +30,9 @@ pub const VZ_ENHANCED_MTU: u64 = 4000;
 ///
 /// This is the policy half of the decision — the VMM sizes its datapath from
 /// it before the device exists. The mechanism half (the
-/// `setMaximumTransmissionUnit:` availability probe and the actual setter
-/// call) stays in [`NetworkDeviceConfiguration`]; on macOS < 13 with the knob
-/// set the device falls back to 1500 while the datapath assumes 4000, an
-/// accepted mismatch on that unsupported, diagnostic-only configuration.
+/// `setMaximumTransmissionUnit:` call in the shim, applied only to
+/// file-handle attachments and only above the default) reads the value passed
+/// through [`NetworkDeviceConfiguration`]'s constructors.
 #[must_use]
 pub fn desired_network_mtu() -> usize {
     if std::env::var_os("ARCBOX_DIAG_NET_MTU_4000").is_some() {
@@ -42,12 +42,29 @@ pub fn desired_network_mtu() -> usize {
     }
 }
 
+/// The MTU override forwarded to the shim: 0 (leave Apple's default) unless
+/// the diagnostic knob raises it.
+fn mtu_override() -> u64 {
+    let desired = desired_network_mtu();
+    if desired > VZ_DEFAULT_MTU {
+        tracing::warn!(
+            "VZ network MTU raised to {desired} (ARCBOX_DIAG_NET_MTU_4000; \
+             expect ABX-423 device stalls under sustained bulk transfer)"
+        );
+        desired as u64
+    } else {
+        tracing::info!("VZ network MTU at default {VZ_DEFAULT_MTU} (ABX-423 mitigation)");
+        0
+    }
+}
+
 /// Configuration for a `VirtIO` network device.
 pub struct NetworkDeviceConfiguration {
     inner: *mut AnyObject,
 }
 
-// SAFETY: Inner ObjC pointer is only used via msg_send! which dispatches to the ObjC runtime.
+// SAFETY: The inner pointer is an ObjC configuration object created by the
+// shim; it is not mutated concurrently.
 unsafe impl Send for NetworkDeviceConfiguration {}
 
 impl NetworkDeviceConfiguration {
@@ -55,14 +72,12 @@ impl NetworkDeviceConfiguration {
     ///
     /// NAT allows the guest to access external networks through the host.
     pub fn nat() -> VZResult<Self> {
-        let attachment = create_nat_attachment()?;
-        Self::with_attachment(attachment, None)
+        Self::nat_inner(None)
     }
 
     /// Creates a network device with NAT attachment and an explicit MAC address.
     pub fn nat_with_mac(mac_address: &str) -> VZResult<Self> {
-        let attachment = create_nat_attachment()?;
-        Self::with_attachment(attachment, Some(mac_address))
+        Self::nat_inner(Some(mac_address))
     }
 
     /// Creates a network device with file handle attachment.
@@ -71,17 +86,7 @@ impl NetworkDeviceConfiguration {
     /// guest via a connected datagram socket. The caller is responsible for
     /// all network processing (ARP, DHCP, DNS, NAT) on the host side.
     pub fn file_handle(fd: RawFd) -> VZResult<Self> {
-        let net_handle = file_handle_for_fd(fd);
-
-        if net_handle.is_null() {
-            return Err(VZError::Internal {
-                code: -1,
-                message: "Failed to create NSFileHandle for network fd".into(),
-            });
-        }
-
-        let attachment = create_file_handle_attachment(net_handle)?;
-        Self::with_attachment(attachment, None)
+        Self::file_handle_inner(fd, None)
     }
 
     /// Creates a network device with file handle attachment and an explicit MAC
@@ -90,91 +95,61 @@ impl NetworkDeviceConfiguration {
     /// Use this when the VZ-side MAC must match an external interface (e.g.
     /// vmnet) so that bridge FDB lookups resolve correctly.
     pub fn file_handle_with_mac(fd: RawFd, mac_address: &str) -> VZResult<Self> {
-        let net_handle = file_handle_for_fd(fd);
-
-        if net_handle.is_null() {
-            return Err(VZError::Internal {
-                code: -1,
-                message: "Failed to create NSFileHandle for network fd".into(),
-            });
-        }
-
-        let attachment = create_file_handle_attachment(net_handle)?;
-        Self::with_attachment(attachment, Some(mac_address))
+        Self::file_handle_inner(fd, Some(mac_address))
     }
 
-    /// Creates a network device with the given attachment.
-    fn with_attachment(attachment: *mut AnyObject, mac_address: Option<&str>) -> VZResult<Self> {
-        // SAFETY: ObjC new on valid VZVirtioNetworkDeviceConfiguration class. Result is checked non-null.
+    fn nat_inner(mac_address: Option<&str>) -> VZResult<Self> {
+        let c_mac = mac_cstring(mac_address)?;
+        let mac_ptr = c_mac.as_ref().map_or(ptr::null(), |m| m.as_ptr());
+        // SAFETY: mac_ptr is null or a valid NUL-terminated string; on
+        // failure the shim writes a strdup'd message.
         unsafe {
-            let cls = get_class("VZVirtioNetworkDeviceConfiguration").ok_or_else(|| {
-                VZError::Internal {
-                    code: -1,
-                    message: "VZVirtioNetworkDeviceConfiguration class not found".into(),
-                }
-            })?;
-            let obj = msg_send!(cls, new);
-
-            if obj.is_null() {
-                return Err(VZError::Internal {
-                    code: -1,
-                    message: "Failed to create network device".into(),
-                });
-            }
-
-            msg_send_void!(obj, setAttachment: attachment);
-
-            // The MTU stays at Apple's default 1500 (ABX-423 — see
-            // VZ_ENHANCED_MTU). desired_network_mtu() reads the
-            // ARCBOX_DIAG_NET_MTU_4000 opt-in for stall reproduction and
-            // throughput A/B runs; raising needs setMaximumTransmissionUnit:
-            // (macOS 13+), so check respondsToSelector: to avoid an
-            // unrecognized-selector crash.
-            if desired_network_mtu() > VZ_DEFAULT_MTU {
-                let mtu_sel = objc2::sel!(setMaximumTransmissionUnit:);
-                // msg_send_bool! doesn't support Sel arguments, so dispatch manually.
-                let responds: bool = {
-                    let check_sel = objc2::sel!(respondsToSelector:);
-                    let func: unsafe extern "C" fn(
-                        *const objc2::runtime::AnyObject,
-                        objc2::runtime::Sel,
-                        objc2::runtime::Sel,
-                    ) -> objc2::runtime::Bool = std::mem::transmute(
-                        crate::ffi::runtime::objc_msgSend as *const std::ffi::c_void,
-                    );
-                    func(
-                        attachment as *const _ as *const objc2::runtime::AnyObject,
-                        check_sel,
-                        mtu_sel,
-                    )
-                    .as_bool()
-                };
-                if responds {
-                    msg_send_void_u64!(attachment, setMaximumTransmissionUnit: VZ_ENHANCED_MTU);
-                    tracing::warn!(
-                        "VZ network MTU raised to {VZ_ENHANCED_MTU} (ARCBOX_DIAG_NET_MTU_4000; \
-                         expect ABX-423 device stalls under sustained bulk transfer)"
-                    );
-                } else {
-                    tracing::warn!(
-                        "ARCBOX_DIAG_NET_MTU_4000 set but the MTU setter is unavailable \
-                         (macOS < 13); MTU stays at {VZ_DEFAULT_MTU}"
-                    );
-                }
-            } else {
-                tracing::info!("VZ network MTU at default {VZ_DEFAULT_MTU} (ABX-423 mitigation)");
-            }
-
-            let mac = match mac_address {
-                Some(mac_address) => create_mac_address(mac_address)?,
-                None => create_random_mac()?,
-            };
-            if !mac.is_null() {
-                msg_send_void!(obj, setMACAddress: mac);
-            }
-
-            Ok(Self { inner: obj })
+            let mut error: *mut std::ffi::c_char = ptr::null_mut();
+            let obj = shim_ffi::abx_network_nat_new(mac_ptr, mtu_override(), &mut error);
+            Self::from_shim(obj, error)
         }
+    }
+
+    fn file_handle_inner(fd: RawFd, mac_address: Option<&str>) -> VZResult<Self> {
+        // Pre-validate the fd so a bad descriptor surfaces as an error here
+        // instead of undefined attachment behavior later.
+        // SAFETY: fcntl(F_GETFD) is safe on any integer fd value.
+        if unsafe { libc::fcntl(fd, libc::F_GETFD) } < 0 {
+            return Err(VZError::InvalidConfiguration(format!(
+                "invalid network fd {fd}: {}",
+                std::io::Error::last_os_error()
+            )));
+        }
+        let c_mac = mac_cstring(mac_address)?;
+        let mac_ptr = c_mac.as_ref().map_or(ptr::null(), |m| m.as_ptr());
+        // SAFETY: fd is validated above; mac_ptr is null or valid; on failure
+        // the shim writes a strdup'd message.
+        unsafe {
+            let mut error: *mut std::ffi::c_char = ptr::null_mut();
+            let obj =
+                shim_ffi::abx_network_file_handle_new(fd, mac_ptr, mtu_override(), &mut error);
+            Self::from_shim(obj, error)
+        }
+    }
+
+    /// Wraps a shim result, converting a null handle + error into `VZError`.
+    ///
+    /// # Safety
+    ///
+    /// `error` must be null or a shim-allocated string (consumed here).
+    unsafe fn from_shim(
+        obj: *mut std::ffi::c_void,
+        error: *mut std::ffi::c_char,
+    ) -> VZResult<Self> {
+        if obj.is_null() {
+            // SAFETY: per contract, `error` is a shim-allocated string.
+            return Err(VZError::InvalidConfiguration(unsafe {
+                shim_ffi::take_error_string(error)
+            }));
+        }
+        Ok(Self {
+            inner: obj as *mut AnyObject,
+        })
     }
 
     /// Consumes the configuration and returns the raw pointer.
@@ -186,132 +161,19 @@ impl NetworkDeviceConfiguration {
     }
 }
 
+/// Converts an optional MAC string, rejecting interior NUL bytes.
+fn mac_cstring(mac: Option<&str>) -> VZResult<Option<CString>> {
+    mac.map(|m| {
+        CString::new(m).map_err(|_| VZError::InvalidConfiguration(format!("MAC contains NUL: {m}")))
+    })
+    .transpose()
+}
+
 impl Drop for NetworkDeviceConfiguration {
     fn drop(&mut self) {
         if !self.inner.is_null() {
-            crate::ffi::release(self.inner);
+            // SAFETY: releasing the +1 handle returned by the shim.
+            unsafe { shim_ffi::abx_object_release(self.inner.cast()) };
         }
-    }
-}
-
-fn create_file_handle_attachment(file_handle: *mut AnyObject) -> VZResult<*mut AnyObject> {
-    // SAFETY: ObjC alloc/init on valid VZFileHandleNetworkDeviceAttachment. ObjC exceptions are caught to prevent abort.
-    unsafe {
-        let cls =
-            get_class("VZFileHandleNetworkDeviceAttachment").ok_or_else(|| VZError::Internal {
-                code: -1,
-                message: "VZFileHandleNetworkDeviceAttachment class not found".into(),
-            })?;
-
-        let obj = msg_send!(cls, alloc);
-
-        // Wrap the init call to catch ObjC exceptions (which would
-        // otherwise abort the process as "foreign exceptions").
-        let obj_safe = std::panic::AssertUnwindSafe(obj);
-        let fh_safe = std::panic::AssertUnwindSafe(file_handle);
-        let result = objc2::exception::catch(move || {
-            let obj = *obj_safe;
-            let fh = *fh_safe;
-            msg_send!(obj, initWithFileHandle: fh)
-        });
-
-        let attachment = match result {
-            Ok(ptr) => ptr,
-            Err(exception) => {
-                // Extract NSException description for diagnostics.
-                let desc = match exception {
-                    Some(exc) => {
-                        let raw = &*exc as *const _ as *const AnyObject as *mut AnyObject;
-                        crate::ffi::nsstring_to_string(msg_send!(raw, description))
-                    }
-                    None => "unknown ObjC exception (nil)".into(),
-                };
-                tracing::error!("VZFileHandleNetworkDeviceAttachment init threw: {}", desc);
-                return Err(VZError::Internal {
-                    code: -2,
-                    message: format!(
-                        "VZFileHandleNetworkDeviceAttachment init threw ObjC exception: {desc}"
-                    ),
-                });
-            }
-        };
-
-        if attachment.is_null() {
-            return Err(VZError::Internal {
-                code: -1,
-                message: "Failed to create file handle network attachment".into(),
-            });
-        }
-
-        Ok(attachment)
-    }
-}
-
-fn create_nat_attachment() -> VZResult<*mut AnyObject> {
-    // SAFETY: ObjC new on valid VZNATNetworkDeviceAttachment class. Result is checked non-null.
-    unsafe {
-        let cls = get_class("VZNATNetworkDeviceAttachment").ok_or_else(|| VZError::Internal {
-            code: -1,
-            message: "VZNATNetworkDeviceAttachment class not found".into(),
-        })?;
-        let obj = msg_send!(cls, new);
-
-        if obj.is_null() {
-            return Err(VZError::Internal {
-                code: -1,
-                message: "Failed to create NAT attachment".into(),
-            });
-        }
-
-        Ok(obj)
-    }
-}
-
-fn create_random_mac() -> VZResult<*mut AnyObject> {
-    // SAFETY: Sending randomLocallyAdministeredAddress to valid VZMACAddress class.
-    unsafe {
-        let cls = get_class("VZMACAddress").ok_or_else(|| VZError::Internal {
-            code: -1,
-            message: "VZMACAddress class not found".into(),
-        })?;
-        let obj = msg_send!(cls, randomLocallyAdministeredAddress);
-
-        if obj.is_null() {
-            return Err(VZError::Internal {
-                code: -1,
-                message: "Failed to create random MAC".into(),
-            });
-        }
-
-        Ok(obj)
-    }
-}
-
-fn create_mac_address(mac_address: &str) -> VZResult<*mut AnyObject> {
-    // SAFETY: ObjC alloc/init on a valid VZMACAddress class with a valid NSString argument.
-    unsafe {
-        let cls = get_class("VZMACAddress").ok_or_else(|| VZError::Internal {
-            code: -1,
-            message: "VZMACAddress class not found".into(),
-        })?;
-        let obj = msg_send!(cls, alloc);
-        if obj.is_null() {
-            return Err(VZError::Internal {
-                code: -1,
-                message: "Failed to allocate MAC address".into(),
-            });
-        }
-
-        let mac_ns = nsstring(mac_address);
-        let initialized = msg_send!(obj, initWithString: mac_ns);
-        release(mac_ns);
-
-        if initialized.is_null() {
-            return Err(VZError::InvalidConfiguration(format!(
-                "Invalid MAC address: {mac_address}"
-            )));
-        }
-
-        Ok(initialized)
     }
 }

--- a/virt/arcbox-vz/src/device/serial.rs
+++ b/virt/arcbox-vz/src/device/serial.rs
@@ -1,8 +1,7 @@
 //! Serial port configuration.
 
 use crate::error::{VZError, VZResult};
-use crate::ffi::{file_handle_for_fd, get_class};
-use crate::{msg_send, msg_send_void};
+use crate::shim_ffi;
 use objc2::runtime::AnyObject;
 use std::os::unix::io::RawFd;
 
@@ -13,7 +12,8 @@ pub struct SerialPortConfiguration {
     fds: Option<(RawFd, RawFd)>,
 }
 
-// SAFETY: Inner ObjC pointer is only used via msg_send! which dispatches to the ObjC runtime.
+// SAFETY: The inner pointer is an ObjC configuration object created by the
+// shim; it is not mutated concurrently.
 unsafe impl Send for SerialPortConfiguration {}
 
 impl SerialPortConfiguration {
@@ -22,11 +22,12 @@ impl SerialPortConfiguration {
     /// This creates a serial port that appears as `hvc0` in the guest.
     /// Returns the configuration and the file descriptors for reading/writing.
     pub fn virtio_console() -> VZResult<Self> {
-        // Create pipes for bidirectional communication
+        // Pipes are created and owned on the Rust side; the shim only wraps
+        // the VZ-facing ends in FileHandles (without closing them).
         let mut input_pipe: [libc::c_int; 2] = [0, 0];
         let mut output_pipe: [libc::c_int; 2] = [0, 0];
 
-        // SAFETY: libc::pipe creates valid fd pairs. File handles are created from valid fds. ObjC objects follow alloc/init pattern with null checks.
+        // SAFETY: libc::pipe writes two valid fds on success.
         unsafe {
             if libc::pipe(input_pipe.as_mut_ptr()) != 0 {
                 return Err(VZError::OperationFailed(
@@ -40,57 +41,19 @@ impl SerialPortConfiguration {
                     "Failed to create output pipe".to_string(),
                 ));
             }
-
-            // Create file handles
-            // For VZ: read from input_pipe[0], write to output_pipe[1]
-            let read_handle = file_handle_for_fd(input_pipe[0]);
-            let write_handle = file_handle_for_fd(output_pipe[1]);
-
-            if read_handle.is_null() || write_handle.is_null() {
-                libc::close(input_pipe[0]);
-                libc::close(input_pipe[1]);
-                libc::close(output_pipe[0]);
-                libc::close(output_pipe[1]);
-                return Err(VZError::OperationFailed(
-                    "Failed to create file handles".to_string(),
-                ));
-            }
-
-            // Create serial port attachment
-            let attachment = create_serial_port_attachment(read_handle, write_handle)?;
-
-            // Create VirtIO console serial port configuration
-            let cls =
-                get_class("VZVirtioConsoleDeviceSerialPortConfiguration").ok_or_else(|| {
-                    VZError::Internal {
-                        code: -1,
-                        message: "VZVirtioConsoleDeviceSerialPortConfiguration class not found"
-                            .into(),
-                    }
-                })?;
-
-            let port = msg_send!(cls, new);
-            if port.is_null() {
-                libc::close(input_pipe[0]);
-                libc::close(input_pipe[1]);
-                libc::close(output_pipe[0]);
-                libc::close(output_pipe[1]);
-                return Err(VZError::Internal {
-                    code: -1,
-                    message: "Failed to create serial port configuration".into(),
-                });
-            }
-
-            msg_send_void!(port, setAttachment: attachment);
-
-            // Store FDs for user access:
-            // output_pipe[0] = read from VM
-            // input_pipe[1] = write to VM
-            Ok(Self {
-                inner: port,
-                fds: Some((output_pipe[0], input_pipe[1])),
-            })
         }
+
+        // VZ reads guest input from input_pipe[0] and writes guest output to
+        // output_pipe[1].
+        // SAFETY: both fds are valid; the shim returns a +1 handle.
+        let obj = unsafe { shim_ffi::abx_serial_console_new(input_pipe[0], output_pipe[1]) };
+
+        // Host-side ends: read guest output from output_pipe[0], write guest
+        // input to input_pipe[1].
+        Ok(Self {
+            inner: obj as *mut AnyObject,
+            fds: Some((output_pipe[0], input_pipe[1])),
+        })
     }
 
     /// Returns the file descriptor for reading output from the VM.
@@ -110,7 +73,7 @@ impl SerialPortConfiguration {
     /// Note: The file descriptors are NOT closed when this is called.
     /// The caller is responsible for managing them.
     #[must_use]
-    pub fn into_ptr(self) -> *mut AnyObject {
+    pub(crate) fn into_ptr(self) -> *mut AnyObject {
         let ptr = self.inner;
         std::mem::forget(self);
         ptr
@@ -120,34 +83,9 @@ impl SerialPortConfiguration {
 impl Drop for SerialPortConfiguration {
     fn drop(&mut self) {
         if !self.inner.is_null() {
-            crate::ffi::release(self.inner);
+            // SAFETY: releasing the +1 handle returned by the shim.
+            unsafe { shim_ffi::abx_object_release(self.inner.cast()) };
         }
         // Note: We don't close fds here as they may still be in use
-    }
-}
-
-fn create_serial_port_attachment(
-    read_handle: *mut AnyObject,
-    write_handle: *mut AnyObject,
-) -> VZResult<*mut AnyObject> {
-    // SAFETY: ObjC alloc/init on valid VZFileHandleSerialPortAttachment class with valid NSFileHandle objects.
-    unsafe {
-        let cls =
-            get_class("VZFileHandleSerialPortAttachment").ok_or_else(|| VZError::Internal {
-                code: -1,
-                message: "VZFileHandleSerialPortAttachment class not found".into(),
-            })?;
-
-        let obj = msg_send!(cls, alloc);
-        let attachment = msg_send!(obj, initWithFileHandleForReading: read_handle, fileHandleForWriting: write_handle);
-
-        if attachment.is_null() {
-            return Err(VZError::Internal {
-                code: -1,
-                message: "Failed to create serial port attachment".into(),
-            });
-        }
-
-        Ok(attachment)
     }
 }

--- a/virt/arcbox-vz/src/device/socket.rs
+++ b/virt/arcbox-vz/src/device/socket.rs
@@ -1,8 +1,7 @@
 //! Socket device configuration.
 
-use crate::error::{VZError, VZResult};
-use crate::ffi::get_class;
-use crate::msg_send;
+use crate::error::VZResult;
+use crate::shim_ffi;
 use objc2::runtime::AnyObject;
 
 /// Configuration for a `VirtIO` socket device.
@@ -12,36 +11,23 @@ pub struct SocketDeviceConfiguration {
     inner: *mut AnyObject,
 }
 
-// SAFETY: Inner ObjC pointer is only used via msg_send! which dispatches to the ObjC runtime.
+// SAFETY: The inner pointer is an ObjC configuration object created by the
+// shim; it is not mutated concurrently.
 unsafe impl Send for SocketDeviceConfiguration {}
 
 impl SocketDeviceConfiguration {
     /// Creates a new socket device configuration.
     pub fn new() -> VZResult<Self> {
-        // SAFETY: ObjC new on valid VZVirtioSocketDeviceConfiguration class. Result is checked non-null.
-        unsafe {
-            let cls = get_class("VZVirtioSocketDeviceConfiguration").ok_or_else(|| {
-                VZError::Internal {
-                    code: -1,
-                    message: "VZVirtioSocketDeviceConfiguration class not found".into(),
-                }
-            })?;
-            let obj = msg_send!(cls, new);
-
-            if obj.is_null() {
-                return Err(VZError::Internal {
-                    code: -1,
-                    message: "Failed to create socket device".into(),
-                });
-            }
-
-            Ok(Self { inner: obj })
-        }
+        // SAFETY: the shim returns a +1 handle, released by Drop.
+        let obj = unsafe { shim_ffi::abx_socket_device_config_new() };
+        Ok(Self {
+            inner: obj as *mut AnyObject,
+        })
     }
 
     /// Consumes the configuration and returns the raw pointer.
     #[must_use]
-    pub fn into_ptr(self) -> *mut AnyObject {
+    pub(crate) fn into_ptr(self) -> *mut AnyObject {
         let ptr = self.inner;
         std::mem::forget(self);
         ptr
@@ -57,7 +43,8 @@ impl Default for SocketDeviceConfiguration {
 impl Drop for SocketDeviceConfiguration {
     fn drop(&mut self) {
         if !self.inner.is_null() {
-            crate::ffi::release(self.inner);
+            // SAFETY: releasing the +1 handle returned by the shim.
+            unsafe { shim_ffi::abx_object_release(self.inner.cast()) };
         }
     }
 }

--- a/virt/arcbox-vz/src/device/storage.rs
+++ b/virt/arcbox-vz/src/device/storage.rs
@@ -1,10 +1,9 @@
 //! Storage device configuration.
 
 use crate::error::{VZError, VZResult};
-use crate::ffi::{get_class, nsurl_file_path};
-use crate::msg_send;
-use objc2::runtime::{AnyObject, Bool};
-use std::ffi::c_void;
+use crate::shim_ffi;
+use objc2::runtime::AnyObject;
+use std::ffi::CString;
 use std::path::Path;
 use std::ptr;
 
@@ -13,7 +12,8 @@ pub struct StorageDeviceConfiguration {
     inner: *mut AnyObject,
 }
 
-// SAFETY: Inner ObjC pointer is only used via msg_send! which dispatches to the ObjC runtime.
+// SAFETY: The inner pointer is an ObjC configuration object created by the
+// shim; it is not mutated concurrently.
 unsafe impl Send for StorageDeviceConfiguration {}
 
 impl StorageDeviceConfiguration {
@@ -28,37 +28,29 @@ impl StorageDeviceConfiguration {
         if !path.exists() {
             return Err(VZError::NotFound(path.display().to_string()));
         }
+        let c_path = CString::new(path.to_string_lossy().as_bytes()).map_err(|_| {
+            VZError::InvalidConfiguration(format!("path contains NUL: {}", path.display()))
+        })?;
 
-        let attachment = create_disk_attachment(&path.to_string_lossy(), read_only)?;
-        Self::with_attachment(attachment)
-    }
-
-    /// Creates a storage device with the given attachment.
-    fn with_attachment(attachment: *mut AnyObject) -> VZResult<Self> {
-        // SAFETY: ObjC alloc/init on valid VZVirtioBlockDeviceConfiguration class with a valid attachment pointer.
+        // SAFETY: c_path is valid; on failure the shim writes a strdup'd
+        // message that take_error_string frees.
         unsafe {
-            let cls =
-                get_class("VZVirtioBlockDeviceConfiguration").ok_or_else(|| VZError::Internal {
-                    code: -1,
-                    message: "VZVirtioBlockDeviceConfiguration class not found".into(),
-                })?;
-            let alloc = msg_send!(cls, alloc);
-            let obj = msg_send!(alloc, initWithAttachment: attachment);
-
+            let mut error: *mut std::ffi::c_char = ptr::null_mut();
+            let obj = shim_ffi::abx_storage_disk_image_new(c_path.as_ptr(), read_only, &mut error);
             if obj.is_null() {
-                return Err(VZError::Internal {
-                    code: -1,
-                    message: "Failed to create block device".into(),
-                });
+                return Err(VZError::InvalidConfiguration(shim_ffi::take_error_string(
+                    error,
+                )));
             }
-
-            Ok(Self { inner: obj })
+            Ok(Self {
+                inner: obj as *mut AnyObject,
+            })
         }
     }
 
     /// Consumes the configuration and returns the raw pointer.
     #[must_use]
-    pub fn into_ptr(self) -> *mut AnyObject {
+    pub(crate) fn into_ptr(self) -> *mut AnyObject {
         let ptr = self.inner;
         std::mem::forget(self);
         ptr
@@ -68,41 +60,8 @@ impl StorageDeviceConfiguration {
 impl Drop for StorageDeviceConfiguration {
     fn drop(&mut self) {
         if !self.inner.is_null() {
-            crate::ffi::release(self.inner);
+            // SAFETY: releasing the +1 handle returned by the shim.
+            unsafe { shim_ffi::abx_object_release(self.inner.cast()) };
         }
-    }
-}
-
-fn create_disk_attachment(path: &str, read_only: bool) -> VZResult<*mut AnyObject> {
-    // SAFETY: ObjC alloc/init on valid VZDiskImageStorageDeviceAttachment class. NSURL from validated path. Error out-parameter is checked.
-    unsafe {
-        let cls =
-            get_class("VZDiskImageStorageDeviceAttachment").ok_or_else(|| VZError::Internal {
-                code: -1,
-                message: "VZDiskImageStorageDeviceAttachment class not found".into(),
-            })?;
-
-        let url = nsurl_file_path(path);
-        let mut error: *mut AnyObject = ptr::null_mut();
-
-        let sel = objc2::sel!(initWithURL:readOnly:error:);
-        let alloc = msg_send!(cls, alloc);
-
-        let func: unsafe extern "C" fn(
-            *mut AnyObject,
-            objc2::runtime::Sel,
-            *mut AnyObject,
-            Bool,
-            *mut *mut AnyObject,
-        ) -> *mut AnyObject =
-            std::mem::transmute(crate::ffi::runtime::objc_msgSend as *const c_void);
-
-        let obj = func(alloc, sel, url, Bool::new(read_only), &mut error);
-
-        if obj.is_null() {
-            return Err(crate::ffi::extract_nserror(error));
-        }
-
-        Ok(obj)
     }
 }

--- a/virt/arcbox-vz/src/shim_ffi.rs
+++ b/virt/arcbox-vz/src/shim_ffi.rs
@@ -76,6 +76,29 @@ unsafe extern "C" {
     pub fn abx_platform_generic_new() -> *mut c_void;
     pub fn abx_platform_generic_nested_supported() -> bool;
     pub fn abx_platform_generic_set_nested(platform: *mut c_void, enabled: bool);
+
+    // Device configurations
+    pub fn abx_storage_disk_image_new(
+        path: *const c_char,
+        read_only: bool,
+        error_out: *mut *mut c_char,
+    ) -> *mut c_void;
+    pub fn abx_network_nat_new(
+        mac: *const c_char,
+        mtu: u64,
+        error_out: *mut *mut c_char,
+    ) -> *mut c_void;
+    pub fn abx_network_file_handle_new(
+        fd: i32,
+        mac: *const c_char,
+        mtu: u64,
+        error_out: *mut *mut c_char,
+    ) -> *mut c_void;
+    pub fn abx_serial_console_new(read_fd: i32, write_fd: i32) -> *mut c_void;
+    pub fn abx_socket_device_config_new() -> *mut c_void;
+    pub fn abx_entropy_new() -> *mut c_void;
+    pub fn abx_balloon_config_new() -> *mut c_void;
+    pub fn abx_graphics_mac_new(width: i64, height: i64, ppi: i64) -> *mut c_void;
 }
 
 /// Takes ownership of a shim-returned error string and frees it.
@@ -129,11 +152,19 @@ mod tests {
         abx_platform_generic_new as *const (),
         abx_platform_generic_nested_supported as *const (),
         abx_platform_generic_set_nested as *const (),
+        abx_storage_disk_image_new as *const (),
+        abx_network_nat_new as *const (),
+        abx_network_file_handle_new as *const (),
+        abx_serial_console_new as *const (),
+        abx_socket_device_config_new as *const (),
+        abx_entropy_new as *const (),
+        abx_balloon_config_new as *const (),
+        abx_graphics_mac_new as *const (),
     ];
 
     /// Update when symbols are added; a mismatch means Exports.swift and this
     /// file have drifted.
-    const EXPECTED_SYMBOL_COUNT: usize = 24;
+    const EXPECTED_SYMBOL_COUNT: usize = 32;
 
     #[test]
     fn link_coverage() {


### PR DESCRIPTION
## Summary

PR 4/11 of the ArcBoxVZShim migration (stacked on #415). All seven device-configuration constructors move to Swift: storage (disk image w/ error propagation), network (NAT + file-handle attachments, MAC parse/random), serial console, vsock socket config, entropy, balloon config, and macOS graphics. −516/+362: the transmuted `objc_msgSend` constructors and hand-rolled attachment helpers die.

Policy stays Rust-side by design:
- Serial pipes are created and owned in Rust; the shim only wraps VZ's ends (`closeOnDealloc: false`).
- The `ARCBOX_DIAG_NET_MTU_4000` knob is read and logged in network.rs and forwarded as an explicit MTU override (applied by the shim only to file-handle attachments above the 1500 default — same ABX-423 semantics).
- File-handle fds are pre-validated with `fcntl(F_GETFD)` before crossing the boundary.

The balloon *runtime* device (queue-affine target get/set) stays on the old path until the lifecycle PR. `into_ptr` narrows to `pub(crate)` across device configs.

## Validation

- `cargo test -p arcbox-vz` (21 + 10 doctests), workspace clippy `-D warnings`, fmt, swift-format strict — green
- e2e `boot_assets` VZ: full Docker lifecycle with every device built by Swift (storage/net/serial/vsock/entropy/balloon-config exercised by the boot + docker run)