### PR TITLE
feat(release): ship vm-agent alongside arcbox-agent

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -219,10 +219,12 @@ jobs:
           retention-days: 5
 
   # ==========================================================================
-  # Build arcbox-agent (Linux guest binary, cross-compiled via musl)
+  # Build guest binaries (Linux, cross-compiled via musl): arcbox-agent (the
+  # System VM agent) and vm-agent (the sandbox microVM init, staged by the
+  # daemon next to arcbox-agent — see app/arcbox-daemon/src/startup/assets.rs).
   # ==========================================================================
   build-agent:
-    name: Build arcbox-agent (Linux musl)
+    name: Build guest binaries (Linux musl)
     runs-on: macos-26
     timeout-minutes: 20
 
@@ -252,20 +254,26 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-cargo-agent-musl-
 
-      - name: Build arcbox-agent
+      - name: Build guest binaries
         timeout-minutes: 10
-        run: cargo build --release --locked -p arcbox-agent --target aarch64-unknown-linux-musl
-
-      - name: Verify artifact
         run: |
-          ls -lh target/aarch64-unknown-linux-musl/release/arcbox-agent
-          file target/aarch64-unknown-linux-musl/release/arcbox-agent
+          cargo build --release --locked -p arcbox-agent --target aarch64-unknown-linux-musl
+          cargo build --release --locked -p arcbox-vm --bin vm-agent --target aarch64-unknown-linux-musl
 
-      - name: Upload agent binary
+      - name: Verify artifacts
+        run: |
+          for bin in arcbox-agent vm-agent; do
+            ls -lh "target/aarch64-unknown-linux-musl/release/$bin"
+            file "target/aarch64-unknown-linux-musl/release/$bin"
+          done
+
+      - name: Upload guest binaries
         uses: actions/upload-artifact@v4
         with:
           name: agent-binary-linux-arm64
-          path: target/aarch64-unknown-linux-musl/release/arcbox-agent
+          path: |
+            target/aarch64-unknown-linux-musl/release/arcbox-agent
+            target/aarch64-unknown-linux-musl/release/vm-agent
           retention-days: 5
 
   # ==========================================================================

--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,7 @@ build-helper:
 
 build-agent:
 	cargo build -p arcbox-agent --target $(AGENT_TARGET) --release
+	cargo build -p arcbox-vm --bin vm-agent --target $(AGENT_TARGET) --release
 
 build-fleet-agent:
 	cargo build -p arcbox-fleet-agent $(CARGO_FLAGS)

--- a/xtask/src/commands/release/package_tarball.rs
+++ b/xtask/src/commands/release/package_tarball.rs
@@ -30,6 +30,10 @@ pub fn run(args: PackageTarballArgs) -> Result<()> {
         args.agent_artifacts.join("arcbox-agent"),
         staging.join("arcbox-agent"),
     )?;
+    super::stage_executable(
+        args.agent_artifacts.join("vm-agent"),
+        staging.join("vm-agent"),
+    )?;
     xtask_fs::copy_file(
         args.host_artifacts.join("bundle/arcbox.entitlements"),
         staging.join("bundle/arcbox.entitlements"),
@@ -117,6 +121,7 @@ mod tests {
             b"plist",
         );
         write_mode_644(&agent.join("arcbox-agent"), b"bin");
+        write_mode_644(&agent.join("vm-agent"), b"bin");
 
         let output_dir = dir.path().join("out");
         run(PackageTarballArgs {


### PR DESCRIPTION
## Problem

`abctl sandbox create` against a bundled daemon fails:

```
core error: default rootfs: vm-agent not found at /arcbox/bin/vm-agent; it is staged by the host daemon next to arcbox-agent
```

The daemon's bundle-seed (`app/arcbox-daemon/src/startup/assets.rs`, step 4) already stages `Resources/bin/vm-agent` into `<data_dir>/bin/`, and the guest rootfs builder requires it — but the release pipeline never built or published the binary, so app bundles ship without it and the seed silently skips.

## Change

- **release.yml**: the musl guest-binary job now also builds `vm-agent` (`-p arcbox-vm --bin vm-agent`) and uploads it in the same artifact.
- **xtask release package-tarball**: stages `vm-agent` into the release tarball (flat, next to `arcbox-agent`); regression test updated.
- **Makefile `build-agent`**: builds both guest binaries, so the desktop DMG source-build path (`make build-rust` → this target) picks vm-agent up automatically.

## Companion

arcbox-desktop PR embeds `vm-agent` from the tarball/local build into `Resources/bin/` (Xcode embed phase + DMG packager). Missing `vm-agent` stays warn-skip there, so this PR is safe to merge first; the fix reaches users with the next arcbox release + desktop `arcbox.version` bump.

## Validation

- `cargo test -p xtask` (tarball layout + mode regression) green
- `make build-agent` builds both musl binaries
- `cargo fmt` / `clippy -D warnings` clean