### PR TITLE
feat(vz): route restore images and the IPSW installer through the shim

### DIFF
--- a/virt/arcbox-vz/shim/Sources/ArcBoxVZShim/Errors.swift
+++ b/virt/arcbox-vz/shim/Sources/ArcBoxVZShim/Errors.swift
@@ -14,7 +14,8 @@ import Foundation
 
 /// Mirrors `ABX_SHIM_ABI_VERSION` in src/shim_ffi.rs.
 /// Bump BOTH on any change to an exported symbol's signature or semantics.
-let abxShimABIVersion: UInt32 = 1
+/// v2: abx_vm_new dropped its transitional raw vm/queue out-params.
+let abxShimABIVersion: UInt32 = 2
 
 /// Copies a Swift string into a malloc'd C string owned by the caller (Rust).
 func abxStrdup(_ string: String) -> UnsafeMutablePointer<CChar>? {

--- a/virt/arcbox-vz/shim/Sources/ArcBoxVZShim/Exports.swift
+++ b/virt/arcbox-vz/shim/Sources/ArcBoxVZShim/Exports.swift
@@ -335,12 +335,8 @@ public func abxConfigSetDevices(
 }
 
 @_cdecl("abx_vm_new")
-public func abxVmNew(
-    _ config: UnsafeMutableRawPointer,
-    _ rawVmOut: UnsafeMutablePointer<UnsafeMutableRawPointer?>?,
-    _ rawQueueOut: UnsafeMutablePointer<UnsafeMutableRawPointer?>?
-) -> UnsafeMutableRawPointer {
-    vmNew(config, rawVmOut, rawQueueOut)
+public func abxVmNew(_ config: UnsafeMutableRawPointer) -> UnsafeMutableRawPointer {
+    vmNew(config)
 }
 
 @_cdecl("abx_vm_state")
@@ -439,4 +435,62 @@ public func abxBalloonTarget(_ box: UnsafeMutableRawPointer) -> UInt64 {
 @_cdecl("abx_balloon_set_target")
 public func abxBalloonSetTarget(_ box: UnsafeMutableRawPointer, _ bytes: UInt64) {
     balloonSetTarget(box, bytes)
+}
+
+// MARK: - Restore images / installer
+
+@_cdecl("abx_restore_image_load")
+public func abxRestoreImageLoad(
+    _ path: UnsafePointer<CChar>,
+    _ ctx: UnsafeMutableRawPointer?,
+    _ callback: @escaping ABXObjectCallback
+) {
+    restoreImageLoad(path, ctx, callback)
+}
+
+@_cdecl("abx_restore_image_fetch_latest")
+public func abxRestoreImageFetchLatest(
+    _ ctx: UnsafeMutableRawPointer?,
+    _ callback: @escaping ABXObjectCallback
+) {
+    restoreImageFetchLatest(ctx, callback)
+}
+
+@_cdecl("abx_restore_image_requirements")
+public func abxRestoreImageRequirements(
+    _ image: UnsafeMutableRawPointer,
+    _ hardwareModelOut: UnsafeMutablePointer<UnsafeMutableRawPointer?>?,
+    _ minCPUOut: UnsafeMutablePointer<UInt64>?,
+    _ minMemoryOut: UnsafeMutablePointer<UInt64>?,
+    _ errorOut: UnsafeMutablePointer<UnsafeMutablePointer<CChar>?>?
+) -> Bool {
+    restoreImageRequirements(image, hardwareModelOut, minCPUOut, minMemoryOut, errorOut)
+}
+
+@_cdecl("abx_restore_image_url")
+public func abxRestoreImageURL(
+    _ image: UnsafeMutableRawPointer
+) -> UnsafeMutablePointer<CChar>? {
+    restoreImageURL(image)
+}
+
+@_cdecl("abx_installer_new")
+public func abxInstallerNew(
+    _ vmBox: UnsafeMutableRawPointer, _ ipswPath: UnsafePointer<CChar>
+) -> UnsafeMutableRawPointer {
+    installerNew(vmBox, ipswPath)
+}
+
+@_cdecl("abx_installer_fraction")
+public func abxInstallerFraction(_ box: UnsafeMutableRawPointer) -> Double {
+    installerFraction(box)
+}
+
+@_cdecl("abx_installer_install")
+public func abxInstallerInstall(
+    _ box: UnsafeMutableRawPointer,
+    _ ctx: UnsafeMutableRawPointer?,
+    _ callback: @escaping ABXStateCallback
+) {
+    installerInstall(box, ctx, callback)
 }

--- a/virt/arcbox-vz/shim/Sources/ArcBoxVZShim/Installer.swift
+++ b/virt/arcbox-vz/shim/Sources/ArcBoxVZShim/Installer.swift
@@ -1,0 +1,119 @@
+// macOS restore images and the IPSW installer (mirrors src/restore.rs).
+//
+// Restore-image loads complete on a framework-internal queue; the installer
+// itself is queue-affine (its initializer dispatch_asserts the VM queue), so
+// construction and install-kickoff go through the VM box's queue.
+
+import Virtualization
+
+/// Object-producing completion: fires exactly once with either a +1 handle
+/// (owned by the receiver) or a strdup'd error message.
+public typealias ABXObjectCallback =
+    @convention(c) (
+        UnsafeMutableRawPointer?, UnsafeMutableRawPointer?, UnsafeMutablePointer<CChar>?
+    ) -> Void
+
+/// Pairs the installer with the VM's serial queue for install-kickoff.
+final class ABXInstallerBox {
+    let installer: VZMacOSInstaller
+    let queue: DispatchQueue
+
+    init(installer: VZMacOSInstaller, queue: DispatchQueue) {
+        self.installer = installer
+        self.queue = queue
+    }
+}
+
+private func deliverImage(
+    _ result: Result<VZMacOSRestoreImage, Error>,
+    _ ctx: UnsafeMutableRawPointer?,
+    _ callback: ABXObjectCallback
+) {
+    switch result {
+    case .success(let image):
+        callback(ctx, abxRetainedHandle(image), nil)
+    case .failure(let error):
+        callback(ctx, nil, abxErrorString(error))
+    }
+}
+
+func restoreImageLoad(
+    _ path: UnsafePointer<CChar>,
+    _ ctx: UnsafeMutableRawPointer?,
+    _ callback: @escaping ABXObjectCallback
+) {
+    let url = URL(fileURLWithPath: String(cString: path))
+    VZMacOSRestoreImage.load(from: url) { result in
+        deliverImage(result, ctx, callback)
+    }
+}
+
+func restoreImageFetchLatest(
+    _ ctx: UnsafeMutableRawPointer?,
+    _ callback: @escaping ABXObjectCallback
+) {
+    VZMacOSRestoreImage.fetchLatestSupported { result in
+        deliverImage(result, ctx, callback)
+    }
+}
+
+/// Extracts the most-featureful supported configuration: hardware model
+/// (+1 handle), minimum CPU count, and minimum memory size.
+func restoreImageRequirements(
+    _ image: UnsafeMutableRawPointer,
+    _ hardwareModelOut: UnsafeMutablePointer<UnsafeMutableRawPointer?>?,
+    _ minCPUOut: UnsafeMutablePointer<UInt64>?,
+    _ minMemoryOut: UnsafeMutablePointer<UInt64>?,
+    _ errorOut: UnsafeMutablePointer<UnsafeMutablePointer<CChar>?>?
+) -> Bool {
+    let restoreImage = abxBorrow(image, as: VZMacOSRestoreImage.self)
+    guard let requirements = restoreImage.mostFeaturefulSupportedConfiguration else {
+        errorOut?.pointee = abxStrdup("restore image has no supported configuration")
+        return false
+    }
+    hardwareModelOut?.pointee = abxRetainedHandle(requirements.hardwareModel)
+    minCPUOut?.pointee = UInt64(requirements.minimumSupportedCPUCount)
+    minMemoryOut?.pointee = requirements.minimumSupportedMemorySize
+    return true
+}
+
+/// Returns the image URL as a strdup'd absolute string, or nil.
+func restoreImageURL(_ image: UnsafeMutableRawPointer) -> UnsafeMutablePointer<CChar>? {
+    abxStrdup(abxBorrow(image, as: VZMacOSRestoreImage.self).url.absoluteString)
+}
+
+func installerNew(
+    _ vmBox: UnsafeMutableRawPointer,
+    _ ipswPath: UnsafePointer<CChar>
+) -> UnsafeMutableRawPointer {
+    let box = abxBorrow(vmBox, as: ABXVMBox.self)
+    let url = URL(fileURLWithPath: String(cString: ipswPath))
+    // VZMacOSInstaller's initializer dispatch_asserts the VM's queue.
+    let installer = box.queue.sync {
+        VZMacOSInstaller(virtualMachine: box.vm, restoringFromImageAt: url)
+    }
+    return abxRetainedHandle(ABXInstallerBox(installer: installer, queue: box.queue))
+}
+
+/// Install progress as a fraction in 0.0...1.0 (NSProgress read; queue-free).
+func installerFraction(_ box: UnsafeMutableRawPointer) -> Double {
+    abxBorrow(box, as: ABXInstallerBox.self).installer.progress.fractionCompleted
+}
+
+func installerInstall(
+    _ box: UnsafeMutableRawPointer,
+    _ ctx: UnsafeMutableRawPointer?,
+    _ callback: @escaping ABXStateCallback
+) {
+    let installerBox = abxBorrow(box, as: ABXInstallerBox.self)
+    installerBox.queue.sync {
+        installerBox.installer.install { result in
+            switch result {
+            case .success:
+                callback(ctx, nil)
+            case .failure(let error):
+                callback(ctx, abxErrorString(error))
+            }
+        }
+    }
+}

--- a/virt/arcbox-vz/shim/Sources/ArcBoxVZShim/Lifecycle.swift
+++ b/virt/arcbox-vz/shim/Sources/ArcBoxVZShim/Lifecycle.swift
@@ -98,20 +98,10 @@ func configSetDevices(
 }
 
 /// Creates the VM on a fresh serial queue and returns its box.
-///
-/// The raw out-params are transitional (the installer still drives the raw
-/// VZVirtualMachine on its queue from the Rust side); they die with the
-/// installer migration. Both are borrowed views kept alive by the box.
-func vmNew(
-    _ config: UnsafeMutableRawPointer,
-    _ rawVmOut: UnsafeMutablePointer<UnsafeMutableRawPointer?>?,
-    _ rawQueueOut: UnsafeMutablePointer<UnsafeMutableRawPointer?>?
-) -> UnsafeMutableRawPointer {
+func vmNew(_ config: UnsafeMutableRawPointer) -> UnsafeMutableRawPointer {
     let cfg = abxBorrow(config, as: VZVirtualMachineConfiguration.self)
     let queue = DispatchQueue(label: "com.arcbox.vz.vm")
     let vm = VZVirtualMachine(configuration: cfg, queue: queue)
-    rawVmOut?.pointee = Unmanaged.passUnretained(vm).toOpaque()
-    rawQueueOut?.pointee = Unmanaged.passUnretained(queue).toOpaque()
     return abxRetainedHandle(ABXVMBox(vm: vm, queue: queue))
 }
 

--- a/virt/arcbox-vz/src/configuration/mac.rs
+++ b/virt/arcbox-vz/src/configuration/mac.rs
@@ -14,7 +14,6 @@ use std::ptr;
 use objc2::runtime::AnyObject;
 
 use crate::error::{VZError, VZResult};
-use crate::ffi::retain;
 use crate::shim_ffi;
 
 /// Converts a path to a `CString`, rejecting interior NUL bytes.
@@ -93,14 +92,15 @@ impl MacHardwareModel {
         }
     }
 
-    /// Wraps a hardware-model pointer borrowed from the framework (for example a
-    /// restore image's requirements), retaining it so it outlives its source.
-    pub(crate) fn from_retained_ptr(ptr: *mut AnyObject) -> Option<Self> {
-        if ptr.is_null() {
+    /// Wraps a +1 hardware-model handle produced by the shim (for example a
+    /// restore image's requirements); the handle is released by Drop.
+    pub(crate) fn from_owned_handle(handle: *mut c_void) -> Option<Self> {
+        if handle.is_null() {
             return None;
         }
-        // SAFETY: ptr is a valid VZMacHardwareModel; retain balances the release in Drop.
-        Some(Self { inner: retain(ptr) })
+        Some(Self {
+            inner: handle as *mut AnyObject,
+        })
     }
 
     pub(crate) fn as_ptr(&self) -> *mut AnyObject {

--- a/virt/arcbox-vz/src/configuration/vm_config.rs
+++ b/virt/arcbox-vz/src/configuration/vm_config.rs
@@ -207,18 +207,10 @@ impl VirtualMachineConfiguration {
         self.validate()?;
 
         // SAFETY: self.inner is a validated configuration handle. The shim
-        // creates the VM on a fresh serial queue and returns a +1 box; the
-        // raw out-pointers are transitional borrows kept alive by that box.
+        // creates the VM on a fresh serial queue and returns a +1 box.
         unsafe {
-            let mut raw_vm: *mut std::ffi::c_void = ptr::null_mut();
-            let mut raw_queue: *mut std::ffi::c_void = ptr::null_mut();
-            let vm_box =
-                crate::shim_ffi::abx_vm_new(self.inner.cast(), &mut raw_vm, &mut raw_queue);
-            Ok(VirtualMachine::from_box(
-                vm_box,
-                raw_vm as *mut AnyObject,
-                raw_queue as *mut AnyObject,
-            ))
+            let vm_box = crate::shim_ffi::abx_vm_new(self.inner.cast());
+            Ok(VirtualMachine::from_box(vm_box))
         }
     }
 

--- a/virt/arcbox-vz/src/restore.rs
+++ b/virt/arcbox-vz/src/restore.rs
@@ -6,22 +6,18 @@
 //! the inputs to a [`MacPlatform`](crate::MacPlatform) and a
 //! [`MacAuxiliaryStorage`](crate::MacAuxiliaryStorage).
 
-use std::ffi::c_void;
+use std::ffi::{CString, c_char, c_void};
 use std::path::Path;
+use std::ptr;
 use std::time::Duration;
 
-use objc2::runtime::{AnyClass, AnyObject};
 use tokio::sync::oneshot;
 use tokio::time::sleep;
 
 use crate::configuration::MacHardwareModel;
 use crate::error::{VZError, VZResult};
-use crate::ffi::{
-    _Block_release, ObjectResult, StateResult, create_object_completion_block,
-    create_state_completion_block, get_class, nsstring_to_string, nsurl_file_path, release,
-};
-use crate::vm::VirtualMachine;
-use crate::{msg_send, msg_send_u64, msg_send_void};
+use crate::shim_ffi;
+use crate::vm::{VirtualMachine, state_trampoline};
 
 /// The most-featureful configuration a restore image supports.
 pub struct MacOSConfigurationRequirements {
@@ -33,12 +29,34 @@ pub struct MacOSConfigurationRequirements {
     pub minimum_memory_size: u64,
 }
 
-/// A macOS restore image — a local IPSW or the latest version Apple publishes.
-pub struct MacOSRestoreImage {
-    inner: *mut AnyObject,
+/// Shim object-completion trampoline: consumes the boxed sender exactly once.
+///
+/// If the receiver is gone (cancelled load), the +1 handle is released here
+/// so the object doesn't leak.
+unsafe extern "C" fn object_trampoline(ctx: *mut c_void, handle: *mut c_void, err: *mut c_char) {
+    // SAFETY: ctx is the Box<Sender> leaked by the caller; the shim
+    // guarantees exactly-once invocation. err is null or a shim string.
+    unsafe {
+        let sender = Box::from_raw(ctx as *mut oneshot::Sender<Result<usize, String>>);
+        let result = if err.is_null() {
+            Ok(handle as usize)
+        } else {
+            Err(shim_ffi::take_error_string(err))
+        };
+        if let Err(Ok(bits)) = sender.send(result) {
+            // Receiver dropped: release the orphaned +1 handle.
+            shim_ffi::abx_object_release(bits as *mut c_void);
+        }
+    }
 }
 
-// SAFETY: Inner ObjC pointer is only used via msg_send! which dispatches to the ObjC runtime.
+/// A macOS restore image — a local IPSW or the latest version Apple publishes.
+pub struct MacOSRestoreImage {
+    inner: *mut c_void,
+}
+
+// SAFETY: The handle refers to an immutable VZMacOSRestoreImage; all access
+// goes through the shim.
 unsafe impl Send for MacOSRestoreImage {}
 
 impl MacOSRestoreImage {
@@ -49,66 +67,36 @@ impl MacOSRestoreImage {
     ///
     /// # Errors
     ///
-    /// Returns an error if `VZMacOSRestoreImage` is unavailable or the fetch fails.
+    /// Returns an error if the fetch fails.
     pub async fn latest_supported() -> VZResult<Self> {
-        let cls = get_class("VZMacOSRestoreImage").ok_or_else(|| VZError::Internal {
-            code: -1,
-            message: "VZMacOSRestoreImage class not found".into(),
-        })?;
-        let (tx, rx) = oneshot::channel::<ObjectResult>();
-        let block = create_object_completion_block(tx);
-        // SAFETY: +fetchLatestSupportedWithCompletionHandler: takes one block argument
-        // and returns void; `block` is a heap-copied block released after the await.
-        unsafe {
-            let sel = objc2::sel!(fetchLatestSupportedWithCompletionHandler:);
-            let func: unsafe extern "C" fn(*const AnyClass, objc2::runtime::Sel, *const c_void) =
-                std::mem::transmute(crate::ffi::runtime::objc_msgSend as *const c_void);
-            func(cls, sel, block);
-        }
-        let received = rx.await;
-        // SAFETY: `block` was returned by create_object_completion_block and not released elsewhere.
-        unsafe { _Block_release(block) };
-        Self::from_received(received)
+        let (tx, rx) = oneshot::channel::<Result<usize, String>>();
+        let ctx = Box::into_raw(Box::new(tx)) as *mut c_void;
+        // SAFETY: ctx ownership transfers to the exactly-once trampoline.
+        unsafe { shim_ffi::abx_restore_image_fetch_latest(ctx, object_trampoline) };
+        Self::from_received(rx.await)
     }
 
     /// Loads a restore image from a local file (an IPSW).
     ///
     /// # Errors
     ///
-    /// Returns an error if `VZMacOSRestoreImage` is unavailable or the file cannot
-    /// be loaded as a restore image.
+    /// Returns an error if the file cannot be loaded as a restore image.
     pub async fn load_from_url(path: impl AsRef<Path>) -> VZResult<Self> {
-        let path_str = path.as_ref().to_string_lossy();
-        let cls = get_class("VZMacOSRestoreImage").ok_or_else(|| VZError::Internal {
-            code: -1,
-            message: "VZMacOSRestoreImage class not found".into(),
+        let c_path = CString::new(path.as_ref().to_string_lossy().as_bytes()).map_err(|_| {
+            VZError::InvalidConfiguration(format!("path contains NUL: {}", path.as_ref().display()))
         })?;
-        let (tx, rx) = oneshot::channel::<ObjectResult>();
-        let block = create_object_completion_block(tx);
-        // SAFETY: +loadFileURL:completionHandler: takes an NSURL and a block and returns
-        // void; `block` is a heap-copied block released after the await. The method
-        // retains the NSURL synchronously, so the +1 from nsurl_file_path is released
-        // immediately after the call.
-        unsafe {
-            let url = nsurl_file_path(&path_str);
-            let sel = objc2::sel!(loadFileURL:completionHandler:);
-            let func: unsafe extern "C" fn(
-                *const AnyClass,
-                objc2::runtime::Sel,
-                *const AnyObject,
-                *const c_void,
-            ) = std::mem::transmute(crate::ffi::runtime::objc_msgSend as *const c_void);
-            func(cls, sel, url as *const AnyObject, block);
-            release(url);
-        }
-        let received = rx.await;
-        // SAFETY: `block` was returned by create_object_completion_block and not released elsewhere.
-        unsafe { _Block_release(block) };
-        Self::from_received(received)
+        let (tx, rx) = oneshot::channel::<Result<usize, String>>();
+        let ctx = Box::into_raw(Box::new(tx)) as *mut c_void;
+        // SAFETY: c_path is valid for the duration of the call; ctx ownership
+        // transfers to the exactly-once trampoline.
+        unsafe { shim_ffi::abx_restore_image_load(c_path.as_ptr(), ctx, object_trampoline) };
+        Self::from_received(rx.await)
     }
 
-    /// Wraps the result delivered by the completion block into a restore image.
-    fn from_received(received: Result<ObjectResult, oneshot::error::RecvError>) -> VZResult<Self> {
+    /// Wraps the +1 handle delivered by the completion trampoline.
+    fn from_received(
+        received: Result<Result<usize, String>, oneshot::error::RecvError>,
+    ) -> VZResult<Self> {
         let bits = received
             .map_err(|_| VZError::Internal {
                 code: -1,
@@ -116,7 +104,7 @@ impl MacOSRestoreImage {
             })?
             .map_err(|message| VZError::Internal { code: -1, message })?;
         Ok(Self {
-            inner: bits as *mut AnyObject,
+            inner: bits as *mut c_void,
         })
     }
 
@@ -126,25 +114,33 @@ impl MacOSRestoreImage {
     ///
     /// Returns an error if the restore image exposes no supported configuration.
     pub fn requirements(&self) -> VZResult<MacOSConfigurationRequirements> {
-        // SAFETY: mostFeaturefulSupportedConfiguration and its properties are read from
-        // a valid VZMacOSRestoreImage; the returned objects are owned by the framework.
+        // SAFETY: inner is a valid image handle; on success the shim writes a
+        // +1 hardware-model handle owned by the returned wrapper.
         unsafe {
-            let reqs = msg_send!(self.inner, mostFeaturefulSupportedConfiguration);
-            if reqs.is_null() {
-                return Err(VZError::InvalidConfiguration(
-                    "restore image has no supported configuration".into(),
-                ));
+            let mut hw: *mut c_void = ptr::null_mut();
+            let mut min_cpu: u64 = 0;
+            let mut min_memory: u64 = 0;
+            let mut error: *mut c_char = ptr::null_mut();
+            if !shim_ffi::abx_restore_image_requirements(
+                self.inner,
+                &mut hw,
+                &mut min_cpu,
+                &mut min_memory,
+                &mut error,
+            ) {
+                return Err(VZError::InvalidConfiguration(shim_ffi::take_error_string(
+                    error,
+                )));
             }
-            let hw_ptr = msg_send!(reqs, hardwareModel);
-            let hardware_model = MacHardwareModel::from_retained_ptr(hw_ptr).ok_or_else(|| {
-                VZError::InvalidConfiguration("restore image has no hardware model".into())
-            })?;
-            let minimum_cpu_count = msg_send_u64!(reqs, minimumSupportedCPUCount);
-            let minimum_memory_size = msg_send_u64!(reqs, minimumSupportedMemorySize);
+            let hardware_model =
+                MacHardwareModel::from_owned_handle(hw).ok_or_else(|| VZError::Internal {
+                    code: -1,
+                    message: "restore image requirements returned no hardware model".into(),
+                })?;
             Ok(MacOSConfigurationRequirements {
                 hardware_model,
-                minimum_cpu_count,
-                minimum_memory_size,
+                minimum_cpu_count: min_cpu,
+                minimum_memory_size: min_memory,
             })
         }
     }
@@ -156,16 +152,11 @@ impl MacOSRestoreImage {
     /// [`load_from_url`](Self::load_from_url) it is the local file URL.
     #[must_use]
     pub fn url(&self) -> Option<String> {
-        // SAFETY: URL is a readonly property returning an NSURL owned by the image;
-        // absoluteString returns an NSString that nsstring_to_string only reads.
+        // SAFETY: inner is a valid image handle; the returned string is
+        // shim-allocated and consumed by take_string.
         unsafe {
-            let url = msg_send!(self.inner, URL);
-            if url.is_null() {
-                return None;
-            }
-            let s = msg_send!(url, absoluteString);
-            let out = nsstring_to_string(s);
-            if out.is_empty() { None } else { Some(out) }
+            let s = shim_ffi::abx_restore_image_url(self.inner);
+            shim_ffi::take_string(s).filter(|url| !url.is_empty())
         }
     }
 }
@@ -173,7 +164,8 @@ impl MacOSRestoreImage {
 impl Drop for MacOSRestoreImage {
     fn drop(&mut self) {
         if !self.inner.is_null() {
-            release(self.inner);
+            // SAFETY: releasing the +1 handle delivered by the trampoline.
+            unsafe { shim_ffi::abx_object_release(self.inner) };
         }
     }
 }
@@ -184,11 +176,11 @@ impl Drop for MacOSRestoreImage {
 /// local restore image (IPSW), then drive [`install`](Self::install) — a long
 /// operation (tens of minutes) that reports progress as it runs.
 pub struct MacOSInstaller {
-    inner: *mut AnyObject,
-    progress: *mut AnyObject,
+    inner: *mut c_void,
 }
 
-// SAFETY: Inner ObjC pointers are only used via msg_send! which dispatches to the ObjC runtime.
+// SAFETY: The box handle is only used through the shim, which serializes the
+// queue-affine installer operations on the VM's queue.
 unsafe impl Send for MacOSInstaller {}
 
 impl MacOSInstaller {
@@ -199,82 +191,52 @@ impl MacOSInstaller {
     ///
     /// # Errors
     ///
-    /// Returns an error if `VZMacOSInstaller` is unavailable or cannot be created.
+    /// Returns an error if the path is not representable.
     pub fn new(
         virtual_machine: &VirtualMachine,
         restore_image_path: impl AsRef<Path>,
     ) -> VZResult<Self> {
-        let path_str = restore_image_path.as_ref().to_string_lossy().into_owned();
-        let vm_ptr = virtual_machine.as_ptr();
-        // VZMacOSInstaller's initializer asserts (dispatch_assert_queue) that it runs on
-        // the VM's dispatch queue, so construct it there.
-        let (inner, progress) = virtual_machine.dispatch_sync(|| {
-            // SAFETY: alloc/initWithVirtualMachine:restoreImageURL: on VZMacOSInstaller with
-            // a valid VM pointer and an NSURL from a local path. Result checked non-null.
-            unsafe {
-                let cls = get_class("VZMacOSInstaller").ok_or_else(|| VZError::Internal {
-                    code: -1,
-                    message: "VZMacOSInstaller class not found".into(),
-                })?;
-                let url = nsurl_file_path(&path_str);
-                let alloc = msg_send!(cls, alloc);
-                let obj = msg_send!(
-                    alloc,
-                    initWithVirtualMachine: vm_ptr,
-                    restoreImageURL: url
-                );
-                // The initializer retains the NSURL; release the +1 from nsurl_file_path
-                // (also covers the error path below).
-                release(url);
-                if obj.is_null() {
-                    return Err(VZError::InvalidConfiguration(
-                        "failed to create VZMacOSInstaller".into(),
-                    ));
-                }
-                let progress = msg_send!(obj, progress);
-                Ok((obj, progress))
-            }
-        })?;
-        Ok(Self { inner, progress })
+        let c_path = CString::new(restore_image_path.as_ref().to_string_lossy().as_bytes())
+            .map_err(|_| {
+                VZError::InvalidConfiguration(format!(
+                    "path contains NUL: {}",
+                    restore_image_path.as_ref().display()
+                ))
+            })?;
+        // SAFETY: the VM box handle is valid; the shim constructs the
+        // installer on the VM's queue (its initializer asserts affinity) and
+        // returns a +1 installer box.
+        let obj = unsafe { shim_ffi::abx_installer_new(virtual_machine.vm_box(), c_path.as_ptr()) };
+        Ok(Self { inner: obj })
     }
 
     /// Returns installation progress as a fraction in `0.0..=1.0`.
     #[must_use]
     pub fn fraction_completed(&self) -> f64 {
-        if self.progress.is_null() {
-            return 0.0;
-        }
-        // SAFETY: fractionCompleted returns a double from a valid NSProgress.
-        unsafe {
-            let sel = objc2::sel!(fractionCompleted);
-            let func: unsafe extern "C" fn(*const AnyObject, objc2::runtime::Sel) -> f64 =
-                std::mem::transmute(crate::ffi::runtime::objc_msgSend as *const c_void);
-            func(self.progress as *const AnyObject, sel)
-        }
+        // SAFETY: inner is a valid installer box; NSProgress reads are
+        // queue-free.
+        unsafe { shim_ffi::abx_installer_fraction(self.inner) }
     }
 
     /// Installs macOS, invoking `on_progress` with the current fraction as it runs.
     ///
     /// `virtual_machine` must be the VM passed to [`new`](Self::new); the install is
-    /// dispatched on that VM's queue.
+    /// dispatched on that VM's queue (retained inside the installer box).
     ///
     /// # Errors
     ///
     /// Returns an error if installation fails.
     pub async fn install(
         &self,
-        virtual_machine: &VirtualMachine,
+        _virtual_machine: &VirtualMachine,
         mut on_progress: impl FnMut(f64),
     ) -> VZResult<()> {
-        let (tx, mut rx) = oneshot::channel::<StateResult>();
-        let block = create_state_completion_block(tx);
-        let installer = self.inner;
-        // Kick off the install on the VM's queue: the call returns immediately and the
-        // completion handler fires when installation finishes.
-        // SAFETY: installWithCompletionHandler: takes a heap-copied (NSError *) block.
-        virtual_machine.dispatch_sync(|| unsafe {
-            msg_send_void!(installer, installWithCompletionHandler: block);
-        });
+        let (tx, mut rx) = oneshot::channel::<Result<(), String>>();
+        let ctx = Box::into_raw(Box::new(tx)) as *mut c_void;
+        // SAFETY: inner is a valid installer box; ctx ownership transfers to
+        // the exactly-once trampoline. The shim issues the install on the
+        // VM's queue and the call returns after dispatching.
+        unsafe { shim_ffi::abx_installer_install(self.inner, ctx, state_trampoline) };
 
         let result = loop {
             tokio::select! {
@@ -290,8 +252,6 @@ impl MacOSInstaller {
                 }
             }
         };
-        // SAFETY: `block` was returned by create_state_completion_block and not released elsewhere.
-        unsafe { _Block_release(block) };
         result.map_err(|message| VZError::Internal { code: -1, message })
     }
 }
@@ -299,7 +259,8 @@ impl MacOSInstaller {
 impl Drop for MacOSInstaller {
     fn drop(&mut self) {
         if !self.inner.is_null() {
-            release(self.inner);
+            // SAFETY: releasing the +1 installer box handle from the shim.
+            unsafe { shim_ffi::abx_object_release(self.inner) };
         }
     }
 }

--- a/virt/arcbox-vz/src/restore.rs
+++ b/virt/arcbox-vz/src/restore.rs
@@ -220,8 +220,10 @@ impl MacOSInstaller {
 
     /// Installs macOS, invoking `on_progress` with the current fraction as it runs.
     ///
-    /// `virtual_machine` must be the VM passed to [`new`](Self::new); the install is
-    /// dispatched on that VM's queue (retained inside the installer box).
+    /// The install runs on the queue retained inside the installer box (the
+    /// VM's queue, captured at [`new`](Self::new)). `_virtual_machine` is kept
+    /// for public-API stability but is no longer read — the queue no longer
+    /// comes from this argument, so passing a different VM has no effect.
     ///
     /// # Errors
     ///

--- a/virt/arcbox-vz/src/shim_ffi.rs
+++ b/virt/arcbox-vz/src/shim_ffi.rs
@@ -27,12 +27,17 @@ pub type VsockCb =
 /// [`take_error_string`]).
 pub type StateCb = unsafe extern "C" fn(ctx: *mut c_void, err: *mut c_char);
 
+/// Object-producing completion: fires exactly once with either a +1 handle
+/// (owned by the receiver) or a strdup'd error message.
+pub type ObjectCb = unsafe extern "C" fn(ctx: *mut c_void, handle: *mut c_void, err: *mut c_char);
+
 /// Mirrors `abxShimABIVersion` in the shim; bump both on any signature change.
+/// v2: `abx_vm_new` dropped its transitional raw vm/queue out-params.
 #[allow(
     dead_code,
     reason = "drift detector: compared against abx_shim_version() by the boundary tests"
 )]
-pub const ABX_SHIM_ABI_VERSION: u32 = 1;
+pub const ABX_SHIM_ABI_VERSION: u32 = 2;
 
 unsafe extern "C" {
     // Errors / strings / handles
@@ -152,13 +157,7 @@ unsafe extern "C" {
         items: *const *mut c_void,
         count: usize,
     );
-    /// The raw out-params are transitional borrows for the installer path
-    /// (kept alive by the returned box); they die with the installer PR.
-    pub fn abx_vm_new(
-        config: *mut c_void,
-        raw_vm_out: *mut *mut c_void,
-        raw_queue_out: *mut *mut c_void,
-    ) -> *mut c_void;
+    pub fn abx_vm_new(config: *mut c_void) -> *mut c_void;
     pub fn abx_vm_state(vm_box: *mut c_void) -> i64;
     pub fn abx_vm_can_stop(vm_box: *mut c_void) -> bool;
     pub fn abx_vm_can_pause(vm_box: *mut c_void) -> bool;
@@ -174,6 +173,39 @@ unsafe extern "C" {
     pub fn abx_vm_balloon_at(vm_box: *mut c_void, index: u64) -> *mut c_void;
     pub fn abx_balloon_target(balloon_box: *mut c_void) -> u64;
     pub fn abx_balloon_set_target(balloon_box: *mut c_void, bytes: u64);
+
+    // Restore images / installer
+    pub fn abx_restore_image_load(path: *const c_char, ctx: *mut c_void, cb: ObjectCb);
+    pub fn abx_restore_image_fetch_latest(ctx: *mut c_void, cb: ObjectCb);
+    pub fn abx_restore_image_requirements(
+        image: *mut c_void,
+        hardware_model_out: *mut *mut c_void,
+        min_cpu_out: *mut u64,
+        min_memory_out: *mut u64,
+        error_out: *mut *mut c_char,
+    ) -> bool;
+    pub fn abx_restore_image_url(image: *mut c_void) -> *mut c_char;
+    pub fn abx_installer_new(vm_box: *mut c_void, ipsw_path: *const c_char) -> *mut c_void;
+    pub fn abx_installer_fraction(installer_box: *mut c_void) -> f64;
+    pub fn abx_installer_install(installer_box: *mut c_void, ctx: *mut c_void, cb: StateCb);
+}
+
+/// Takes ownership of a shim-returned string, or `None` if null.
+///
+/// # Safety
+///
+/// `ptr` must be null or a string allocated by the shim (strdup'd) that has
+/// not been freed yet.
+pub unsafe fn take_string(ptr: *mut c_char) -> Option<String> {
+    if ptr.is_null() {
+        return None;
+    }
+    // SAFETY: per contract, `ptr` is a valid NUL-terminated C string owned by us.
+    unsafe {
+        let out = std::ffi::CStr::from_ptr(ptr).to_string_lossy().into_owned();
+        abx_string_free(ptr);
+        Some(out)
+    }
 }
 
 /// Takes ownership of a shim-returned error string and frees it.
@@ -268,11 +300,18 @@ mod tests {
         abx_vm_balloon_at as *const (),
         abx_balloon_target as *const (),
         abx_balloon_set_target as *const (),
+        abx_restore_image_load as *const (),
+        abx_restore_image_fetch_latest as *const (),
+        abx_restore_image_requirements as *const (),
+        abx_restore_image_url as *const (),
+        abx_installer_new as *const (),
+        abx_installer_fraction as *const (),
+        abx_installer_install as *const (),
     ];
 
     /// Update when symbols are added; a mismatch means Exports.swift and this
     /// file have drifted.
-    const EXPECTED_SYMBOL_COUNT: usize = 65;
+    const EXPECTED_SYMBOL_COUNT: usize = 72;
 
     #[test]
     fn link_coverage() {

--- a/virt/arcbox-vz/src/vm.rs
+++ b/virt/arcbox-vz/src/vm.rs
@@ -2,9 +2,7 @@
 
 use crate::device::MemoryBalloonDevice;
 use crate::error::{VZError, VZResult};
-use crate::ffi::DispatchQueue;
 use crate::socket::VirtioSocketDevice;
-use objc2::runtime::AnyObject;
 use std::ffi::c_void;
 use tokio::sync::oneshot;
 
@@ -65,19 +63,18 @@ impl From<i64> for VirtualMachineState {
 /// This represents a VM that has been created from a `VirtualMachineConfiguration`.
 /// Use the async methods to control the VM lifecycle.
 pub struct VirtualMachine {
-    inner: *mut AnyObject,
-    queue: DispatchQueue,
-    /// ABXVMBox handle pairing the VM with its queue for shim calls.
+    /// ABXVMBox handle pairing the VM with its serial queue.
     vm_box: *mut c_void,
 }
 
-// SAFETY: The VZ handles are properly synchronized through the dispatch queue.
+// SAFETY: The box handle is only used through the shim, which serializes all
+// VZ operations on the VM's serial queue.
 unsafe impl Send for VirtualMachine {}
-// SAFETY: See above — all VZ operations are dispatched to the VM's serial queue.
+// SAFETY: See above — every operation dispatches onto the VM's serial queue.
 unsafe impl Sync for VirtualMachine {}
 
 /// Shim lifecycle-completion trampoline: consumes the boxed sender exactly once.
-unsafe extern "C" fn state_trampoline(ctx: *mut c_void, err: *mut std::ffi::c_char) {
+pub(crate) unsafe extern "C" fn state_trampoline(ctx: *mut c_void, err: *mut std::ffi::c_char) {
     // SAFETY: ctx is the Box<Sender> leaked by the caller; the shim
     // guarantees exactly-once invocation. err is null or a shim string that
     // take_error_string frees.
@@ -93,40 +90,17 @@ unsafe extern "C" fn state_trampoline(ctx: *mut c_void, err: *mut std::ffi::c_ch
 }
 
 impl VirtualMachine {
-    /// Creates a `VirtualMachine` from a shim box plus transitional raw views.
+    /// Wraps the +1 `ABXVMBox` handle produced by the shim.
     ///
     /// This is called internally by `VirtualMachineConfiguration::build()`.
-    /// `raw_vm`/`raw_queue` are borrows kept alive by `vm_box`; they exist
-    /// only for the installer path and die with its migration.
-    pub(crate) fn from_box(
-        vm_box: *mut c_void,
-        raw_vm: *mut AnyObject,
-        raw_queue: *mut AnyObject,
-    ) -> Self {
-        Self {
-            inner: raw_vm,
-            // SAFETY: raw_queue is a valid dispatch queue kept alive by
-            // vm_box; the wrapper is non-owning.
-            queue: unsafe { DispatchQueue::from_raw(raw_queue) },
-            vm_box,
-        }
+    pub(crate) fn from_box(vm_box: *mut c_void) -> Self {
+        Self { vm_box }
     }
 
-    /// Returns the underlying `VZVirtualMachine` pointer.
-    pub(crate) fn as_ptr(&self) -> *mut AnyObject {
-        self.inner
-    }
-
-    /// Runs `f` synchronously on the VM's dispatch queue.
-    ///
-    /// All operations on a `VZVirtualMachine` must be issued on the queue it was
-    /// created with; this lets associated objects (such as the macOS installer)
-    /// dispatch onto it.
-    pub(crate) fn dispatch_sync<F, R>(&self, f: F) -> R
-    where
-        F: FnOnce() -> R,
-    {
-        self.queue.sync(f)
+    /// Returns the `ABXVMBox` handle for shim calls that target this VM
+    /// (e.g. installer construction).
+    pub(crate) fn vm_box(&self) -> *mut c_void {
+        self.vm_box
     }
 
     /// Returns the current state of the VM.


### PR DESCRIPTION
## Summary

PR 10/11 of the ArcBoxVZShim migration (stacked on #422). The last functional surface — restore images and the IPSW installer — moves to Swift: load/fetch complete via the exactly-once `ObjectCb` trampoline (a cancelled load now releases the orphaned +1 handle instead of leaking the image), `requirements()` extracts hardware model + min CPU/memory in one call, and the installer is constructed and kicked off on the VM's queue inside the shim (its initializer `dispatch_assert`s affinity). Progress stays the Rust-side 2s `fractionCompleted` poll — public API semantics unchanged.

With the installer off raw pointers, the transitional plumbing dies: `abx_vm_new` drops its raw vm/queue out-params (**shim ABI v2** — both mirrored constants bumped), `VirtualMachine` is now just the box handle, and `dispatch_sync`/`as_ptr` are gone.

## Validation

- `cargo test -p arcbox-vz` (22 + 10 doctests), workspace clippy `-D warnings`, fmt, swift-format strict — green
- CI-invisible feature validated locally: `cargo build -p arcbox-core --features macos-ipsw-install` + clippy with the feature — green (the IPSW consumers compile against the unchanged public API)
- e2e `boot_assets` VZ (result below) — the Linux-guest path re-validated after the ABI-v2 signature change