### PR TITLE
feat(core,api,cli): machine service correctness — CID, stop semantics, inspect, summary distro

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -237,12 +237,14 @@ dependencies = [
 name = "arcbox-api"
 version = "0.4.22"
 dependencies = [
+ "arcbox-constants",
  "arcbox-core",
  "arcbox-docker",
  "arcbox-error",
  "arcbox-grpc",
  "arcbox-protocol",
  "async-stream",
+ "chrono",
  "dimicon",
  "libc",
  "prost",

--- a/app/arcbox-api/Cargo.toml
+++ b/app/arcbox-api/Cargo.toml
@@ -9,6 +9,8 @@ repository.workspace = true
 authors.workspace = true
 
 [dependencies]
+arcbox-constants = { workspace = true }
+chrono = { workspace = true }
 arcbox-core = { workspace = true }
 arcbox-protocol = { workspace = true }
 arcbox-grpc = { workspace = true }

--- a/app/arcbox-api/src/grpc/machine.rs
+++ b/app/arcbox-api/src/grpc/machine.rs
@@ -15,6 +15,18 @@ use tonic::{Request, Response, Status};
 
 use super::{SharedRuntime, SharedRuntimeExt};
 
+/// The NAT gateway every machine's primary interface routes through; it also
+/// serves DNS (same literal the guest agent's DHCP path documents).
+const NAT_GATEWAY: &str = "10.0.2.1";
+
+/// Converts a chrono timestamp to the wire `Timestamp`.
+fn timestamp(t: chrono::DateTime<chrono::Utc>) -> arcbox_protocol::v1::Timestamp {
+    arcbox_protocol::v1::Timestamp {
+        seconds: t.timestamp(),
+        nanos: i32::try_from(t.timestamp_subsec_nanos()).unwrap_or(0),
+    }
+}
+
 /// Machine service implementation.
 pub struct MachineServiceImpl {
     runtime: SharedRuntime,
@@ -159,13 +171,37 @@ impl machine_service_server::MachineService for MachineServiceImpl {
     }
 
     async fn stop(&self, request: Request<StopMachineRequest>) -> Result<Response<Empty>, Status> {
-        let id = request.into_inner().id;
+        let req = request.into_inner();
         let runtime = self.runtime.ready()?;
+        let manager = std::sync::Arc::clone(runtime.machine_manager());
 
-        runtime
-            .machine_manager()
-            .stop(&id)
-            .map_err(|e| Status::internal(e.to_string()))?;
+        // Graceful stop (guest ACPI) with a force fallback, unless the caller
+        // asked for an immediate force stop. Both are synchronous VM calls
+        // that can block up to the shutdown window; keep them off the async
+        // workers.
+        let force = req.force;
+        let id = req.id;
+        tokio::task::spawn_blocking(move || {
+            if force {
+                return manager.stop(&id);
+            }
+            match manager.graceful_stop(
+                &id,
+                std::time::Duration::from_secs(
+                    arcbox_constants::timeouts::HOST_SHUTDOWN_TIMEOUT_SECS,
+                ),
+            ) {
+                Ok(true) => Ok(()),
+                Ok(false) => {
+                    tracing::warn!(machine = %id, "graceful stop timed out; force stopping");
+                    manager.stop(&id)
+                }
+                Err(e) => Err(e),
+            }
+        })
+        .await
+        .map_err(|e| Status::internal(format!("stop task panicked: {e}")))?
+        .map_err(|e| Status::internal(e.to_string()))?;
 
         Ok(Response::new(Empty {}))
     }
@@ -204,6 +240,8 @@ impl machine_service_server::MachineService for MachineServiceImpl {
                 disk_size: m.disk_gb * 1024 * 1024 * 1024,
                 ip_address: m.ip_address.unwrap_or_default(),
                 created: m.created_at.timestamp(),
+                distro: m.distro.unwrap_or_default(),
+                distro_version: m.distro_version.unwrap_or_default(),
             })
             .collect();
 
@@ -234,16 +272,31 @@ impl machine_service_server::MachineService for MachineServiceImpl {
                 arch: std::env::consts::ARCH.to_string(),
             }),
             network: Some(MachineNetwork {
+                // Gateway/DNS only exist once the guest has an address; both
+                // are the NAT gateway (which also serves DNS — the same
+                // topology the agent's DHCP path configures).
+                gateway: machine
+                    .ip_address
+                    .as_ref()
+                    .map(|_| NAT_GATEWAY.to_string())
+                    .unwrap_or_default(),
+                dns_servers: machine
+                    .ip_address
+                    .as_ref()
+                    .map(|_| vec![NAT_GATEWAY.to_string()])
+                    .unwrap_or_default(),
                 ip_address: machine.ip_address.clone().unwrap_or_default(),
-                gateway: String::new(),
                 mac_address: String::new(),
-                dns_servers: vec![],
                 bridge_mac_address: arcbox_core::vm::bridge_nic_mac_for_vm_id(&machine.vm_id),
             }),
             storage: Some(arcbox_protocol::v1::MachineStorage {
                 disk_size: machine.disk_gb * 1024 * 1024 * 1024,
                 disk_format: "raw".to_string(),
-                disk_path: String::new(),
+                disk_path: machine
+                    .disk_path
+                    .as_ref()
+                    .map(|p| p.to_string_lossy().into_owned())
+                    .unwrap_or_default(),
             }),
             os: Some(arcbox_protocol::v1::MachineOs {
                 distro: machine
@@ -253,8 +306,8 @@ impl machine_service_server::MachineService for MachineServiceImpl {
                 version: machine.distro_version.clone().unwrap_or_default(),
                 kernel: machine.kernel.unwrap_or_default(),
             }),
-            created: None,
-            started_at: None,
+            created: Some(timestamp(machine.created_at)),
+            started_at: machine.started_at.map(timestamp),
             mounts: vec![],
         }))
     }

--- a/app/arcbox-api/src/grpc/machine.rs
+++ b/app/arcbox-api/src/grpc/machine.rs
@@ -395,13 +395,50 @@ impl machine_service_server::MachineService for MachineServiceImpl {
     type ExecStream =
         Pin<Box<dyn Stream<Item = Result<MachineExecOutput, Status>> + Send + 'static>>;
 
+    /// Runs a command in the machine root via the guest agent, streaming
+    /// stdout/stderr frames and a final exit-code frame.
+    ///
+    /// Non-interactive: the agent rejects `tty` requests until the bidi exec
+    /// session lands. Streaming requires the async agent transport (VZ);
+    /// the HV blocking transport shares the sandbox-streaming limitation.
     async fn exec(
         &self,
-        _request: Request<MachineExecRequest>,
+        request: Request<MachineExecRequest>,
     ) -> Result<Response<Self::ExecStream>, Status> {
-        Err(Status::unimplemented(
-            "machine exec is no longer supported by guest agent RPC",
-        ))
+        let req = request.into_inner();
+        let agent = self
+            .runtime
+            .ready()?
+            .get_agent(&req.id)
+            .map_err(|e| Status::internal(e.to_string()))?;
+
+        let mut rx = agent
+            .machine_exec(req)
+            .await
+            .map_err(|e| Status::internal(e.to_string()))?;
+
+        let stream = async_stream::stream! {
+            while let Some(item) = rx.recv().await {
+                match item {
+                    Ok(output) => {
+                        let done = output.done;
+                        yield Ok(output);
+                        if done {
+                            break;
+                        }
+                    }
+                    Err(arcbox_core::error::CoreError::Agent { code: 400, message }) => {
+                        yield Err(Status::invalid_argument(message));
+                        break;
+                    }
+                    Err(e) => {
+                        yield Err(Status::internal(e.to_string()));
+                        break;
+                    }
+                }
+            }
+        };
+        Ok(Response::new(Box::pin(stream)))
     }
 
     async fn ssh_info(

--- a/app/arcbox-api/src/grpc/stats.rs
+++ b/app/arcbox-api/src/grpc/stats.rs
@@ -53,13 +53,16 @@ impl stats_service_server::StatsService for StatsServiceImpl {
         request: Request<StatsWatchRequest>,
     ) -> Result<Response<Self::WatchStream>, Status> {
         let req = request.into_inner();
-        if !req.machine_id.is_empty() && req.machine_id != DEFAULT_MACHINE_NAME {
-            return Err(Status::unimplemented(
-                "per-machine stats are not implemented yet; omit machine_id for the System VM",
-            ));
-        }
+        let machine_id = if req.machine_id.is_empty() {
+            DEFAULT_MACHINE_NAME.to_string()
+        } else {
+            req.machine_id
+        };
         let runtime = std::sync::Arc::clone(self.runtime.ready()?);
-        let mut rx = runtime.subscribe_machine_stats();
+        if machine_id != DEFAULT_MACHINE_NAME && !runtime.machine_manager().exists(&machine_id) {
+            return Err(Status::not_found(format!("machine '{machine_id}'")));
+        }
+        let mut rx = runtime.subscribe_machine_stats_for(&machine_id).await;
         let stream = async_stream::stream! {
             loop {
                 match rx.recv().await {

--- a/app/arcbox-cli/src/commands/machine.rs
+++ b/app/arcbox-cli/src/commands/machine.rs
@@ -180,9 +180,6 @@ pub struct RemoveArgs {
     /// Force removal
     #[arg(short, long)]
     pub force: bool,
-    /// Remove associated volumes
-    #[arg(short, long)]
-    pub volumes: bool,
 }
 
 #[derive(Args)]
@@ -369,7 +366,9 @@ async fn execute_remove(args: RemoveArgs) -> Result<()> {
         .remove(tonic::Request::new(RemoveMachineRequest {
             id: args.name.clone(),
             force: args.force,
-            volumes: args.volumes,
+            // Removal always deletes the machine directory; the wire field
+            // is retained for compatibility only.
+            volumes: false,
         }))
         .await
         .context("Failed to remove machine")?;
@@ -405,15 +404,23 @@ async fn execute_list(args: ListArgs) -> Result<()> {
 
     // Print header
     println!(
-        "{:<20} {:<12} {:<6} {:<12} {:<10}",
-        "NAME", "STATE", "CPUS", "MEMORY", "DISK"
+        "{:<20} {:<18} {:<12} {:<6} {:<12} {:<10}",
+        "NAME", "DISTRO", "STATE", "CPUS", "MEMORY", "DISK"
     );
 
     // Print machines
     for machine in &machines {
+        let distro = if machine.distro.is_empty() {
+            "-".to_string()
+        } else if machine.distro_version.is_empty() {
+            machine.distro.clone()
+        } else {
+            format!("{}:{}", machine.distro, machine.distro_version)
+        };
         println!(
-            "{:<20} {:<12} {:<6} {:<12} {:<10}",
+            "{:<20} {:<18} {:<12} {:<6} {:<12} {:<10}",
             machine.name,
+            distro,
             title_case_state(&machine.state),
             machine.cpus,
             format!("{} MB", machine.memory / (1024 * 1024)),

--- a/app/arcbox-cli/src/commands/machine.rs
+++ b/app/arcbox-cli/src/commands/machine.rs
@@ -552,13 +552,14 @@ async fn execute_info(args: InfoArgs) -> Result<()> {
 }
 
 async fn execute_ssh(args: SshArgs) -> Result<()> {
-    let (cmd, tty) = if args.command.is_empty() {
-        (vec!["/bin/sh".to_string(), "-l".to_string()], true)
-    } else {
-        (args.command.clone(), false)
-    };
-
-    exec_via_grpc(&args.name, cmd, HashMap::new(), tty).await
+    if args.command.is_empty() {
+        anyhow::bail!(
+            "interactive machine sessions are not available yet; \
+             run a command instead: arcbox machine ssh {} <command>",
+            args.name
+        );
+    }
+    exec_via_grpc(&args.name, args.command, HashMap::new(), false).await
 }
 
 async fn execute_exec(args: ExecArgs) -> Result<()> {

--- a/app/arcbox-core/src/agent_client.rs
+++ b/app/arcbox-core/src/agent_client.rs
@@ -1216,6 +1216,91 @@ impl AgentClient {
         Ok(())
     }
 
+    /// Runs a command in the machine root (the agent's own mount namespace)
+    /// and returns a channel of streaming output.
+    ///
+    /// Consumes the client because the stream task requires exclusive
+    /// transport access. Non-interactive: the guest rejects `tty` requests
+    /// until the bidi exec session lands.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the initial send fails.
+    pub async fn machine_exec(
+        mut self,
+        req: arcbox_protocol::v1::MachineExecRequest,
+    ) -> Result<mpsc::Receiver<Result<arcbox_protocol::v1::MachineExecOutput>>> {
+        if !self.connected {
+            self.connect().await?;
+        }
+
+        let payload = req.encode_to_vec();
+        let buf = wire::build_message(MessageType::MachineExecRequest, "", &payload);
+        self.transport
+            .async_send(buf)
+            .await
+            .map_err(|e| CoreError::Machine(format!("failed to send exec request: {}", e)))?;
+
+        let (tx, rx) = mpsc::channel(STREAM_CHANNEL_CAPACITY);
+        tokio::spawn(async move {
+            loop {
+                let raw = match self.transport.async_recv().await {
+                    Ok(r) => r,
+                    Err(e) => {
+                        let _ = tx
+                            .send(Err(CoreError::Machine(format!("recv error: {}", e))))
+                            .await;
+                        break;
+                    }
+                };
+
+                let (resp_type, _, resp_payload) = match wire::parse_response(&raw) {
+                    Ok(p) => p,
+                    Err(e) => {
+                        let _ = tx.send(Err(e)).await;
+                        break;
+                    }
+                };
+
+                if resp_type == MessageType::Error as u32 {
+                    let (code, message) = wire::parse_error_response(&resp_payload)
+                        .unwrap_or_else(|_| (500, "unknown error".to_string()));
+                    let _ = tx.send(Err(CoreError::Agent { code, message })).await;
+                    break;
+                }
+
+                if resp_type != MessageType::MachineExecOutput as u32 {
+                    let _ = tx
+                        .send(Err(CoreError::Machine(format!(
+                            "unexpected response type: 0x{:04x}",
+                            resp_type
+                        ))))
+                        .await;
+                    break;
+                }
+
+                match arcbox_protocol::v1::MachineExecOutput::decode(&resp_payload[..]) {
+                    Ok(output) => {
+                        let done = output.done;
+                        // Stop reading if the consumer dropped, so a spewing
+                        // process isn't drained into the void indefinitely.
+                        if tx.send(Ok(output)).await.is_err() || done {
+                            break;
+                        }
+                    }
+                    Err(e) => {
+                        let _ = tx
+                            .send(Err(CoreError::Machine(format!("decode error: {}", e))))
+                            .await;
+                        break;
+                    }
+                }
+            }
+        });
+
+        Ok(rx)
+    }
+
     /// Runs a command inside a sandbox and returns a channel of streaming output.
     ///
     /// Consumes the client because the stream task requires exclusive transport access.

--- a/app/arcbox-core/src/machine.rs
+++ b/app/arcbox-core/src/machine.rs
@@ -70,6 +70,8 @@ pub struct MachineInfo {
     pub backend: arcbox_vmm::VmBackend,
     /// Creation time.
     pub created_at: DateTime<Utc>,
+    /// Last successful start time.
+    pub started_at: Option<DateTime<Utc>>,
 }
 
 /// A pulled distro rootfs image a machine boots from.
@@ -273,6 +275,7 @@ impl MachineManager {
                     ip_address: persisted.ip_address.clone(),
                     backend: persisted.backend,
                     created_at: persisted.created_at,
+                    started_at: persisted.started_at,
                 };
                 machines.insert(persisted.name.clone(), info);
             }
@@ -438,6 +441,7 @@ impl MachineManager {
             ip_address: None,
             backend: config.backend,
             created_at: Utc::now(),
+            started_at: None,
         };
 
         // Persist the machine config
@@ -473,6 +477,7 @@ impl MachineManager {
             .start(&vm_id, self.shared_dns_hosts.clone())?;
 
         // Update machine state
+        let started_at = Utc::now();
         {
             let mut machines = self.machines.write().map_err(|_| CoreError::LockPoisoned)?;
 
@@ -480,6 +485,7 @@ impl MachineManager {
                 machine.state = MachineState::Running;
                 machine.cid = Some(cid);
                 machine.ip_address = None;
+                machine.started_at = Some(started_at);
 
                 tracing::info!("Machine '{}' started with CID {}", name, cid);
             }
@@ -489,6 +495,7 @@ impl MachineManager {
         if let Err(e) = self.persistence.update(name, |m| {
             m.state = MachineState::Running.into();
             m.ip_address = None;
+            m.started_at = Some(started_at);
         }) {
             tracing::warn!("Failed to persist state for machine '{}': {}", name, e);
         }
@@ -570,7 +577,7 @@ impl MachineManager {
     }
 
     fn assign_cid_for_start(&self, name: &str) -> Result<(VmId, u32)> {
-        let (vm_id, running_count) = {
+        let (vm_id, cid) = {
             let machines = self.machines.read().map_err(|_| CoreError::LockPoisoned)?;
 
             let machine = machines
@@ -589,16 +596,21 @@ impl MachineManager {
                 )));
             }
 
-            // Count running machines. CIDs 0, 1 are reserved, 2 is the host. We start from 3.
-            let running_count = machines
-                .values()
-                .filter(|m| m.state == MachineState::Running && m.cid.is_some())
-                .count() as u32;
+            // Lowest CID not held by another machine. CIDs 0/1 are reserved
+            // and 2 is the host, so guests start at 3. Uniqueness across
+            // machines is cosmetic — vsock routing is per-VM device
+            // (`VmManager::connect_vsock` addresses by VM id, and the guest
+            // only sees its own CID) — but distinct CIDs keep guest-side
+            // identity unambiguous in logs and diagnostics.
+            let used: std::collections::HashSet<u32> =
+                machines.values().filter_map(|m| m.cid).collect();
+            let cid = (3..=u32::MAX)
+                .find(|c| !used.contains(c))
+                .expect("fewer than u32::MAX machines");
 
-            (machine.vm_id.clone(), running_count)
+            (machine.vm_id.clone(), cid)
         };
 
-        let cid = 3 + running_count;
         self.vm_manager.set_guest_cid(&vm_id, cid)?;
 
         Ok((vm_id, cid))
@@ -1096,6 +1108,7 @@ impl MachineManager {
             ip_address: None,
             backend: arcbox_vmm::VmBackend::default(),
             created_at: Utc::now(),
+            started_at: None,
         };
 
         machines.insert(name.to_string(), info);

--- a/app/arcbox-core/src/machine.rs
+++ b/app/arcbox-core/src/machine.rs
@@ -799,7 +799,11 @@ impl MachineManager {
         self.vm_manager.debug_snapshot(&machine.vm_id)
     }
 
-    /// Stops a machine.
+    /// Stops a machine (force).
+    ///
+    /// Accepts `Stopping` as well as `Running` so a force stop can preempt
+    /// an in-flight graceful stop instead of erroring for up to the whole
+    /// graceful-shutdown window.
     ///
     /// # Errors
     ///
@@ -811,7 +815,10 @@ impl MachineManager {
             .get_mut(name)
             .ok_or_else(|| CoreError::not_found(name.to_string()))?;
 
-        if machine.state != MachineState::Running {
+        if !matches!(
+            machine.state,
+            MachineState::Running | MachineState::Stopping
+        ) {
             return Err(CoreError::invalid_state(format!(
                 "machine '{name}' is not running"
             )));
@@ -965,20 +972,25 @@ impl MachineManager {
                 Ok(true)
             }
             Ok(false) => {
-                if let Ok(mut machines) = self.machines.write() {
-                    if let Some(machine) = machines.get_mut(name) {
-                        machine.state = MachineState::Running;
-                    }
-                }
+                self.rollback_stopping(name);
                 Ok(false)
             }
             Err(e) => {
-                if let Ok(mut machines) = self.machines.write() {
-                    if let Some(machine) = machines.get_mut(name) {
-                        machine.state = MachineState::Running;
-                    }
-                }
+                self.rollback_stopping(name);
                 Err(e)
+            }
+        }
+    }
+
+    /// Rolls a failed graceful stop back to `Running` — but only if the
+    /// machine is still `Stopping`: a concurrent force [`Self::stop`] may
+    /// have already stopped it, and its `Stopped` must not be overwritten.
+    fn rollback_stopping(&self, name: &str) {
+        if let Ok(mut machines) = self.machines.write() {
+            if let Some(machine) = machines.get_mut(name) {
+                if machine.state == MachineState::Stopping {
+                    machine.state = MachineState::Running;
+                }
             }
         }
     }

--- a/app/arcbox-core/src/machine/tests.rs
+++ b/app/arcbox-core/src/machine/tests.rs
@@ -277,3 +277,27 @@ async fn test_create_without_shim_boots_rootfs_directly() {
     );
     assert!(!cmdline.contains("init="), "{cmdline}");
 }
+
+#[tokio::test]
+async fn test_assign_cid_skips_cids_held_by_other_machines() {
+    let temp_dir = tempdir().unwrap();
+    let machine_manager = test_machine_manager(temp_dir.path());
+
+    machine_manager
+        .register_mock_machine("holder-a", 3)
+        .unwrap();
+    machine_manager
+        .register_mock_machine("holder-b", 5)
+        .unwrap();
+
+    let name = machine_manager
+        .create(MachineConfig {
+            name: "fresh".to_string(),
+            ..Default::default()
+        })
+        .await
+        .unwrap();
+
+    let (_, cid) = machine_manager.assign_cid_for_start(&name).unwrap();
+    assert_eq!(cid, 4, "lowest CID not held by another machine");
+}

--- a/app/arcbox-core/src/persistence.rs
+++ b/app/arcbox-core/src/persistence.rs
@@ -56,6 +56,9 @@ pub struct PersistedMachine {
     /// Creation timestamp.
     #[serde(default = "default_created_at")]
     pub created_at: DateTime<Utc>,
+    /// Last successful start timestamp.
+    #[serde(default)]
+    pub started_at: Option<DateTime<Utc>>,
 }
 
 /// Default creation time for backward compatibility with old configs.
@@ -140,6 +143,7 @@ impl From<&MachineInfo> for PersistedMachine {
             vm_id: info.vm_id.to_string(),
             backend: info.backend,
             created_at: info.created_at,
+            started_at: info.started_at,
         }
     }
 }
@@ -316,6 +320,7 @@ mod tests {
         let created_at = Utc::now();
         let info = MachineInfo {
             name: "test-vm".to_string(),
+            started_at: None,
             state: MachineState::Created,
             vm_id: VmId::new(),
             cpus: 4,
@@ -357,6 +362,7 @@ mod tests {
         for name in ["vm1", "vm2", "vm3"] {
             let info = MachineInfo {
                 name: name.to_string(),
+                started_at: None,
                 state: MachineState::Created,
                 vm_id: VmId::new(),
                 cpus: 2,
@@ -391,6 +397,7 @@ mod tests {
 
         let info = MachineInfo {
             name: "test-vm".to_string(),
+            started_at: None,
             state: MachineState::Created,
             vm_id: VmId::new(),
             cpus: 2,
@@ -423,6 +430,7 @@ mod tests {
 
         let info = MachineInfo {
             name: "test-vm".to_string(),
+            started_at: None,
             state: MachineState::Created,
             vm_id: VmId::new(),
             cpus: 2,
@@ -470,6 +478,7 @@ mod tests {
 
         let info = MachineInfo {
             name: "crash-vm".to_string(),
+            started_at: None,
             state: MachineState::Running,
             vm_id: VmId::new(),
             cpus: 2,

--- a/app/arcbox-core/src/runtime.rs
+++ b/app/arcbox-core/src/runtime.rs
@@ -118,6 +118,14 @@ pub struct Runtime {
     /// Fan-out for System VM machine stats: one guest stream shared by all
     /// subscribers, none while nobody watches.
     stats_hub: Arc<crate::stats_hub::StatsHub<crate::stats_hub::AgentStatsSource>>,
+    /// Per-machine stats hubs, created lazily on first watch (the System VM
+    /// hub lives in `stats_hub`). A hub whose machine is gone simply fails
+    /// its next open; idle hubs hold no guest stream.
+    machine_stats_hubs: Arc<
+        TokioRwLock<
+            HashMap<String, Arc<crate::stats_hub::StatsHub<crate::stats_hub::AgentStatsSource>>>,
+        >,
+    >,
 }
 
 /// Parameters of one sandbox port exposure (the host listener half).
@@ -247,6 +255,7 @@ impl Runtime {
             dns_entries: Arc::new(TokioRwLock::new(HashMap::new())),
             container_aliases: Arc::new(TokioRwLock::new(HashMap::new())),
             stats_hub,
+            machine_stats_hubs: Arc::new(TokioRwLock::new(HashMap::new())),
         })
     }
 
@@ -258,6 +267,28 @@ impl Runtime {
         &self,
     ) -> tokio::sync::broadcast::Receiver<arcbox_protocol::agent::MachineStats> {
         self.stats_hub.subscribe()
+    }
+
+    /// Subscribes to live stats for a named machine, lazily creating its
+    /// fan-out hub. The default machine reuses the System VM hub.
+    pub async fn subscribe_machine_stats_for(
+        &self,
+        name: &str,
+    ) -> tokio::sync::broadcast::Receiver<arcbox_protocol::agent::MachineStats> {
+        if name == DEFAULT_MACHINE_NAME {
+            return self.stats_hub.subscribe();
+        }
+        if let Some(hub) = self.machine_stats_hubs.read().await.get(name) {
+            return hub.subscribe();
+        }
+        let mut hubs = self.machine_stats_hubs.write().await;
+        let hub = hubs.entry(name.to_string()).or_insert_with(|| {
+            crate::stats_hub::StatsHub::new(crate::stats_hub::AgentStatsSource::new(
+                Arc::clone(&self.machine_manager),
+                name,
+            ))
+        });
+        hub.subscribe()
     }
 
     /// Returns the configuration.

--- a/app/arcbox-core/src/vm_lifecycle/tests.rs
+++ b/app/arcbox-core/src/vm_lifecycle/tests.rs
@@ -160,6 +160,7 @@ fn sample_machine(cpus: u32, memory_mb: u64, kernel: &str, cmdline: &str) -> Mac
         ip_address: None,
         backend: arcbox_vmm::VmBackend::default(),
         created_at: chrono::Utc::now(),
+        started_at: None,
     }
 }
 

--- a/common/arcbox-constants/src/wire.rs
+++ b/common/arcbox-constants/src/wire.rs
@@ -108,6 +108,12 @@ pub enum MessageType {
     SandboxListSnapshotsRequest = 0x0042,
     SandboxDeleteSnapshotRequest = 0x0043,
 
+    /// Starts a machine-level exec: runs a command in the machine root (the
+    /// agent's own mount namespace), streamed back as
+    /// [`Self::MachineExecOutput`] frames (payload:
+    /// `arcbox.v1.MachineExecRequest`).
+    MachineExecRequest = 0x0050,
+
     // Response types (0x1000 - 0x1FFF).
     PingResponse = 0x1001,
     GetSystemInfoResponse = 0x1002,
@@ -169,6 +175,10 @@ pub enum MessageType {
     SandboxListSnapshotsResponse = 0x1042,
     SandboxDeleteSnapshotResponse = 0x1043,
 
+    /// One machine exec output frame (payload: `arcbox.v1.MachineExecOutput`;
+    /// `done == true` on the final frame carrying the exit code).
+    MachineExecOutput = 0x1050,
+
     // Special types.
     Empty = 0x0000,
     Error = 0xFFFF,
@@ -219,6 +229,8 @@ impl MessageType {
             0x0041 => Some(Self::SandboxRestoreRequest),
             0x0042 => Some(Self::SandboxListSnapshotsRequest),
             0x0043 => Some(Self::SandboxDeleteSnapshotRequest),
+            // Machine-level exec.
+            0x0050 => Some(Self::MachineExecRequest),
             // Responses.
             0x1001 => Some(Self::PingResponse),
             0x1002 => Some(Self::GetSystemInfoResponse),
@@ -259,6 +271,7 @@ impl MessageType {
             0x1041 => Some(Self::SandboxRestoreResponse),
             0x1042 => Some(Self::SandboxListSnapshotsResponse),
             0x1043 => Some(Self::SandboxDeleteSnapshotResponse),
+            0x1050 => Some(Self::MachineExecOutput),
             0x0000 => Some(Self::Empty),
             0xFFFF => Some(Self::Error),
             _ => None,
@@ -389,6 +402,9 @@ mod tests {
             (0x1041, MessageType::SandboxRestoreResponse),
             (0x1042, MessageType::SandboxListSnapshotsResponse),
             (0x1043, MessageType::SandboxDeleteSnapshotResponse),
+            // Machine-level exec.
+            (0x0050, MessageType::MachineExecRequest),
+            (0x1050, MessageType::MachineExecOutput),
         ];
 
         for (raw, expected) in CASES {

--- a/guest/arcbox-agent/src/agent/linux/machine_exec.rs
+++ b/guest/arcbox-agent/src/agent/linux/machine_exec.rs
@@ -57,19 +57,26 @@ where
     }
 
     if !req.user.is_empty() {
-        let uid = match resolve_uid(&req.user) {
-            Ok(uid) => uid,
+        let (uid, gid) = match resolve_user(&req.user) {
+            Ok(ids) => ids,
             Err(e) => {
                 let err = ErrorResponse::new(400, e.to_string());
                 write_message(stream, MessageType::Error, trace_id, &err.encode()).await?;
                 return Ok(());
             }
         };
-        // SAFETY: `setuid` is async-signal-safe and `uid` came from the
-        // passwd database (or a numeric literal) above.
+        // Full privilege drop, in the one order that works: supplementary
+        // groups, then gid, then uid — the reverse would lose the right to
+        // change groups before using it (setuid alone would leave the child
+        // in root's group).
+        // SAFETY: async-signal-safe syscalls; the ids came from the passwd
+        // database (or a numeric literal) above.
         unsafe {
             cmd.pre_exec(move || {
-                if libc::setuid(uid) != 0 {
+                if libc::setgroups(1, &raw const gid) != 0
+                    || libc::setgid(gid) != 0
+                    || libc::setuid(uid) != 0
+                {
                     return Err(std::io::Error::last_os_error());
                 }
                 Ok(())
@@ -80,6 +87,9 @@ where
     cmd.stdin(Stdio::null());
     cmd.stdout(Stdio::piped());
     cmd.stderr(Stdio::piped());
+    // A host disconnect mid-stream aborts this handler via `?`; the dropped
+    // child must not keep running detached in the machine.
+    cmd.kill_on_drop(true);
 
     let mut child = match cmd.spawn() {
         Ok(c) => c,
@@ -168,10 +178,12 @@ where
     Ok(())
 }
 
-/// Resolves a username or numeric UID string to a `uid_t`.
-fn resolve_uid(user: &str) -> anyhow::Result<libc::uid_t> {
+/// Resolves a username or numeric UID string to `(uid, gid)`.
+///
+/// A numeric string is taken as a UID with GID equal to it.
+fn resolve_user(user: &str) -> anyhow::Result<(libc::uid_t, libc::gid_t)> {
     if let Ok(uid) = user.parse::<libc::uid_t>() {
-        return Ok(uid);
+        return Ok((uid, uid));
     }
     let c_name = std::ffi::CString::new(user).context("invalid user name")?;
     // SAFETY: `c_name` is a valid nul-terminated C string; `getpwnam` returns
@@ -181,5 +193,5 @@ fn resolve_uid(user: &str) -> anyhow::Result<libc::uid_t> {
         anyhow::bail!("unknown user: {user}");
     }
     // SAFETY: `pw` is non-null and points to a valid passwd struct.
-    Ok(unsafe { (*pw).pw_uid })
+    Ok(unsafe { ((*pw).pw_uid, (*pw).pw_gid) })
 }

--- a/guest/arcbox-agent/src/agent/linux/machine_exec.rs
+++ b/guest/arcbox-agent/src/agent/linux/machine_exec.rs
@@ -1,0 +1,185 @@
+//! Machine-level command execution.
+//!
+//! Handles [`MessageType::MachineExecRequest`] by spawning the command in the
+//! agent's own mount namespace — which for a distro machine is the machine's
+//! overlay root — and streaming stdout/stderr back as
+//! [`MessageType::MachineExecOutput`] frames. The final frame carries
+//! `done == true` and the exit code.
+//!
+//! Non-interactive only: stdin is closed and `tty` requests are rejected. The
+//! interactive PTY session (stdin + resize) is the planned bidi follow-up —
+//! see `internal-docs/plans/machine-boot-shim.md`.
+
+use std::process::Stdio;
+
+use anyhow::Context;
+use prost::Message;
+use tokio::io::{AsyncReadExt, AsyncWrite};
+use tokio::process::Command;
+
+use crate::rpc::{ErrorResponse, MessageType, write_message};
+
+/// Handles a machine-level exec request on the current connection.
+pub(super) async fn handle_machine_exec<S>(
+    stream: &mut S,
+    trace_id: &str,
+    payload: &[u8],
+) -> anyhow::Result<()>
+where
+    S: AsyncWrite + Unpin,
+{
+    let req = arcbox_protocol::MachineExecRequest::decode(payload)
+        .context("failed to decode MachineExecRequest")?;
+
+    if req.cmd.is_empty() {
+        let err = ErrorResponse::new(400, "cmd must not be empty");
+        write_message(stream, MessageType::Error, trace_id, &err.encode()).await?;
+        return Ok(());
+    }
+    if req.tty {
+        let err = ErrorResponse::new(
+            400,
+            "interactive (tty) machine exec is not supported yet; run without a TTY",
+        );
+        write_message(stream, MessageType::Error, trace_id, &err.encode()).await?;
+        return Ok(());
+    }
+
+    let mut cmd = Command::new(&req.cmd[0]);
+    if req.cmd.len() > 1 {
+        cmd.args(&req.cmd[1..]);
+    }
+    if !req.working_dir.is_empty() {
+        cmd.current_dir(&req.working_dir);
+    }
+    for (k, v) in &req.env {
+        cmd.env(k, v);
+    }
+
+    if !req.user.is_empty() {
+        let uid = match resolve_uid(&req.user) {
+            Ok(uid) => uid,
+            Err(e) => {
+                let err = ErrorResponse::new(400, e.to_string());
+                write_message(stream, MessageType::Error, trace_id, &err.encode()).await?;
+                return Ok(());
+            }
+        };
+        // SAFETY: `setuid` is async-signal-safe and `uid` came from the
+        // passwd database (or a numeric literal) above.
+        unsafe {
+            cmd.pre_exec(move || {
+                if libc::setuid(uid) != 0 {
+                    return Err(std::io::Error::last_os_error());
+                }
+                Ok(())
+            });
+        }
+    }
+
+    cmd.stdin(Stdio::null());
+    cmd.stdout(Stdio::piped());
+    cmd.stderr(Stdio::piped());
+
+    let mut child = match cmd.spawn() {
+        Ok(c) => c,
+        Err(e) => {
+            let err = ErrorResponse::new(500, format!("failed to spawn process: {e}"));
+            write_message(stream, MessageType::Error, trace_id, &err.encode()).await?;
+            return Ok(());
+        }
+    };
+
+    let mut stdout = child.stdout.take().expect("stdout piped");
+    let mut stderr = child.stderr.take().expect("stderr piped");
+
+    let mut stdout_buf = [0u8; 8192];
+    let mut stderr_buf = [0u8; 8192];
+    let mut stdout_done = false;
+    let mut stderr_done = false;
+
+    while !stdout_done || !stderr_done {
+        tokio::select! {
+            res = stdout.read(&mut stdout_buf), if !stdout_done => {
+                match res {
+                    Ok(0) => stdout_done = true,
+                    Ok(n) => {
+                        write_output(stream, trace_id, "stdout", &stdout_buf[..n]).await?;
+                    }
+                    Err(e) => {
+                        tracing::warn!(error = %e, "machine exec stdout read error");
+                        stdout_done = true;
+                    }
+                }
+            }
+            res = stderr.read(&mut stderr_buf), if !stderr_done => {
+                match res {
+                    Ok(0) => stderr_done = true,
+                    Ok(n) => {
+                        write_output(stream, trace_id, "stderr", &stderr_buf[..n]).await?;
+                    }
+                    Err(e) => {
+                        tracing::warn!(error = %e, "machine exec stderr read error");
+                        stderr_done = true;
+                    }
+                }
+            }
+        }
+    }
+
+    let status = child.wait().await.context("failed to wait for child")?;
+    let final_out = arcbox_protocol::MachineExecOutput {
+        done: true,
+        exit_code: status.code().unwrap_or(-1),
+        ..Default::default()
+    };
+    write_message(
+        stream,
+        MessageType::MachineExecOutput,
+        trace_id,
+        &final_out.encode_to_vec(),
+    )
+    .await?;
+
+    Ok(())
+}
+
+async fn write_output<S>(
+    stream: &mut S,
+    trace_id: &str,
+    name: &str,
+    data: &[u8],
+) -> anyhow::Result<()>
+where
+    S: AsyncWrite + Unpin,
+{
+    let out = arcbox_protocol::MachineExecOutput {
+        stream: name.to_string(),
+        data: data.to_vec(),
+        ..Default::default()
+    };
+    write_message(
+        stream,
+        MessageType::MachineExecOutput,
+        trace_id,
+        &out.encode_to_vec(),
+    )
+    .await?;
+    Ok(())
+}
+
+/// Resolves a username or numeric UID string to a `uid_t`.
+fn resolve_uid(user: &str) -> anyhow::Result<libc::uid_t> {
+    if let Ok(uid) = user.parse::<libc::uid_t>() {
+        return Ok(uid);
+    }
+    let c_name = std::ffi::CString::new(user).context("invalid user name")?;
+    // SAFETY: `c_name` is a valid nul-terminated C string; `getpwnam` returns
+    // a pointer to a static passwd struct (or null).
+    let pw = unsafe { libc::getpwnam(c_name.as_ptr()) };
+    if pw.is_null() {
+        anyhow::bail!("unknown user: {user}");
+    }
+    // SAFETY: `pw` is non-null and points to a valid passwd struct.
+    Ok(unsafe { (*pw).pw_uid })
+}

--- a/guest/arcbox-agent/src/agent/linux/mod.rs
+++ b/guest/arcbox-agent/src/agent/linux/mod.rs
@@ -8,6 +8,7 @@ mod btrfs;
 mod cmdline;
 mod disk;
 mod kubernetes;
+mod machine_exec;
 mod memory_pressure;
 mod port_forward;
 mod probe;

--- a/guest/arcbox-agent/src/agent/linux/rpc.rs
+++ b/guest/arcbox-agent/src/agent/linux/rpc.rs
@@ -75,6 +75,16 @@ where
             continue;
         }
 
+        // Machine-level exec also streams multiple frames on this connection.
+        if matches!(msg_type, crate::rpc::MessageType::MachineExecRequest) {
+            if let Err(e) =
+                super::machine_exec::handle_machine_exec(&mut stream, &trace_id, &payload).await
+            {
+                tracing::warn!(trace_id = %trace_id, error = %e, "machine exec handler error");
+            }
+            continue;
+        }
+
         // Parse and handle the request.
         let result = match parse_request(msg_type, &payload) {
             Ok(RpcRequest::WatchReadiness(req)) => {

--- a/rpc/arcbox-protocol/proto/machine.proto
+++ b/rpc/arcbox-protocol/proto/machine.proto
@@ -155,7 +155,8 @@ message RemoveMachineRequest {
     string id = 1;
     // Force removal.
     bool force = 2;
-    // Remove volumes.
+    // Ignored: machine removal always deletes the machine directory
+    // (including the data disk). Retained for wire compatibility.
     bool volumes = 3;
 }
 
@@ -189,6 +190,10 @@ message MachineSummary {
     string ip_address = 7;
     // Creation timestamp.
     int64 created = 8;
+    // Distribution name (e.g., "ubuntu"); empty for plain VMs.
+    string distro = 9;
+    // Distribution release (e.g., "noble").
+    string distro_version = 10;
 }
 
 // Request to inspect a machine.

--- a/rpc/arcbox-protocol/src/generated/arcbox.v1.rs
+++ b/rpc/arcbox-protocol/src/generated/arcbox.v1.rs
@@ -241,7 +241,8 @@ pub struct RemoveMachineRequest {
     /// Force removal.
     #[prost(bool, tag = "2")]
     pub force: bool,
-    /// Remove volumes.
+    /// Ignored: machine removal always deletes the machine directory
+    /// (including the data disk). Retained for wire compatibility.
     #[prost(bool, tag = "3")]
     pub volumes: bool,
 }
@@ -292,6 +293,12 @@ pub struct MachineSummary {
     /// Creation timestamp.
     #[prost(int64, tag = "8")]
     pub created: i64,
+    /// Distribution name (e.g., "ubuntu"); empty for plain VMs.
+    #[prost(string, tag = "9")]
+    pub distro: ::prost::alloc::string::String,
+    /// Distribution release (e.g., "noble").
+    #[prost(string, tag = "10")]
+    pub distro_version: ::prost::alloc::string::String,
 }
 /// Request to inspect a machine.
 #[derive(serde::Serialize, serde::Deserialize)]


### PR DESCRIPTION
**Stacked on #432.** The 协议/Manager/参数/guest/Inspect/Monitor slice of the machine service surface, in three commits:

## 1. Machine service correctness (Manager / 参数 / Inspect / 协议-additive)
- **CID allocation**: lowest CID not held by another machine, replacing `3 + running_count`. Verified the old collision is cosmetic — vsock routing is per-VM device — but distinct CIDs keep guest identity unambiguous. Unit-tested.
- **Stop semantics**: graceful guest-ACPI stop within the shutdown-timeout window, force fallback; `force: true` skips straight to force. Off the async workers via `spawn_blocking`.
- **started_at** tracked + persisted (serde-default compatible), surfaced in Inspect.
- **Inspect** fills `disk_path`, `created`, `started_at`, `gateway`/`dns_servers` (NAT gateway once the guest has an IP).
- **Proto (additive)**: `MachineSummary.distro/distro_version` (desktop list + new `machine ls` DISTRO column); `RemoveMachineRequest.volumes` documented as ignored, CLI flag removed.

## 2. Machine exec (guest / 协议)
Implements the long-unimplemented server-streaming `MachineService.Exec`:
- wire `MachineExecRequest` (0x0050) / `MachineExecOutput` (0x1050) frames (additive; the host↔agent channel is not buf-gated but is additive-only by convention);
- guest `handle_machine_exec` runs the command in the agent's own mount namespace — the machine's overlay root — streaming stdout/stderr + exit code (adapted from the stale `feat/sandbox-exec` machine-run handler `612ef798`);
- `AgentClient::machine_exec` mirrors `sandbox_run`; gRPC bridges to the stream, mapping agent 400s to `INVALID_ARGUMENT`;
- `machine exec` works end to end; interactive `machine ssh` fails client-side with a clear message. **Phase 2 (separate PR): bidi PTY ExecSession** for real interactive sessions + the desktop Terminal tab.

## 3. Per-machine stats (Monitor)
`StatsService.Watch` with a non-default `machine_id` resolves a lazily-created per-machine StatsHub (`AgentStatsSource` was already name-parameterized) after an existence check.

## Verification
153 core + 11 constants tests green (new: CID allocation, wire roundtrips); agent cross-checked for `aarch64-unknown-linux-musl`; clippy `-D warnings` + fmt clean on all touched crates.

## Not here (tracked next)
- Interactive ExecSession (PTY/stdin/resize) — phase 2.
- `mounts` parameter → per-machine VirtioFS shares (needs a shim-contract addition).
- Machine e2e suite — needs #434's boot assets merged for a real boot.