### PR TITLE
feat(vz): route macOS identity types and MacPlatform through the shim

### DIFF
--- a/virt/arcbox-vz/shim/Sources/ArcBoxVZShim/Exports.swift
+++ b/virt/arcbox-vz/shim/Sources/ArcBoxVZShim/Exports.swift
@@ -245,3 +245,67 @@ public func abxVirtiofsSetShare(
 ) {
     virtiofsSetShare(config, share)
 }
+
+// MARK: - macOS identity + platform
+
+@_cdecl("abx_mac_hw_model_from_data")
+public func abxMacHwModelFromData(
+    _ bytes: UnsafeRawPointer, _ length: UInt
+) -> UnsafeMutableRawPointer? {
+    macHardwareModelFromData(bytes, length)
+}
+
+@_cdecl("abx_mac_hw_model_supported")
+public func abxMacHwModelSupported(_ handle: UnsafeMutableRawPointer) -> Bool {
+    macHardwareModelSupported(handle)
+}
+
+@_cdecl("abx_mac_hw_model_data")
+public func abxMacHwModelData(
+    _ handle: UnsafeMutableRawPointer, _ lengthOut: UnsafeMutablePointer<UInt>?
+) -> UnsafeMutableRawPointer? {
+    macHardwareModelData(handle, lengthOut)
+}
+
+@_cdecl("abx_mac_machine_id_new")
+public func abxMacMachineIdNew() -> UnsafeMutableRawPointer {
+    macMachineIdNew()
+}
+
+@_cdecl("abx_mac_machine_id_from_data")
+public func abxMacMachineIdFromData(
+    _ bytes: UnsafeRawPointer, _ length: UInt
+) -> UnsafeMutableRawPointer? {
+    macMachineIdFromData(bytes, length)
+}
+
+@_cdecl("abx_mac_machine_id_data")
+public func abxMacMachineIdData(
+    _ handle: UnsafeMutableRawPointer, _ lengthOut: UnsafeMutablePointer<UInt>?
+) -> UnsafeMutableRawPointer? {
+    macMachineIdData(handle, lengthOut)
+}
+
+@_cdecl("abx_aux_storage_open")
+public func abxAuxStorageOpen(_ path: UnsafePointer<CChar>) -> UnsafeMutableRawPointer {
+    auxStorageOpen(path)
+}
+
+@_cdecl("abx_aux_storage_create")
+public func abxAuxStorageCreate(
+    _ path: UnsafePointer<CChar>,
+    _ hardwareModel: UnsafeMutableRawPointer,
+    _ overwrite: Bool,
+    _ errorOut: UnsafeMutablePointer<UnsafeMutablePointer<CChar>?>?
+) -> UnsafeMutableRawPointer? {
+    auxStorageCreate(path, hardwareModel, overwrite, errorOut)
+}
+
+@_cdecl("abx_platform_mac_new")
+public func abxPlatformMacNew(
+    _ hardwareModel: UnsafeMutableRawPointer,
+    _ machineIdentifier: UnsafeMutableRawPointer,
+    _ auxiliaryStorage: UnsafeMutableRawPointer
+) -> UnsafeMutableRawPointer {
+    platformMacNew(hardwareModel, machineIdentifier, auxiliaryStorage)
+}

--- a/virt/arcbox-vz/shim/Sources/ArcBoxVZShim/MacIdentity.swift
+++ b/virt/arcbox-vz/shim/Sources/ArcBoxVZShim/MacIdentity.swift
@@ -1,0 +1,91 @@
+// macOS guest identity types (mirrors src/configuration/mac.rs) and the
+// MacPlatform assembly (mirrors the MacPlatform half of platform.rs).
+
+import Virtualization
+
+/// Copies `data` into a malloc'd buffer owned by the caller (Rust), freed via
+/// `abx_bytes_free`. Returns nil (len 0) for empty data.
+private func abxDataCopy(
+    _ data: Data, _ lengthOut: UnsafeMutablePointer<UInt>?
+) -> UnsafeMutableRawPointer? {
+    lengthOut?.pointee = UInt(data.count)
+    guard !data.isEmpty, let buffer = malloc(data.count) else { return nil }
+    data.copyBytes(
+        to: UnsafeMutableRawBufferPointer(start: buffer, count: data.count))
+    return buffer
+}
+
+func macHardwareModelFromData(
+    _ bytes: UnsafeRawPointer, _ length: UInt
+) -> UnsafeMutableRawPointer? {
+    let data = Data(bytes: bytes, count: Int(length))
+    guard let model = VZMacHardwareModel(dataRepresentation: data) else { return nil }
+    return abxRetainedHandle(model)
+}
+
+func macHardwareModelSupported(_ handle: UnsafeMutableRawPointer) -> Bool {
+    abxBorrow(handle, as: VZMacHardwareModel.self).isSupported
+}
+
+func macHardwareModelData(
+    _ handle: UnsafeMutableRawPointer, _ lengthOut: UnsafeMutablePointer<UInt>?
+) -> UnsafeMutableRawPointer? {
+    abxDataCopy(abxBorrow(handle, as: VZMacHardwareModel.self).dataRepresentation, lengthOut)
+}
+
+func macMachineIdNew() -> UnsafeMutableRawPointer {
+    abxRetainedHandle(VZMacMachineIdentifier())
+}
+
+func macMachineIdFromData(
+    _ bytes: UnsafeRawPointer, _ length: UInt
+) -> UnsafeMutableRawPointer? {
+    let data = Data(bytes: bytes, count: Int(length))
+    guard let identifier = VZMacMachineIdentifier(dataRepresentation: data) else { return nil }
+    return abxRetainedHandle(identifier)
+}
+
+func macMachineIdData(
+    _ handle: UnsafeMutableRawPointer, _ lengthOut: UnsafeMutablePointer<UInt>?
+) -> UnsafeMutableRawPointer? {
+    abxDataCopy(abxBorrow(handle, as: VZMacMachineIdentifier.self).dataRepresentation, lengthOut)
+}
+
+func auxStorageOpen(_ path: UnsafePointer<CChar>) -> UnsafeMutableRawPointer {
+    let url = URL(fileURLWithPath: String(cString: path))
+    return abxRetainedHandle(VZMacAuxiliaryStorage(url: url))
+}
+
+func auxStorageCreate(
+    _ path: UnsafePointer<CChar>,
+    _ hardwareModel: UnsafeMutableRawPointer,
+    _ overwrite: Bool,
+    _ errorOut: UnsafeMutablePointer<UnsafeMutablePointer<CChar>?>?
+) -> UnsafeMutableRawPointer? {
+    let url = URL(fileURLWithPath: String(cString: path))
+    let model = abxBorrow(hardwareModel, as: VZMacHardwareModel.self)
+    do {
+        let storage = try VZMacAuxiliaryStorage(
+            creatingStorageAt: url,
+            hardwareModel: model,
+            options: overwrite ? [.allowOverwrite] : [])
+        return abxRetainedHandle(storage)
+    } catch {
+        errorOut?.pointee = abxErrorString(error)
+        return nil
+    }
+}
+
+func platformMacNew(
+    _ hardwareModel: UnsafeMutableRawPointer,
+    _ machineIdentifier: UnsafeMutableRawPointer,
+    _ auxiliaryStorage: UnsafeMutableRawPointer
+) -> UnsafeMutableRawPointer {
+    // The platform's properties are strong, so the borrows do not consume
+    // the caller's +1 references.
+    let platform = VZMacPlatformConfiguration()
+    platform.hardwareModel = abxBorrow(hardwareModel, as: VZMacHardwareModel.self)
+    platform.machineIdentifier = abxBorrow(machineIdentifier, as: VZMacMachineIdentifier.self)
+    platform.auxiliaryStorage = abxBorrow(auxiliaryStorage, as: VZMacAuxiliaryStorage.self)
+    return abxRetainedHandle(platform)
+}

--- a/virt/arcbox-vz/src/configuration/mac.rs
+++ b/virt/arcbox-vz/src/configuration/mac.rs
@@ -7,16 +7,40 @@
 //! hardware model and the machine identifier round-trip through an opaque data
 //! representation so a base image can be reconstructed for every clone.
 
-use std::ffi::c_void;
+use std::ffi::{CString, c_void};
 use std::path::Path;
+use std::ptr;
 
 use objc2::runtime::AnyObject;
 
 use crate::error::{VZError, VZResult};
-use crate::ffi::{
-    extract_nserror, get_class, nsdata_from_bytes, nsdata_to_vec, nsurl_file_path, release, retain,
-};
-use crate::{msg_send, msg_send_bool};
+use crate::ffi::retain;
+use crate::shim_ffi;
+
+/// Converts a path to a `CString`, rejecting interior NUL bytes.
+fn path_cstring(path: &Path) -> VZResult<CString> {
+    CString::new(path.to_string_lossy().as_bytes()).map_err(|_| {
+        VZError::InvalidConfiguration(format!("path contains NUL: {}", path.display()))
+    })
+}
+
+/// Takes ownership of a shim-malloc'd byte buffer as a `Vec<u8>`.
+///
+/// # Safety
+///
+/// `bytes` must be null (with `len == 0`) or a shim-allocated buffer of `len`
+/// bytes that has not been freed yet.
+unsafe fn take_bytes(bytes: *mut c_void, len: usize) -> Vec<u8> {
+    if bytes.is_null() {
+        return Vec::new();
+    }
+    // SAFETY: per contract, `bytes` points to `len` readable bytes owned by us.
+    unsafe {
+        let out = std::slice::from_raw_parts(bytes as *const u8, len).to_vec();
+        shim_ffi::abx_bytes_free(bytes);
+        out
+    }
+}
 
 /// A macOS guest hardware model.
 ///
@@ -27,7 +51,8 @@ pub struct MacHardwareModel {
     inner: *mut AnyObject,
 }
 
-// SAFETY: Inner ObjC pointer is only used via msg_send! which dispatches to the ObjC runtime.
+// SAFETY: The inner pointer is an immutable ObjC identity object created by
+// the shim (or retained from the framework).
 unsafe impl Send for MacHardwareModel {}
 
 impl MacHardwareModel {
@@ -35,42 +60,37 @@ impl MacHardwareModel {
     ///
     /// # Errors
     ///
-    /// Returns an error if `VZMacHardwareModel` is unavailable or the data is not a
-    /// valid representation.
+    /// Returns an error if the data is not a valid representation.
     pub fn from_data(data: &[u8]) -> VZResult<Self> {
-        // SAFETY: alloc/initWithDataRepresentation: on VZMacHardwareModel with an NSData
-        // built from a valid slice. The temporary NSData is released after init.
-        unsafe {
-            let cls = get_class("VZMacHardwareModel").ok_or_else(|| VZError::Internal {
-                code: -1,
-                message: "VZMacHardwareModel class not found".into(),
-            })?;
-            let nsdata = nsdata_from_bytes(data);
-            let alloc = msg_send!(cls, alloc);
-            let obj = msg_send!(alloc, initWithDataRepresentation: nsdata);
-            release(nsdata);
-            if obj.is_null() {
-                return Err(VZError::InvalidConfiguration(
-                    "invalid macOS hardware model data representation".into(),
-                ));
-            }
-            Ok(Self { inner: obj })
+        // SAFETY: the slice is valid for the duration of the call; the shim
+        // returns null for invalid representations.
+        let obj = unsafe { shim_ffi::abx_mac_hw_model_from_data(data.as_ptr().cast(), data.len()) };
+        if obj.is_null() {
+            return Err(VZError::InvalidConfiguration(
+                "invalid macOS hardware model data representation".into(),
+            ));
         }
+        Ok(Self {
+            inner: obj as *mut AnyObject,
+        })
     }
 
     /// Returns whether this hardware model is supported by the current host.
     #[must_use]
     pub fn is_supported(&self) -> bool {
-        // SAFETY: Sending isSupported to a valid VZMacHardwareModel.
-        unsafe { msg_send_bool!(self.inner, isSupported).as_bool() }
+        // SAFETY: self.inner is a valid hardware-model handle.
+        unsafe { shim_ffi::abx_mac_hw_model_supported(self.inner.cast()) }
     }
 
     /// Returns the opaque data representation for persistence.
     #[must_use]
     pub fn data_representation(&self) -> Vec<u8> {
-        // SAFETY: dataRepresentation returns an NSData owned by the model; nsdata_to_vec only reads it.
-        let data = unsafe { msg_send!(self.inner, dataRepresentation) };
-        nsdata_to_vec(data)
+        // SAFETY: valid handle; the shim mallocs the buffer that take_bytes frees.
+        unsafe {
+            let mut len: usize = 0;
+            let bytes = shim_ffi::abx_mac_hw_model_data(self.inner.cast(), &mut len);
+            take_bytes(bytes, len)
+        }
     }
 
     /// Wraps a hardware-model pointer borrowed from the framework (for example a
@@ -91,7 +111,8 @@ impl MacHardwareModel {
 impl Drop for MacHardwareModel {
     fn drop(&mut self) {
         if !self.inner.is_null() {
-            release(self.inner);
+            // SAFETY: releasing the +1 held by this wrapper.
+            unsafe { shim_ffi::abx_object_release(self.inner.cast()) };
         }
     }
 }
@@ -105,67 +126,49 @@ pub struct MacMachineIdentifier {
     inner: *mut AnyObject,
 }
 
-// SAFETY: Inner ObjC pointer is only used via msg_send! which dispatches to the ObjC runtime.
+// SAFETY: The inner pointer is an immutable ObjC identity object created by
+// the shim.
 unsafe impl Send for MacMachineIdentifier {}
 
 impl MacMachineIdentifier {
     /// Creates a new random machine identifier.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if `VZMacMachineIdentifier` is unavailable.
     pub fn new() -> VZResult<Self> {
-        // SAFETY: ObjC alloc/init pattern on VZMacMachineIdentifier. Result checked non-null.
-        unsafe {
-            let cls = get_class("VZMacMachineIdentifier").ok_or_else(|| VZError::Internal {
-                code: -1,
-                message: "VZMacMachineIdentifier class not found".into(),
-            })?;
-            let alloc = msg_send!(cls, alloc);
-            let obj = msg_send!(alloc, init);
-            if obj.is_null() {
-                return Err(VZError::Internal {
-                    code: -1,
-                    message: "Failed to create VZMacMachineIdentifier".into(),
-                });
-            }
-            Ok(Self { inner: obj })
-        }
+        // SAFETY: the shim returns a +1 handle, released by Drop.
+        let obj = unsafe { shim_ffi::abx_mac_machine_id_new() };
+        Ok(Self {
+            inner: obj as *mut AnyObject,
+        })
     }
 
     /// Reconstructs a machine identifier from its opaque data representation.
     ///
     /// # Errors
     ///
-    /// Returns an error if `VZMacMachineIdentifier` is unavailable or the data is not
-    /// a valid representation.
+    /// Returns an error if the data is not a valid representation.
     pub fn from_data(data: &[u8]) -> VZResult<Self> {
-        // SAFETY: alloc/initWithDataRepresentation: on VZMacMachineIdentifier with an
-        // NSData built from a valid slice. The temporary NSData is released after init.
-        unsafe {
-            let cls = get_class("VZMacMachineIdentifier").ok_or_else(|| VZError::Internal {
-                code: -1,
-                message: "VZMacMachineIdentifier class not found".into(),
-            })?;
-            let nsdata = nsdata_from_bytes(data);
-            let alloc = msg_send!(cls, alloc);
-            let obj = msg_send!(alloc, initWithDataRepresentation: nsdata);
-            release(nsdata);
-            if obj.is_null() {
-                return Err(VZError::InvalidConfiguration(
-                    "invalid macOS machine identifier data representation".into(),
-                ));
-            }
-            Ok(Self { inner: obj })
+        // SAFETY: the slice is valid for the duration of the call; the shim
+        // returns null for invalid representations.
+        let obj =
+            unsafe { shim_ffi::abx_mac_machine_id_from_data(data.as_ptr().cast(), data.len()) };
+        if obj.is_null() {
+            return Err(VZError::InvalidConfiguration(
+                "invalid macOS machine identifier data representation".into(),
+            ));
         }
+        Ok(Self {
+            inner: obj as *mut AnyObject,
+        })
     }
 
     /// Returns the opaque data representation for persistence.
     #[must_use]
     pub fn data_representation(&self) -> Vec<u8> {
-        // SAFETY: dataRepresentation returns an NSData owned by the identifier; nsdata_to_vec only reads it.
-        let data = unsafe { msg_send!(self.inner, dataRepresentation) };
-        nsdata_to_vec(data)
+        // SAFETY: valid handle; the shim mallocs the buffer that take_bytes frees.
+        unsafe {
+            let mut len: usize = 0;
+            let bytes = shim_ffi::abx_mac_machine_id_data(self.inner.cast(), &mut len);
+            take_bytes(bytes, len)
+        }
     }
 
     pub(crate) fn as_ptr(&self) -> *mut AnyObject {
@@ -176,7 +179,8 @@ impl MacMachineIdentifier {
 impl Drop for MacMachineIdentifier {
     fn drop(&mut self) {
         if !self.inner.is_null() {
-            release(self.inner);
+            // SAFETY: releasing the +1 handle returned by the shim.
+            unsafe { shim_ffi::abx_object_release(self.inner.cast()) };
         }
     }
 }
@@ -186,7 +190,8 @@ pub struct MacAuxiliaryStorage {
     inner: *mut AnyObject,
 }
 
-// SAFETY: Inner ObjC pointer is only used via msg_send! which dispatches to the ObjC runtime.
+// SAFETY: The inner pointer is an ObjC object created by the shim; it is not
+// mutated concurrently.
 unsafe impl Send for MacAuxiliaryStorage {}
 
 impl MacAuxiliaryStorage {
@@ -194,30 +199,15 @@ impl MacAuxiliaryStorage {
     ///
     /// # Errors
     ///
-    /// Returns an error if `VZMacAuxiliaryStorage` is unavailable or the storage
-    /// cannot be opened.
+    /// Returns an error if the path is not representable; whether the file is
+    /// usable is checked when the VM configuration is validated.
     pub fn open(path: impl AsRef<Path>) -> VZResult<Self> {
-        let path_str = path.as_ref().to_string_lossy();
-        // SAFETY: ObjC alloc/initWithURL: pattern on VZMacAuxiliaryStorage with an NSURL
-        // built from a valid path. Result checked non-null.
-        unsafe {
-            let cls = get_class("VZMacAuxiliaryStorage").ok_or_else(|| VZError::Internal {
-                code: -1,
-                message: "VZMacAuxiliaryStorage class not found".into(),
-            })?;
-            let url = nsurl_file_path(&path_str);
-            let alloc = msg_send!(cls, alloc);
-            let obj = msg_send!(alloc, initWithURL: url);
-            // initWithURL: retains the NSURL; release the +1 from nsurl_file_path
-            // (also covers the error path below).
-            release(url);
-            if obj.is_null() {
-                return Err(VZError::InvalidConfiguration(format!(
-                    "failed to open macOS auxiliary storage: {path_str}"
-                )));
-            }
-            Ok(Self { inner: obj })
-        }
+        let c_path = path_cstring(path.as_ref())?;
+        // SAFETY: c_path is valid; the shim returns a +1 handle.
+        let obj = unsafe { shim_ffi::abx_aux_storage_open(c_path.as_ptr()) };
+        Ok(Self {
+            inner: obj as *mut AnyObject,
+        })
     }
 
     /// Creates new auxiliary storage at `path` for `hardware_model`.
@@ -226,51 +216,29 @@ impl MacAuxiliaryStorage {
     ///
     /// # Errors
     ///
-    /// Returns an error if `VZMacAuxiliaryStorage` is unavailable or the storage
-    /// cannot be created.
+    /// Returns an error if the storage cannot be created.
     pub fn create(
         path: impl AsRef<Path>,
         hardware_model: &MacHardwareModel,
         overwrite: bool,
     ) -> VZResult<Self> {
-        let path_str = path.as_ref().to_string_lossy();
-        // SAFETY: alloc + initCreatingStorageAtURL:hardwareModel:options:error: on
-        // VZMacAuxiliaryStorage. The error out-parameter is written only on failure.
+        let c_path = path_cstring(path.as_ref())?;
+        // SAFETY: both arguments are valid; on failure the shim writes a
+        // strdup'd message that take_error_string frees.
         unsafe {
-            let cls = get_class("VZMacAuxiliaryStorage").ok_or_else(|| VZError::Internal {
-                code: -1,
-                message: "VZMacAuxiliaryStorage class not found".into(),
-            })?;
-            let url = nsurl_file_path(&path_str);
-            let alloc = msg_send!(cls, alloc);
-            // VZMacAuxiliaryStorageInitializationOptionAllowOverwrite = 1 << 0.
-            let options: u64 = u64::from(overwrite);
-            let mut error: *mut AnyObject = std::ptr::null_mut();
-            let sel = objc2::sel!(initCreatingStorageAtURL:hardwareModel:options:error:);
-            let func: unsafe extern "C" fn(
-                *mut AnyObject,
-                objc2::runtime::Sel,
-                *const AnyObject,
-                *const AnyObject,
-                u64,
-                *mut *mut AnyObject,
-            ) -> *mut AnyObject =
-                std::mem::transmute(crate::ffi::runtime::objc_msgSend as *const c_void);
-            let obj = func(
-                alloc,
-                sel,
-                url as *const AnyObject,
-                hardware_model.as_ptr() as *const AnyObject,
-                options,
+            let mut error: *mut std::ffi::c_char = ptr::null_mut();
+            let obj = shim_ffi::abx_aux_storage_create(
+                c_path.as_ptr(),
+                hardware_model.as_ptr().cast(),
+                overwrite,
                 &mut error,
             );
-            // The initializer retains the NSURL; release the +1 from nsurl_file_path
-            // (also covers the error path below).
-            release(url);
             if obj.is_null() {
-                return Err(extract_nserror(error));
+                return Err(VZError::OperationFailed(shim_ffi::take_error_string(error)));
             }
-            Ok(Self { inner: obj })
+            Ok(Self {
+                inner: obj as *mut AnyObject,
+            })
         }
     }
 
@@ -282,7 +250,8 @@ impl MacAuxiliaryStorage {
 impl Drop for MacAuxiliaryStorage {
     fn drop(&mut self) {
         if !self.inner.is_null() {
-            release(self.inner);
+            // SAFETY: releasing the +1 handle returned by the shim.
+            unsafe { shim_ffi::abx_object_release(self.inner.cast()) };
         }
     }
 }

--- a/virt/arcbox-vz/src/configuration/platform.rs
+++ b/virt/arcbox-vz/src/configuration/platform.rs
@@ -1,8 +1,6 @@
 //! Platform configurations.
 
-use crate::error::{VZError, VZResult};
-use crate::ffi::{get_class, release};
-use crate::{msg_send, msg_send_void};
+use crate::error::VZResult;
 use objc2::runtime::AnyObject;
 
 use super::mac::{MacAuxiliaryStorage, MacHardwareModel, MacMachineIdentifier};
@@ -105,29 +103,18 @@ impl MacPlatform {
         machine_identifier: &MacMachineIdentifier,
         auxiliary_storage: &MacAuxiliaryStorage,
     ) -> VZResult<Self> {
-        // SAFETY: ObjC alloc/init on VZMacPlatformConfiguration, then strong-property
-        // setters that retain their arguments. Result checked non-null.
-        unsafe {
-            let cls = get_class("VZMacPlatformConfiguration").ok_or_else(|| VZError::Internal {
-                code: -1,
-                message: "VZMacPlatformConfiguration class not found".into(),
-            })?;
-            let alloc = msg_send!(cls, alloc);
-            let obj = msg_send!(alloc, init);
-
-            if obj.is_null() {
-                return Err(VZError::Internal {
-                    code: -1,
-                    message: "Failed to create VZMacPlatformConfiguration".into(),
-                });
-            }
-
-            msg_send_void!(obj, setHardwareModel: hardware_model.as_ptr());
-            msg_send_void!(obj, setMachineIdentifier: machine_identifier.as_ptr());
-            msg_send_void!(obj, setAuxiliaryStorage: auxiliary_storage.as_ptr());
-
-            Ok(Self { inner: obj })
-        }
+        // SAFETY: all three are valid handles; the platform's properties are
+        // strong, so the arguments may be dropped after this returns.
+        let obj = unsafe {
+            crate::shim_ffi::abx_platform_mac_new(
+                hardware_model.as_ptr().cast(),
+                machine_identifier.as_ptr().cast(),
+                auxiliary_storage.as_ptr().cast(),
+            )
+        };
+        Ok(Self {
+            inner: obj as *mut AnyObject,
+        })
     }
 }
 
@@ -140,7 +127,8 @@ impl Platform for MacPlatform {
 impl Drop for MacPlatform {
     fn drop(&mut self) {
         if !self.inner.is_null() {
-            release(self.inner);
+            // SAFETY: releasing the +1 handle returned by the shim.
+            unsafe { crate::shim_ffi::abx_object_release(self.inner.cast()) };
         }
     }
 }

--- a/virt/arcbox-vz/src/shim_ffi.rs
+++ b/virt/arcbox-vz/src/shim_ffi.rs
@@ -107,6 +107,26 @@ unsafe extern "C" {
     pub fn abx_rosetta_share_new(error_out: *mut *mut c_char) -> *mut c_void;
     pub fn abx_virtiofs_new(tag: *const c_char, error_out: *mut *mut c_char) -> *mut c_void;
     pub fn abx_virtiofs_set_share(config: *mut c_void, share: *mut c_void);
+
+    // macOS identity + platform
+    pub fn abx_mac_hw_model_from_data(bytes: *const c_void, length: usize) -> *mut c_void;
+    pub fn abx_mac_hw_model_supported(handle: *mut c_void) -> bool;
+    pub fn abx_mac_hw_model_data(handle: *mut c_void, length_out: *mut usize) -> *mut c_void;
+    pub fn abx_mac_machine_id_new() -> *mut c_void;
+    pub fn abx_mac_machine_id_from_data(bytes: *const c_void, length: usize) -> *mut c_void;
+    pub fn abx_mac_machine_id_data(handle: *mut c_void, length_out: *mut usize) -> *mut c_void;
+    pub fn abx_aux_storage_open(path: *const c_char) -> *mut c_void;
+    pub fn abx_aux_storage_create(
+        path: *const c_char,
+        hardware_model: *mut c_void,
+        overwrite: bool,
+        error_out: *mut *mut c_char,
+    ) -> *mut c_void;
+    pub fn abx_platform_mac_new(
+        hardware_model: *mut c_void,
+        machine_identifier: *mut c_void,
+        auxiliary_storage: *mut c_void,
+    ) -> *mut c_void;
 }
 
 /// Takes ownership of a shim-returned error string and frees it.
@@ -174,11 +194,20 @@ mod tests {
         abx_rosetta_share_new as *const (),
         abx_virtiofs_new as *const (),
         abx_virtiofs_set_share as *const (),
+        abx_mac_hw_model_from_data as *const (),
+        abx_mac_hw_model_supported as *const (),
+        abx_mac_hw_model_data as *const (),
+        abx_mac_machine_id_new as *const (),
+        abx_mac_machine_id_from_data as *const (),
+        abx_mac_machine_id_data as *const (),
+        abx_aux_storage_open as *const (),
+        abx_aux_storage_create as *const (),
+        abx_platform_mac_new as *const (),
     ];
 
     /// Update when symbols are added; a mismatch means Exports.swift and this
     /// file have drifted.
-    const EXPECTED_SYMBOL_COUNT: usize = 38;
+    const EXPECTED_SYMBOL_COUNT: usize = 47;
 
     #[test]
     fn link_coverage() {
@@ -245,6 +274,40 @@ mod tests {
             abx_bootloader_linux_set_initrd(bl, c_path.as_ptr());
             abx_bootloader_linux_set_cmdline(bl, c_cmdline.as_ptr());
             abx_object_release(bl);
+        }
+    }
+
+    #[test]
+    fn machine_id_data_roundtrip() {
+        // SAFETY: identity objects are plain allocations (no entitlement);
+        // buffers are shim-malloc'd and freed via abx_bytes_free.
+        unsafe {
+            let id = abx_mac_machine_id_new();
+            assert!(!id.is_null());
+
+            let mut len: usize = 0;
+            let bytes = abx_mac_machine_id_data(id, &mut len);
+            assert!(!bytes.is_null());
+            assert!(len > 0);
+
+            let id2 = abx_mac_machine_id_from_data(bytes, len);
+            assert!(!id2.is_null(), "round-trip through data representation");
+            let mut len2: usize = 0;
+            let bytes2 = abx_mac_machine_id_data(id2, &mut len2);
+            assert_eq!(len, len2);
+            let a = std::slice::from_raw_parts(bytes as *const u8, len);
+            let b = std::slice::from_raw_parts(bytes2 as *const u8, len2);
+            assert_eq!(a, b);
+
+            abx_bytes_free(bytes);
+            abx_bytes_free(bytes2);
+            abx_object_release(id2);
+            abx_object_release(id);
+
+            // Garbage bytes must be rejected, not crash.
+            let garbage = [0u8; 16];
+            let bad = abx_mac_machine_id_from_data(garbage.as_ptr().cast(), garbage.len());
+            assert!(bad.is_null());
         }
     }
 


### PR DESCRIPTION
## Summary

PR 6/11 of the ArcBoxVZShim migration (stacked on #418). The macOS-guest identity types move to Swift: `MacHardwareModel`, `MacMachineIdentifier` (opaque data-representation round-trips via shim-malloc'd buffers + `abx_bytes_free`), `MacAuxiliaryStorage` (open/create with framework error propagation on create), and `MacPlatform` assembly.

Semantics note: `MacAuxiliaryStorage::open` no longer pretends to verify the file at construction — the Swift `VZMacAuxiliaryStorage(url:)` initializer is non-failable and VZ actually checks the file at configuration-validate time (the old null-check was theater).

New boundary test (runs unsigned in CI): machine-identifier data round-trip incl. the garbage-bytes-rejected case.

## Validation

- `cargo test -p arcbox-vz` (22 + 10 doctests), workspace clippy `-D warnings`, fmt, swift-format strict — green
- Per plan, no e2e for this slice: the Linux-guest `boot_assets` scenario never enters the mac-identity path; coverage is the unsigned round-trip tests + (feature-gated) IPSW flow validated in the installer PR