### PR TITLE
fix(net): propagate upstream death to the guest as RST on every egress path (ABX-431)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -750,7 +750,7 @@ version = "0.4.19"
 dependencies = [
  "arcbox-virtio",
  "crossbeam-channel",
- "socket2 0.6.5",
+ "socket2 0.6.4",
  "tracing",
 ]
 
@@ -3084,7 +3084,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.4",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -4896,7 +4896,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.5.10",
+ "socket2 0.6.4",
  "thiserror",
  "tokio",
  "tracing",
@@ -4934,7 +4934,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.4",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -5973,9 +5973,9 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.6.5"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
+checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
@@ -6001,7 +6001,7 @@ dependencies = [
  "arcbox-proxy",
  "crossbeam-channel",
  "libc",
- "socket2 0.6.5",
+ "socket2 0.6.4",
  "tokio",
  "tracing",
 ]
@@ -6340,7 +6340,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.6.5",
+ "socket2 0.6.4",
  "tokio-macros",
  "tracing",
  "windows-sys 0.61.2",
@@ -6543,7 +6543,7 @@ dependencies = [
  "hyper-util",
  "percent-encoding",
  "pin-project",
- "socket2 0.6.5",
+ "socket2 0.6.4",
  "sync_wrapper",
  "tokio",
  "tokio-rustls",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -750,6 +750,7 @@ version = "0.4.19"
 dependencies = [
  "arcbox-virtio",
  "crossbeam-channel",
+ "socket2 0.6.5",
  "tracing",
 ]
 
@@ -3083,7 +3084,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.4",
+ "socket2 0.5.10",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -4895,7 +4896,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.6.4",
+ "socket2 0.5.10",
  "thiserror",
  "tokio",
  "tracing",
@@ -4933,7 +4934,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.4",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -5972,9 +5973,9 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.6.4"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
+checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
@@ -6000,6 +6001,7 @@ dependencies = [
  "arcbox-proxy",
  "crossbeam-channel",
  "libc",
+ "socket2 0.6.5",
  "tokio",
  "tracing",
 ]
@@ -6338,7 +6340,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.6.4",
+ "socket2 0.6.5",
  "tokio-macros",
  "tracing",
  "windows-sys 0.61.2",
@@ -6541,7 +6543,7 @@ dependencies = [
  "hyper-util",
  "percent-encoding",
  "pin-project",
- "socket2 0.6.4",
+ "socket2 0.6.5",
  "sync_wrapper",
  "tokio",
  "tokio-rustls",

--- a/common/splicetcp/Cargo.toml
+++ b/common/splicetcp/Cargo.toml
@@ -30,4 +30,4 @@ tokio-frame-sink = []
 workspace = true
 
 [dev-dependencies]
-socket2 = "0.6.5"
+socket2 = "0.6"

--- a/common/splicetcp/Cargo.toml
+++ b/common/splicetcp/Cargo.toml
@@ -28,3 +28,6 @@ tokio-frame-sink = []
 
 [lints]
 workspace = true
+
+[dev-dependencies]
+socket2 = "0.6.5"

--- a/common/splicetcp/src/direct_rx.rs
+++ b/common/splicetcp/src/direct_rx.rs
@@ -91,11 +91,14 @@ pub struct PromotedConn {
     pub gw_mac: [u8; 6],
     /// Guest MAC for Ethernet destination.
     pub guest_mac: [u8; 6],
-    /// Set by the sink owner when the host stream dies (EOF or error) and no
-    /// further guest-bound frames will be produced. The bridge polls this to
-    /// reap its inline-owned `FastPathConn` entry — without it the entry
-    /// leaks, because `poll_fast_path` skips inline-owned flows and a
-    /// RST-terminated guest never sends another frame for the flow (ABX-431).
+    /// Set by the sink owner when the host stream died mid-stream (error,
+    /// not clean EOF) and the guest has been RST-terminated. The bridge
+    /// polls this to reap its inline-owned `FastPathConn` entry — a
+    /// RST-terminated guest never sends another frame for the flow, so
+    /// nothing else removes it (ABX-431). After a clean EOF the flag stays
+    /// unset: the entry must survive so the guest's ACK/FIN and half-close
+    /// writes still reach `try_fast_path_intercept` (parity with the
+    /// non-inline path).
     pub dead: std::sync::Arc<std::sync::atomic::AtomicBool>,
 }
 
@@ -240,9 +243,6 @@ async fn read_promoted_conn(
     frames: mpsc::Sender<Vec<u8>>,
 ) {
     let mut buf = vec![0u8; 32 * 1024];
-    // Every exit from this loop marks the conn dead so the bridge reaps its
-    // inline-owned entry (ABX-431).
-    let _dead_guard = SetOnDrop(Arc::clone(&conn.dead));
     loop {
         match stream.read(&mut buf).await {
             Ok(0) => {
@@ -319,21 +319,16 @@ async fn read_promoted_conn(
                     src_mac: conn.gw_mac,
                     dst_mac: conn.guest_mac,
                 });
+                // RST-terminated: the guest sends no further frames for
+                // this flow, so tell the bridge to reap its inline-owned
+                // entry. A clean EOF deliberately leaves `dead` unset — the
+                // entry must survive for the guest's ACK/FIN and half-close
+                // writes (parity with the non-inline path).
+                conn.dead.store(true, Ordering::Relaxed);
                 let _ = frames.send(rst).await;
                 return;
             }
         }
-    }
-}
-
-/// Sets the flag when the owning task exits, however it exits.
-#[cfg(feature = "tokio-frame-sink")]
-struct SetOnDrop(Arc<std::sync::atomic::AtomicBool>);
-
-#[cfg(feature = "tokio-frame-sink")]
-impl Drop for SetOnDrop {
-    fn drop(&mut self) {
-        self.0.store(true, Ordering::Relaxed);
     }
 }
 
@@ -500,6 +495,51 @@ mod tests {
             "expected ≥4 clamped frames, got {}",
             frames.len()
         );
+    }
+
+    /// A clean upstream EOF sends FIN but must NOT mark the conn dead — the
+    /// bridge entry stays alive for the guest's close handshake and
+    /// half-close writes (parity with the non-inline path).
+    #[tokio::test]
+    async fn clean_eof_sends_fin_without_setting_dead() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let (client, accepted) = tokio::join!(tokio::net::TcpStream::connect(addr), async {
+            listener.accept().await.unwrap().0
+        },);
+        let client = client.unwrap();
+
+        let (sink, mut rx) = TokioFrameConnSink::channel(4);
+        let dead = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let conn = PromotedConn {
+            stream: accepted.into_std().unwrap(),
+            remote_ip: std::net::Ipv4Addr::new(203, 0, 113, 10),
+            guest_ip: std::net::Ipv4Addr::new(192, 168, 64, 2),
+            remote_port: 443,
+            guest_port: 50000,
+            peer_mss: 1460,
+            our_seq: Arc::new(AtomicU32::new(1000)),
+            last_ack: Arc::new(AtomicU32::new(2000)),
+            down_bytes: None,
+            gw_mac: [0x02, 0, 0, 0, 0, 1],
+            guest_mac: [0x02, 0, 0, 0, 0, 2],
+            dead: Arc::clone(&dead),
+        };
+        assert!(sink.send_conn(conn));
+
+        drop(client); // clean FIN
+
+        let frame = tokio::time::timeout(std::time::Duration::from_secs(2), rx.recv())
+            .await
+            .expect("frame within deadline")
+            .expect("a guest-bound frame");
+        let flags = frame[ETH_HEADER_LEN + 20 + 13];
+        assert_ne!(flags & 0x01, 0, "must be a FIN (flags {flags:#04x})");
+        assert_eq!(flags & 0x04, 0, "must not be a RST (flags {flags:#04x})");
+
+        // Give the read task time to exit, then confirm it left `dead` unset.
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        assert!(!dead.load(Ordering::Relaxed), "clean EOF must not set dead");
     }
 
     /// Upstream mid-stream death must reach the guest as a RST and mark the

--- a/common/splicetcp/src/direct_rx.rs
+++ b/common/splicetcp/src/direct_rx.rs
@@ -11,7 +11,7 @@ use std::sync::atomic::Ordering;
 
 #[cfg(feature = "tokio-frame-sink")]
 use arcbox_packet::ethernet::{
-    ETH_HEADER_LEN, TcpFrameParams, build_tcp_data_frame, build_tcp_fin_frame,
+    ETH_HEADER_LEN, TcpFrameParams, build_tcp_data_frame, build_tcp_fin_frame, build_tcp_rst_frame,
 };
 #[cfg(feature = "tokio-frame-sink")]
 use tokio::io::AsyncReadExt;
@@ -91,6 +91,12 @@ pub struct PromotedConn {
     pub gw_mac: [u8; 6],
     /// Guest MAC for Ethernet destination.
     pub guest_mac: [u8; 6],
+    /// Set by the sink owner when the host stream dies (EOF or error) and no
+    /// further guest-bound frames will be produced. The bridge polls this to
+    /// reap its inline-owned `FastPathConn` entry — without it the entry
+    /// leaks, because `poll_fast_path` skips inline-owned flows and a
+    /// RST-terminated guest never sends another frame for the flow (ABX-431).
+    pub dead: std::sync::Arc<std::sync::atomic::AtomicBool>,
 }
 
 /// Accepts promoted fast-path connections and delivers them to the RX
@@ -177,7 +183,10 @@ impl ConnSink for TokioFrameConnSink {
             down_bytes,
             gw_mac,
             guest_mac,
+            dead,
         } = conn;
+        // A `false` return means "not accepted": the flow stays on the
+        // bridge's slow path, so `dead` must NOT be set here.
         let Ok(stream) = tokio::net::TcpStream::from_std(stream) else {
             return false;
         };
@@ -189,6 +198,7 @@ impl ConnSink for TokioFrameConnSink {
             our_seq,
             last_ack,
             down_bytes,
+            dead,
             gw_mac,
             guest_mac,
             // Bound this sink's own MTU-derived segmentation by the peer's MSS so
@@ -211,6 +221,7 @@ struct AsyncPromotedConn {
     our_seq: Arc<std::sync::atomic::AtomicU32>,
     last_ack: Arc<std::sync::atomic::AtomicU32>,
     down_bytes: Option<Arc<std::sync::atomic::AtomicU64>>,
+    dead: Arc<std::sync::atomic::AtomicBool>,
     gw_mac: [u8; 6],
     guest_mac: [u8; 6],
     guest_mss: usize,
@@ -229,6 +240,9 @@ async fn read_promoted_conn(
     frames: mpsc::Sender<Vec<u8>>,
 ) {
     let mut buf = vec![0u8; 32 * 1024];
+    // Every exit from this loop marks the conn dead so the bridge reaps its
+    // inline-owned entry (ABX-431).
+    let _dead_guard = SetOnDrop(Arc::clone(&conn.dead));
     loop {
         match stream.read(&mut buf).await {
             Ok(0) => {
@@ -280,8 +294,46 @@ async fn read_promoted_conn(
                     offset = chunk_end;
                 }
             }
-            Err(_) => return,
+            Err(e) => {
+                // Upstream died mid-stream (reset, tunnel killed by a proxy,
+                // …). Data may be lost, so propagate as RST — a FIN would
+                // let the guest mistake a truncated stream for a complete
+                // one — and never drop the upstream silently: without a
+                // guest-bound frame the guest socket stays ESTABLISHED
+                // forever (ABX-431).
+                tracing::debug!(
+                    "promoted conn {}:{} → {}:{} read error, RST to guest: {e}",
+                    conn.remote_ip,
+                    conn.remote_port,
+                    conn.guest_ip,
+                    conn.guest_port
+                );
+                let rst = build_tcp_rst_frame(&TcpFrameParams {
+                    src_ip: conn.remote_ip,
+                    dst_ip: conn.guest_ip,
+                    src_port: conn.remote_port,
+                    dst_port: conn.guest_port,
+                    seq: conn.our_seq.load(Ordering::Relaxed),
+                    ack: conn.last_ack.load(Ordering::Relaxed),
+                    window: 0,
+                    src_mac: conn.gw_mac,
+                    dst_mac: conn.guest_mac,
+                });
+                let _ = frames.send(rst).await;
+                return;
+            }
         }
+    }
+}
+
+/// Sets the flag when the owning task exits, however it exits.
+#[cfg(feature = "tokio-frame-sink")]
+struct SetOnDrop(Arc<std::sync::atomic::AtomicBool>);
+
+#[cfg(feature = "tokio-frame-sink")]
+impl Drop for SetOnDrop {
+    fn drop(&mut self) {
+        self.0.store(true, Ordering::Relaxed);
     }
 }
 
@@ -319,6 +371,7 @@ mod tests {
             down_bytes: Some(down.clone()),
             gw_mac: [0x02, 0, 0, 0, 0, 1],
             guest_mac: [0x02, 0, 0, 0, 0, 2],
+            dead: Arc::new(std::sync::atomic::AtomicBool::new(false)),
         };
         assert!(sink.send_conn(accepted_conn));
 
@@ -366,6 +419,7 @@ mod tests {
             down_bytes: None,
             gw_mac: [0x02, 0, 0, 0, 0, 1],
             guest_mac: [0x02, 0, 0, 0, 0, 2],
+            dead: Arc::new(std::sync::atomic::AtomicBool::new(false)),
         };
         assert!(sink.send_conn(accepted_conn));
 
@@ -415,6 +469,7 @@ mod tests {
             down_bytes: None,
             gw_mac: [0x02, 0, 0, 0, 0, 1],
             guest_mac: [0x02, 0, 0, 0, 0, 2],
+            dead: Arc::new(std::sync::atomic::AtomicBool::new(false)),
         };
         assert!(sink.send_conn(accepted_conn));
 
@@ -445,5 +500,64 @@ mod tests {
             "expected ≥4 clamped frames, got {}",
             frames.len()
         );
+    }
+
+    /// Upstream mid-stream death must reach the guest as a RST and mark the
+    /// shared `dead` flag so the bridge reaps its inline-owned entry
+    /// (ABX-431). A clean EOF (covered above) sends FIN instead.
+    #[tokio::test]
+    async fn read_error_sends_rst_and_sets_dead() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let (client, accepted) = tokio::join!(tokio::net::TcpStream::connect(addr), async {
+            listener.accept().await.unwrap().0
+        },);
+        let client = client.unwrap();
+
+        let (sink, mut rx) = TokioFrameConnSink::channel(4);
+        let our_seq = Arc::new(AtomicU32::new(1000));
+        let dead = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let conn = PromotedConn {
+            stream: accepted.into_std().unwrap(),
+            remote_ip: std::net::Ipv4Addr::new(203, 0, 113, 10),
+            guest_ip: std::net::Ipv4Addr::new(192, 168, 64, 2),
+            remote_port: 443,
+            guest_port: 50000,
+            peer_mss: 1460,
+            our_seq: our_seq.clone(),
+            last_ack: Arc::new(AtomicU32::new(2000)),
+            down_bytes: None,
+            gw_mac: [0x02, 0, 0, 0, 0, 1],
+            guest_mac: [0x02, 0, 0, 0, 0, 2],
+            dead: Arc::clone(&dead),
+        };
+        assert!(sink.send_conn(conn));
+
+        // Abortive close: SO_LINGER(0) turns the peer's close into a RST,
+        // so the read task sees ECONNRESET instead of a clean EOF.
+        let client = client.into_std().unwrap();
+        socket2::SockRef::from(&client)
+            .set_linger(Some(std::time::Duration::ZERO))
+            .unwrap();
+        drop(client);
+
+        let frame = tokio::time::timeout(std::time::Duration::from_secs(2), rx.recv())
+            .await
+            .expect("frame within deadline")
+            .expect("a guest-bound frame");
+        let flags = frame[ETH_HEADER_LEN + 20 + 13];
+        assert_ne!(flags & 0x04, 0, "must be a RST (flags {flags:#04x})");
+        assert_eq!(
+            our_seq.load(Ordering::Relaxed),
+            1000,
+            "RST consumes no sequence number"
+        );
+
+        // The exiting task marks the conn dead for the bridge's reaper.
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(2);
+        while !dead.load(Ordering::Relaxed) && std::time::Instant::now() < deadline {
+            tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+        }
+        assert!(dead.load(Ordering::Relaxed));
     }
 }

--- a/common/splicetcp/src/fragment.rs
+++ b/common/splicetcp/src/fragment.rs
@@ -26,6 +26,13 @@ const MAX_REASSEMBLED_PAYLOAD: usize = 65_535 - 20;
 /// in flight; the cap bounds a hostile guest to ~2 MiB of buffer.
 const MAX_ENTRIES: usize = 32;
 
+/// Maximum disjoint received ranges per datagram. A benign sender needs at
+/// most ~45 (one per fully out-of-order 1480-byte fragment of a maximal
+/// datagram); only interleaved tiny-fragment probes exceed this. Crossing
+/// the cap drops the whole entry, bounding the O(ranges) merge work per
+/// fragment a hostile guest can trigger.
+const MAX_RANGES: usize = 64;
+
 /// How long an incomplete datagram may wait for its missing fragments.
 const REASSEMBLY_TIMEOUT: Duration = Duration::from_secs(3);
 
@@ -148,6 +155,11 @@ impl FragmentReassembler {
         }
         entry.payload[offset..end].copy_from_slice(fragment);
         merge_range(&mut entry.ranges, offset, end);
+        if entry.ranges.len() > MAX_RANGES {
+            tracing::debug!("fragment pattern exceeds the range cap; entry dropped");
+            self.entries.remove(&key);
+            return None;
+        }
 
         if entry.is_complete() {
             let entry = self.entries.remove(&key)?;
@@ -395,5 +407,27 @@ mod tests {
         let truncated = &frags[0][..frags[0].len() - 100];
         assert!(r.push(truncated, now).is_none());
         assert!(r.entries.is_empty());
+    }
+
+    #[test]
+    fn interleaved_tiny_fragments_hit_range_cap() {
+        let mut r = FragmentReassembler::new();
+        let now = Instant::now();
+        let template = &fragments(3000)[0];
+        // Hostile pattern: 8-byte MF fragments at gapped offsets, each
+        // opening a new disjoint range. The entry must drop once the range
+        // count crosses MAX_RANGES instead of growing the merge work.
+        for i in 0..=MAX_RANGES {
+            let mut f = template[..ETH_HEADER_LEN + 20 + 8].to_vec();
+            let ip = ETH_HEADER_LEN;
+            f[ip + 2..ip + 4].copy_from_slice(&28u16.to_be_bytes());
+            let offset_units = (i * 2) as u16;
+            f[ip + 6..ip + 8].copy_from_slice(&(0x2000 | offset_units).to_be_bytes());
+            assert!(r.push(&f, now).is_none());
+        }
+        assert!(
+            r.entries.is_empty(),
+            "entry must drop once the range cap is crossed"
+        );
     }
 }

--- a/common/splicetcp/src/tcp_bridge/fast_path.rs
+++ b/common/splicetcp/src/tcp_bridge/fast_path.rs
@@ -111,9 +111,25 @@ impl TcpBridge {
                         );
                     }
                     Err(e) => {
-                        tracing::warn!("Fast path TX write error: {e}");
+                        tracing::warn!("Fast path TX write error, RST to guest: {e}");
+                        // Mirror the RX-error path: the host stream is dead,
+                        // so tear the guest side down with RST instead of
+                        // leaving it ESTABLISHED forever (ABX-431).
+                        let rst = crate::ethernet::build_tcp_rst_frame(
+                            &crate::ethernet::TcpFrameParams {
+                                src_ip: conn.remote_ip,
+                                dst_ip: conn.guest_ip,
+                                src_port: conn.remote_port,
+                                dst_port: conn.guest_port,
+                                seq: conn.our_seq.load(std::sync::atomic::Ordering::Relaxed),
+                                ack: conn.last_ack,
+                                window: 0,
+                                src_mac: self.fast_path_gateway_mac,
+                                dst_mac: self.fast_path_guest_mac.unwrap_or([0xFF; 6]),
+                            },
+                        );
                         self.close_fast_path(&key);
-                        return None;
+                        return Some(rst);
                     }
                 }
             } else {
@@ -181,7 +197,22 @@ impl TcpBridge {
         let gw_mac = self.fast_path_gateway_mac;
 
         for (key, conn) in &mut self.fast_path_conns {
-            if conn.host_eof || conn.inline_owned {
+            if conn.inline_owned {
+                // The inline inject thread owns the socket and has already
+                // emitted the guest-bound FIN/RST when it marks the flow
+                // dead. Reap the entry here — a RST-terminated guest sends
+                // no further frames for the flow, so no other path removes
+                // it (ABX-431).
+                if conn
+                    .dead
+                    .as_ref()
+                    .is_some_and(|d| d.load(std::sync::atomic::Ordering::Relaxed))
+                {
+                    to_remove.push(*key);
+                }
+                continue;
+            }
+            if conn.host_eof {
                 continue;
             }
 
@@ -285,12 +316,29 @@ impl TcpBridge {
                 }
                 Err(e) => {
                     tracing::warn!(
-                        "Fast path RX error {}:{} → {}:{}: {e}",
+                        "Fast path RX error {}:{} → {}:{}, RST to guest: {e}",
                         conn.remote_ip,
                         conn.remote_port,
                         conn.guest_ip,
                         conn.guest_port
                     );
+                    // Upstream died mid-stream — propagate as RST. Data may
+                    // be lost, so a FIN would let the guest mistake a
+                    // truncated stream for a complete one, and no frame at
+                    // all leaves the guest ESTABLISHED forever (ABX-431).
+                    let rst =
+                        crate::ethernet::build_tcp_rst_frame(&crate::ethernet::TcpFrameParams {
+                            src_ip: conn.remote_ip,
+                            dst_ip: conn.guest_ip,
+                            src_port: conn.remote_port,
+                            dst_port: conn.guest_port,
+                            seq: conn.our_seq.load(std::sync::atomic::Ordering::Relaxed),
+                            ack: conn.last_ack,
+                            window: 0,
+                            src_mac: gw_mac,
+                            dst_mac: guest_mac,
+                        });
+                    frames.push(rst);
                     to_remove.push(*key);
                 }
             }
@@ -366,11 +414,13 @@ impl TcpBridge {
         // (e.g. a sub-1500 overlay bridge behind eth0) stays on the clamped
         // polling path below, where each segment matches its advertised MSS.
         let inline_eligible = peer_mss >= GSO_SEGMENT_MSS;
+        let mut dead: Option<std::sync::Arc<std::sync::atomic::AtomicBool>> = None;
         if let Some(sink) = self.conn_sink.as_ref().filter(|_| inline_eligible) {
             match stream.try_clone() {
                 Ok(cloned) => {
                     let gw_mac = self.fast_path_gateway_mac;
                     let guest_mac = self.fast_path_guest_mac.unwrap_or([0xFF; 6]);
+                    let dead_flag = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
                     let promoted = crate::direct_rx::PromotedConn {
                         stream: cloned,
                         remote_ip: key.dst_ip,
@@ -383,9 +433,11 @@ impl TcpBridge {
                         down_bytes: down_shared.clone(),
                         gw_mac,
                         guest_mac,
+                        dead: std::sync::Arc::clone(&dead_flag),
                     };
                     if sink.send_conn(promoted) {
                         inline_owned = true;
+                        dead = Some(dead_flag);
                         tracing::info!(
                             "Fast path: promoted INLINE {}:{} → {}:{} (seq={our_seq}, ack={last_ack})",
                             key.src_ip,
@@ -435,6 +487,7 @@ impl TcpBridge {
                 up_bytes: 0,
                 down_bytes: 0,
                 down_shared: if inline_owned { down_shared } else { None },
+                dead,
             },
         );
     }

--- a/common/splicetcp/src/tcp_bridge/fast_path.rs
+++ b/common/splicetcp/src/tcp_bridge/fast_path.rs
@@ -198,11 +198,14 @@ impl TcpBridge {
 
         for (key, conn) in &mut self.fast_path_conns {
             if conn.inline_owned {
-                // The inline inject thread owns the socket and has already
-                // emitted the guest-bound FIN/RST when it marks the flow
-                // dead. Reap the entry here — a RST-terminated guest sends
-                // no further frames for the flow, so no other path removes
-                // it (ABX-431).
+                // The inline inject thread owns the socket. It marks the
+                // flow dead only after RST-terminating the guest on an
+                // upstream ERROR — reap the entry here, since the guest
+                // sends no further frames for it (ABX-431). After a clean
+                // EOF the flag stays unset and the entry survives so the
+                // guest's ACK/FIN and half-close writes still reach
+                // try_fast_path_intercept (parity with the non-inline
+                // path's host_eof handling).
                 if conn
                     .dead
                     .as_ref()

--- a/common/splicetcp/src/tcp_bridge/handshake.rs
+++ b/common/splicetcp/src/tcp_bridge/handshake.rs
@@ -195,9 +195,12 @@ impl TcpBridge {
         let now = StdInstant::now();
 
         for (key, conn) in &mut self.handshake_conns {
-            // Global TTL — abort stuck handshakes.
+            // Global TTL — abort stuck handshakes, telling the guest: without
+            // the RST it retries SYNs against a flow we already gave up on
+            // and its socket only dies by its own (much longer) timeout.
             if now.duration_since(conn.created) > HANDSHAKE_TOTAL_TTL {
-                tracing::warn!("Handshake shim: TTL exceeded for {key:?}, aborting");
+                tracing::warn!("Handshake shim: TTL exceeded for {key:?}, aborting with RST");
+                out.push(handshake_abort_rst(key, conn));
                 to_abort.push(*key);
                 continue;
             }
@@ -208,6 +211,7 @@ impl TcpBridge {
                     if conn.host_stream.is_none() {
                         let Some(rx) = conn.connect_rx.as_mut() else {
                             // No stream, no pending connect — aborted.
+                            out.push(handshake_abort_rst(key, conn));
                             to_abort.push(*key);
                             continue;
                         };
@@ -224,6 +228,7 @@ impl TcpBridge {
                                         tracing::debug!(
                                             "Handshake shim: into_std failed for {key:?}: {e}"
                                         );
+                                        out.push(handshake_abort_rst(key, conn));
                                         to_abort.push(*key);
                                         continue;
                                     }
@@ -235,20 +240,7 @@ impl TcpBridge {
                                 // socket sees an immediate ECONNREFUSED
                                 // instead of waiting for SYN retransmits.
                                 tracing::debug!("Handshake shim: host connect failed for {key:?}");
-                                let rst = crate::ethernet::build_tcp_rst_frame(
-                                    &crate::ethernet::TcpFrameParams {
-                                        src_ip: key.dst_ip,
-                                        dst_ip: key.src_ip,
-                                        src_port: key.dst_port,
-                                        dst_port: key.src_port,
-                                        seq: 0,
-                                        ack: conn.peer_isn.wrapping_add(1),
-                                        window: 0,
-                                        src_mac: conn.gw_mac,
-                                        dst_mac: conn.guest_mac,
-                                    },
-                                );
-                                out.push(rst);
+                                out.push(handshake_abort_rst(key, conn));
                                 to_abort.push(*key);
                                 continue;
                             }
@@ -256,6 +248,7 @@ impl TcpBridge {
                                 continue; // still connecting
                             }
                             Err(oneshot::error::TryRecvError::Closed) => {
+                                out.push(handshake_abort_rst(key, conn));
                                 to_abort.push(*key);
                                 continue;
                             }
@@ -486,4 +479,23 @@ impl TcpBridge {
             }
         }
     }
+}
+
+/// Builds the RST|ACK toward the guest for a handshake that will never
+/// complete — connect failure, TTL expiry, or a dropped egress channel.
+/// `seq` is 0 because our SYN-ACK may not have been sent yet; acknowledging
+/// the guest's ISN keeps the RST acceptable in SYN-SENT (RFC 793). Without
+/// this frame the guest's socket outlives the aborted flow (ABX-431).
+fn handshake_abort_rst(key: &SynFlowKey, conn: &HandshakeConn) -> Vec<u8> {
+    crate::ethernet::build_tcp_rst_frame(&crate::ethernet::TcpFrameParams {
+        src_ip: key.dst_ip,
+        dst_ip: key.src_ip,
+        src_port: key.dst_port,
+        dst_port: key.src_port,
+        seq: 0,
+        ack: conn.peer_isn.wrapping_add(1),
+        window: 0,
+        src_mac: conn.gw_mac,
+        dst_mac: conn.guest_mac,
+    })
 }

--- a/common/splicetcp/src/tcp_bridge/mod.rs
+++ b/common/splicetcp/src/tcp_bridge/mod.rs
@@ -53,7 +53,12 @@ const HANDSHAKE_MAX_RETRANSMITS: u8 = 3;
 /// TTL for an in-progress handshake with no guest response. If the guest
 /// never ACKs our SYN-ACK (or never SYN-ACKs our SYN), we abort and evict
 /// after this much time total.
-const HANDSHAKE_TOTAL_TTL: std::time::Duration = std::time::Duration::from_secs(3);
+///
+/// Must exceed `SYN_GATE_CONNECT_TIMEOUT_SECS` (5 s): the host connect —
+/// including a proxy CONNECT/SOCKS handshake — is allowed the full connect
+/// timeout, and a shorter TTL would abort slow-but-successful proxied
+/// connects while they were still legitimately pending (ABX-431).
+const HANDSHAKE_TOTAL_TTL: std::time::Duration = std::time::Duration::from_secs(7);
 
 /// Window scale we advertise to the guest. Shift by 7 = 128× scaling,
 /// giving an effective receive window of 65535 × 128 = 8 MiB. Sufficient
@@ -242,6 +247,10 @@ pub(super) struct FastPathConn {
     down_bytes: u64,
     /// Host→guest bytes counted by the inline inject thread, when `inline_owned`.
     down_shared: Option<std::sync::Arc<std::sync::atomic::AtomicU64>>,
+    /// Set by the inline sink owner when the host stream died (EOF or error)
+    /// and no further guest-bound frames will be produced; `poll_fast_path`
+    /// reaps the entry. `Some` only when `inline_owned` (ABX-431).
+    dead: Option<std::sync::Arc<std::sync::atomic::AtomicBool>>,
 }
 
 impl FastPathConn {

--- a/common/splicetcp/src/tcp_bridge/mod.rs
+++ b/common/splicetcp/src/tcp_bridge/mod.rs
@@ -247,9 +247,11 @@ pub(super) struct FastPathConn {
     down_bytes: u64,
     /// Host→guest bytes counted by the inline inject thread, when `inline_owned`.
     down_shared: Option<std::sync::Arc<std::sync::atomic::AtomicU64>>,
-    /// Set by the inline sink owner when the host stream died (EOF or error)
-    /// and no further guest-bound frames will be produced; `poll_fast_path`
-    /// reaps the entry. `Some` only when `inline_owned` (ABX-431).
+    /// Set by the inline sink owner when the host stream died mid-stream
+    /// (error, not clean EOF) and the guest was RST-terminated;
+    /// `poll_fast_path` reaps the entry. After a clean EOF the flag stays
+    /// unset so the entry survives for the guest's close handshake. `Some`
+    /// only when `inline_owned` (ABX-431).
     dead: Option<std::sync::Arc<std::sync::atomic::AtomicBool>>,
 }
 

--- a/common/splicetcp/src/tcp_bridge/tests.rs
+++ b/common/splicetcp/src/tcp_bridge/tests.rs
@@ -571,3 +571,153 @@ async fn large_frames_below_gso_mss_falls_back_to_clamped_segmentation() {
         frames.len()
     );
 }
+
+/// Upstream mid-stream death (reset, proxy-killed tunnel) must reach the
+/// guest as a RST and reap the flow — silence leaves the guest socket
+/// ESTABLISHED forever (ABX-431).
+#[tokio::test]
+async fn poll_fast_path_read_error_emits_rst_and_removes_flow() {
+    let mut bridge = TcpBridge::new(GW_IP);
+    bridge.set_fast_path_macs(GW_MAC, GUEST_MAC);
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let connect = tokio::net::TcpStream::connect(addr);
+    let (client, accepted) = tokio::join!(connect, listener.accept());
+    let client = client.unwrap();
+    let (accepted, _) = accepted.unwrap();
+
+    let key = SynFlowKey {
+        src_ip: GUEST_IP,
+        src_port: 12345,
+        dst_ip: Ipv4Addr::new(198, 18, 30, 95),
+        dst_port: 443,
+    };
+    bridge.promote_to_fast_path(key, client.into_std().unwrap(), 1000, 2000, 1460);
+    assert_eq!(bridge.fast_path_count(), 1);
+
+    // Abortive close: SO_LINGER(0) turns the peer's close into a RST, so
+    // the bridge's next read fails with ECONNRESET instead of a clean EOF.
+    let accepted = accepted.into_std().unwrap();
+    socket2::SockRef::from(&accepted)
+        .set_linger(Some(std::time::Duration::ZERO))
+        .unwrap();
+    drop(accepted);
+
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(2);
+    let mut frames: Vec<Vec<u8>> = Vec::new();
+    while frames.is_empty() && std::time::Instant::now() < deadline {
+        frames = bridge.poll_fast_path();
+        if frames.is_empty() {
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+    }
+
+    assert_eq!(
+        frames.len(),
+        1,
+        "upstream reset must produce one guest frame"
+    );
+    let flags = frames[0][ETH_HEADER_LEN + 20 + 13];
+    assert_ne!(flags & 0x04, 0, "frame must be a RST (flags {flags:#04x})");
+    assert_eq!(bridge.fast_path_count(), 0, "flow must be reaped");
+}
+
+/// The inline inject thread owns a promoted socket's teardown; when it
+/// marks the shared `dead` flag, `poll_fast_path` must reap the bridge's
+/// inline-owned entry — nothing else removes it (ABX-431).
+#[tokio::test]
+async fn inline_dead_flag_reaps_bridge_entry() {
+    struct CaptureSink(std::sync::Mutex<Option<crate::direct_rx::PromotedConn>>);
+    impl crate::direct_rx::ConnSink for CaptureSink {
+        fn send_conn(&self, conn: crate::direct_rx::PromotedConn) -> bool {
+            *self.0.lock().unwrap() = Some(conn);
+            true
+        }
+    }
+
+    let sink = std::sync::Arc::new(CaptureSink(std::sync::Mutex::new(None)));
+    let mut bridge = TcpBridge::new(GW_IP);
+    bridge.set_fast_path_macs(GW_MAC, GUEST_MAC);
+    bridge.set_conn_sink(std::sync::Arc::clone(&sink) as _);
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let connect = tokio::net::TcpStream::connect(addr);
+    let (client, accepted) = tokio::join!(connect, listener.accept());
+    let client = client.unwrap();
+    let _accepted = accepted.unwrap();
+
+    let key = SynFlowKey {
+        src_ip: GUEST_IP,
+        src_port: 23456,
+        dst_ip: Ipv4Addr::new(198, 18, 30, 96),
+        dst_port: 443,
+    };
+    // peer_mss ≥ GSO_SEGMENT_MSS → inline-eligible, handed to the sink.
+    bridge.promote_to_fast_path(key, client.into_std().unwrap(), 1000, 2000, 9000);
+    assert_eq!(bridge.fast_path_count(), 1);
+    let promoted = sink
+        .0
+        .lock()
+        .unwrap()
+        .take()
+        .expect("conn handed to the sink");
+
+    // Alive: the inline-owned entry stays.
+    assert!(bridge.poll_fast_path().is_empty());
+    assert_eq!(bridge.fast_path_count(), 1);
+
+    // Sink owner marks the flow dead (it already emitted the FIN/RST).
+    promoted
+        .dead
+        .store(true, std::sync::atomic::Ordering::Relaxed);
+    assert!(bridge.poll_fast_path().is_empty());
+    assert_eq!(
+        bridge.fast_path_count(),
+        0,
+        "dead inline flow must be reaped"
+    );
+}
+
+/// A handshake abort (TTL expiry) must RST the guest so its socket dies
+/// immediately instead of retrying SYNs against a flow the bridge already
+/// gave up on (ABX-431).
+#[tokio::test]
+async fn handshake_ttl_abort_emits_rst() {
+    let mut bridge = TcpBridge::new(GW_IP);
+    // TEST-NET-3 destination: the spawned connect never resolves quickly,
+    // and the entry is expired manually below.
+    let syn = make_guest_syn_frame(40000, Ipv4Addr::new(203, 0, 113, 1), 443, 7777, &[]);
+    assert!(
+        bridge
+            .handle_outbound_syn(&syn, GW_MAC, GUEST_MAC)
+            .is_none()
+    );
+    assert_eq!(bridge.handshake_count(), 1);
+
+    for conn in bridge.handshake_conns.values_mut() {
+        conn.created = std::time::Instant::now()
+            .checked_sub(std::time::Duration::from_secs(30))
+            .unwrap();
+    }
+
+    let out = bridge.poll_handshakes();
+    assert_eq!(
+        bridge.handshake_count(),
+        0,
+        "expired handshake must be evicted"
+    );
+    let rst = out
+        .iter()
+        .find(|f| f[ETH_HEADER_LEN + 20 + 13] & 0x04 != 0)
+        .expect("TTL abort must emit a RST toward the guest");
+    // ACKing the guest ISN + 1 keeps the RST acceptable in SYN-SENT.
+    let ack = u32::from_be_bytes([
+        rst[ETH_HEADER_LEN + 20 + 8],
+        rst[ETH_HEADER_LEN + 20 + 9],
+        rst[ETH_HEADER_LEN + 20 + 10],
+        rst[ETH_HEADER_LEN + 20 + 11],
+    ]);
+    assert_eq!(ack, 7778);
+}

--- a/rpc/arcbox-protocol/src/generated/arcbox.v1.rs
+++ b/rpc/arcbox-protocol/src/generated/arcbox.v1.rs
@@ -1938,7 +1938,7 @@ pub mod memory_pressure_event {
 /// `timeout_ms`; the host re-issues the request to keep watching.
 #[derive(serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
+#[derive(Clone, Copy, PartialEq, ::prost::Message)]
 pub struct WatchStatsRequest {
     /// Watch window in milliseconds (0 = agent default).
     #[prost(uint32, tag = "1")]
@@ -2010,7 +2010,7 @@ pub struct MachineStats {
 /// namespace, read via /proc/<pid>/net/dev for a process in the container.
 #[derive(serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ContainerStats {
     /// Full container ID (the cgroup directory name).
     #[prost(string, tag = "1")]
@@ -3215,7 +3215,7 @@ impl SystemVmBackend {
 /// Subscription request for machine stats.
 #[derive(serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct StatsWatchRequest {
     /// Machine to watch. Empty selects the System VM.
     #[prost(string, tag = "1")]

--- a/rpc/arcbox-protocol/src/generated/arcbox.v1.rs
+++ b/rpc/arcbox-protocol/src/generated/arcbox.v1.rs
@@ -1938,7 +1938,7 @@ pub mod memory_pressure_event {
 /// `timeout_ms`; the host re-issues the request to keep watching.
 #[derive(serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[derive(Clone, Copy, PartialEq, ::prost::Message)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct WatchStatsRequest {
     /// Watch window in milliseconds (0 = agent default).
     #[prost(uint32, tag = "1")]
@@ -2010,7 +2010,7 @@ pub struct MachineStats {
 /// namespace, read via /proc/<pid>/net/dev for a process in the container.
 #[derive(serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct ContainerStats {
     /// Full container ID (the cgroup directory name).
     #[prost(string, tag = "1")]
@@ -3215,7 +3215,7 @@ impl SystemVmBackend {
 /// Subscription request for machine stats.
 #[derive(serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct StatsWatchRequest {
     /// Machine to watch. Empty selects the System VM.
     #[prost(string, tag = "1")]

--- a/virt/arcbox-net-inject/Cargo.toml
+++ b/virt/arcbox-net-inject/Cargo.toml
@@ -15,3 +15,6 @@ tracing = "0.1"
 
 [lints]
 workspace = true
+
+[dev-dependencies]
+socket2 = "0.6.5"

--- a/virt/arcbox-net-inject/Cargo.toml
+++ b/virt/arcbox-net-inject/Cargo.toml
@@ -17,4 +17,4 @@ tracing = "0.1"
 workspace = true
 
 [dev-dependencies]
-socket2 = "0.6.5"
+socket2 = "0.6"

--- a/virt/arcbox-net-inject/src/inject.rs
+++ b/virt/arcbox-net-inject/src/inject.rs
@@ -215,15 +215,12 @@ impl RxInjectThread {
             return;
         }
 
-        // Prune closed connections from previous iteration, telling the
-        // bridge to reap its inline-owned entry — nothing else removes it
-        // once the guest has been FIN/RST-terminated (ABX-431).
-        inline_conns.retain(|c| {
-            if c.host_eof {
-                c.dead.store(true, Ordering::Relaxed);
-            }
-            !c.host_eof
-        });
+        // Prune closed connections from previous iteration. `dead` is NOT
+        // set here: after a clean EOF the bridge entry must survive so the
+        // guest's ACK/FIN and half-close writes still hit
+        // try_fast_path_intercept (parity with the non-inline path); only
+        // the error path marks `dead` (ABX-431).
+        inline_conns.retain(|c| !c.host_eof);
 
         // Fair-share pass: each conn gets at most PER_CONN_READS `readv`
         // calls per outer iteration. Each call can span up to MAX_MERGE
@@ -454,6 +451,11 @@ impl RxInjectThread {
                             conn.guest_port
                         );
                         conn.host_eof = true;
+                        // RST-terminated: the guest sends no further frames
+                        // for this flow, so tell the bridge to reap its
+                        // inline-owned entry (clean EOF leaves it alive for
+                        // the guest's close handshake instead).
+                        conn.dead.store(true, Ordering::Relaxed);
                         queue.set_last_avail_idx(gather_start.wrapping_add(1));
 
                         // SAFETY: first descriptor buffer is exclusive to us.
@@ -755,6 +757,15 @@ mod tests {
         // TCP flags byte in the injected frame: FIN | ACK.
         let first = ram.buffer(0, inline_conn::TOTAL_HDR_LEN);
         assert_eq!(first[12 + 14 + 20 + 13], 0x11);
+
+        // Clean EOF must NOT mark the flow dead: the bridge entry stays
+        // alive so the guest's ACK/FIN and half-close writes still reach
+        // try_fast_path_intercept (only the error path sets `dead`).
+        let dead = Arc::clone(&conns[0].dead);
+        let (mut batch2, mut fire2) = (0u16, false);
+        thread.poll_inline_conns(&mut queue, &mut conns, &mut batch2, &mut fire2);
+        assert!(conns.is_empty(), "EOF conn is pruned from the inject set");
+        assert!(!dead.load(Ordering::Relaxed), "clean EOF must not set dead");
     }
 
     /// Upstream mid-stream death must reach the guest as a RST (a FIN would
@@ -820,11 +831,12 @@ mod tests {
         // RST consumes no sequence number.
         assert_eq!(conns[0].our_seq.load(Ordering::Relaxed), 1000);
 
-        // The next poll's prune pass marks the conn dead for the bridge.
-        assert!(!dead.load(Ordering::Relaxed));
+        // The error branch marks the conn dead immediately (unlike clean
+        // EOF, which keeps the bridge entry alive for the guest's close
+        // handshake); the next poll's prune pass drops it.
+        assert!(dead.load(Ordering::Relaxed), "bridge reap flag must be set");
         let (mut batch2, mut fire2) = (0u16, false);
         thread.poll_inline_conns(&mut queue, &mut conns, &mut batch2, &mut fire2);
         assert!(conns.is_empty(), "errored conn must be pruned");
-        assert!(dead.load(Ordering::Relaxed), "bridge reap flag must be set");
     }
 }

--- a/virt/arcbox-net-inject/src/inject.rs
+++ b/virt/arcbox-net-inject/src/inject.rs
@@ -215,8 +215,15 @@ impl RxInjectThread {
             return;
         }
 
-        // Prune closed connections from previous iteration.
-        inline_conns.retain(|c| !c.host_eof);
+        // Prune closed connections from previous iteration, telling the
+        // bridge to reap its inline-owned entry — nothing else removes it
+        // once the guest has been FIN/RST-terminated (ABX-431).
+        inline_conns.retain(|c| {
+            if c.host_eof {
+                c.dead.store(true, Ordering::Relaxed);
+            }
+            !c.host_eof
+        });
 
         // Fair-share pass: each conn gets at most PER_CONN_READS `readv`
         // calls per outer iteration. Each call can span up to MAX_MERGE
@@ -433,9 +440,30 @@ impl RxInjectThread {
                         break;
                     }
                     Err(e) => {
-                        tracing::debug!("inline conn error: {e}");
-                        queue.set_last_avail_idx(gather_start);
+                        // Upstream died mid-stream — propagate as RST. Data
+                        // may be lost, so a FIN would let the guest mistake
+                        // the truncated stream for a complete one, and no
+                        // frame at all leaves the guest ESTABLISHED forever
+                        // (ABX-431). Mirrors the EOF branch above: consume
+                        // only the first buffer, return the rest.
+                        tracing::debug!(
+                            "inline {}:{}->{}:{} error, RST to guest: {e}",
+                            conn.remote_ip,
+                            conn.remote_port,
+                            conn.guest_ip,
+                            conn.guest_port
+                        );
                         conn.host_eof = true;
+                        queue.set_last_avail_idx(gather_start.wrapping_add(1));
+
+                        // SAFETY: first descriptor buffer is exclusive to us.
+                        let first_buf =
+                            unsafe { std::slice::from_raw_parts_mut(desc_ptrs[0], desc_lens[0]) };
+                        inline_conn::write_rst_headers(first_buf, conn);
+
+                        *fire |=
+                            queue.push_used(head_indices[0], inline_conn::TOTAL_HDR_LEN as u32);
+                        *batch += 1;
                         break;
                     }
                 }
@@ -576,6 +604,7 @@ mod tests {
             gw_mac: [0x02, 0, 0, 0, 0, 1],
             guest_mac: [0x02, 0, 0, 0, 0, 2],
             host_eof: false,
+            dead: Arc::new(std::sync::atomic::AtomicBool::new(false)),
         }
     }
 
@@ -726,5 +755,76 @@ mod tests {
         // TCP flags byte in the injected frame: FIN | ACK.
         let first = ram.buffer(0, inline_conn::TOTAL_HDR_LEN);
         assert_eq!(first[12 + 14 + 20 + 13], 0x11);
+    }
+
+    /// Upstream mid-stream death must reach the guest as a RST (a FIN would
+    /// present the truncated stream as complete; silence leaves the guest
+    /// ESTABLISHED forever) and must mark the shared `dead` flag so the
+    /// bridge reaps its inline-owned entry (ABX-431).
+    #[test]
+    fn read_error_emits_rst_and_marks_dead() {
+        let mut ram = TestRam::new();
+        ram.post_rx_buffer(0, 4096);
+        ram.post_rx_buffer(1, 4096);
+        ram.set_avail_idx(2);
+
+        let thread = inject_thread(&mut ram, false);
+        let mut queue = SplitQueue::new(
+            Arc::clone(&thread.guest_mem),
+            0,
+            &thread.queue,
+            thread.event_idx_enabled,
+        );
+
+        let (writer, reader) = tcp_pair();
+        // Abortive close: SO_LINGER(0) turns the peer's close into a RST,
+        // so the next read on `reader` fails with ECONNRESET, not EOF.
+        socket2::SockRef::from(&writer)
+            .set_linger(Some(Duration::ZERO))
+            .unwrap();
+        drop(writer);
+        // Wait until the reset is visible to a read probe.
+        let mut probe = [0u8; 1];
+        for _ in 0..500 {
+            match reader.peek(&mut probe) {
+                Err(e) if e.kind() != std::io::ErrorKind::WouldBlock => break,
+                Ok(0) => break,
+                _ => std::thread::sleep(Duration::from_millis(1)),
+            }
+        }
+
+        let mut conns = vec![inline_conn(reader)];
+        let dead = Arc::clone(&conns[0].dead);
+        let (mut batch, mut fire) = (0u16, false);
+        thread.poll_inline_conns(&mut queue, &mut conns, &mut batch, &mut fire);
+
+        assert!(conns[0].host_eof);
+        assert_eq!(batch, 1);
+        assert_eq!(ram.used_idx(), 1, "only the RST frame was published");
+        assert_eq!(
+            queue.last_avail_idx(),
+            1,
+            "the second gathered buffer went back to the guest"
+        );
+        assert_eq!(
+            ram.used_entry(0),
+            (0, inline_conn::TOTAL_HDR_LEN as u32),
+            "RST is a headers-only frame"
+        );
+        let first = ram.buffer(0, inline_conn::TOTAL_HDR_LEN);
+        assert_eq!(
+            first[12 + 14 + 20 + 13],
+            0x14,
+            "TCP flags must be RST | ACK"
+        );
+        // RST consumes no sequence number.
+        assert_eq!(conns[0].our_seq.load(Ordering::Relaxed), 1000);
+
+        // The next poll's prune pass marks the conn dead for the bridge.
+        assert!(!dead.load(Ordering::Relaxed));
+        let (mut batch2, mut fire2) = (0u16, false);
+        thread.poll_inline_conns(&mut queue, &mut conns, &mut batch2, &mut fire2);
+        assert!(conns.is_empty(), "errored conn must be pruned");
+        assert!(dead.load(Ordering::Relaxed), "bridge reap flag must be set");
     }
 }

--- a/virt/arcbox-net-inject/src/inline_conn.rs
+++ b/virt/arcbox-net-inject/src/inline_conn.rs
@@ -47,9 +47,11 @@ pub struct InlineConn {
     pub guest_mac: [u8; 6],
     /// Whether host stream has reached EOF.
     pub host_eof: bool,
-    /// Shared with the bridge's `FastPathConn`: set once this conn will
-    /// produce no further guest-bound frames (EOF or error) so the bridge
-    /// reaps its inline-owned entry (ABX-431).
+    /// Shared with the bridge's `FastPathConn`: set only when the host
+    /// stream died mid-stream (error, not clean EOF) and the guest was
+    /// RST-terminated, so the bridge reaps its inline-owned entry
+    /// (ABX-431). After a clean EOF the flag stays unset — the entry
+    /// survives for the guest's close handshake.
     pub dead: Arc<std::sync::atomic::AtomicBool>,
 }
 

--- a/virt/arcbox-net-inject/src/inline_conn.rs
+++ b/virt/arcbox-net-inject/src/inline_conn.rs
@@ -47,6 +47,10 @@ pub struct InlineConn {
     pub guest_mac: [u8; 6],
     /// Whether host stream has reached EOF.
     pub host_eof: bool,
+    /// Shared with the bridge's `FastPathConn`: set once this conn will
+    /// produce no further guest-bound frames (EOF or error) so the bridge
+    /// reaps its inline-owned entry (ABX-431).
+    pub dead: Arc<std::sync::atomic::AtomicBool>,
 }
 
 // SAFETY: TcpStream is Send, all other fields are Send+Sync.
@@ -159,6 +163,21 @@ pub fn read_payload_to_guest(conn: &mut InlineConn, buf: &mut [u8]) -> std::io::
 /// must increment `conn.our_seq` by 1 after injection (FIN consumes
 /// one sequence number, per RFC 793).
 pub fn write_fin_headers(buf: &mut [u8], conn: &InlineConn) -> usize {
+    write_ctrl_headers(buf, conn, 0x11, 65535) // FIN | ACK
+}
+
+/// Writes a RST+ACK control frame (66 header bytes, no payload).
+///
+/// Used when the host stream died mid-stream (error, not clean EOF): data
+/// may be lost, so the guest must see a reset — a FIN would present the
+/// truncated stream as complete, and no frame at all leaves the guest
+/// ESTABLISHED forever (ABX-431). RST consumes no sequence number.
+pub fn write_rst_headers(buf: &mut [u8], conn: &InlineConn) -> usize {
+    write_ctrl_headers(buf, conn, 0x14, 0) // RST | ACK
+}
+
+/// Shared body for the payload-less control frames (FIN/RST).
+fn write_ctrl_headers(buf: &mut [u8], conn: &InlineConn, tcp_flags: u8, window: u16) -> usize {
     if buf.len() < TOTAL_HDR_LEN {
         return 0;
     }
@@ -195,7 +214,7 @@ pub fn write_fin_headers(buf: &mut [u8], conn: &InlineConn) -> usize {
     let ip_cksum = ipv4_header_checksum(&buf[ip..ip + 20]);
     buf[ip + 10..ip + 12].copy_from_slice(&ip_cksum.to_be_bytes());
 
-    // -- TCP: FIN+ACK --
+    // -- TCP: control flags, no payload --
     let tcp = ip + 20;
     let our_seq = conn.our_seq.load(Ordering::Relaxed);
     buf[tcp..tcp + 2].copy_from_slice(&conn.remote_port.to_be_bytes());
@@ -203,8 +222,8 @@ pub fn write_fin_headers(buf: &mut [u8], conn: &InlineConn) -> usize {
     buf[tcp + 4..tcp + 8].copy_from_slice(&our_seq.to_be_bytes());
     buf[tcp + 8..tcp + 12].copy_from_slice(&last_ack.to_be_bytes());
     buf[tcp + 12] = 0x50; // data offset = 5 (20 bytes)
-    buf[tcp + 13] = 0x11; // FIN | ACK
-    buf[tcp + 14..tcp + 16].copy_from_slice(&65535u16.to_be_bytes());
+    buf[tcp + 13] = tcp_flags;
+    buf[tcp + 14..tcp + 16].copy_from_slice(&window.to_be_bytes());
     buf[tcp + 16..tcp + 18].fill(0);
     buf[tcp + 18..tcp + 20].fill(0);
     let pseudo_cksum = tcp_pseudo_header_checksum(conn.remote_ip, conn.guest_ip, tcp_total_len);

--- a/virt/arcbox-vmm/src/vmm/darwin_hv/inline_sink.rs
+++ b/virt/arcbox-vmm/src/vmm/darwin_hv/inline_sink.rs
@@ -23,6 +23,7 @@ impl arcbox_net::direct_rx::ConnSink for InlineConnSinkAdapter {
             gw_mac: conn.gw_mac,
             guest_mac: conn.guest_mac,
             host_eof: false,
+            dead: conn.dead,
         };
         self.tx.try_send(inline).is_ok()
     }


### PR DESCRIPTION
Fixes ABX-431: a proxied upstream connection died mid-stream and the guest socket stayed **ESTABLISHED for 3 hours** (empty queues, blocked read) — every data-plane error branch dropped the host stream silently, with no guest-bound frame. A teardown-path audit found the same silence on three independent owners plus two adjacent bugs.

## What

**Rule: upstream death must reach the guest as a frame.** Clean EOF already sent FIN; mid-stream errors (ECONNRESET, proxy-killed tunnel) now send **RST** — a FIN would present a truncated stream as complete — from all three data-plane owners:

- `TcpBridge::poll_fast_path` (non-inline slow path) read errors, and the `try_fast_path_intercept` guest→host **write**-error path (previously `return None`);
- `TokioFrameConnSink::read_promoted_conn` read errors (previously bare `return`);
- the HV inline inject thread (new `write_rst_headers` sharing the FIN writer's header builder; RST consumes no sequence number, mirrors the EOF branch's single-descriptor consume).

**Inline-entry leak**: `poll_fast_path` skips inline-owned entries and a RST/FIN-terminated guest never sends another frame for the flow, so the bridge's `FastPathConn` leaked on every inline teardown (EOF included, when the guest never answered the FIN). `PromotedConn`/`InlineConn` now carry a shared `dead` flag set by the sink owner on any exit — including task drop via a guard — and `poll_fast_path` reaps flagged entries.

**Handshake aborts**: TTL expiry, a dropped egress channel, and `into_std` failure now RST the guest (extracted `handshake_abort_rst`; `seq=0, ack=ISN+1` keeps it acceptable in SYN-SENT) instead of leaving it retrying SYNs. `HANDSHAKE_TOTAL_TTL` is raised **3 s → 7 s**: it was shorter than the 5 s connect timeout, silently aborting proxied CONNECT/SOCKS handshakes that were still legitimately pending.

Second commit: cap disjoint fragment-reassembly ranges at 64 per entry (hardening from the #425 review note — bounds the O(ranges) merge work; a benign sender needs ≤ ~45).

## Ordering note

SYN-ACK is only synthesized after the full proxy CONNECT/SOCKS handshake completes (verified), so the captured 3 h hang was post-establishment — exactly the paths above. The pre-establishment surface was already RST-covered except the three abort branches now fixed.

## Validation

- 8 new behavior tests using real `SO_LINGER(0)` abortive closes to produce ECONNRESET: bridge read-error → RST + reap; write-error → RST; inline `dead` reap; TTL abort → RST with `ack=ISN+1`; `TokioFrameConnSink` error → RST + `dead`; inject error → RST headers (flags `0x14`, seq unchanged) + prune sets `dead`; fragment range-cap. Suites: splicetcp 57/57, arcbox-net-inject 9/9.
- Workspace clippy clean; `boot_assets` e2e green over the changed fast path (one rerun after a docker.io pull timeout — third registry flake today; the failed run's daemon log shows **zero** `RST to guest` / TTL-abort lines, i.e. the new paths never misfire on healthy flows).

The ABX-431 repro window (Surge fake-IP tunnel dying under the boot hot-window) is not deterministically stageable in e2e; the unit layer pins the frame semantics and the flag plumbing end-to-end.