### PR TITLE
feat/vz shim lifecycle ops

### DIFF
--- a/virt/arcbox-hypervisor/src/darwin/vcpu.rs
+++ b/virt/arcbox-hypervisor/src/darwin/vcpu.rs
@@ -5,16 +5,13 @@
 //! KVM or Hypervisor.framework, there is no direct `run vCPU` API.
 //!
 //! The `DarwinVcpu` implementation adapts to this model:
-//! - `run()` waits for VM state changes (from Running to another state)
+//! - `run()` is a compatibility stub that returns `Halt` immediately; VM
+//!   lifecycle observation happens through `arcbox_vz::VirtualMachine`
 //! - Register access is not supported (Virtualization.framework doesn't expose this)
 //! - The actual vCPU execution is handled by `VZVirtualMachine.start()`
 
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::time::Duration;
-
-use arcbox_vz::VirtualMachineState;
-use objc2::runtime::AnyObject;
 
 use crate::{
     error::HypervisorError,
@@ -42,58 +39,15 @@ pub struct DarwinVcpu {
     /// Current register state (cached, not synced with actual vCPU).
     /// Note: Virtualization.framework doesn't expose register access.
     regs: Registers,
-    /// Raw pointer to the `VZVirtualMachine` for state queries.
-    /// This is safe to read from any thread (state property is thread-safe).
-    vz_vm: *mut AnyObject,
 }
-
-// Safety: The vz_vm pointer is only used for reading the state property,
-// which is documented as thread-safe by Apple.
-unsafe impl Send for DarwinVcpu {}
 
 impl DarwinVcpu {
     /// Creates a new vCPU.
-    ///
-    /// For managed execution VMs (Virtualization.framework), use `new_managed()`
-    /// to pass the VM pointer for state queries.
-    #[allow(dead_code)]
     pub(crate) fn new(id: u32) -> Self {
         Self {
             id,
             running: Arc::new(AtomicBool::new(false)),
             regs: Registers::default(),
-            vz_vm: std::ptr::null_mut(),
-        }
-    }
-
-    /// Creates a new vCPU with a reference to the VZ VM for state queries.
-    ///
-    /// This is the preferred constructor for Virtualization.framework VMs,
-    /// as it enables `run()` to properly wait for VM state changes.
-    pub(crate) fn new_managed(id: u32, vz_vm: *mut AnyObject) -> Self {
-        Self {
-            id,
-            running: Arc::new(AtomicBool::new(false)),
-            regs: Registers::default(),
-            vz_vm,
-        }
-    }
-
-    /// Queries the current VM state from Virtualization.framework.
-    ///
-    /// Returns `None` if no VZ VM pointer is available.
-    fn query_vm_state(&self) -> Option<VirtualMachineState> {
-        if self.vz_vm.is_null() {
-            return None;
-        }
-
-        unsafe {
-            // VZVirtualMachine.state is thread-safe to read
-            let sel = objc2::sel!(state);
-            let func: unsafe extern "C" fn(*const AnyObject, objc2::runtime::Sel) -> i64 =
-                std::mem::transmute(objc2::ffi::objc_msgSend as *const std::ffi::c_void);
-            let state = func(self.vz_vm as *const AnyObject, sel);
-            Some(VirtualMachineState::from(state))
         }
     }
 
@@ -166,75 +120,18 @@ impl DarwinVcpu {
 
 impl Vcpu for DarwinVcpu {
     fn run(&mut self) -> Result<VcpuExit, HypervisorError> {
+        // Virtualization.framework manages vCPU execution internally; VM
+        // lifecycle is observed through `arcbox_vz::VirtualMachine::state()`.
+        // Every construction site historically passed a null VM pointer here,
+        // so this has always returned Halt immediately — now it does so
+        // without the vestigial state-poll machinery.
         self.running.store(true, Ordering::SeqCst);
-
-        // On Virtualization.framework, vCPU execution is managed internally.
-        // The run() method waits for VM state changes instead of executing guest code.
-        //
-        // This implementation polls the VM state until:
-        // - The VM exits Running state (pause, stop, error)
-        // - The VZ VM pointer is not available (legacy mode, return immediately)
-
-        let poll_interval = Duration::from_millis(100);
-
-        // If no VZ VM pointer, return immediately (legacy behavior or placeholder vCPU)
-        if self.vz_vm.is_null() {
-            tracing::warn!(
-                "vCPU {} run() called without VZ VM pointer, returning Halt",
-                self.id
-            );
-            self.running.store(false, Ordering::SeqCst);
-            return Ok(VcpuExit::Halt);
-        }
-
-        tracing::debug!("vCPU {} entering managed execution wait loop", self.id);
-
-        loop {
-            let state = if let Some(s) = self.query_vm_state() {
-                s
-            } else {
-                // VM pointer became invalid
-                self.running.store(false, Ordering::SeqCst);
-                return Ok(VcpuExit::Halt);
-            };
-
-            match state {
-                VirtualMachineState::Running => {
-                    // VM is still running, continue waiting
-                    std::thread::sleep(poll_interval);
-                }
-                VirtualMachineState::Stopped => {
-                    tracing::debug!("vCPU {} detected VM stopped", self.id);
-                    self.running.store(false, Ordering::SeqCst);
-                    return Ok(VcpuExit::Shutdown);
-                }
-                VirtualMachineState::Paused => {
-                    tracing::debug!("vCPU {} detected VM paused", self.id);
-                    self.running.store(false, Ordering::SeqCst);
-                    return Ok(VcpuExit::Halt);
-                }
-                VirtualMachineState::Error => {
-                    tracing::error!("vCPU {} detected VM error state", self.id);
-                    self.running.store(false, Ordering::SeqCst);
-                    return Err(HypervisorError::VcpuRunError(
-                        "VM entered error state".to_string(),
-                    ));
-                }
-                VirtualMachineState::Starting
-                | VirtualMachineState::Pausing
-                | VirtualMachineState::Resuming
-                | VirtualMachineState::Stopping => {
-                    // Transitional states, wait for final state
-                    tracing::trace!("vCPU {} VM in transitional state: {:?}", self.id, state);
-                    std::thread::sleep(poll_interval);
-                }
-                VirtualMachineState::Saving | VirtualMachineState::Restoring => {
-                    // Snapshot operations (macOS 14+), wait for completion
-                    tracing::trace!("vCPU {} VM performing snapshot operation", self.id);
-                    std::thread::sleep(poll_interval);
-                }
-            }
-        }
+        tracing::debug!(
+            "vCPU {} run() is a managed-execution stub, returning Halt",
+            self.id
+        );
+        self.running.store(false, Ordering::SeqCst);
+        Ok(VcpuExit::Halt)
     }
 
     fn get_regs(&self) -> Result<Registers, HypervisorError> {
@@ -460,16 +357,6 @@ mod tests {
         let vcpu = DarwinVcpu::new(0);
         assert_eq!(vcpu.id(), 0);
         assert!(!vcpu.is_running());
-        assert!(vcpu.vz_vm.is_null());
-    }
-
-    #[test]
-    fn test_vcpu_creation_managed() {
-        // Create with null pointer (for testing)
-        let vcpu = DarwinVcpu::new_managed(1, std::ptr::null_mut());
-        assert_eq!(vcpu.id(), 1);
-        assert!(!vcpu.is_running());
-        assert!(vcpu.vz_vm.is_null());
     }
 
     #[test]
@@ -575,18 +462,9 @@ mod tests {
     // ========================================================================
 
     #[test]
-    fn test_vcpu_run_without_vm() {
-        // When run() is called without a VZ VM pointer, it should return Halt immediately
+    fn test_vcpu_run_returns_halt() {
+        // run() is a managed-execution stub: Halt immediately, not running after.
         let mut vcpu = DarwinVcpu::new(0);
-        let exit = vcpu.run().unwrap();
-        assert!(matches!(exit, VcpuExit::Halt));
-        assert!(!vcpu.is_running());
-    }
-
-    #[test]
-    fn test_vcpu_run_with_null_managed() {
-        // new_managed with null pointer should also return Halt immediately
-        let mut vcpu = DarwinVcpu::new_managed(0, std::ptr::null_mut());
         let exit = vcpu.run().unwrap();
         assert!(matches!(exit, VcpuExit::Halt));
         assert!(!vcpu.is_running());
@@ -621,23 +499,6 @@ mod tests {
         // After run (which returns immediately with null VM), should be false again
         let _ = vcpu.run();
         assert!(!running_flag.load(std::sync::atomic::Ordering::SeqCst));
-    }
-
-    // ========================================================================
-    // VM State Query Tests
-    // ========================================================================
-
-    #[test]
-    fn test_vcpu_query_vm_state_without_vm() {
-        let vcpu = DarwinVcpu::new(0);
-        // Without VZ VM pointer, should return None
-        assert!(vcpu.query_vm_state().is_none());
-    }
-
-    #[test]
-    fn test_vcpu_query_vm_state_null_managed() {
-        let vcpu = DarwinVcpu::new_managed(0, std::ptr::null_mut());
-        assert!(vcpu.query_vm_state().is_none());
     }
 
     // ========================================================================
@@ -792,6 +653,7 @@ mod tests {
 
     #[test]
     fn test_vz_state_from_i64() {
+        use arcbox_vz::VirtualMachineState;
         // Test VirtualMachineState::from(i64) mapping
         assert_eq!(VirtualMachineState::from(0), VirtualMachineState::Stopped);
         assert_eq!(VirtualMachineState::from(1), VirtualMachineState::Running);

--- a/virt/arcbox-hypervisor/src/darwin/vm/virtual_machine.rs
+++ b/virt/arcbox-hypervisor/src/darwin/vm/virtual_machine.rs
@@ -59,10 +59,9 @@ impl VirtualMachine for DarwinVm {
 
         // Create vCPU for managed execution.
         // On Virtualization.framework, vCPU execution is managed internally by the framework.
-        // The vCPU struct is a lightweight handle that tracks vCPU ID and state.
-        // NOTE: We pass null_mut() because arcbox-vz doesn't expose VM's raw pointer.
-        // The VM state is queried through the DarwinVm's state() method instead.
-        let vcpu = DarwinVcpu::new_managed(id, std::ptr::null_mut());
+        // The vCPU struct is a lightweight handle that tracks vCPU ID and state;
+        // VM state is queried through the DarwinVm's state() method instead.
+        let vcpu = DarwinVcpu::new(id);
 
         // Record creation
         {

--- a/virt/arcbox-vz/shim/Sources/ArcBoxVZShim/Exports.swift
+++ b/virt/arcbox-vz/shim/Sources/ArcBoxVZShim/Exports.swift
@@ -312,13 +312,6 @@ public func abxPlatformMacNew(
 
 // MARK: - Vsock
 
-@_cdecl("abx_socket_device_box_from_raw")
-public func abxSocketDeviceBoxFromRaw(
-    _ device: UnsafeMutableRawPointer, _ queue: UnsafeMutableRawPointer
-) -> UnsafeMutableRawPointer {
-    socketDeviceBoxFromRaw(device, queue)
-}
-
 @_cdecl("abx_vsock_connect")
 public func abxVsockConnect(
     _ box: UnsafeMutableRawPointer,
@@ -331,11 +324,23 @@ public func abxVsockConnect(
 
 // MARK: - VM lifecycle
 
-@_cdecl("abx_vm_box_from_raw")
-public func abxVmBoxFromRaw(
-    _ vm: UnsafeMutableRawPointer, _ queue: UnsafeMutableRawPointer
+@_cdecl("abx_config_set_devices")
+public func abxConfigSetDevices(
+    _ config: UnsafeMutableRawPointer,
+    _ kind: UInt32,
+    _ items: UnsafePointer<UnsafeMutableRawPointer?>?,
+    _ count: UInt
+) {
+    configSetDevices(config, kind, items, count)
+}
+
+@_cdecl("abx_vm_new")
+public func abxVmNew(
+    _ config: UnsafeMutableRawPointer,
+    _ rawVmOut: UnsafeMutablePointer<UnsafeMutableRawPointer?>?,
+    _ rawQueueOut: UnsafeMutablePointer<UnsafeMutableRawPointer?>?
 ) -> UnsafeMutableRawPointer {
-    vmBoxFromRaw(vm, queue)
+    vmNew(config, rawVmOut, rawQueueOut)
 }
 
 @_cdecl("abx_vm_state")
@@ -373,4 +378,65 @@ public func abxVmStart(
     _ callback: @escaping ABXStateCallback
 ) {
     vmStart(box, ctx, callback)
+}
+
+@_cdecl("abx_vm_stop")
+public func abxVmStop(
+    _ box: UnsafeMutableRawPointer,
+    _ ctx: UnsafeMutableRawPointer?,
+    _ callback: @escaping ABXStateCallback
+) {
+    vmStop(box, ctx, callback)
+}
+
+@_cdecl("abx_vm_pause")
+public func abxVmPause(
+    _ box: UnsafeMutableRawPointer,
+    _ ctx: UnsafeMutableRawPointer?,
+    _ callback: @escaping ABXStateCallback
+) {
+    vmPause(box, ctx, callback)
+}
+
+@_cdecl("abx_vm_resume")
+public func abxVmResume(
+    _ box: UnsafeMutableRawPointer,
+    _ ctx: UnsafeMutableRawPointer?,
+    _ callback: @escaping ABXStateCallback
+) {
+    vmResume(box, ctx, callback)
+}
+
+@_cdecl("abx_vm_socket_device_count")
+public func abxVmSocketDeviceCount(_ box: UnsafeMutableRawPointer) -> UInt64 {
+    vmSocketDeviceCount(box)
+}
+
+@_cdecl("abx_vm_socket_device_at")
+public func abxVmSocketDeviceAt(
+    _ box: UnsafeMutableRawPointer, _ index: UInt64
+) -> UnsafeMutableRawPointer? {
+    vmSocketDeviceAt(box, index)
+}
+
+@_cdecl("abx_vm_balloon_count")
+public func abxVmBalloonCount(_ box: UnsafeMutableRawPointer) -> UInt64 {
+    vmBalloonCount(box)
+}
+
+@_cdecl("abx_vm_balloon_at")
+public func abxVmBalloonAt(
+    _ box: UnsafeMutableRawPointer, _ index: UInt64
+) -> UnsafeMutableRawPointer? {
+    vmBalloonAt(box, index)
+}
+
+@_cdecl("abx_balloon_target")
+public func abxBalloonTarget(_ box: UnsafeMutableRawPointer) -> UInt64 {
+    balloonTarget(box)
+}
+
+@_cdecl("abx_balloon_set_target")
+public func abxBalloonSetTarget(_ box: UnsafeMutableRawPointer, _ bytes: UInt64) {
+    balloonSetTarget(box, bytes)
 }

--- a/virt/arcbox-vz/shim/Sources/ArcBoxVZShim/Lifecycle.swift
+++ b/virt/arcbox-vz/shim/Sources/ArcBoxVZShim/Lifecycle.swift
@@ -26,15 +26,93 @@ final class ABXVMBox {
     }
 }
 
-/// Migration-only: wraps raw (vm, queue) ObjC pointers produced by the
-/// pre-shim `build()` path. Dies once build() hands out boxes directly.
-func vmBoxFromRaw(
-    _ vm: UnsafeMutableRawPointer, _ queue: UnsafeMutableRawPointer
+/// Pairs a balloon device with the owning VM's serial queue (VZ device
+/// objects are queue-affine).
+final class ABXBalloonBox {
+    let device: VZMemoryBalloonDevice
+    let queue: DispatchQueue
+
+    init(device: VZMemoryBalloonDevice, queue: DispatchQueue) {
+        self.device = device
+        self.queue = queue
+    }
+}
+
+/// Device-array kinds for `configSetDevices`; values are part of the C ABI
+/// (mirrored by the Rust caller).
+enum ABXDeviceKind: UInt32 {
+    case storage = 0
+    case network = 1
+    case serial = 2
+    case socket = 3
+    case entropy = 4
+    case directorySharing = 5
+    case memoryBalloon = 6
+    case graphics = 7
+}
+
+/// Applies one device array onto the configuration, borrowing every handle
+/// (the configuration retains; the caller keeps its +1s).
+func configSetDevices(
+    _ config: UnsafeMutableRawPointer,
+    _ kind: UInt32,
+    _ items: UnsafePointer<UnsafeMutableRawPointer?>?,
+    _ count: UInt
+) {
+    let cfg = abxBorrow(config, as: VZVirtualMachineConfiguration.self)
+    var handles: [UnsafeMutableRawPointer] = []
+    if let items {
+        for index in 0..<Int(count) {
+            if let handle = items[index] {
+                handles.append(handle)
+            }
+        }
+    }
+    guard let deviceKind = ABXDeviceKind(rawValue: kind) else {
+        fatalError("configSetDevices: unknown device kind \(kind) — Rust/Swift kind maps drifted")
+    }
+    switch deviceKind {
+    case .storage:
+        cfg.storageDevices = handles.map { abxBorrow($0, as: VZStorageDeviceConfiguration.self) }
+    case .network:
+        cfg.networkDevices = handles.map {
+            abxBorrow($0, as: VZNetworkDeviceConfiguration.self)
+        }
+    case .serial:
+        cfg.serialPorts = handles.map { abxBorrow($0, as: VZSerialPortConfiguration.self) }
+    case .socket:
+        cfg.socketDevices = handles.map { abxBorrow($0, as: VZSocketDeviceConfiguration.self) }
+    case .entropy:
+        cfg.entropyDevices = handles.map { abxBorrow($0, as: VZEntropyDeviceConfiguration.self) }
+    case .directorySharing:
+        cfg.directorySharingDevices = handles.map {
+            abxBorrow($0, as: VZDirectorySharingDeviceConfiguration.self)
+        }
+    case .memoryBalloon:
+        cfg.memoryBalloonDevices = handles.map {
+            abxBorrow($0, as: VZMemoryBalloonDeviceConfiguration.self)
+        }
+    case .graphics:
+        cfg.graphicsDevices = handles.map { abxBorrow($0, as: VZGraphicsDeviceConfiguration.self) }
+    }
+}
+
+/// Creates the VM on a fresh serial queue and returns its box.
+///
+/// The raw out-params are transitional (the installer still drives the raw
+/// VZVirtualMachine on its queue from the Rust side); they die with the
+/// installer migration. Both are borrowed views kept alive by the box.
+func vmNew(
+    _ config: UnsafeMutableRawPointer,
+    _ rawVmOut: UnsafeMutablePointer<UnsafeMutableRawPointer?>?,
+    _ rawQueueOut: UnsafeMutablePointer<UnsafeMutableRawPointer?>?
 ) -> UnsafeMutableRawPointer {
-    abxRetainedHandle(
-        ABXVMBox(
-            vm: abxBorrow(vm, as: VZVirtualMachine.self),
-            queue: abxBorrow(queue, as: DispatchQueue.self)))
+    let cfg = abxBorrow(config, as: VZVirtualMachineConfiguration.self)
+    let queue = DispatchQueue(label: "com.arcbox.vz.vm")
+    let vm = VZVirtualMachine(configuration: cfg, queue: queue)
+    rawVmOut?.pointee = Unmanaged.passUnretained(vm).toOpaque()
+    rawQueueOut?.pointee = Unmanaged.passUnretained(queue).toOpaque()
+    return abxRetainedHandle(ABXVMBox(vm: vm, queue: queue))
 }
 
 /// Raw values match `VZVirtualMachine.State` (stopped=0 … restoring=9); the
@@ -90,5 +168,114 @@ func vmStart(
                 callback(ctx, abxErrorString(error))
             }
         }
+    }
+}
+
+func vmStop(
+    _ box: UnsafeMutableRawPointer,
+    _ ctx: UnsafeMutableRawPointer?,
+    _ callback: @escaping ABXStateCallback
+) {
+    let vmBox = abxBorrow(box, as: ABXVMBox.self)
+    vmBox.queue.sync {
+        vmBox.vm.stop { error in
+            if let error {
+                callback(ctx, abxErrorString(error))
+            } else {
+                callback(ctx, nil)
+            }
+        }
+    }
+}
+
+func vmPause(
+    _ box: UnsafeMutableRawPointer,
+    _ ctx: UnsafeMutableRawPointer?,
+    _ callback: @escaping ABXStateCallback
+) {
+    let vmBox = abxBorrow(box, as: ABXVMBox.self)
+    vmBox.queue.sync {
+        vmBox.vm.pause { result in
+            switch result {
+            case .success:
+                callback(ctx, nil)
+            case .failure(let error):
+                callback(ctx, abxErrorString(error))
+            }
+        }
+    }
+}
+
+func vmResume(
+    _ box: UnsafeMutableRawPointer,
+    _ ctx: UnsafeMutableRawPointer?,
+    _ callback: @escaping ABXStateCallback
+) {
+    let vmBox = abxBorrow(box, as: ABXVMBox.self)
+    vmBox.queue.sync {
+        vmBox.vm.resume { result in
+            switch result {
+            case .success:
+                callback(ctx, nil)
+            case .failure(let error):
+                callback(ctx, abxErrorString(error))
+            }
+        }
+    }
+}
+
+func vmSocketDeviceCount(_ box: UnsafeMutableRawPointer) -> UInt64 {
+    let vmBox = abxBorrow(box, as: ABXVMBox.self)
+    return vmBox.queue.sync { UInt64(vmBox.vm.socketDevices.count) }
+}
+
+func vmSocketDeviceAt(
+    _ box: UnsafeMutableRawPointer, _ index: UInt64
+) -> UnsafeMutableRawPointer? {
+    let vmBox = abxBorrow(box, as: ABXVMBox.self)
+    return vmBox.queue.sync {
+        let devices = vmBox.vm.socketDevices
+        guard let device = devices[safe: Int(index)] as? VZVirtioSocketDevice else { return nil }
+        return abxRetainedHandle(ABXSocketDeviceBox(device: device, queue: vmBox.queue))
+    }
+}
+
+func vmBalloonCount(_ box: UnsafeMutableRawPointer) -> UInt64 {
+    let vmBox = abxBorrow(box, as: ABXVMBox.self)
+    return vmBox.queue.sync { UInt64(vmBox.vm.memoryBalloonDevices.count) }
+}
+
+func vmBalloonAt(_ box: UnsafeMutableRawPointer, _ index: UInt64) -> UnsafeMutableRawPointer? {
+    let vmBox = abxBorrow(box, as: ABXVMBox.self)
+    return vmBox.queue.sync {
+        guard let device = vmBox.vm.memoryBalloonDevices[safe: Int(index)] else { return nil }
+        return abxRetainedHandle(ABXBalloonBox(device: device, queue: vmBox.queue))
+    }
+}
+
+func balloonTarget(_ box: UnsafeMutableRawPointer) -> UInt64 {
+    let balloonBox = abxBorrow(box, as: ABXBalloonBox.self)
+    return balloonBox.queue.sync {
+        guard let device = balloonBox.device as? VZVirtioTraditionalMemoryBalloonDevice else {
+            return 0
+        }
+        return device.targetVirtualMachineMemorySize
+    }
+}
+
+func balloonSetTarget(_ box: UnsafeMutableRawPointer, _ bytes: UInt64) {
+    let balloonBox = abxBorrow(box, as: ABXBalloonBox.self)
+    balloonBox.queue.sync {
+        guard let device = balloonBox.device as? VZVirtioTraditionalMemoryBalloonDevice else {
+            return
+        }
+        device.targetVirtualMachineMemorySize = bytes
+    }
+}
+
+extension Array {
+    /// Bounds-checked subscript: nil instead of a trap on out-of-range.
+    fileprivate subscript(safe index: Int) -> Element? {
+        indices.contains(index) ? self[index] : nil
     }
 }

--- a/virt/arcbox-vz/shim/Sources/ArcBoxVZShim/Vsock.swift
+++ b/virt/arcbox-vz/shim/Sources/ArcBoxVZShim/Vsock.swift
@@ -26,18 +26,6 @@ final class ABXSocketDeviceBox {
     }
 }
 
-/// Migration-only: wraps raw (device, queue) ObjC pointers produced by the
-/// pre-shim `socket_devices()` path. Dies once the lifecycle PR hands out
-/// boxes directly.
-func socketDeviceBoxFromRaw(
-    _ device: UnsafeMutableRawPointer, _ queue: UnsafeMutableRawPointer
-) -> UnsafeMutableRawPointer {
-    abxRetainedHandle(
-        ABXSocketDeviceBox(
-            device: abxBorrow(device, as: VZVirtioSocketDevice.self),
-            queue: abxBorrow(queue, as: DispatchQueue.self)))
-}
-
 func vsockConnect(
     _ box: UnsafeMutableRawPointer,
     _ port: UInt32,

--- a/virt/arcbox-vz/src/configuration/vm_config.rs
+++ b/virt/arcbox-vz/src/configuration/vm_config.rs
@@ -6,9 +6,7 @@ use crate::device::{
     StorageDeviceConfiguration, VirtioFileSystemDeviceConfiguration,
 };
 use crate::error::{VZError, VZResult};
-use crate::ffi::{DispatchQueue, get_class, nsarray, release};
 use crate::vm::VirtualMachine;
-use crate::{msg_send, msg_send_void};
 use objc2::runtime::AnyObject;
 use std::ptr;
 
@@ -205,79 +203,53 @@ impl VirtualMachineConfiguration {
     /// This finalizes all device configurations and creates the
     /// `VirtualMachine` instance.
     pub fn build(mut self) -> VZResult<VirtualMachine> {
-        // Apply device arrays
         self.apply_devices();
-
-        // Validate
         self.validate()?;
 
-        // Create dispatch queue
-        let queue = DispatchQueue::new("com.arcbox.vz.vm");
-
-        // Create VM with queue
-        // SAFETY: ObjC alloc/init pattern on VZVirtualMachine with a validated configuration and a valid dispatch queue.
-        let vm_ptr = unsafe {
-            let cls = get_class("VZVirtualMachine").ok_or_else(|| VZError::Internal {
-                code: -1,
-                message: "VZVirtualMachine class not found".into(),
-            })?;
-            let alloc = msg_send!(cls, alloc);
-            let obj = msg_send!(alloc, initWithConfiguration: self.inner, queue: queue.as_ptr());
-
-            if obj.is_null() {
-                return Err(VZError::Internal {
-                    code: -1,
-                    message: "Failed to create VZVirtualMachine".into(),
-                });
-            }
-            obj
-        };
-
-        Ok(VirtualMachine::from_raw(vm_ptr, queue))
+        // SAFETY: self.inner is a validated configuration handle. The shim
+        // creates the VM on a fresh serial queue and returns a +1 box; the
+        // raw out-pointers are transitional borrows kept alive by that box.
+        unsafe {
+            let mut raw_vm: *mut std::ffi::c_void = ptr::null_mut();
+            let mut raw_queue: *mut std::ffi::c_void = ptr::null_mut();
+            let vm_box =
+                crate::shim_ffi::abx_vm_new(self.inner.cast(), &mut raw_vm, &mut raw_queue);
+            Ok(VirtualMachine::from_box(
+                vm_box,
+                raw_vm as *mut AnyObject,
+                raw_queue as *mut AnyObject,
+            ))
+        }
     }
 
     /// Applies all device configurations to the VZ configuration.
+    ///
+    /// The shim borrows each handle (the configuration retains); ownership of
+    /// the +1s stays in the vectors, released by Drop.
     fn apply_devices(&mut self) {
-        // SAFETY: self.inner is a valid VZVirtualMachineConfiguration. Each device pointer was obtained from a valid VZ configuration object's into_ptr().
-        unsafe {
-            if !self.storage_devices.is_empty() {
-                let array = nsarray(&self.storage_devices);
-                msg_send_void!(self.inner, setStorageDevices: array);
-            }
-
-            if !self.network_devices.is_empty() {
-                let array = nsarray(&self.network_devices);
-                msg_send_void!(self.inner, setNetworkDevices: array);
-            }
-
-            if !self.serial_ports.is_empty() {
-                let array = nsarray(&self.serial_ports);
-                msg_send_void!(self.inner, setSerialPorts: array);
-            }
-
-            if !self.socket_devices.is_empty() {
-                let array = nsarray(&self.socket_devices);
-                msg_send_void!(self.inner, setSocketDevices: array);
-            }
-
-            if !self.entropy_devices.is_empty() {
-                let array = nsarray(&self.entropy_devices);
-                msg_send_void!(self.inner, setEntropyDevices: array);
-            }
-
-            if !self.directory_sharing_devices.is_empty() {
-                let array = nsarray(&self.directory_sharing_devices);
-                msg_send_void!(self.inner, setDirectorySharingDevices: array);
-            }
-
-            if !self.memory_balloon_devices.is_empty() {
-                let array = nsarray(&self.memory_balloon_devices);
-                msg_send_void!(self.inner, setMemoryBalloonDevices: array);
-            }
-
-            if !self.graphics_devices.is_empty() {
-                let array = nsarray(&self.graphics_devices);
-                msg_send_void!(self.inner, setGraphicsDevices: array);
+        // Kind values mirror the shim's ABXDeviceKind.
+        let arrays: [(u32, &Vec<*mut AnyObject>); 8] = [
+            (0, &self.storage_devices),
+            (1, &self.network_devices),
+            (2, &self.serial_ports),
+            (3, &self.socket_devices),
+            (4, &self.entropy_devices),
+            (5, &self.directory_sharing_devices),
+            (6, &self.memory_balloon_devices),
+            (7, &self.graphics_devices),
+        ];
+        for (kind, handles) in arrays {
+            if !handles.is_empty() {
+                // SAFETY: every element is a valid +1 device handle produced
+                // by the shim; the slice is valid for the duration of the call.
+                unsafe {
+                    crate::shim_ffi::abx_config_set_devices(
+                        self.inner.cast(),
+                        kind,
+                        handles.as_ptr().cast(),
+                        handles.len(),
+                    );
+                }
             }
         }
     }
@@ -285,8 +257,29 @@ impl VirtualMachineConfiguration {
 
 impl Drop for VirtualMachineConfiguration {
     fn drop(&mut self) {
+        // Release the stored device handles: the configuration (if built)
+        // holds its own retains, and unbuilt configurations would otherwise
+        // leak every added device.
+        for handles in [
+            &self.storage_devices,
+            &self.network_devices,
+            &self.serial_ports,
+            &self.socket_devices,
+            &self.entropy_devices,
+            &self.directory_sharing_devices,
+            &self.memory_balloon_devices,
+            &self.graphics_devices,
+        ] {
+            for &handle in handles {
+                if !handle.is_null() {
+                    // SAFETY: each entry is an unconsumed +1 shim handle.
+                    unsafe { crate::shim_ffi::abx_object_release(handle.cast()) };
+                }
+            }
+        }
         if !self.inner.is_null() {
-            release(self.inner);
+            // SAFETY: releasing the +1 configuration handle from the shim.
+            unsafe { crate::shim_ffi::abx_object_release(self.inner.cast()) };
         }
     }
 }

--- a/virt/arcbox-vz/src/device/balloon.rs
+++ b/virt/arcbox-vz/src/device/balloon.rs
@@ -5,7 +5,6 @@
 //! (returning memory to the guest).
 
 use crate::error::VZResult;
-use crate::{msg_send, msg_send_u64, msg_send_void_u64};
 use objc2::runtime::AnyObject;
 
 // ============================================================================
@@ -67,38 +66,26 @@ impl Drop for MemoryBalloonDeviceConfiguration {
 /// This represents an active balloon device on a running VM.
 /// Use `set_target_memory_size()` to adjust the balloon.
 ///
-/// Every accessor dispatches onto the VM's serial queue: Virtualization
-/// framework device objects are queue-affine, and calling them from any
-/// other thread trips `dispatch_assert_queue` inside the framework and
-/// aborts the process (observed on the idle-state balloon shrink).
+/// Every accessor dispatches onto the VM's serial queue (inside the shim):
+/// Virtualization framework device objects are queue-affine, and calling
+/// them from any other thread trips `dispatch_assert_queue` inside the
+/// framework and aborts the process (observed on the idle-state balloon
+/// shrink).
 pub struct MemoryBalloonDevice {
-    inner: *mut AnyObject,
-    /// The owning VM's dispatch queue (non-owned handle).
-    queue: crate::ffi::DispatchQueue,
+    /// ABXBalloonBox handle pairing the device with the VM's queue.
+    balloon_box: *mut std::ffi::c_void,
 }
 
-// SAFETY: The inner pointer refers to a VZ framework-managed object and is
-// only messaged through `queue.sync`, which serializes access on the VM's
-// queue as the framework requires.
+// SAFETY: The box handle is only used through the shim, which serializes
+// every device access on the VM's queue as the framework requires.
 unsafe impl Send for MemoryBalloonDevice {}
 // SAFETY: See above — every method dispatches onto the VM's serial queue.
 unsafe impl Sync for MemoryBalloonDevice {}
 
 impl MemoryBalloonDevice {
-    /// Creates a balloon device wrapper from a raw pointer plus the owning
-    /// VM's dispatch queue.
-    ///
-    /// # Safety
-    ///
-    /// The caller must ensure that `ptr` is a valid
-    /// `VZVirtioTraditionalMemoryBalloonDevice` and `queue_ptr` is the
-    /// owning VM's dispatch queue, both outliving this wrapper.
-    pub(crate) unsafe fn from_raw(ptr: *mut AnyObject, queue_ptr: *mut AnyObject) -> Self {
-        Self {
-            inner: ptr,
-            // SAFETY: caller guarantees `queue_ptr` outlives the wrapper.
-            queue: unsafe { crate::ffi::DispatchQueue::from_raw(queue_ptr) },
-        }
+    /// Wraps a +1 `ABXBalloonBox` handle produced by the shim.
+    pub(crate) fn from_box(balloon_box: *mut std::ffi::c_void) -> Self {
+        Self { balloon_box }
     }
 
     /// Sets the target virtual machine memory size.
@@ -111,17 +98,8 @@ impl MemoryBalloonDevice {
     ///
     /// * `bytes` - Target memory size in bytes
     pub fn set_target_memory_size(&self, bytes: u64) {
-        if self.inner.is_null() {
-            tracing::warn!("set_target_memory_size called on null device");
-            return;
-        }
-        self.queue.sync(|| {
-            // SAFETY: self.inner is checked non-null above; we are on the
-            // VM's dispatch queue as the framework requires.
-            unsafe {
-                msg_send_void_u64!(self.inner, setTargetVirtualMachineMemorySize: bytes);
-            }
-        });
+        // SAFETY: balloon_box is a valid handle; the shim queue-syncs the write.
+        unsafe { crate::shim_ffi::abx_balloon_set_target(self.balloon_box, bytes) };
         tracing::debug!(
             "Set balloon target memory to {} bytes ({}MB)",
             bytes,
@@ -133,63 +111,16 @@ impl MemoryBalloonDevice {
     ///
     /// Returns the target memory size in bytes.
     pub fn target_memory_size(&self) -> u64 {
-        if self.inner.is_null() {
-            tracing::warn!("target_memory_size called on null device");
-            return 0;
-        }
-        // SAFETY: self.inner is checked non-null above; dispatched onto the
-        // VM's queue as the framework requires.
-        self.queue
-            .sync(|| unsafe { msg_send_u64!(self.inner, targetVirtualMachineMemorySize) })
-    }
-
-    /// Returns the raw object pointer.
-    #[must_use]
-    pub fn as_ptr(&self) -> *mut AnyObject {
-        self.inner
+        // SAFETY: balloon_box is a valid handle; the shim queue-syncs the read.
+        unsafe { crate::shim_ffi::abx_balloon_target(self.balloon_box) }
     }
 }
 
-// ============================================================================
-// Helper Functions
-// ============================================================================
-
-/// Gets the memory balloon devices from a running VM.
-///
-/// # Arguments
-///
-/// * `vm_ptr` - Raw pointer to `VZVirtualMachine`
-/// * `queue_ptr` - The VM's dispatch queue, which every returned wrapper
-///   uses for its (queue-affine) framework calls
-///
-/// # Returns
-///
-/// A vector of `MemoryBalloonDevice` wrappers.
-pub fn vm_memory_balloon_devices(
-    vm_ptr: *mut AnyObject,
-    queue_ptr: *mut AnyObject,
-) -> Vec<MemoryBalloonDevice> {
-    if vm_ptr.is_null() {
-        return Vec::new();
-    }
-
-    // SAFETY: vm_ptr is checked non-null above. Sending memoryBalloonDevices returns a valid NSArray. Elements are valid balloon device pointers.
-    unsafe {
-        let devices: *mut AnyObject = msg_send!(vm_ptr, memoryBalloonDevices);
-        if devices.is_null() {
-            return Vec::new();
+impl Drop for MemoryBalloonDevice {
+    fn drop(&mut self) {
+        if !self.balloon_box.is_null() {
+            // SAFETY: releasing the +1 box handle returned by the shim.
+            unsafe { crate::shim_ffi::abx_object_release(self.balloon_box) };
         }
-
-        let count = crate::ffi::nsarray_count(devices);
-        let mut result = Vec::with_capacity(count);
-
-        for i in 0..count {
-            let device = crate::ffi::nsarray_object_at_index(devices, i);
-            if !device.is_null() {
-                result.push(MemoryBalloonDevice::from_raw(device, queue_ptr));
-            }
-        }
-
-        result
     }
 }

--- a/virt/arcbox-vz/src/device/mod.rs
+++ b/virt/arcbox-vz/src/device/mod.rs
@@ -12,7 +12,6 @@ mod serial;
 mod socket;
 mod storage;
 
-pub(crate) use balloon::vm_memory_balloon_devices;
 pub use balloon::{MemoryBalloonDevice, MemoryBalloonDeviceConfiguration};
 pub use entropy::EntropyDeviceConfiguration;
 pub use filesystem::{

--- a/virt/arcbox-vz/src/shim_ffi.rs
+++ b/virt/arcbox-vz/src/shim_ffi.rs
@@ -140,21 +140,40 @@ unsafe extern "C" {
     ) -> *mut c_void;
 
     // Vsock
-    /// Migration-only (dies with the old socket_devices path): wraps raw
-    /// (device, queue) pointers into an ABXSocketDeviceBox handle.
-    pub fn abx_socket_device_box_from_raw(device: *mut c_void, queue: *mut c_void) -> *mut c_void;
     pub fn abx_vsock_connect(device_box: *mut c_void, port: u32, ctx: *mut c_void, cb: VsockCb);
 
     // VM lifecycle
-    /// Migration-only (dies when build() hands out boxes): wraps raw
-    /// (vm, queue) pointers into an ABXVMBox handle.
-    pub fn abx_vm_box_from_raw(vm: *mut c_void, queue: *mut c_void) -> *mut c_void;
+    /// `kind` values mirror the shim's `ABXDeviceKind` (storage=0, network=1,
+    /// serial=2, socket=3, entropy=4, directory_sharing=5, memory_balloon=6,
+    /// graphics=7). The configuration retains the borrowed handles.
+    pub fn abx_config_set_devices(
+        config: *mut c_void,
+        kind: u32,
+        items: *const *mut c_void,
+        count: usize,
+    );
+    /// The raw out-params are transitional borrows for the installer path
+    /// (kept alive by the returned box); they die with the installer PR.
+    pub fn abx_vm_new(
+        config: *mut c_void,
+        raw_vm_out: *mut *mut c_void,
+        raw_queue_out: *mut *mut c_void,
+    ) -> *mut c_void;
     pub fn abx_vm_state(vm_box: *mut c_void) -> i64;
     pub fn abx_vm_can_stop(vm_box: *mut c_void) -> bool;
     pub fn abx_vm_can_pause(vm_box: *mut c_void) -> bool;
     pub fn abx_vm_can_resume(vm_box: *mut c_void) -> bool;
     pub fn abx_vm_request_stop(vm_box: *mut c_void, error_out: *mut *mut c_char) -> bool;
     pub fn abx_vm_start(vm_box: *mut c_void, ctx: *mut c_void, cb: StateCb);
+    pub fn abx_vm_stop(vm_box: *mut c_void, ctx: *mut c_void, cb: StateCb);
+    pub fn abx_vm_pause(vm_box: *mut c_void, ctx: *mut c_void, cb: StateCb);
+    pub fn abx_vm_resume(vm_box: *mut c_void, ctx: *mut c_void, cb: StateCb);
+    pub fn abx_vm_socket_device_count(vm_box: *mut c_void) -> u64;
+    pub fn abx_vm_socket_device_at(vm_box: *mut c_void, index: u64) -> *mut c_void;
+    pub fn abx_vm_balloon_count(vm_box: *mut c_void) -> u64;
+    pub fn abx_vm_balloon_at(vm_box: *mut c_void, index: u64) -> *mut c_void;
+    pub fn abx_balloon_target(balloon_box: *mut c_void) -> u64;
+    pub fn abx_balloon_set_target(balloon_box: *mut c_void, bytes: u64);
 }
 
 /// Takes ownership of a shim-returned error string and frees it.
@@ -231,20 +250,29 @@ mod tests {
         abx_aux_storage_open as *const (),
         abx_aux_storage_create as *const (),
         abx_platform_mac_new as *const (),
-        abx_socket_device_box_from_raw as *const (),
         abx_vsock_connect as *const (),
-        abx_vm_box_from_raw as *const (),
+        abx_config_set_devices as *const (),
+        abx_vm_new as *const (),
         abx_vm_state as *const (),
         abx_vm_can_stop as *const (),
         abx_vm_can_pause as *const (),
         abx_vm_can_resume as *const (),
         abx_vm_request_stop as *const (),
         abx_vm_start as *const (),
+        abx_vm_stop as *const (),
+        abx_vm_pause as *const (),
+        abx_vm_resume as *const (),
+        abx_vm_socket_device_count as *const (),
+        abx_vm_socket_device_at as *const (),
+        abx_vm_balloon_count as *const (),
+        abx_vm_balloon_at as *const (),
+        abx_balloon_target as *const (),
+        abx_balloon_set_target as *const (),
     ];
 
     /// Update when symbols are added; a mismatch means Exports.swift and this
     /// file have drifted.
-    const EXPECTED_SYMBOL_COUNT: usize = 56;
+    const EXPECTED_SYMBOL_COUNT: usize = 65;
 
     #[test]
     fn link_coverage() {

--- a/virt/arcbox-vz/src/socket.rs
+++ b/virt/arcbox-vz/src/socket.rs
@@ -24,7 +24,6 @@
 
 use crate::error::{VZError, VZResult};
 use crate::shim_ffi;
-use objc2::runtime::AnyObject;
 use std::ffi::{c_char, c_void};
 use std::os::unix::io::RawFd;
 use std::sync::mpsc as std_mpsc;
@@ -121,15 +120,8 @@ unsafe impl Send for VirtioSocketDevice {}
 unsafe impl Sync for VirtioSocketDevice {}
 
 impl VirtioSocketDevice {
-    /// Creates a device wrapper from raw pointers.
-    ///
-    /// The caller must ensure that `ptr` is a valid `VZVirtioSocketDevice`
-    /// and `queue` is the VM's dispatch queue.
-    pub(crate) fn from_raw(ptr: *mut AnyObject, queue: *mut AnyObject) -> Self {
-        // SAFETY: per the caller contract both pointers are valid; the shim
-        // box retains them, released by Drop.
-        let device_box =
-            unsafe { shim_ffi::abx_socket_device_box_from_raw(ptr.cast(), queue.cast()) };
+    /// Wraps a +1 `ABXSocketDeviceBox` handle produced by the shim.
+    pub(crate) fn from_box(device_box: *mut c_void) -> Self {
         Self { device_box }
     }
 

--- a/virt/arcbox-vz/src/vm.rs
+++ b/virt/arcbox-vz/src/vm.rs
@@ -1,17 +1,11 @@
 //! Virtual machine runtime.
 
-use crate::device::{MemoryBalloonDevice, vm_memory_balloon_devices};
+use crate::device::MemoryBalloonDevice;
 use crate::error::{VZError, VZResult};
-use crate::ffi::{
-    _Block_copy, _NSConcreteStackBlock, BlockPtr, DispatchQueue, SIMPLE_BLOCK_DESCRIPTOR,
-    nsstring_to_string,
-};
-use crate::msg_send;
+use crate::ffi::DispatchQueue;
 use crate::socket::VirtioSocketDevice;
 use objc2::runtime::AnyObject;
 use std::ffi::c_void;
-use std::sync::OnceLock;
-use std::time::Duration;
 use tokio::sync::oneshot;
 
 // ============================================================================
@@ -99,17 +93,21 @@ unsafe extern "C" fn state_trampoline(ctx: *mut c_void, err: *mut std::ffi::c_ch
 }
 
 impl VirtualMachine {
-    /// Creates a `VirtualMachine` from raw pointers.
+    /// Creates a `VirtualMachine` from a shim box plus transitional raw views.
     ///
     /// This is called internally by `VirtualMachineConfiguration::build()`.
-    pub(crate) fn from_raw(ptr: *mut AnyObject, queue: DispatchQueue) -> Self {
-        // SAFETY: both pointers are valid per the caller contract; the box
-        // retains them and is released in Drop.
-        let vm_box =
-            unsafe { crate::shim_ffi::abx_vm_box_from_raw(ptr.cast(), queue.as_ptr().cast()) };
+    /// `raw_vm`/`raw_queue` are borrows kept alive by `vm_box`; they exist
+    /// only for the installer path and die with its migration.
+    pub(crate) fn from_box(
+        vm_box: *mut c_void,
+        raw_vm: *mut AnyObject,
+        raw_queue: *mut AnyObject,
+    ) -> Self {
         Self {
-            inner: ptr,
-            queue,
+            inner: raw_vm,
+            // SAFETY: raw_queue is a valid dispatch queue kept alive by
+            // vm_box; the wrapper is non-owning.
+            queue: unsafe { DispatchQueue::from_raw(raw_queue) },
             vm_box,
         }
     }
@@ -195,85 +193,20 @@ impl VirtualMachine {
             });
         }
 
-        // For simplicity, use polling instead of completion handler
-        let inner = self.inner;
-        // SAFETY: Calling stopWithCompletionHandler: on a valid VZVirtualMachine on its dispatch
-        // queue. ObjC exceptions are caught.
-        let stop_dispatch: VZResult<()> = self.queue.sync(|| unsafe {
-            // Create a simple completion block
-            static STOP_BLOCK: OnceLock<BlockPtr> = OnceLock::new();
-
-            let block_ptr = STOP_BLOCK.get_or_init(|| {
-                #[repr(C)]
-                struct CompletionBlock {
-                    isa: *const c_void,
-                    flags: i32,
-                    reserved: i32,
-                    invoke: unsafe extern "C" fn(*const c_void, *mut AnyObject),
-                    descriptor: *const crate::ffi::BlockDescriptor,
-                }
-
-                unsafe extern "C" fn stop_handler(_block: *const c_void, error: *mut AnyObject) {
-                    // SAFETY: error is checked non-null. Sending localizedDescription to a valid NSError.
-                    unsafe {
-                        if !error.is_null() {
-                            let desc = msg_send!(error, localizedDescription);
-                            tracing::error!("VM stop failed: {}", nsstring_to_string(desc));
-                        }
-                    }
-                }
-
-                let stack_block = CompletionBlock {
-                    isa: _NSConcreteStackBlock,
-                    flags: 0,
-                    reserved: 0,
-                    invoke: stop_handler,
-                    descriptor: &SIMPLE_BLOCK_DESCRIPTOR,
-                };
-
-                let heap_block =
-                    _Block_copy(&stack_block as *const CompletionBlock as *const c_void);
-                BlockPtr(heap_block)
-            });
-
-            let sel = objc2::sel!(stopWithCompletionHandler:);
-            let func: unsafe extern "C" fn(*const AnyObject, objc2::runtime::Sel, *const c_void) =
-                std::mem::transmute(crate::ffi::runtime::objc_msgSend as *const c_void);
-            let result = objc2::exception::catch(std::panic::AssertUnwindSafe(|| {
-                func(inner as *const AnyObject, sel, block_ptr.0);
-            }));
-
-            match result {
-                Ok(()) => Ok(()),
-                Err(exception) => {
-                    let desc = match exception {
-                        Some(exc) => {
-                            let raw = &*exc as *const _ as *const AnyObject as *mut AnyObject;
-                            crate::ffi::nsstring_to_string(msg_send!(raw, description))
-                        }
-                        None => "unknown ObjC exception (nil)".to_string(),
-                    };
-                    Err(VZError::Internal {
-                        code: -2,
-                        message: format!("VM stop threw ObjC exception: {desc}"),
-                    })
-                }
-            }
-        });
-        stop_dispatch?;
-
-        // Poll for stopped state
-        let timeout = Duration::from_secs(10);
-        let start = std::time::Instant::now();
-
-        while self.state() != VirtualMachineState::Stopped {
-            if start.elapsed() > timeout {
-                return Err(VZError::Timeout("Stop operation timed out".into()));
-            }
-            tokio::time::sleep(Duration::from_millis(100)).await;
+        let (tx, rx) = oneshot::channel::<Result<(), String>>();
+        let ctx = Box::into_raw(Box::new(tx)) as *mut c_void;
+        // SAFETY: vm_box is valid; ctx ownership transfers to the
+        // exactly-once trampoline. The completion fires when the VM has
+        // stopped (or on error) per the VZ contract — no state polling.
+        unsafe {
+            crate::shim_ffi::abx_vm_stop(self.vm_box, ctx, state_trampoline);
         }
 
-        Ok(())
+        let result = rx.await.map_err(|_| VZError::Internal {
+            code: -1,
+            message: "Stop operation cancelled".into(),
+        })?;
+        result.map_err(|msg| VZError::OperationFailed(format!("VM stop failed: {msg}")))
     }
 
     /// Pauses the virtual machine.
@@ -288,62 +221,20 @@ impl VirtualMachine {
             });
         }
 
-        let inner = self.inner;
-        // SAFETY: Calling pauseWithCompletionHandler: on a valid VZVirtualMachine on its dispatch queue.
-        self.queue.sync(|| unsafe {
-            static PAUSE_BLOCK: OnceLock<BlockPtr> = OnceLock::new();
-
-            let block_ptr = PAUSE_BLOCK.get_or_init(|| {
-                #[repr(C)]
-                struct CompletionBlock {
-                    isa: *const c_void,
-                    flags: i32,
-                    reserved: i32,
-                    invoke: unsafe extern "C" fn(*const c_void, *mut AnyObject),
-                    descriptor: *const crate::ffi::BlockDescriptor,
-                }
-
-                unsafe extern "C" fn pause_handler(_block: *const c_void, error: *mut AnyObject) {
-                    // SAFETY: error is checked non-null. Sending localizedDescription to a valid NSError.
-                    unsafe {
-                        if !error.is_null() {
-                            let desc = msg_send!(error, localizedDescription);
-                            tracing::error!("VM pause failed: {}", nsstring_to_string(desc));
-                        }
-                    }
-                }
-
-                let stack_block = CompletionBlock {
-                    isa: _NSConcreteStackBlock,
-                    flags: 0,
-                    reserved: 0,
-                    invoke: pause_handler,
-                    descriptor: &SIMPLE_BLOCK_DESCRIPTOR,
-                };
-
-                let heap_block =
-                    _Block_copy(&stack_block as *const CompletionBlock as *const c_void);
-                BlockPtr(heap_block)
-            });
-
-            let sel = objc2::sel!(pauseWithCompletionHandler:);
-            let func: unsafe extern "C" fn(*const AnyObject, objc2::runtime::Sel, *const c_void) =
-                std::mem::transmute(crate::ffi::runtime::objc_msgSend as *const c_void);
-            func(inner as *const AnyObject, sel, block_ptr.0);
-        });
-
-        // Poll for paused state.
-        let timeout = Duration::from_secs(10);
-        let start = std::time::Instant::now();
-
-        while self.state() != VirtualMachineState::Paused {
-            if start.elapsed() > timeout {
-                return Err(VZError::Timeout("Pause operation timed out".into()));
-            }
-            tokio::time::sleep(Duration::from_millis(100)).await;
+        let (tx, rx) = oneshot::channel::<Result<(), String>>();
+        let ctx = Box::into_raw(Box::new(tx)) as *mut c_void;
+        // SAFETY: vm_box is valid; ctx ownership transfers to the
+        // exactly-once trampoline. The completion fires once the VM is
+        // paused (or on error) — no state polling.
+        unsafe {
+            crate::shim_ffi::abx_vm_pause(self.vm_box, ctx, state_trampoline);
         }
 
-        Ok(())
+        let result = rx.await.map_err(|_| VZError::Internal {
+            code: -1,
+            message: "Pause operation cancelled".into(),
+        })?;
+        result.map_err(|msg| VZError::OperationFailed(format!("VM pause failed: {msg}")))
     }
 
     /// Resumes a paused virtual machine.
@@ -358,62 +249,20 @@ impl VirtualMachine {
             });
         }
 
-        let inner = self.inner;
-        // SAFETY: Calling resumeWithCompletionHandler: on a valid VZVirtualMachine on its dispatch queue.
-        self.queue.sync(|| unsafe {
-            static RESUME_BLOCK: OnceLock<BlockPtr> = OnceLock::new();
-
-            let block_ptr = RESUME_BLOCK.get_or_init(|| {
-                #[repr(C)]
-                struct CompletionBlock {
-                    isa: *const c_void,
-                    flags: i32,
-                    reserved: i32,
-                    invoke: unsafe extern "C" fn(*const c_void, *mut AnyObject),
-                    descriptor: *const crate::ffi::BlockDescriptor,
-                }
-
-                unsafe extern "C" fn resume_handler(_block: *const c_void, error: *mut AnyObject) {
-                    // SAFETY: error is checked non-null. Sending localizedDescription to a valid NSError.
-                    unsafe {
-                        if !error.is_null() {
-                            let desc = msg_send!(error, localizedDescription);
-                            tracing::error!("VM resume failed: {}", nsstring_to_string(desc));
-                        }
-                    }
-                }
-
-                let stack_block = CompletionBlock {
-                    isa: _NSConcreteStackBlock,
-                    flags: 0,
-                    reserved: 0,
-                    invoke: resume_handler,
-                    descriptor: &SIMPLE_BLOCK_DESCRIPTOR,
-                };
-
-                let heap_block =
-                    _Block_copy(&stack_block as *const CompletionBlock as *const c_void);
-                BlockPtr(heap_block)
-            });
-
-            let sel = objc2::sel!(resumeWithCompletionHandler:);
-            let func: unsafe extern "C" fn(*const AnyObject, objc2::runtime::Sel, *const c_void) =
-                std::mem::transmute(crate::ffi::runtime::objc_msgSend as *const c_void);
-            func(inner as *const AnyObject, sel, block_ptr.0);
-        });
-
-        // Poll for running state.
-        let timeout = Duration::from_secs(10);
-        let start = std::time::Instant::now();
-
-        while self.state() != VirtualMachineState::Running {
-            if start.elapsed() > timeout {
-                return Err(VZError::Timeout("Resume operation timed out".into()));
-            }
-            tokio::time::sleep(Duration::from_millis(100)).await;
+        let (tx, rx) = oneshot::channel::<Result<(), String>>();
+        let ctx = Box::into_raw(Box::new(tx)) as *mut c_void;
+        // SAFETY: vm_box is valid; ctx ownership transfers to the
+        // exactly-once trampoline. The completion fires once the VM is
+        // running again (or on error) — no state polling.
+        unsafe {
+            crate::shim_ffi::abx_vm_resume(self.vm_box, ctx, state_trampoline);
         }
 
-        Ok(())
+        let result = rx.await.map_err(|_| VZError::Internal {
+            code: -1,
+            message: "Resume operation cancelled".into(),
+        })?;
+        result.map_err(|msg| VZError::OperationFailed(format!("VM resume failed: {msg}")))
     }
 
     /// Requests a graceful stop, asking the guest to shut down cleanly.
@@ -445,27 +294,17 @@ impl VirtualMachine {
     ///
     /// These can be used for vsock communication with the guest.
     pub fn socket_devices(&self) -> Vec<VirtioSocketDevice> {
-        // SAFETY: Sending socketDevices to a valid VZVirtualMachine on its
-        // queue (device-array properties are queue-affine). NSArray elements
-        // are valid VZVirtioSocketDevice pointers retained by the framework.
-        self.queue.sync(|| unsafe {
-            let devices: *mut AnyObject = msg_send!(self.inner, socketDevices);
-            if devices.is_null() {
-                return Vec::new();
-            }
-
-            let count = crate::ffi::nsarray_count(devices);
-            let mut result = Vec::with_capacity(count);
-
-            for i in 0..count {
-                let device = crate::ffi::nsarray_object_at_index(devices, i);
-                if !device.is_null() {
-                    result.push(VirtioSocketDevice::from_raw(device, self.queue.as_ptr()));
-                }
-            }
-
-            result
-        })
+        // SAFETY: vm_box is valid; the shim queue-syncs the reads and hands
+        // out +1 ABXSocketDeviceBox handles.
+        unsafe {
+            let count = crate::shim_ffi::abx_vm_socket_device_count(self.vm_box);
+            (0..count)
+                .filter_map(|i| {
+                    let device_box = crate::shim_ffi::abx_vm_socket_device_at(self.vm_box, i);
+                    (!device_box.is_null()).then(|| VirtioSocketDevice::from_box(device_box))
+                })
+                .collect()
+        }
     }
 
     /// Returns the memory balloon devices configured on this VM.
@@ -473,8 +312,17 @@ impl VirtualMachine {
     /// These can be used for dynamic memory management between host and guest.
     #[must_use]
     pub fn memory_balloon_devices(&self) -> Vec<MemoryBalloonDevice> {
-        self.queue
-            .sync(|| vm_memory_balloon_devices(self.inner, self.queue.as_ptr()))
+        // SAFETY: vm_box is valid; the shim queue-syncs the reads and hands
+        // out +1 ABXBalloonBox handles.
+        unsafe {
+            let count = crate::shim_ffi::abx_vm_balloon_count(self.vm_box);
+            (0..count)
+                .filter_map(|i| {
+                    let balloon_box = crate::shim_ffi::abx_vm_balloon_at(self.vm_box, i);
+                    (!balloon_box.is_null()).then(|| MemoryBalloonDevice::from_box(balloon_box))
+                })
+                .collect()
+        }
     }
 
     /// Returns the first memory balloon device, if any.
@@ -488,12 +336,11 @@ impl VirtualMachine {
 
 impl Drop for VirtualMachine {
     fn drop(&mut self) {
+        // `inner`/`queue` are borrows kept alive by the box — only the box's
+        // +1 is ours to release.
         if !self.vm_box.is_null() {
             // SAFETY: releasing the +1 box handle returned by the shim.
             unsafe { crate::shim_ffi::abx_object_release(self.vm_box) };
-        }
-        if !self.inner.is_null() {
-            crate::ffi::release(self.inner);
         }
     }
 }


### PR DESCRIPTION
## Summary

PR 9/11 of the ArcBoxVZShim migration (stacked on #421), two commits:

**Lifecycle completion.** `build()` creates the VM + serial queue in Swift (`abx_vm_new`); `stop`/`pause`/`resume` await per-call completions via the exactly-once `StateCb` trampoline. Deleted: the 100ms state-polling loops, the global `OnceLock` completion blocks (which could only log errors, never return them — callers now get the real framework error), and the last `objc2::exception::catch` site. `socket_devices`/`memory_balloon_devices` enumerate via queue-synced shim accessors; balloon target get/set is queue-synced in Swift (the dispatch_assert_queue crash class from the idle-balloon incident stays fenced). Both `*_box_from_raw` migration symbols die. Also fixes a pre-existing leak: device configs transferred via `into_ptr` were never released; `apply_devices` now borrows and the config's Drop releases every stored +1.

**DarwinVcpu dead-code drop** (arcbox-hypervisor): every construction site passed a null VM pointer, so the cross-thread transmuted `objc_msgSend` state poll — flagged during planning as the one consumer-side raw-ObjC bypass — was unreachable. `run()` becomes an honest managed-execution stub with identical observable behavior (−158 lines).

vm.rs retains transitional raw vm/queue borrows (kept alive by the box) solely for the installer path; they die next PR.

## Validation

- `cargo test -p arcbox-vz -p arcbox-hypervisor`, workspace clippy `-D warnings`, fmt, swift-format strict — green
- e2e `boot_assets` VZ + `backend_matrix` (results below); balloon runtime set/get additionally exercised by the daemon's idle path in the end-state acceptance run