### PR TITLE
chore(assets): bump boot assets to 0.6.4

### DIFF
--- a/assets.lock
+++ b/assets.lock
@@ -14,9 +14,9 @@
 # and the [boot] bump.
 
 [boot]
-version = "0.6.3"
+version = "0.6.4"
 cdn = "https://boot.arcboxcdn.com"
-manifest_sha256 = "80c04d681dcf8384f8e4c76160a3d72b84b1d57a7b5663cf89325382073a5256"
+manifest_sha256 = "bb7885c381c5b5e76a22c10437a168624069f623a4096d691d1e592f151abfea"
 
 [[tools]]
 name = "docker"


### PR DESCRIPTION
Boot bundle 0.6.3 → 0.6.4 ([boot-assets release](https://github.com/arcboxlabs/boot-assets/releases/tag/v0.6.4)), bringing:

- **kernel v0.0.18** — Linux 6.12.95 (84 stable point releases of fixes since 6.12.11) + squashfs (xz/zstd, percpu decompression) for machine distro images (kernel#10, kernel#11)
- **machine boot shim** at `/sbin/arcbox-machine-init` in the EROFS (boot-assets#40) — inert for the System VM, used by #432's machine boot contract

Verified against the live CDN: `latest.json` → 0.6.4, manifest `source_ref: v0.0.18`, sha256 matches this lock entry, and the published arm64 EROFS contains `arcbox-machine-init`.

With this merged, #431 + #432 have everything needed for a first real `machine create --distro` boot on the HV/VZ backends.