### PR TITLE
feat(core,api,agent): machine boot shim contract — devices, cmdline, machine-init

### DIFF
--- a/app/arcbox-api/src/grpc/machine.rs
+++ b/app/arcbox-api/src/grpc/machine.rs
@@ -73,9 +73,27 @@ impl machine_service_server::MachineService for MachineServiceImpl {
                 image = %format!("{}@{}", image.manifest.name, image.manifest.version),
                 "machine image ready"
             );
+
+            // Resolve the boot shim (kernel + EROFS with
+            // /sbin/arcbox-machine-init) from the same boot-assets cache the
+            // daemon populates for the System VM; a warm cache is a no-op.
+            let shim = async {
+                let provider = arcbox_core::boot_assets::BootAssetProvider::new(
+                    runtime.config().data_dir.join("boot"),
+                )?;
+                let assets = provider.get_assets().await?;
+                Ok::<_, arcbox_core::error::CoreError>(arcbox_core::machine::BootShim {
+                    kernel: assets.kernel,
+                    rootfs: assets.rootfs_image,
+                })
+            }
+            .await
+            .map_err(|e| Status::internal(format!("resolve boot shim: {e}")))?;
+
             Some(arcbox_core::machine::MachineRootfs {
                 path: image.rootfs_path(),
                 format: image.manifest.rootfs.format,
+                shim: Some(shim),
             })
         };
 

--- a/app/arcbox-core/src/machine.rs
+++ b/app/arcbox-core/src/machine.rs
@@ -79,6 +79,21 @@ pub struct MachineRootfs {
     pub path: PathBuf,
     /// Image format (`squashfs`), used for the kernel `rootfstype=`.
     pub format: String,
+    /// Boot shim staging the rootfs (see
+    /// `internal-docs/plans/machine-boot-shim.md`). When set, devices are
+    /// vda=shim EROFS / vdb=rootfs / vdc=data and the kernel command line
+    /// follows the machine-init contract; when `None`, the rootfs itself
+    /// boots as vda (custom-kernel testing).
+    pub shim: Option<BootShim>,
+}
+
+/// The boot-assets artifacts that stage a distro machine's boot.
+#[derive(Debug, Clone)]
+pub struct BootShim {
+    /// Boot-assets kernel image path.
+    pub kernel: PathBuf,
+    /// Boot-assets EROFS rootfs path (ships `/sbin/arcbox-machine-init`).
+    pub rootfs: PathBuf,
 }
 
 /// Machine configuration.
@@ -140,15 +155,40 @@ impl Default for MachineConfig {
     }
 }
 
-/// Kernel command line for a distro machine: root on the read-only rootfs
-/// image at vda. The console device follows the boot-assets convention for
-/// the host architecture.
-fn default_distro_cmdline(rootfs_format: &str) -> String {
+/// Console device for the host architecture, following the boot-assets
+/// convention.
+const fn boot_console() -> &'static str {
     #[cfg(target_arch = "x86_64")]
-    let console = "ttyS0";
+    {
+        "ttyS0"
+    }
     #[cfg(not(target_arch = "x86_64"))]
-    let console = "hvc0";
+    {
+        "hvc0"
+    }
+}
+
+/// Kernel command line for a shim-less distro machine: root on the read-only
+/// rootfs image at vda (custom-kernel testing).
+fn default_distro_cmdline(rootfs_format: &str) -> String {
+    let console = boot_console();
     format!("console={console} root=/dev/vda ro rootfstype={rootfs_format} earlycon")
+}
+
+/// Kernel command line for the machine boot shim: the shim EROFS boots as
+/// root and stages the distro rootfs + data disk named by the `arcbox.*`
+/// keys (see `internal-docs/plans/machine-boot-shim.md`).
+fn machine_shim_cmdline(rootfs_format: &str) -> String {
+    use arcbox_constants::cmdline::{
+        MACHINE_DATA_KEY, MACHINE_INIT_PATH, MACHINE_ROOTFS_KEY, MACHINE_ROOTFS_TYPE_KEY,
+    };
+    let console = boot_console();
+    format!(
+        "console={console} root=/dev/vda ro rootfstype=erofs earlycon \
+         init={MACHINE_INIT_PATH} \
+         {MACHINE_ROOTFS_KEY}/dev/vdb {MACHINE_ROOTFS_TYPE_KEY}{rootfs_format} \
+         {MACHINE_DATA_KEY}/dev/vdc"
+    )
 }
 
 /// Machine manager.
@@ -306,10 +346,12 @@ impl MachineManager {
             shared_dirs.push(SharedDirConfig::new(MOUNT_PRIVATE, TAG_PRIVATE));
         }
 
-        // Distro machines boot the pulled rootfs image as read-only vda with
-        // a sparse per-machine data disk after it; plain VMs keep the
-        // caller-provided block devices untouched.
-        let (block_devices, cmdline, disk_path) = match &config.rootfs {
+        // Distro machines boot the pulled rootfs image (behind the boot shim
+        // when configured) with a sparse per-machine data disk; plain VMs
+        // keep the caller-provided kernel and block devices untouched.
+        // Device contract: [shim?, rootfs, data, ..extras] so the shim's
+        // vda/vdb/vdc expectations hold regardless of extra devices.
+        let (kernel, block_devices, cmdline, disk_path) = match &config.rootfs {
             Some(rootfs) => {
                 // A distro rootfs carries no kernel; without an explicit one
                 // the VM would boot with an empty kernel path and fail
@@ -326,32 +368,50 @@ impl MachineManager {
                     &data_disk,
                     config.disk_gb.saturating_mul(1024 * 1024 * 1024),
                 )?;
-                let mut devices = config.block_devices.clone();
-                devices.insert(
-                    0,
-                    crate::vm::BlockDeviceConfig {
-                        path: rootfs.path.to_string_lossy().into_owned(),
+                let mut devices = Vec::new();
+                if let Some(shim) = &rootfs.shim {
+                    devices.push(crate::vm::BlockDeviceConfig {
+                        path: shim.rootfs.to_string_lossy().into_owned(),
                         read_only: true,
-                    },
-                );
+                    });
+                }
+                devices.push(crate::vm::BlockDeviceConfig {
+                    path: rootfs.path.to_string_lossy().into_owned(),
+                    read_only: true,
+                });
                 devices.push(crate::vm::BlockDeviceConfig {
                     path: data_disk.to_string_lossy().into_owned(),
                     read_only: false,
                 });
-                let cmdline = config
-                    .cmdline
-                    .clone()
-                    .or_else(|| Some(default_distro_cmdline(&rootfs.format)));
-                (devices, cmdline, Some(data_disk))
+                devices.extend(config.block_devices.clone());
+
+                let kernel = config.kernel.clone().or_else(|| {
+                    rootfs
+                        .shim
+                        .as_ref()
+                        .map(|s| s.kernel.to_string_lossy().into_owned())
+                });
+                let cmdline = config.cmdline.clone().or_else(|| {
+                    Some(match &rootfs.shim {
+                        Some(_) => machine_shim_cmdline(&rootfs.format),
+                        None => default_distro_cmdline(&rootfs.format),
+                    })
+                });
+                (kernel, devices, cmdline, Some(data_disk))
             }
-            None => (config.block_devices.clone(), config.cmdline.clone(), None),
+            None => (
+                config.kernel.clone(),
+                config.block_devices.clone(),
+                config.cmdline.clone(),
+                None,
+            ),
         };
 
         // Create underlying VM
         let vm_config = VmConfig {
             cpus: config.cpus,
             memory_mb: config.memory_mb,
-            kernel: config.kernel.clone(),
+            kernel: kernel.clone(),
             cmdline: cmdline.clone(),
             shared_dirs,
             block_devices: block_devices.clone(),
@@ -369,7 +429,7 @@ impl MachineManager {
             cpus: config.cpus,
             memory_mb: config.memory_mb,
             disk_gb: config.disk_gb,
-            kernel: config.kernel,
+            kernel,
             cmdline,
             block_devices,
             distro: config.distro,

--- a/app/arcbox-core/src/machine.rs
+++ b/app/arcbox-core/src/machine.rs
@@ -353,14 +353,13 @@ impl MachineManager {
         // vda/vdb/vdc expectations hold regardless of extra devices.
         let (kernel, block_devices, cmdline, disk_path) = match &config.rootfs {
             Some(rootfs) => {
-                // A distro rootfs carries no kernel; without an explicit one
-                // the VM would boot with an empty kernel path and fail
-                // obscurely. The boot-shim integration (stacked change)
-                // supplies the boot-assets kernel automatically.
-                if config.kernel.is_none() {
+                // A distro rootfs carries no kernel: the shim supplies the
+                // boot-assets kernel; without a shim an explicit kernel is
+                // required or the VM would boot with an empty kernel path.
+                if rootfs.shim.is_none() && config.kernel.is_none() {
                     return Err(CoreError::config(
-                        "distro machines require an explicit kernel (pass --kernel) \
-                         until the boot shim supplies one",
+                        "a distro rootfs without a boot shim requires an explicit \
+                         kernel (pass --kernel)",
                     ));
                 }
                 let data_disk = machine_dir.join("data.img");

--- a/app/arcbox-core/src/machine/tests.rs
+++ b/app/arcbox-core/src/machine/tests.rs
@@ -233,10 +233,28 @@ async fn test_create_without_shim_boots_rootfs_directly() {
     let rootfs_img = temp_dir.path().join("rootfs.squashfs");
     std::fs::write(&rootfs_img, b"squash").unwrap();
 
+    // Without a shim, the rootfs alone cannot boot: an explicit kernel is
+    // required (custom-kernel testing path).
+    let err = machine_manager
+        .create(MachineConfig {
+            name: "plain-distro".to_string(),
+            disk_gb: 1,
+            rootfs: Some(MachineRootfs {
+                path: rootfs_img.clone(),
+                format: "squashfs".to_string(),
+                shim: None,
+            }),
+            ..Default::default()
+        })
+        .await
+        .unwrap_err();
+    assert!(err.to_string().contains("explicit"), "{err}");
+
     machine_manager
         .create(MachineConfig {
             name: "plain-distro".to_string(),
             disk_gb: 1,
+            kernel: Some("/custom/kernel".to_string()),
             rootfs: Some(MachineRootfs {
                 path: rootfs_img.clone(),
                 format: "squashfs".to_string(),
@@ -251,7 +269,7 @@ async fn test_create_without_shim_boots_rootfs_directly() {
     let devices = &machine.block_devices;
     assert_eq!(devices.len(), 2);
     assert_eq!(devices[0].path, rootfs_img.to_string_lossy());
-    assert!(machine.kernel.is_none());
+    assert_eq!(machine.kernel.as_deref(), Some("/custom/kernel"));
     let cmdline = machine.cmdline.as_deref().unwrap();
     assert!(
         cmdline.contains("root=/dev/vda ro rootfstype=squashfs"),

--- a/app/arcbox-core/src/machine/tests.rs
+++ b/app/arcbox-core/src/machine/tests.rs
@@ -138,3 +138,124 @@ async fn test_create_concurrent_same_name_no_duplicate() {
     );
     assert_eq!(machines[0].name, name);
 }
+
+#[tokio::test]
+async fn test_create_with_shim_assembles_boot_contract() {
+    let temp_dir = tempdir().unwrap();
+    let machine_manager = test_machine_manager(temp_dir.path());
+
+    let rootfs_img = temp_dir.path().join("rootfs.squashfs");
+    std::fs::write(&rootfs_img, b"squash").unwrap();
+    let shim_kernel = temp_dir.path().join("kernel");
+    let shim_rootfs = temp_dir.path().join("shim.erofs");
+
+    machine_manager
+        .create(MachineConfig {
+            name: "shimmed".to_string(),
+            disk_gb: 1,
+            rootfs: Some(MachineRootfs {
+                path: rootfs_img.clone(),
+                format: "squashfs".to_string(),
+                shim: Some(BootShim {
+                    kernel: shim_kernel.clone(),
+                    rootfs: shim_rootfs.clone(),
+                }),
+            }),
+            ..Default::default()
+        })
+        .await
+        .unwrap();
+
+    let machine = machine_manager.get("shimmed").unwrap();
+
+    // Device contract: vda=shim EROFS ro, vdb=distro rootfs ro, vdc=data rw.
+    let devices = &machine.block_devices;
+    assert_eq!(devices.len(), 3);
+    assert_eq!(devices[0].path, shim_rootfs.to_string_lossy());
+    assert!(devices[0].read_only);
+    assert_eq!(devices[1].path, rootfs_img.to_string_lossy());
+    assert!(devices[1].read_only);
+    assert!(devices[2].path.ends_with("data.img"));
+    assert!(!devices[2].read_only);
+
+    // The data disk was provisioned sparse at the requested size.
+    let data_disk = machine.disk_path.as_ref().unwrap();
+    assert_eq!(
+        std::fs::metadata(data_disk).unwrap().len(),
+        1024 * 1024 * 1024
+    );
+
+    // Kernel comes from the shim; cmdline follows the machine-init contract.
+    assert_eq!(
+        machine.kernel.as_deref(),
+        Some(&*shim_kernel.to_string_lossy())
+    );
+    let cmdline = machine.cmdline.as_deref().unwrap();
+    assert!(
+        cmdline.contains("root=/dev/vda ro rootfstype=erofs"),
+        "{cmdline}"
+    );
+    assert!(
+        cmdline.contains(&format!(
+            "init={}",
+            arcbox_constants::cmdline::MACHINE_INIT_PATH
+        )),
+        "{cmdline}"
+    );
+    assert!(
+        cmdline.contains(&format!(
+            "{}/dev/vdb",
+            arcbox_constants::cmdline::MACHINE_ROOTFS_KEY
+        )),
+        "{cmdline}"
+    );
+    assert!(
+        cmdline.contains(&format!(
+            "{}squashfs",
+            arcbox_constants::cmdline::MACHINE_ROOTFS_TYPE_KEY
+        )),
+        "{cmdline}"
+    );
+    assert!(
+        cmdline.contains(&format!(
+            "{}/dev/vdc",
+            arcbox_constants::cmdline::MACHINE_DATA_KEY
+        )),
+        "{cmdline}"
+    );
+}
+
+#[tokio::test]
+async fn test_create_without_shim_boots_rootfs_directly() {
+    let temp_dir = tempdir().unwrap();
+    let machine_manager = test_machine_manager(temp_dir.path());
+
+    let rootfs_img = temp_dir.path().join("rootfs.squashfs");
+    std::fs::write(&rootfs_img, b"squash").unwrap();
+
+    machine_manager
+        .create(MachineConfig {
+            name: "plain-distro".to_string(),
+            disk_gb: 1,
+            rootfs: Some(MachineRootfs {
+                path: rootfs_img.clone(),
+                format: "squashfs".to_string(),
+                shim: None,
+            }),
+            ..Default::default()
+        })
+        .await
+        .unwrap();
+
+    let machine = machine_manager.get("plain-distro").unwrap();
+    let devices = &machine.block_devices;
+    assert_eq!(devices.len(), 2);
+    assert_eq!(devices[0].path, rootfs_img.to_string_lossy());
+    assert!(machine.kernel.is_none());
+    let cmdline = machine.cmdline.as_deref().unwrap();
+    assert!(
+        cmdline.contains("root=/dev/vda ro rootfstype=squashfs"),
+        "{cmdline}"
+    );
+    assert!(!cmdline.contains("init="), "{cmdline}");
+}

--- a/common/arcbox-constants/src/cmdline.rs
+++ b/common/arcbox-constants/src/cmdline.rs
@@ -13,6 +13,26 @@ pub const DOCKER_DATA_DEVICE_KEY: &str = "arcbox.docker_data_device=";
 /// hangs before networking.
 pub const DEBUG_CONSOLE_KEY: &str = "arcbox.debug_console=";
 
+/// Guest path of the machine boot shim executed as PID 1 via `init=`.
+///
+/// Packaged into the boot-assets EROFS; the shim stages the distro rootfs
+/// (overlay over squashfs), spawns the agent, and `switch_root`s into the
+/// distro's own init.
+pub const MACHINE_INIT_PATH: &str = "/sbin/arcbox-machine-init";
+
+/// Kernel cmdline key carrying the distro rootfs block device (`/dev/vdb`)
+/// the machine boot shim mounts as the overlay lower layer.
+pub const MACHINE_ROOTFS_KEY: &str = "arcbox.machine_rootfs=";
+
+/// Kernel cmdline key carrying the distro rootfs filesystem type
+/// (`squashfs`), from the machine image manifest.
+pub const MACHINE_ROOTFS_TYPE_KEY: &str = "arcbox.machine_rootfs_type=";
+
+/// Kernel cmdline key carrying the per-machine data block device
+/// (`/dev/vdc`) the shim first-boot-formats as btrfs and uses as the overlay
+/// upper layer.
+pub const MACHINE_DATA_KEY: &str = "arcbox.machine_data=";
+
 /// Explicit `earlycon` directive pinning the kernel's early console to the
 /// custom-HV PL011 UART emulator at `0x0B00_0000` (see
 /// `arcbox_vmm::vmm::darwin_hv::pl011::PL011_BASE`).

--- a/guest/arcbox-agent/src/init.rs
+++ b/guest/arcbox-agent/src/init.rs
@@ -481,6 +481,39 @@ mod platform {
         setup_sandbox_forwarding();
     }
 
+    /// One-shot init for distro machines (boot shim path).
+    ///
+    /// The overlay root is the distro's own filesystem: no tmpfs staging and
+    /// no `/etc` population — the distro init owns those. Only networking is
+    /// brought up here (mirrored images ship without the incus network
+    /// config, so nothing in the guest would configure eth0 otherwise), plus
+    /// a resolver when the distro image left none.
+    pub fn machine_init() {
+        run_init_cmd(
+            "/bin/busybox",
+            &["ip", "link", "set", "lo", "up"],
+            "ip link lo up",
+            Duration::from_secs(5),
+        );
+        configure_primary_interface_dhcp();
+        write_machine_resolv_conf();
+    }
+
+    /// Points `/etc/resolv.conf` at the NAT gateway resolver (10.0.2.1), but
+    /// only when the distro has no usable resolver of its own — a
+    /// systemd-resolved symlink or a non-empty file is left alone.
+    fn write_machine_resolv_conf() {
+        let path = Path::new("/etc/resolv.conf");
+        if let Ok(meta) = fs::symlink_metadata(path) {
+            if meta.file_type().is_symlink() || meta.len() > 0 {
+                return;
+            }
+        }
+        if let Err(e) = fs::write(path, "nameserver 10.0.2.1\n") {
+            tracing::warn!(error = %e, "failed to write /etc/resolv.conf");
+        }
+    }
+
     fn configure_primary_interface_dhcp() {
         let Some(interface) = detect_primary_interface() else {
             tracing::warn!("no non-loopback network interface found for DHCP");
@@ -898,11 +931,16 @@ fn docker_daemon_json() -> String {
 }
 
 #[cfg(target_os = "linux")]
-pub use platform::init_system;
+pub use platform::{init_system, machine_init};
 
 #[cfg(not(target_os = "linux"))]
 pub fn init_system() {
     tracing::warn!("init_system is only functional on Linux");
+}
+
+#[cfg(not(target_os = "linux"))]
+pub fn machine_init() {
+    tracing::warn!("machine_init is only functional on Linux");
 }
 
 /// The writable tmpfs layers the long-running agent cannot function without:

--- a/guest/arcbox-agent/src/main.rs
+++ b/guest/arcbox-agent/src/main.rs
@@ -71,6 +71,11 @@ enum Mode {
     /// One-shot system initialization (`arcbox-agent init`), run by busybox init's
     /// sysinit (rcS) before the agent is respawned. Performs `init_system` and exits.
     Init,
+    /// One-shot distro machine initialization (`arcbox-agent machine-init`),
+    /// run by the machine boot shim inside the overlay root before
+    /// `switch_root`. Brings networking up and exits; the distro init owns
+    /// everything else.
+    MachineInit,
     /// Long-running agent (default / `serve`): vsock RPC listener and background
     /// services. busybox init respawns it if it exits.
     Serve,
@@ -78,11 +83,13 @@ enum Mode {
 
 /// Selects the startup [`Mode`] from `args` (typically `std::env::args()`).
 ///
-/// `arcbox-agent init` runs one-shot system initialization; anything else — no
-/// subcommand or `serve` — runs the long-running agent.
+/// `arcbox-agent init` runs one-shot system initialization, `arcbox-agent
+/// machine-init` the distro-machine variant; anything else — no subcommand or
+/// `serve` — runs the long-running agent.
 fn parse_mode(args: &[String]) -> Mode {
     match args.get(1).map(String::as_str) {
         Some("init") => Mode::Init,
+        Some("machine-init") => Mode::MachineInit,
         _ => Mode::Serve,
     }
 }
@@ -168,6 +175,14 @@ async fn main() -> Result<()> {
     // `arcbox-agent init` is the one-shot system-init entry that busybox init's
     // sysinit (rcS) runs before respawning the long-running agent: it performs the
     // system initialization and exits without starting the serving stack.
+    if parse_mode(&std::env::args().collect::<Vec<_>>()) == Mode::MachineInit {
+        tracing::info!("Running one-shot machine initialization");
+        // No critical-mount verification: the machine root is the distro's
+        // own writable overlay, not the tmpfs-staged EROFS layout.
+        init::machine_init();
+        return Ok(());
+    }
+
     if parse_mode(&std::env::args().collect::<Vec<_>>()) == Mode::Init {
         tracing::info!("Running one-shot system initialization");
         init::init_system();
@@ -256,6 +271,11 @@ mod tests {
     #[test]
     fn init_subcommand_selects_init_mode() {
         assert_eq!(parse_mode(&argv(&["init"])), Mode::Init);
+    }
+
+    #[test]
+    fn machine_init_subcommand_selects_machine_init_mode() {
+        assert_eq!(parse_mode(&argv(&["machine-init"])), Mode::MachineInit);
     }
 
     #[test]

--- a/internal-docs/plans/machine-boot-shim.md
+++ b/internal-docs/plans/machine-boot-shim.md
@@ -68,19 +68,25 @@ kernel + devices verbatim) for custom-kernel testing.
    `/arcbox` there; copy the shim's static busybox to `/newroot/bin/busybox`
    only if absent (the agent's DHCP path shells out to `/bin/busybox udhcpc`;
    Alpine already ships one, systemd distros don't).
-7. One-shot machine init inside the new root:
+7. Move `/proc`, `/sys`, `/dev` into `/newroot` **before anything runs
+   inside it**: the agent needs `/dev` for vsock and `/sys/class/net` for
+   interface discovery. All three moves are load-bearing (poweroff on
+   failure). This ordering is what the shipped `machine-init.sh` implements.
+8. One-shot machine init inside the new root:
    `chroot /newroot /arcbox/bin/arcbox-agent machine-init` — brings up eth0
    via DHCP and writes `/etc/resolv.conf` when the distro left none. Unlike
    the System VM's `agent init`, this must NOT tmpfs-over `/etc`/`/var`
    (the overlay already provides writable state and the distro owns those
    trees).
-8. Spawn the long-running agent, detached, inside the new root:
-   `chroot /newroot /arcbox/bin/arcbox-agent serve &` — it survives
-   `switch_root` (reparented to the distro init) and serves ping /
-   system-info / future exec over vsock.
-9. Move `/proc`, `/sys`, `/dev` into `/newroot`, then
-   `exec switch_root /newroot /sbin/init` — the distro's systemd (or
-   OpenRC on Alpine) becomes PID 1.
+9. Spawn the long-running agent, detached, inside the new root:
+   `chroot /newroot /arcbox/bin/arcbox-agent serve </newroot/dev/null …&` —
+   stdio must be opened via the moved `/dev`; the process survives the pivot
+   (reparented to the distro init) and serves ping / system-info / exec over
+   vsock.
+10. `cd /newroot && pivot_root . mnt && exec chroot . /sbin/init` — the
+    distro's systemd (or OpenRC on Alpine) becomes PID 1. busybox
+    `switch_root` is not usable here: it requires an initramfs root and the
+    shim boots from the EROFS block device.
 
 Failure policy mirrors rcS: any load-bearing step failing prints a console
 marker and powers off (`poweroff -f`), so the host sees a clean boot failure

--- a/internal-docs/plans/machine-boot-shim.md
+++ b/internal-docs/plans/machine-boot-shim.md
@@ -1,0 +1,135 @@
+# Machine Boot Shim
+
+Boot a user machine from a pulled distro rootfs (squashfs, mirrored from
+images.linuxcontainers.org via `image.arcboxcdn.com/linux`) into the distro's
+own init, with the ArcBox agent reachable over vsock — the OrbStack-style
+"real Linux machine" experience on ArcBox's own kernel.
+
+Stacked on `feat/machine-image-pull` (arcbox#431: image pull + block-device
+attach) and `arcboxlabs/kernel#10` (`CONFIG_SQUASHFS` + xz/zstd).
+
+## Constraints that shape the design
+
+1. **The distro image is immutable and byte-identical to upstream.** No agent
+   or init can be baked into it; everything ArcBox needs must arrive via block
+   devices, VirtioFS, or the kernel command line.
+2. **No initramfs.** The ArcBox kernel boots `root=` directly and execs the
+   root filesystem's init; our first code must therefore live on a block
+   device the kernel can mount as root.
+3. **`switch_root` must run as PID 1.** The System VM's busybox-inittab path
+   (rcS runs as a *child* of busybox init) cannot hand PID 1 to the distro's
+   init. The machine path instead boots with `init=/sbin/arcbox-machine-init`,
+   so the shim script itself is PID 1 and can `exec switch_root`.
+4. **The readiness gate needs both vsock and an IP.**
+   `MachineManager::wait_for_machine_ready` polls agent ping + a routable IP,
+   so the shim must guarantee the agent runs and DHCP happens even on distros
+   whose image doesn't auto-configure networking (the mirror drops the incus
+   metadata tarball that normally does this).
+
+## Device and cmdline contract
+
+| Device | Content | Mode |
+| --- | --- | --- |
+| vda | boot-assets EROFS (the shim: busybox, mkfs.btrfs, machine-init) | ro |
+| vdb | distro rootfs (`rootfs.squashfs` from the image registry) | ro |
+| vdc | per-machine sparse `data.img` (btrfs, first-boot formatted) | rw |
+
+Kernel: the boot-assets kernel (same as the System VM). Command line:
+
+```
+console=hvc0 root=/dev/vda ro rootfstype=erofs earlycon \
+  init=/sbin/arcbox-machine-init \
+  arcbox.machine_rootfs=/dev/vdb arcbox.machine_rootfs_type=squashfs \
+  arcbox.machine_data=/dev/vdc
+```
+
+The `arcbox.machine_*` keys live in `arcbox-constants` (host side) and are
+parsed by the shim script from `/proc/cmdline`, so boot-assets and arcbox
+cannot drift silently. `rootfs_type` is carried from the image manifest —
+a future EROFS/zstd recompression on the mirror changes only the manifest.
+
+A machine created *without* a distro keeps the plain path from #431 (caller
+kernel + devices verbatim) for custom-kernel testing.
+
+## Shim flow (`/sbin/arcbox-machine-init`, PID 1, busybox sh)
+
+1. Mount `/proc`, `/sys`, `/dev` (devtmpfs); honor `arcbox.debug_console`
+   exactly like rcS.
+2. Mount VirtioFS `arcbox` share at `/arcbox` (agent binary, logs).
+3. `mount -t $rootfs_type -o ro $machine_rootfs /lower`.
+4. Data disk: if `$machine_data` has no btrfs superblock, `mkfs.btrfs` it
+   (same first-boot pattern as the System VM data disk). Mount at `/data`,
+   create `upper/`, `work/`.
+5. `mount -t overlay overlay -o lowerdir=/lower,upperdir=/data/upper,workdir=/data/work /newroot` —
+   the machine's writable root; all distro writes land on the btrfs disk,
+   the squashfs stays pristine (and shared across machines of the same
+   image version).
+6. Stage host bits into the new root: `mkdir -p /newroot/arcbox` and move-mount
+   `/arcbox` there; copy the shim's static busybox to `/newroot/bin/busybox`
+   only if absent (the agent's DHCP path shells out to `/bin/busybox udhcpc`;
+   Alpine already ships one, systemd distros don't).
+7. One-shot machine init inside the new root:
+   `chroot /newroot /arcbox/bin/arcbox-agent machine-init` — brings up eth0
+   via DHCP and writes `/etc/resolv.conf` when the distro left none. Unlike
+   the System VM's `agent init`, this must NOT tmpfs-over `/etc`/`/var`
+   (the overlay already provides writable state and the distro owns those
+   trees).
+8. Spawn the long-running agent, detached, inside the new root:
+   `chroot /newroot /arcbox/bin/arcbox-agent serve &` — it survives
+   `switch_root` (reparented to the distro init) and serves ping /
+   system-info / future exec over vsock.
+9. Move `/proc`, `/sys`, `/dev` into `/newroot`, then
+   `exec switch_root /newroot /sbin/init` — the distro's systemd (or
+   OpenRC on Alpine) becomes PID 1.
+
+Failure policy mirrors rcS: any load-bearing step failing prints a console
+marker and powers off (`poweroff -f`), so the host sees a clean boot failure
+instead of a half-configured guest.
+
+## Change inventory
+
+- **arcboxlabs/kernel#10** — squashfs (xz today, zstd headroom). Merged
+  first; boot-assets picks it up on its next release bump.
+- **boot-assets** — `scripts/machine-init.sh` packaged at
+  `/sbin/arcbox-machine-init` in the EROFS. Pure addition: the System VM
+  path (inittab → rcS → agent) is untouched.
+- **arcbox (this branch)** —
+  - `arcbox-constants`: `arcbox.machine_*` cmdline keys + shim init path.
+  - `machine.rs`: `MachineRootfs.shim` (kernel + EROFS from boot assets);
+    shim-aware device/cmdline assembly in `create`.
+  - `grpc/machine.rs`: resolve `BootAssetProvider` (same `data_dir/boot`
+    cache the daemon already populates) and fill the shim for distro
+    machines.
+  - `guest/arcbox-agent`: `machine-init` mode — networking + resolv.conf
+    only; no System-VM mount setup.
+
+## Agent supervision (phase 2)
+
+The spawned agent has no supervisor after `switch_root`. Once the base flow
+is proven, the shim can drop a generated systemd unit (or OpenRC script)
+into the overlay upper (`/etc/systemd/system/arcbox-agent.service` +
+`multi-user.target.wants` symlink) so the distro's init owns restarts. Not
+load-bearing for v1: the agent is stable, and a crashed agent only degrades
+host-side visibility, not the machine itself.
+
+## Testing
+
+1. Unit: shim device order / cmdline assembly in `machine::tests`.
+2. boot-assets QEMU e2e gains a machine-mode boot: shim EROFS + a tiny
+   squashfs fixture + blank data disk, asserting the guest reaches the
+   fixture's `/sbin/init` (observable via console marker) — same harness as
+   `qemu_boots_x86_64_linux`.
+3. arcbox e2e (ignored, macOS): `machine create --distro alpine` +
+   `machine start` reaching Running with an IP, once the kernel release with
+   squashfs lands in boot-assets.
+
+## Open questions
+
+- Multi-machine CID collisions (`machine.rs:517`, `3 + running_count`) —
+  pre-existing bug that bites as soon as two machines run; fix alongside
+  phase 2.
+- Per-machine VirtioFS: today every machine shares the System VM's `arcbox`
+  tag (fine: agent + logs) plus `/Users` — revisit mount scoping when
+  machine-specific mounts (`--mount host:guest`) are implemented.
+- systemd's `/` remount: systemd may remount root rw — harmless on overlay,
+  verify on first ubuntu boot.


### PR DESCRIPTION
**Stacked on #431** (machine image pull). Design doc: `internal-docs/plans/machine-boot-shim.md` (in this PR).

Distro machines boot the boot-assets EROFS as a **shim**: the kernel runs `init=/sbin/arcbox-machine-init` as PID 1, which mounts the distro squashfs (vdb) as an overlay lower over the first-boot-formatted btrfs data disk (vdc), stages `/arcbox` (VirtioFS) + busybox into the new root, runs `arcbox-agent machine-init` (DHCP + resolv fallback), spawns `arcbox-agent serve`, and `exec switch_root`s into the distro's own init — which becomes PID 1.

This PR lands the **arcbox side of the contract**:

- `arcbox-constants`: `arcbox.machine_rootfs=` / `arcbox.machine_rootfs_type=` / `arcbox.machine_data=` cmdline keys + `MACHINE_INIT_PATH` — single source of truth for host assembly and (by reference) the boot-assets script.
- `machine.rs`: `MachineRootfs.shim` (boot-assets kernel + EROFS). Device contract `[shim, rootfs, data, ..extras]` so vda/vdb/vdc hold regardless of extras; machine cmdline built from the constants. Shim-less path retained for custom-kernel testing.
- `grpc/machine.rs`: Create resolves the shim from the daemon's existing `data_dir/boot` asset cache (warm-cache no-op).
- `guest/arcbox-agent`: `machine-init` mode — brings up lo + eth0 DHCP and writes a gateway resolver only when the distro left none. Explicitly no tmpfs staging: the overlay root is the distro's own filesystem.

Tests: shim/shimless assembly contracts in `machine::tests` (device order, sparse data disk size, cmdline keys), `parse_mode` coverage; clippy `-D warnings` + fmt clean.

## Remaining to boot end-to-end

1. arcboxlabs/kernel#10 — squashfs support (merged → next boot-assets release).
2. boot-assets — `/sbin/arcbox-machine-init` script (PR follows; flow specified in the design doc).
3. Known pre-existing: CID collision for concurrent machines (`machine.rs` `3 + running_count`), agent unsupervised after switch_root (phase 2: systemd unit dropped into the overlay).