### PR TITLE
feat: resolve image layer paths for the Images Files tab (c8d)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -515,6 +515,7 @@ dependencies = [
  "libc",
  "serde",
  "serde_json",
+ "sha2 0.10.9",
  "tempfile",
  "tokio",
  "tokio-stream",

--- a/app/arcbox-api/src/system.rs
+++ b/app/arcbox-api/src/system.rs
@@ -8,9 +8,10 @@ use std::sync::Arc;
 
 use arcbox_grpc::SystemService;
 use arcbox_protocol::v1::{
-    Empty, ResolveContainerFsRequest, ResolveContainerFsResponse, SetSystemVmBackendRequest,
-    SetupStatus, SystemVmBackend, SystemVmBackendInfo, VcpuDebug, VirtioDebugInfo,
-    VirtioDeviceDebug, VirtioQueueDebug, setup_status,
+    Empty, ResolveContainerFsRequest, ResolveContainerFsResponse, ResolveImageFsRequest,
+    ResolveImageFsResponse, SetSystemVmBackendRequest, SetupStatus, SystemVmBackend,
+    SystemVmBackendInfo, VcpuDebug, VirtioDebugInfo, VirtioDeviceDebug, VirtioQueueDebug,
+    setup_status,
 };
 use tokio::sync::watch;
 use tokio_stream::Stream;
@@ -316,6 +317,24 @@ impl SystemService for SystemServiceImpl {
             .map_err(|e| Status::failed_precondition(e.to_string()))?;
         Ok(Response::new(ResolveContainerFsResponse {
             upper_dir: paths.upper_dir,
+            lower_dirs: paths.lower_dirs,
+        }))
+    }
+
+    async fn resolve_image_fs(
+        &self,
+        request: Request<ResolveImageFsRequest>,
+    ) -> Result<Response<ResolveImageFsResponse>, Status> {
+        let runtime = self.runtime.ready()?;
+        let req = request.into_inner();
+        if req.top_chain_id.is_empty() {
+            return Err(Status::invalid_argument("top_chain_id must not be empty"));
+        }
+        let paths = runtime
+            .image_fs_paths(&req.top_chain_id)
+            .await
+            .map_err(|e| Status::failed_precondition(e.to_string()))?;
+        Ok(Response::new(ResolveImageFsResponse {
             lower_dirs: paths.lower_dirs,
         }))
     }

--- a/app/arcbox-core/src/agent_client.rs
+++ b/app/arcbox-core/src/agent_client.rs
@@ -11,13 +11,13 @@ use arcbox_constants::ports::AGENT_PORT;
 use arcbox_constants::wire::MessageType;
 use arcbox_protocol::agent::{
     ContainerFsPathsRequest, ContainerFsPathsResponse, DiskTrimRequest, DiskTrimResponse,
-    KubernetesDeleteRequest, KubernetesDeleteResponse, KubernetesKubeconfigRequest,
-    KubernetesKubeconfigResponse, KubernetesStartRequest, KubernetesStartResponse,
-    KubernetesStatusRequest, KubernetesStatusResponse, KubernetesStopRequest,
-    KubernetesStopResponse, MachineStats, MemoryPressureEvent, MmapReadFileRequest,
-    MmapReadFileResponse, PingRequest, PingResponse, ReadinessEvent, RuntimeEnsureRequest,
-    RuntimeEnsureResponse, RuntimeStatusRequest, RuntimeStatusResponse, SystemInfo,
-    WatchMemoryPressureRequest, WatchReadinessRequest, WatchStatsRequest,
+    ImageFsPathsRequest, ImageFsPathsResponse, KubernetesDeleteRequest, KubernetesDeleteResponse,
+    KubernetesKubeconfigRequest, KubernetesKubeconfigResponse, KubernetesStartRequest,
+    KubernetesStartResponse, KubernetesStatusRequest, KubernetesStatusResponse,
+    KubernetesStopRequest, KubernetesStopResponse, MachineStats, MemoryPressureEvent,
+    MmapReadFileRequest, MmapReadFileResponse, PingRequest, PingResponse, ReadinessEvent,
+    RuntimeEnsureRequest, RuntimeEnsureResponse, RuntimeStatusRequest, RuntimeStatusResponse,
+    SystemInfo, WatchMemoryPressureRequest, WatchReadinessRequest, WatchStatsRequest,
 };
 use arcbox_protocol::sandbox_v1::{
     CheckpointRequest, CheckpointResponse, CreateSandboxRequest, CreateSandboxResponse,
@@ -899,6 +899,45 @@ impl AgentClient {
             MessageType::ContainerFsPathsRequest,
             &payload,
             MessageType::ContainerFsPathsResponse,
+        )
+    }
+
+    /// Resolves an image's layer directories (guest paths) from its top
+    /// layer chain ID via containerd snapshot metadata in the guest.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the request fails or the image's snapshot chain
+    /// is absent (e.g. the image was removed).
+    pub async fn image_fs_paths(&mut self, top_chain_id: &str) -> Result<ImageFsPathsResponse> {
+        let payload = ImageFsPathsRequest {
+            top_chain_id: top_chain_id.to_string(),
+        }
+        .encode_to_vec();
+        self.unary_rpc(
+            MessageType::ImageFsPathsRequest,
+            &payload,
+            MessageType::ImageFsPathsResponse,
+        )
+        .await
+    }
+
+    /// Blocking variant of [`Self::image_fs_paths`] for the HV socketpair
+    /// transport. Call from `spawn_blocking`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the request fails or the image's snapshot chain
+    /// is absent (e.g. the image was removed).
+    pub fn image_fs_paths_blocking(&mut self, top_chain_id: &str) -> Result<ImageFsPathsResponse> {
+        let payload = ImageFsPathsRequest {
+            top_chain_id: top_chain_id.to_string(),
+        }
+        .encode_to_vec();
+        self.unary_rpc_blocking(
+            MessageType::ImageFsPathsRequest,
+            &payload,
+            MessageType::ImageFsPathsResponse,
         )
     }
 

--- a/app/arcbox-core/src/runtime.rs
+++ b/app/arcbox-core/src/runtime.rs
@@ -22,8 +22,9 @@ use arcbox_net::darwin::inbound_relay::{InboundListenerManager, InboundProtocol}
 #[cfg(not(target_os = "macos"))]
 use arcbox_net::port_forward::{PortForwardRule, PortForwarder};
 use arcbox_protocol::agent::{
-    ContainerFsPathsResponse, KubernetesDeleteResponse, KubernetesKubeconfigResponse,
-    KubernetesStartResponse, KubernetesStatusResponse, KubernetesStopResponse, ServiceStatus,
+    ContainerFsPathsResponse, ImageFsPathsResponse, KubernetesDeleteResponse,
+    KubernetesKubeconfigResponse, KubernetesStartResponse, KubernetesStatusResponse,
+    KubernetesStopResponse, ServiceStatus,
 };
 use assets::ensure_guest_binaries;
 use kubeconfig::{KUBERNETES_HOST_ENDPOINT, rewrite_kubeconfig_server};
@@ -528,6 +529,32 @@ impl Runtime {
                 .map_err(|e| CoreError::Vm(format!("container fs paths task panicked: {e}")))?
         } else {
             agent.container_fs_paths(container_id).await
+        }
+    }
+
+    /// Resolves an image's layer directories (guest paths) from its top
+    /// layer chain ID via containerd snapshot metadata in the System VM.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the System VM is not running, the agent is
+    /// unreachable, or the image's snapshot chain is absent.
+    pub async fn image_fs_paths(&self, top_chain_id: &str) -> Result<ImageFsPathsResponse> {
+        // Same transport contract as `container_fs_paths`: blocking connect
+        // off the executor, then dispatch on the transport kind.
+        let machine_manager = Arc::clone(&self.machine_manager);
+        let mut agent = tokio::task::spawn_blocking(move || {
+            machine_manager.connect_agent(DEFAULT_MACHINE_NAME)
+        })
+        .await
+        .map_err(|e| CoreError::Vm(format!("agent connect task panicked: {e}")))??;
+        if agent.is_blocking() {
+            let id = top_chain_id.to_string();
+            tokio::task::spawn_blocking(move || agent.image_fs_paths_blocking(&id))
+                .await
+                .map_err(|e| CoreError::Vm(format!("image fs paths task panicked: {e}")))?
+        } else {
+            agent.image_fs_paths(top_chain_id).await
         }
     }
 

--- a/common/arcbox-constants/src/wire.rs
+++ b/common/arcbox-constants/src/wire.rs
@@ -64,6 +64,9 @@ pub enum MessageType {
     /// Resolve a container's filesystem layer directories from containerd
     /// snapshot metadata (payload: `arcbox.agent.ContainerFsPathsRequest`).
     ContainerFsPathsRequest = 0x0011,
+    /// Resolve an image's layer directories from containerd snapshot
+    /// metadata (payload: `arcbox.agent.ImageFsPathsRequest`).
+    ImageFsPathsRequest = 0x0012,
 
     // Sandbox CRUD request types (0x0020 - 0x0026).
     SandboxCreateRequest = 0x0020,
@@ -132,6 +135,9 @@ pub enum MessageType {
     /// Answers [`Self::ContainerFsPathsRequest`] (payload:
     /// `arcbox.agent.ContainerFsPathsResponse`).
     ContainerFsPathsResponse = 0x1011,
+    /// Answers [`Self::ImageFsPathsRequest`] (payload:
+    /// `arcbox.agent.ImageFsPathsResponse`).
+    ImageFsPathsResponse = 0x1012,
     PortBindingsChanged = 0x1030,
     PortBindingsRemoved = 0x1031,
 
@@ -190,6 +196,7 @@ impl MessageType {
             0x000F => Some(Self::WatchMemoryPressureRequest),
             0x0010 => Some(Self::WatchStatsRequest),
             0x0011 => Some(Self::ContainerFsPathsRequest),
+            0x0012 => Some(Self::ImageFsPathsRequest),
             // Sandbox CRUD requests.
             0x0020 => Some(Self::SandboxCreateRequest),
             0x0021 => Some(Self::SandboxStopRequest),
@@ -230,6 +237,7 @@ impl MessageType {
             0x100F => Some(Self::MemoryPressureEvent),
             0x1010 => Some(Self::MachineStats),
             0x1011 => Some(Self::ContainerFsPathsResponse),
+            0x1012 => Some(Self::ImageFsPathsResponse),
             0x1030 => Some(Self::PortBindingsChanged),
             0x1031 => Some(Self::PortBindingsRemoved),
             // Sandbox CRUD responses.
@@ -320,9 +328,11 @@ mod tests {
             (0x000F, MessageType::WatchMemoryPressureRequest),
             (0x0010, MessageType::WatchStatsRequest),
             (0x0011, MessageType::ContainerFsPathsRequest),
+            (0x0012, MessageType::ImageFsPathsRequest),
             (0x100F, MessageType::MemoryPressureEvent),
             (0x1010, MessageType::MachineStats),
             (0x1011, MessageType::ContainerFsPathsResponse),
+            (0x1012, MessageType::ImageFsPathsResponse),
             (0x1001, MessageType::PingResponse),
             (0x1002, MessageType::GetSystemInfoResponse),
             (0x1003, MessageType::EnsureRuntimeResponse),

--- a/guest/arcbox-agent/src/agent/linux/rpc.rs
+++ b/guest/arcbox-agent/src/agent/linux/rpc.rs
@@ -136,6 +136,7 @@ async fn handle_request(request: RpcRequest) -> RequestResult {
         RpcRequest::ContainerFsPaths(req) => {
             RequestResult::Single(handle_container_fs_paths(req).await)
         }
+        RpcRequest::ImageFsPaths(req) => RequestResult::Single(handle_image_fs_paths(req).await),
         RpcRequest::KillAgent => RequestResult::Single(handle_kill_agent()),
         RpcRequest::WatchReadiness(_) => unreachable!("watch readiness is streaming"),
         RpcRequest::WatchMemoryPressure(_) => {
@@ -338,6 +339,36 @@ async fn handle_container_fs_paths(
         Err(e) => RpcResponse::Error(crate::rpc::ErrorResponse::new(
             libc::EIO,
             format!("container fs paths: {e}"),
+        )),
+    }
+}
+
+/// Handles an `ImageFsPaths` request.
+///
+/// Resolves an image's layer directories from its top layer chain ID via
+/// an ephemeral containerd View snapshot. The host reads the returned
+/// guest paths through the read-only NFS export.
+async fn handle_image_fs_paths(req: arcbox_protocol::agent::ImageFsPathsRequest) -> RpcResponse {
+    let chain_id = req.top_chain_id.as_str();
+    // Chain IDs are `sha256:` + 64 hex chars; charset-check the untrusted
+    // input before handing it to containerd as a snapshot key.
+    let is_valid = chain_id
+        .strip_prefix("sha256:")
+        .is_some_and(|d| d.len() == 64 && d.bytes().all(|b| b.is_ascii_hexdigit()));
+    if !is_valid {
+        return RpcResponse::Error(crate::rpc::ErrorResponse::new(
+            libc::EINVAL,
+            format!("invalid top chain id {chain_id:?}"),
+        ));
+    }
+
+    match crate::containerd::image_snapshot_paths(chain_id).await {
+        Ok(paths) => RpcResponse::ImageFsPaths(arcbox_protocol::agent::ImageFsPathsResponse {
+            lower_dirs: paths.lower_dirs,
+        }),
+        Err(e) => RpcResponse::Error(crate::rpc::ErrorResponse::new(
+            libc::EIO,
+            format!("image fs paths: {e}"),
         )),
     }
 }

--- a/guest/arcbox-agent/src/containerd.rs
+++ b/guest/arcbox-agent/src/containerd.rs
@@ -44,6 +44,39 @@ pub struct MountsResponse {
     pub mounts: Vec<Mount>,
 }
 
+/// Mirrors `containerd.services.snapshots.v1.ViewSnapshotRequest` (the
+/// `labels` map field is deliberately omitted — unused, and proto3 treats
+/// an absent field as empty).
+#[derive(Clone, PartialEq, Message)]
+pub struct ViewSnapshotRequest {
+    #[prost(string, tag = "1")]
+    pub snapshotter: String,
+    #[prost(string, tag = "2")]
+    pub key: String,
+    #[prost(string, tag = "3")]
+    pub parent: String,
+}
+
+/// Mirrors `containerd.services.snapshots.v1.ViewSnapshotResponse`.
+#[derive(Clone, PartialEq, Message)]
+pub struct ViewSnapshotResponse {
+    #[prost(message, repeated, tag = "1")]
+    pub mounts: Vec<Mount>,
+}
+
+/// Mirrors `containerd.services.snapshots.v1.RemoveSnapshotRequest`.
+#[derive(Clone, PartialEq, Message)]
+pub struct RemoveSnapshotRequest {
+    #[prost(string, tag = "1")]
+    pub snapshotter: String,
+    #[prost(string, tag = "2")]
+    pub key: String,
+}
+
+/// Mirrors `google.protobuf.Empty` (the Remove response).
+#[derive(Clone, PartialEq, Message)]
+pub struct Empty {}
+
 /// A snapshot's filesystem layer directories, top-most lower first.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SnapshotPaths {
@@ -116,16 +149,78 @@ mod client {
     use tonic::transport::Endpoint;
     use tower::Service;
 
-    use super::{MountsRequest, SnapshotPaths, parse_snapshot_paths};
+    use super::{
+        MountsRequest, RemoveSnapshotRequest, SnapshotPaths, ViewSnapshotRequest,
+        parse_snapshot_paths,
+    };
 
     /// dockerd runs everything in the fixed `moby` containerd namespace.
     const NAMESPACE: &str = "moby";
     /// The snapshotter dockerd's containerd image store uses on this guest;
-    /// its snapshot key for a container is the container ID.
+    /// its snapshot key for a container is the container ID, and for an
+    /// image layer chain the top layer's chain ID (`sha256:<digest>`).
     const SNAPSHOTTER: &str = "overlayfs";
 
     /// Resolves a container's snapshot layer directories via containerd.
     pub async fn container_snapshot_paths(container_id: &str) -> Result<SnapshotPaths, String> {
+        let mut grpc = connect().await?;
+        let response: super::MountsResponse = unary(
+            &mut grpc,
+            "/containerd.services.snapshots.v1.Snapshots/Mounts",
+            MountsRequest {
+                snapshotter: SNAPSHOTTER.to_string(),
+                key: container_id.to_string(),
+            },
+        )
+        .await
+        .map_err(|e| format!("snapshots.Mounts({container_id}) failed: {e}"))?;
+
+        parse_snapshot_paths(&response.mounts)
+    }
+
+    /// Resolves an image's layer directories via containerd.
+    ///
+    /// Committed snapshots have no mount spec of their own, so this creates
+    /// an ephemeral read-only View child of the image's top chain-ID
+    /// snapshot, reads the layer directories off the View's mounts, and
+    /// removes the View again. The returned directories belong to the
+    /// committed parents and outlive the View.
+    pub async fn image_snapshot_paths(top_chain_id: &str) -> Result<SnapshotPaths, String> {
+        let mut grpc = connect().await?;
+        let view_key = format!("arcbox-browse-{}", uuid::Uuid::new_v4());
+
+        let response: super::ViewSnapshotResponse = unary(
+            &mut grpc,
+            "/containerd.services.snapshots.v1.Snapshots/View",
+            ViewSnapshotRequest {
+                snapshotter: SNAPSHOTTER.to_string(),
+                key: view_key.clone(),
+                parent: top_chain_id.to_string(),
+            },
+        )
+        .await
+        .map_err(|e| format!("snapshots.View({top_chain_id}) failed: {e}"))?;
+
+        // Best-effort: a leaked view is inert metadata and the next GC or a
+        // retried browse never depends on it being gone.
+        let removed: Result<super::Empty, String> = unary(
+            &mut grpc,
+            "/containerd.services.snapshots.v1.Snapshots/Remove",
+            RemoveSnapshotRequest {
+                snapshotter: SNAPSHOTTER.to_string(),
+                key: view_key.clone(),
+            },
+        )
+        .await;
+        if let Err(e) = removed {
+            tracing::warn!(view_key, error = %e, "failed to remove browse view snapshot");
+        }
+
+        parse_snapshot_paths(&response.mounts)
+    }
+
+    /// Connects to the containerd socket and waits for service readiness.
+    async fn connect() -> Result<tonic::client::Grpc<tonic::transport::Channel>, String> {
         // The URI is required by the HTTP/2 layer but unused: the connector
         // dials the fixed containerd Unix socket.
         let channel = Endpoint::from_static("http://[::1]")
@@ -137,32 +232,37 @@ mod client {
         grpc.ready()
             .await
             .map_err(|e| format!("containerd not ready({e})"))?;
+        Ok(grpc)
+    }
 
-        let mut request = tonic::Request::new(MountsRequest {
-            snapshotter: SNAPSHOTTER.to_string(),
-            key: container_id.to_string(),
-        });
+    /// One unary call in the moby namespace.
+    async fn unary<Req, Resp>(
+        grpc: &mut tonic::client::Grpc<tonic::transport::Channel>,
+        path: &'static str,
+        message: Req,
+    ) -> Result<Resp, String>
+    where
+        Req: prost::Message + 'static,
+        Resp: prost::Message + Default + 'static,
+    {
+        grpc.ready()
+            .await
+            .map_err(|e| format!("containerd not ready({e})"))?;
+        let mut request = tonic::Request::new(message);
         request.metadata_mut().insert(
             "containerd-namespace",
             NAMESPACE.parse().expect("static namespace is valid ascii"),
         );
 
-        let response: tonic::Response<super::MountsResponse> = grpc
+        let response: tonic::Response<Resp> = grpc
             .unary(
                 request,
-                PathAndQuery::from_static("/containerd.services.snapshots.v1.Snapshots/Mounts"),
+                PathAndQuery::from_static(path),
                 tonic_prost::ProstCodec::default(),
             )
             .await
-            .map_err(|status| {
-                format!(
-                    "snapshots.Mounts({SNAPSHOTTER}, {container_id}) failed: {} {}",
-                    status.code(),
-                    status.message()
-                )
-            })?;
-
-        parse_snapshot_paths(&response.into_inner().mounts)
+            .map_err(|status| format!("{} {}", status.code(), status.message()))?;
+        Ok(response.into_inner())
     }
 
     /// Minimal tower connector dialing the fixed containerd Unix socket.
@@ -187,7 +287,7 @@ mod client {
 }
 
 #[cfg(target_os = "linux")]
-pub use client::container_snapshot_paths;
+pub use client::{container_snapshot_paths, image_snapshot_paths};
 
 #[cfg(test)]
 mod tests {

--- a/guest/arcbox-agent/src/rpc.rs
+++ b/guest/arcbox-agent/src/rpc.rs
@@ -15,14 +15,14 @@ pub use arcbox_constants::wire::MessageType;
 use arcbox_protocol::Empty;
 use arcbox_protocol::agent::{
     ContainerFsPathsRequest, ContainerFsPathsResponse, DiskTrimRequest, DiskTrimResponse,
-    KubernetesDeleteRequest, KubernetesDeleteResponse, KubernetesKubeconfigRequest,
-    KubernetesKubeconfigResponse, KubernetesStartRequest, KubernetesStartResponse,
-    KubernetesStatusRequest, KubernetesStatusResponse, KubernetesStopRequest,
-    KubernetesStopResponse, MemoryPressureEvent, MmapReadFileRequest, MmapReadFileResponse,
-    PingRequest, PingResponse, PortBindingsChanged, PortBindingsRemoved, ReadinessEvent,
-    RuntimeEnsureRequest, RuntimeEnsureResponse, RuntimeStatusRequest, RuntimeStatusResponse,
-    ShutdownRequest, ShutdownResponse, SystemInfo, WatchMemoryPressureRequest,
-    WatchReadinessRequest, WatchStatsRequest,
+    ImageFsPathsRequest, ImageFsPathsResponse, KubernetesDeleteRequest, KubernetesDeleteResponse,
+    KubernetesKubeconfigRequest, KubernetesKubeconfigResponse, KubernetesStartRequest,
+    KubernetesStartResponse, KubernetesStatusRequest, KubernetesStatusResponse,
+    KubernetesStopRequest, KubernetesStopResponse, MemoryPressureEvent, MmapReadFileRequest,
+    MmapReadFileResponse, PingRequest, PingResponse, PortBindingsChanged, PortBindingsRemoved,
+    ReadinessEvent, RuntimeEnsureRequest, RuntimeEnsureResponse, RuntimeStatusRequest,
+    RuntimeStatusResponse, ShutdownRequest, ShutdownResponse, SystemInfo,
+    WatchMemoryPressureRequest, WatchReadinessRequest, WatchStatsRequest,
 };
 
 /// Agent version string.
@@ -83,6 +83,7 @@ pub enum RpcRequest {
     MmapReadFile(MmapReadFileRequest),
     DiskTrim(DiskTrimRequest),
     ContainerFsPaths(ContainerFsPathsRequest),
+    ImageFsPaths(ImageFsPathsRequest),
     WatchReadiness(WatchReadinessRequest),
     WatchMemoryPressure(WatchMemoryPressureRequest),
     WatchStats(WatchStatsRequest),
@@ -112,6 +113,7 @@ pub enum RpcResponse {
     Error(ErrorResponse),
     MmapReadFile(MmapReadFileResponse),
     ContainerFsPaths(ContainerFsPathsResponse),
+    ImageFsPaths(ImageFsPathsResponse),
     /// Test-only: acknowledgement for [`RpcRequest::KillAgent`].
     KillAgent,
 }
@@ -139,6 +141,7 @@ impl RpcResponse {
             Self::Error(_) => MessageType::Error,
             Self::MmapReadFile(_) => MessageType::MmapReadFileResponse,
             Self::ContainerFsPaths(_) => MessageType::ContainerFsPathsResponse,
+            Self::ImageFsPaths(_) => MessageType::ImageFsPathsResponse,
             Self::KillAgent => MessageType::KillAgentResponse,
         }
     }
@@ -165,6 +168,7 @@ impl RpcResponse {
             Self::Error(err) => err.encode(),
             Self::MmapReadFile(msg) => msg.encode_to_vec(),
             Self::ContainerFsPaths(msg) => msg.encode_to_vec(),
+            Self::ImageFsPaths(msg) => msg.encode_to_vec(),
             Self::KillAgent => Empty::default().encode_to_vec(),
         }
     }
@@ -340,6 +344,10 @@ pub fn parse_request(msg_type: MessageType, payload: &[u8]) -> Result<RpcRequest
         MessageType::ContainerFsPathsRequest => {
             let req = ContainerFsPathsRequest::decode(payload)?;
             Ok(RpcRequest::ContainerFsPaths(req))
+        }
+        MessageType::ImageFsPathsRequest => {
+            let req = ImageFsPathsRequest::decode(payload)?;
+            Ok(RpcRequest::ImageFsPaths(req))
         }
         MessageType::WatchReadinessRequest => {
             let req = WatchReadinessRequest::decode(payload)?;

--- a/rpc/arcbox-protocol/proto/agent.proto
+++ b/rpc/arcbox-protocol/proto/agent.proto
@@ -454,3 +454,18 @@ message ContainerFsPathsResponse {
     // Read-only layer directories, top-most first.
     repeated string lower_dirs = 2;
 }
+
+// Resolve an image's layer directories from containerd's snapshot
+// metadata (committed snapshots keyed by layer chain ID).
+message ImageFsPathsRequest {
+    // Chain ID of the image's top layer (`sha256:<64 hex>`), computed
+    // from the image config's diff_ids.
+    string top_chain_id = 1;
+}
+
+// Response to `ImageFsPathsRequest`. All paths are guest paths under the
+// containerd data mount.
+message ImageFsPathsResponse {
+    // Read-only layer directories, top-most first.
+    repeated string lower_dirs = 1;
+}

--- a/rpc/arcbox-protocol/proto/api.proto
+++ b/rpc/arcbox-protocol/proto/api.proto
@@ -212,6 +212,12 @@ service SystemService {
     // browsers call this and read the returned guest paths through the
     // read-only ~/ArcBox NFS export.
     rpc ResolveContainerFs(ResolveContainerFsRequest) returns (ResolveContainerFsResponse);
+
+    // Resolves an image's layer directories from containerd snapshot
+    // metadata in the guest, keyed by the image's top layer chain ID
+    // (computed from the image config's diff_ids). Same read path as
+    // ResolveContainerFs.
+    rpc ResolveImageFs(ResolveImageFsRequest) returns (ResolveImageFsResponse);
 }
 
 // Hypervisor backend for the single System VM.
@@ -247,6 +253,19 @@ message ResolveContainerFsResponse {
     string upper_dir = 1;
     // Read-only layer directories, top-most first.
     repeated string lower_dirs = 2;
+}
+
+// Request to resolve an image's layer directories.
+message ResolveImageFsRequest {
+    // Chain ID of the image's top layer (`sha256:<64 hex>`).
+    string top_chain_id = 1;
+}
+
+// An image's layer directories, as guest paths under the containerd data
+// mount.
+message ResolveImageFsResponse {
+    // Read-only layer directories, top-most first.
+    repeated string lower_dirs = 1;
 }
 
 // Diagnostic snapshot of the System VM's virtio devices and vCPUs.

--- a/rpc/arcbox-protocol/src/generated/arcbox.v1.rs
+++ b/rpc/arcbox-protocol/src/generated/arcbox.v1.rs
@@ -2294,6 +2294,27 @@ pub struct ContainerFsPathsResponse {
     #[prost(string, repeated, tag = "2")]
     pub lower_dirs: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
 }
+/// Resolve an image's layer directories from containerd's snapshot
+/// metadata (committed snapshots keyed by layer chain ID).
+#[derive(serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct ImageFsPathsRequest {
+    /// Chain ID of the image's top layer (`sha256:<64 hex>`), computed
+    /// from the image config's diff_ids.
+    #[prost(string, tag = "1")]
+    pub top_chain_id: ::prost::alloc::string::String,
+}
+/// Response to `ImageFsPathsRequest`. All paths are guest paths under the
+/// containerd data mount.
+#[derive(serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct ImageFsPathsResponse {
+    /// Read-only layer directories, top-most first.
+    #[prost(string, repeated, tag = "1")]
+    pub lower_dirs: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
+}
 /// Request to create a network.
 #[derive(serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -2531,6 +2552,25 @@ pub struct ResolveContainerFsResponse {
     pub upper_dir: ::prost::alloc::string::String,
     /// Read-only layer directories, top-most first.
     #[prost(string, repeated, tag = "2")]
+    pub lower_dirs: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
+}
+/// Request to resolve an image's layer directories.
+#[derive(serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct ResolveImageFsRequest {
+    /// Chain ID of the image's top layer (`sha256:<64 hex>`).
+    #[prost(string, tag = "1")]
+    pub top_chain_id: ::prost::alloc::string::String,
+}
+/// An image's layer directories, as guest paths under the containerd data
+/// mount.
+#[derive(serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct ResolveImageFsResponse {
+    /// Read-only layer directories, top-most first.
+    #[prost(string, repeated, tag = "1")]
     pub lower_dirs: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
 }
 /// Diagnostic snapshot of the System VM's virtio devices and vCPUs.

--- a/rpc/arcbox-protocol/src/lib.rs
+++ b/rpc/arcbox-protocol/src/lib.rs
@@ -94,15 +94,16 @@ pub mod image {
 pub mod agent {
     pub use super::v1::{
         AgentPingRequest, AgentPingResponse, ContainerFsPathsRequest, ContainerFsPathsResponse,
-        ContainerStats, DiskTrimRequest, DiskTrimResponse, KubernetesDeleteRequest,
-        KubernetesDeleteResponse, KubernetesKubeconfigRequest, KubernetesKubeconfigResponse,
-        KubernetesStartRequest, KubernetesStartResponse, KubernetesStatusRequest,
-        KubernetesStatusResponse, KubernetesStopRequest, KubernetesStopResponse, MachineStats,
-        MemoryPressureEvent, MmapReadFileRequest, MmapReadFileResponse, PortBindingsChanged,
-        PortBindingsRemoved, ReadinessEvent, RuntimeEnsureRequest, RuntimeEnsureResponse,
-        RuntimeStatusRequest, RuntimeStatusResponse, ServiceStatus, ShutdownRequest,
-        ShutdownResponse, SystemInfo, WatchMemoryPressureRequest, WatchReadinessRequest,
-        WatchStatsRequest, memory_pressure_event, readiness_event,
+        ContainerStats, DiskTrimRequest, DiskTrimResponse, ImageFsPathsRequest,
+        ImageFsPathsResponse, KubernetesDeleteRequest, KubernetesDeleteResponse,
+        KubernetesKubeconfigRequest, KubernetesKubeconfigResponse, KubernetesStartRequest,
+        KubernetesStartResponse, KubernetesStatusRequest, KubernetesStatusResponse,
+        KubernetesStopRequest, KubernetesStopResponse, MachineStats, MemoryPressureEvent,
+        MmapReadFileRequest, MmapReadFileResponse, PortBindingsChanged, PortBindingsRemoved,
+        ReadinessEvent, RuntimeEnsureRequest, RuntimeEnsureResponse, RuntimeStatusRequest,
+        RuntimeStatusResponse, ServiceStatus, ShutdownRequest, ShutdownResponse, SystemInfo,
+        WatchMemoryPressureRequest, WatchReadinessRequest, WatchStatsRequest,
+        memory_pressure_event, readiness_event,
     };
 
     // Backward compatibility type aliases (short names without Agent prefix).
@@ -135,7 +136,8 @@ pub mod api {
     pub use super::v1::{
         Event, EventActor, EventsRequest, GetInfoRequest, GetInfoResponse, GetVersionRequest,
         GetVersionResponse, PruneRequest, PruneResponse, ResolveContainerFsRequest,
-        ResolveContainerFsResponse, SystemPingRequest, SystemPingResponse,
+        ResolveContainerFsResponse, ResolveImageFsRequest, ResolveImageFsResponse,
+        SystemPingRequest, SystemPingResponse,
     };
 
     // Volume service types
@@ -205,7 +207,8 @@ pub use v1::{
 pub use v1::{
     Event, EventActor, EventsRequest, GetInfoRequest, GetInfoResponse, GetVersionRequest,
     GetVersionResponse, PruneRequest, PruneResponse, ResolveContainerFsRequest,
-    ResolveContainerFsResponse, SystemPingRequest, SystemPingResponse,
+    ResolveContainerFsResponse, ResolveImageFsRequest, ResolveImageFsResponse, SystemPingRequest,
+    SystemPingResponse,
 };
 
 // API types - Volume

--- a/tests/e2e/Cargo.toml
+++ b/tests/e2e/Cargo.toml
@@ -20,6 +20,7 @@ hyper-util = { version = "0.1.20", features = ["tokio"] }
 libc.workspace = true
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
+sha2.workspace = true
 tempfile.workspace = true
 tokio.workspace = true
 tokio-stream.workspace = true

--- a/tests/e2e/tests/container_fs.rs
+++ b/tests/e2e/tests/container_fs.rs
@@ -1,8 +1,10 @@
-//! Live check for `SystemService.ResolveContainerFs` and the containerd
-//! child NFS export: boots the System VM through a real daemon, runs a
-//! container that writes a marker into its rootfs, resolves the
-//! container's snapshot layer directories over gRPC, and reads the marker
-//! back through the host NFS mount (`<data_dir>/ArcBox/containerd/...`).
+//! Live check for `SystemService.ResolveContainerFs` / `ResolveImageFs`
+//! and the containerd child NFS export: boots the System VM through a real
+//! daemon, runs a container that writes a marker into its rootfs, resolves
+//! the container's snapshot layer directories over gRPC, reads the marker
+//! back through the host NFS mount (`<data_dir>/ArcBox/containerd/...`),
+//! then resolves the image's layers by top chain ID and checks they are
+//! visible through the same mount.
 
 use std::path::{Path, PathBuf};
 use std::sync::Once;
@@ -13,7 +15,8 @@ use arcbox_e2e::boot_assets::{resolve_boot_version, stage_dev_boot_assets};
 use arcbox_e2e::daemon::{DaemonConfig, DaemonHandle, connect_unix};
 use arcbox_e2e::docker::docker_output;
 use arcbox_grpc::SystemServiceClient;
-use arcbox_protocol::v1::ResolveContainerFsRequest;
+use arcbox_protocol::v1::{ResolveContainerFsRequest, ResolveImageFsRequest};
+use sha2::{Digest, Sha256};
 use tracing_subscriber::EnvFilter;
 
 static TRACING: Once = Once::new();
@@ -130,8 +133,84 @@ fn scenario(data_dir: &Path) -> Result<()> {
         bail!("lower layer not visible at {}", lower_host.display());
     }
 
+    image_scenario(data_dir, &image)?;
+
     tracing::info!("container fs resolution + NFS read-through check passed");
     Ok(())
+}
+
+/// Resolves the pulled image's layers by top chain ID and checks the top
+/// layer directory is visible through the NFS mount.
+fn image_scenario(data_dir: &Path, image: &str) -> Result<()> {
+    let layers_json = docker_output(
+        data_dir,
+        &["image", "inspect", "-f", "{{json .RootFS.Layers}}", image],
+        DOCKER_TIMEOUT,
+    )?;
+    let diff_ids: Vec<String> =
+        serde_json::from_str(layers_json.trim()).context("parsing image RootFS.Layers")?;
+    let top_chain_id = top_chain_id(&diff_ids)?;
+
+    let image_paths = resolve_image_fs(data_dir, &top_chain_id)?;
+    tracing::info!(
+        %top_chain_id,
+        lowers = image_paths.lower_dirs.len(),
+        "resolved image fs paths"
+    );
+
+    if image_paths.lower_dirs.len() != diff_ids.len() {
+        bail!(
+            "expected {} image layers, got {:?}",
+            diff_ids.len(),
+            image_paths.lower_dirs
+        );
+    }
+    for lower in &image_paths.lower_dirs {
+        if !lower.starts_with(CONTAINERD_PREFIX) {
+            bail!("image lower_dir {lower} not under {CONTAINERD_PREFIX}");
+        }
+    }
+    let top_host = host_path(data_dir, &image_paths.lower_dirs[0])?;
+    if !top_host.is_dir() {
+        bail!("image top layer not visible at {}", top_host.display());
+    }
+    Ok(())
+}
+
+/// Chain ID of the last layer, per the OCI image spec: the first chain ID
+/// is the first diff ID; each next one is `sha256(prev + " " + diff)`.
+fn top_chain_id(diff_ids: &[String]) -> Result<String> {
+    let (first, rest) = diff_ids
+        .split_first()
+        .context("image reports no rootfs layers")?;
+    let mut chain = first.clone();
+    for diff in rest {
+        let digest = Sha256::digest(format!("{chain} {diff}").as_bytes());
+        chain = format!("sha256:{digest:x}");
+    }
+    Ok(chain)
+}
+
+fn resolve_image_fs(
+    data_dir: &Path,
+    top_chain_id: &str,
+) -> Result<arcbox_protocol::v1::ResolveImageFsResponse> {
+    let socket = data_dir.join("run/arcbox.sock");
+    let top_chain_id = top_chain_id.to_owned();
+    tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .context("building tokio runtime for ResolveImageFs")?
+        .block_on(async {
+            let channel = connect_unix(&socket).await?;
+            let mut client = SystemServiceClient::new(channel);
+            anyhow::Ok(
+                client
+                    .resolve_image_fs(ResolveImageFsRequest { top_chain_id })
+                    .await?
+                    .into_inner(),
+            )
+        })
 }
 
 fn resolve_container_fs(


### PR DESCRIPTION
Completes the ABX-425 follow-up: under the containerd image store the Images Files tab had no path to browse — committed image snapshots have no mount spec, unlike container (active) snapshots.

- **Agent**: `image_snapshot_paths` creates an ephemeral read-only containerd **View** child of the image's top chain-ID snapshot, reads the layer directories off the View's mounts, and removes it (best-effort — a leaked view is inert metadata). The directories belong to the committed parents and outlive the View.
- **Wire**: additive `ImageFsPaths` agent RPC (0x0012/0x1012, no protocol bump); chain-ID input validated (`sha256:` + 64 hex) before reaching containerd.
- **API**: `SystemService.ResolveImageFs` takes the top layer chain ID (computed from the image config's diff_ids by the caller) and returns the layer directories, top-first, for the ~/ArcBox containerd export.
- **e2e**: `container_fs` now also inspects the pulled image, computes the chain ID host-side (OCI formula), resolves via gRPC, and checks the top layer through the NFS mount — **green on live hardware**, and the computed chain ID matched containerd's committed snapshot key exactly.

Desktop companion (Images Files tab fallback + chain-ID computation) follows the usual release/bump sequencing.

`buf breaking` clean; workspace clippy clean; agent musl clippy zero new warnings.