### PR TITLE
feat(pty,agent,core,api,cli): interactive machine sessions — PTY primitives crate + bidi ExecSession

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -817,6 +817,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "arcbox-pty"
+version = "0.4.20"
+dependencies = [
+ "libc",
+ "nix 0.29.0",
+]
+
+[[package]]
 name = "arcbox-route"
 version = "0.4.22"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -198,6 +198,7 @@ dependencies = [
  "arcbox-ext4",
  "arcbox-logging",
  "arcbox-protocol",
+ "arcbox-pty",
  "arcbox-vm",
  "async-trait",
  "bytes",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -818,7 +818,7 @@ dependencies = [
 
 [[package]]
 name = "arcbox-pty"
-version = "0.4.20"
+version = "0.4.22"
 dependencies = [
  "libc",
  "nix 0.29.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     # L0: Common (MIT OR Apache-2.0)
     # ============================================
     "common/arcbox-constants",
+    "common/arcbox-pty",
     "common/arcbox-error",
     "common/arcbox-dns",
     "common/arcbox-asset",

--- a/app/arcbox-api/src/grpc/machine.rs
+++ b/app/arcbox-api/src/grpc/machine.rs
@@ -2,15 +2,18 @@
 
 use std::pin::Pin;
 
+use arcbox_core::ExecSessionInput;
 use arcbox_core::machine_image;
 use arcbox_grpc::v1::machine_service_server;
 use arcbox_protocol::v1::{
     CreateMachineRequest, CreateMachineResponse, Empty, InspectMachineRequest, ListMachinesRequest,
-    ListMachinesResponse, MachineAgentRequest, MachineExecOutput, MachineExecRequest, MachineInfo,
-    MachineNetwork, MachinePingResponse, MachineSummary, MachineSystemInfo, RemoveMachineRequest,
-    StartMachineRequest, StopMachineRequest,
+    ListMachinesResponse, MachineAgentRequest, MachineExecInput, MachineExecOutput,
+    MachineExecRequest, MachineInfo, MachineNetwork, MachinePingResponse, MachineSummary,
+    MachineSystemInfo, RemoveMachineRequest, StartMachineRequest, StopMachineRequest,
+    machine_exec_input,
 };
 use tokio_stream::Stream;
+use tokio_stream::StreamExt as _;
 use tonic::{Request, Response, Status};
 
 use super::{SharedRuntime, SharedRuntimeExt};
@@ -447,5 +450,84 @@ impl machine_service_server::MachineService for MachineServiceImpl {
     ) -> Result<Response<arcbox_protocol::v1::SshInfoResponse>, Status> {
         // TODO: Implement SSH info.
         Err(Status::unimplemented("ssh_info not implemented"))
+    }
+
+    type ExecSessionStream =
+        Pin<Box<dyn Stream<Item = Result<MachineExecOutput, Status>> + Send + 'static>>;
+
+    /// Interactive machine exec: a bidi PTY session bridged to the agent's
+    /// machine-exec frames. The first client message must carry Init; stdin
+    /// and resize messages follow on the same stream.
+    async fn exec_session(
+        &self,
+        request: Request<tonic::Streaming<MachineExecInput>>,
+    ) -> Result<Response<Self::ExecSessionStream>, Status> {
+        let mut stream = request.into_inner();
+
+        let first = stream.next().await.ok_or_else(|| {
+            Status::invalid_argument("exec session: stream closed before Init message")
+        })??;
+        let exec_req = match first.payload {
+            Some(machine_exec_input::Payload::Init(req)) => req,
+            _ => {
+                return Err(Status::invalid_argument(
+                    "exec session: first message must be Init",
+                ));
+            }
+        };
+
+        let agent = self
+            .runtime
+            .ready()?
+            .get_agent(&exec_req.id)
+            .map_err(|e| Status::internal(e.to_string()))?;
+
+        // Feed remaining gRPC input (stdin + TTY resizes) into a channel for
+        // the core layer. Stream end sends the empty-stdin EOF sentinel.
+        let (in_tx, in_rx) = tokio::sync::mpsc::channel(16);
+        tokio::spawn(async move {
+            while let Some(Ok(input)) = stream.next().await {
+                let msg = match input.payload {
+                    Some(machine_exec_input::Payload::Stdin(data)) => ExecSessionInput::Stdin(data),
+                    Some(machine_exec_input::Payload::Resize(size)) => ExecSessionInput::Resize {
+                        width: u16::try_from(size.width).unwrap_or(u16::MAX),
+                        height: u16::try_from(size.height).unwrap_or(u16::MAX),
+                    },
+                    _ => continue,
+                };
+                if in_tx.send(msg).await.is_err() {
+                    return;
+                }
+            }
+            let _ = in_tx.send(ExecSessionInput::Stdin(Vec::new())).await;
+        });
+
+        let mut out_rx = agent
+            .machine_exec_session(exec_req, in_rx)
+            .await
+            .map_err(|e| Status::internal(e.to_string()))?;
+
+        let out_stream = async_stream::stream! {
+            while let Some(item) = out_rx.recv().await {
+                match item {
+                    Ok(output) => {
+                        let done = output.done;
+                        yield Ok(output);
+                        if done {
+                            break;
+                        }
+                    }
+                    Err(arcbox_core::error::CoreError::Agent { code: 400, message }) => {
+                        yield Err(Status::invalid_argument(message));
+                        break;
+                    }
+                    Err(e) => {
+                        yield Err(Status::internal(e.to_string()));
+                        break;
+                    }
+                }
+            }
+        };
+        Ok(Response::new(Box::pin(out_stream)))
     }
 }

--- a/app/arcbox-cli/src/commands/machine.rs
+++ b/app/arcbox-cli/src/commands/machine.rs
@@ -1,11 +1,13 @@
 //! Machine management commands.
 
 use anyhow::{Context, Result};
+use arcbox_cli::terminal::{RawModeGuard, TerminalSize};
 use arcbox_grpc::v1::machine_service_client::MachineServiceClient;
+use arcbox_protocol::v1::TerminalSize as ProtoTerminalSize;
 use arcbox_protocol::v1::{
     CreateMachineRequest, DirectoryMount, InspectMachineRequest, ListMachinesRequest,
-    MachineAgentRequest, MachineExecRequest, RemoveMachineRequest, StartMachineRequest,
-    StopMachineRequest,
+    MachineAgentRequest, MachineExecInput, MachineExecRequest, RemoveMachineRequest,
+    StartMachineRequest, StopMachineRequest, machine_exec_input,
 };
 use clap::{Args, Subcommand};
 use humantime::format_duration;
@@ -16,7 +18,9 @@ use std::io::Write;
 use std::path::PathBuf;
 use std::pin::Pin;
 use std::task::{Context as TaskContext, Poll};
+use tokio::io::AsyncReadExt as _;
 use tokio::net::UnixStream;
+use tokio_stream::wrappers::ReceiverStream;
 use tonic::codegen::{Service, http::Uri};
 use tonic::transport::{Channel, Endpoint};
 
@@ -553,13 +557,120 @@ async fn execute_info(args: InfoArgs) -> Result<()> {
 
 async fn execute_ssh(args: SshArgs) -> Result<()> {
     if args.command.is_empty() {
-        anyhow::bail!(
-            "interactive machine sessions are not available yet; \
-             run a command instead: arcbox machine ssh {} <command>",
-            args.name
-        );
+        return exec_session_interactive(&args.name, vec!["/bin/sh".to_string(), "-l".to_string()])
+            .await;
     }
     exec_via_grpc(&args.name, args.command, HashMap::new(), false).await
+}
+
+/// Runs an interactive PTY session in a machine: local terminal in raw mode,
+/// stdin and SIGWINCH resizes pumped up, merged PTY output written to stdout.
+async fn exec_session_interactive(name: &str, cmd: Vec<String>) -> Result<()> {
+    let mut client = machine_client().await?;
+
+    let (msg_tx, msg_rx) = tokio::sync::mpsc::channel::<MachineExecInput>(16);
+
+    let tty_size = TerminalSize::current().ok().map(|s| ProtoTerminalSize {
+        width: u32::from(s.cols),
+        height: u32::from(s.rows),
+    });
+
+    // The first message in the stream must be the Init payload.
+    msg_tx
+        .send(MachineExecInput {
+            payload: Some(machine_exec_input::Payload::Init(MachineExecRequest {
+                id: name.to_string(),
+                cmd,
+                tty: true,
+                tty_size,
+                ..Default::default()
+            })),
+        })
+        .await
+        .context("Failed to send exec session init")?;
+
+    let raw_guard = RawModeGuard::new()?;
+
+    // Resize pump: SIGWINCH → resize messages.
+    let resize_tx = msg_tx.clone();
+    match arcbox_cli::terminal::ResizeWatcher::new() {
+        Ok(mut watcher) => {
+            tokio::spawn(async move {
+                while let Some(size) = watcher.recv().await {
+                    let msg = MachineExecInput {
+                        payload: Some(machine_exec_input::Payload::Resize(ProtoTerminalSize {
+                            width: u32::from(size.cols),
+                            height: u32::from(size.rows),
+                        })),
+                    };
+                    if resize_tx.send(msg).await.is_err() {
+                        break;
+                    }
+                }
+            });
+        }
+        Err(e) => tracing::warn!(error = %e, "terminal resize forwarding disabled"),
+    }
+
+    // Stdin pump: local terminal → session stream.
+    let stdin_tx = msg_tx;
+    tokio::spawn(async move {
+        let mut stdin = tokio::io::stdin();
+        let mut buf = [0u8; 1024];
+        loop {
+            match stdin.read(&mut buf).await {
+                Ok(0) | Err(_) => break,
+                Ok(n) => {
+                    if stdin_tx
+                        .send(MachineExecInput {
+                            payload: Some(machine_exec_input::Payload::Stdin(buf[..n].to_vec())),
+                        })
+                        .await
+                        .is_err()
+                    {
+                        break;
+                    }
+                }
+            }
+        }
+    });
+
+    let mut stream = client
+        .exec_session(tonic::Request::new(ReceiverStream::new(msg_rx)))
+        .await
+        .context("Failed to open machine exec session")?
+        .into_inner();
+
+    let mut exit_code = 0i32;
+    let mut received_done = false;
+    while let Some(output) = stream
+        .message()
+        .await
+        .context("Failed to read session output")?
+    {
+        if !output.data.is_empty() {
+            // The PTY merges stdout/stderr into one stream.
+            std::io::stdout()
+                .write_all(&output.data)
+                .context("Failed to write output")?;
+            std::io::stdout().flush()?;
+        }
+        if output.done {
+            exit_code = output.exit_code;
+            received_done = true;
+        }
+    }
+
+    // Restore the terminal before exiting.
+    drop(raw_guard);
+
+    if !received_done {
+        anyhow::bail!("session stream closed without a terminal status frame");
+    }
+    if exit_code != 0 {
+        std::process::exit(exit_code);
+    }
+    Ok(())
 }
 
 async fn execute_exec(args: ExecArgs) -> Result<()> {
@@ -582,6 +693,7 @@ async fn exec_via_grpc(
             user: String::new(),
             env,
             tty,
+            tty_size: None,
         }))
         .await
         .context("Failed to execute command in machine")?

--- a/app/arcbox-core/src/agent_client.rs
+++ b/app/arcbox-core/src/agent_client.rs
@@ -1301,6 +1301,135 @@ impl AgentClient {
         Ok(rx)
     }
 
+    /// Starts an interactive exec session in the machine root (PTY-backed).
+    ///
+    /// Consumes the client because the stream task requires exclusive
+    /// transport access. The caller supplies a receiver of
+    /// [`ExecSessionInput`]s (stdin bytes, TTY resizes, or EOF) and gets an
+    /// output receiver of [`arcbox_protocol::v1::MachineExecOutput`] frames
+    /// (stdout/stderr merged by the PTY; final frame carries the exit code).
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the initial send fails.
+    pub async fn machine_exec_session(
+        mut self,
+        req: arcbox_protocol::v1::MachineExecRequest,
+        mut input_rx: mpsc::Receiver<ExecSessionInput>,
+    ) -> Result<mpsc::Receiver<Result<arcbox_protocol::v1::MachineExecOutput>>> {
+        if !self.connected {
+            self.connect().await?;
+        }
+
+        let payload = req.encode_to_vec();
+        let buf = wire::build_message(MessageType::MachineExecRequest, "", &payload);
+        self.transport
+            .async_send(buf)
+            .await
+            .map_err(|e| CoreError::Machine(format!("failed to send exec request: {}", e)))?;
+
+        let (mut sender, mut receiver) = self
+            .transport
+            .into_split()
+            .map_err(|e| CoreError::Machine(format!("failed to split transport: {e}")))?;
+
+        let (out_tx, out_rx) = mpsc::channel(STREAM_CHANNEL_CAPACITY);
+
+        // Input pump: channel → MachineExecInput / MachineExecResize frames.
+        let stdin_handle = tokio::spawn(async move {
+            loop {
+                match input_rx.recv().await {
+                    Some(ExecSessionInput::Stdin(data)) => {
+                        let is_eof = data.is_empty();
+                        let frame = wire::build_message(MessageType::MachineExecInput, "", &data);
+                        if sender.send(frame).await.is_err() || is_eof {
+                            break;
+                        }
+                    }
+                    Some(ExecSessionInput::Resize { width, height }) => {
+                        let size = arcbox_protocol::v1::TerminalSize {
+                            width: u32::from(width),
+                            height: u32::from(height),
+                        };
+                        let frame = wire::build_message(
+                            MessageType::MachineExecResize,
+                            "",
+                            &size.encode_to_vec(),
+                        );
+                        if sender.send(frame).await.is_err() {
+                            break;
+                        }
+                    }
+                    None => {
+                        // Channel closed without explicit EOF; best-effort EOF
+                        // frame so the guest session doesn't hang on stdin.
+                        let eof = wire::build_message(MessageType::MachineExecInput, "", &[]);
+                        let _ = sender.send(eof).await;
+                        break;
+                    }
+                }
+            }
+        });
+
+        // Output pump: MachineExecOutput frames → channel.
+        tokio::spawn(async move {
+            loop {
+                let raw = match receiver.recv().await {
+                    Ok(r) => r,
+                    Err(e) => {
+                        let _ = out_tx
+                            .send(Err(CoreError::Machine(format!("recv error: {}", e))))
+                            .await;
+                        break;
+                    }
+                };
+
+                let (resp_type, _, resp_payload) = match wire::parse_response(&raw) {
+                    Ok(p) => p,
+                    Err(e) => {
+                        let _ = out_tx.send(Err(e)).await;
+                        break;
+                    }
+                };
+
+                if resp_type == MessageType::Error as u32 {
+                    let (code, message) = wire::parse_error_response(&resp_payload)
+                        .unwrap_or_else(|_| (500, "unknown error".to_string()));
+                    let _ = out_tx.send(Err(CoreError::Agent { code, message })).await;
+                    break;
+                }
+
+                if resp_type != MessageType::MachineExecOutput as u32 {
+                    let _ = out_tx
+                        .send(Err(CoreError::Machine(format!(
+                            "unexpected response type: 0x{:04x}",
+                            resp_type
+                        ))))
+                        .await;
+                    break;
+                }
+
+                match arcbox_protocol::v1::MachineExecOutput::decode(&resp_payload[..]) {
+                    Ok(output) => {
+                        let done = output.done;
+                        if out_tx.send(Ok(output)).await.is_err() || done {
+                            break;
+                        }
+                    }
+                    Err(e) => {
+                        let _ = out_tx
+                            .send(Err(CoreError::Machine(format!("decode error: {}", e))))
+                            .await;
+                        break;
+                    }
+                }
+            }
+            stdin_handle.abort();
+        });
+
+        Ok(out_rx)
+    }
+
     /// Runs a command inside a sandbox and returns a channel of streaming output.
     ///
     /// Consumes the client because the stream task requires exclusive transport access.

--- a/common/arcbox-constants/src/wire.rs
+++ b/common/arcbox-constants/src/wire.rs
@@ -113,6 +113,12 @@ pub enum MessageType {
     /// [`Self::MachineExecOutput`] frames (payload:
     /// `arcbox.v1.MachineExecRequest`).
     MachineExecRequest = 0x0050,
+    /// Stdin bytes for an interactive machine session (raw payload; empty
+    /// payload means stdin EOF).
+    MachineExecInput = 0x0051,
+    /// Terminal resize for an interactive machine session (payload:
+    /// `arcbox.v1.TerminalSize`).
+    MachineExecResize = 0x0052,
 
     // Response types (0x1000 - 0x1FFF).
     PingResponse = 0x1001,
@@ -231,6 +237,8 @@ impl MessageType {
             0x0043 => Some(Self::SandboxDeleteSnapshotRequest),
             // Machine-level exec.
             0x0050 => Some(Self::MachineExecRequest),
+            0x0051 => Some(Self::MachineExecInput),
+            0x0052 => Some(Self::MachineExecResize),
             // Responses.
             0x1001 => Some(Self::PingResponse),
             0x1002 => Some(Self::GetSystemInfoResponse),
@@ -404,6 +412,8 @@ mod tests {
             (0x1043, MessageType::SandboxDeleteSnapshotResponse),
             // Machine-level exec.
             (0x0050, MessageType::MachineExecRequest),
+            (0x0051, MessageType::MachineExecInput),
+            (0x0052, MessageType::MachineExecResize),
             (0x1050, MessageType::MachineExecOutput),
         ];
 

--- a/common/arcbox-pty/Cargo.toml
+++ b/common/arcbox-pty/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "arcbox-pty"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+authors.workspace = true
+description = "PTY session primitives shared by ArcBox guest agents"
+
+[target.'cfg(target_os = "linux")'.dependencies]
+libc = { workspace = true }
+nix = { workspace = true, features = ["term", "user", "process", "fs"] }
+
+[lints]
+workspace = true

--- a/common/arcbox-pty/src/lib.rs
+++ b/common/arcbox-pty/src/lib.rs
@@ -1,0 +1,202 @@
+//! PTY session primitives shared by ArcBox guest agents.
+//!
+//! Both interactive-exec implementations — the sandbox microVM's `vm-agent`
+//! and the machine-level session in `arcbox-agent` — need the same subtle,
+//! security-relevant steps: allocating a sized PTY, wiring the slave as the
+//! child's controlling terminal, and dropping privileges in the one order
+//! that works. This crate is the single home for those steps; everything the
+//! consumers legitimately differ on (process reaping, sync vs async pumps,
+//! wire framing) stays with them.
+//!
+//! Linux-only: on other targets the crate compiles to nothing so host-side
+//! workspace builds stay unaffected.
+
+#[cfg(target_os = "linux")]
+mod linux {
+    use std::io;
+    use std::os::fd::{AsRawFd, OwnedFd};
+
+    /// Terminal dimensions in character cells.
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    pub struct WinSize {
+        pub cols: u16,
+        pub rows: u16,
+    }
+
+    impl WinSize {
+        const fn to_libc(self) -> libc::winsize {
+            libc::winsize {
+                ws_col: self.cols,
+                ws_row: self.rows,
+                ws_xpixel: 0,
+                ws_ypixel: 0,
+            }
+        }
+    }
+
+    /// An allocated PTY pair. The slave is handed to the child (via
+    /// [`child_terminal_setup`]); the parent keeps the master and must close
+    /// its slave copy after spawning.
+    #[derive(Debug)]
+    pub struct PtyPair {
+        pub master: OwnedFd,
+        pub slave: OwnedFd,
+    }
+
+    /// Allocates a PTY, optionally applying an initial window size.
+    ///
+    /// # Errors
+    /// Returns an error if the kernel refuses a PTY (e.g. devpts missing).
+    pub fn openpty_sized(size: Option<WinSize>) -> io::Result<PtyPair> {
+        let pty = nix::pty::openpty(None, None).map_err(io::Error::from)?;
+        if let Some(size) = size {
+            resize(&pty.master, size)?;
+        }
+        Ok(PtyPair {
+            master: pty.master,
+            slave: pty.slave,
+        })
+    }
+
+    /// Applies a window size to a PTY master (initial or mid-session).
+    ///
+    /// # Errors
+    /// Returns an error if the ioctl fails (master closed).
+    pub fn resize(master: &impl AsRawFd, size: WinSize) -> io::Result<()> {
+        let ws = size.to_libc();
+        // SAFETY: the fd is a live PTY master owned by the caller and `ws`
+        // is a valid winsize.
+        if unsafe { libc::ioctl(master.as_raw_fd(), libc::TIOCSWINSZ, &ws) } != 0 {
+            return Err(io::Error::last_os_error());
+        }
+        Ok(())
+    }
+
+    /// Credentials to drop to before exec, resolved via [`resolve_user`].
+    #[derive(Debug, Clone, Copy)]
+    pub struct RunAs {
+        pub uid: libc::uid_t,
+        pub gid: libc::gid_t,
+    }
+
+    /// Resolves a username or numeric UID to run-as credentials.
+    ///
+    /// A numeric string is taken as a UID with GID equal to it — matching the
+    /// behavior both agents shipped historically.
+    ///
+    /// # Errors
+    /// Returns an error for an unknown user name.
+    pub fn resolve_user(user: &str) -> io::Result<RunAs> {
+        if let Ok(uid) = user.parse::<libc::uid_t>() {
+            return Ok(RunAs { uid, gid: uid });
+        }
+        let entry = nix::unistd::User::from_name(user)
+            .map_err(io::Error::from)?
+            .ok_or_else(|| {
+                io::Error::new(io::ErrorKind::NotFound, format!("unknown user: {user}"))
+            })?;
+        Ok(RunAs {
+            uid: entry.uid.as_raw(),
+            gid: entry.gid.as_raw(),
+        })
+    }
+
+    /// Builds a `pre_exec`-compatible closure that turns the child into an
+    /// interactive session leader on `slave` and optionally drops privileges.
+    ///
+    /// Steps, in load-bearing order:
+    /// 1. `setsid` — new session, detached from the agent's controlling TTY.
+    /// 2. `TIOCSCTTY` — the PTY slave becomes the controlling terminal.
+    /// 3. `dup2` the slave over stdin/stdout/stderr (and close the original
+    ///    when it lies above fd 2).
+    /// 4. `setgroups → setgid → setuid` — the reverse order would drop the
+    ///    right to change groups before using it. Any failure aborts the
+    ///    exec rather than running the workload with the wrong identity.
+    ///
+    /// The returned closure is async-signal-safe: raw syscalls only.
+    ///
+    /// Must only be used with `Command::pre_exec` (it runs post-fork,
+    /// pre-exec); `slave` must remain open in the parent until after spawn.
+    #[must_use]
+    pub fn child_terminal_setup(
+        slave: libc::c_int,
+        run_as: Option<RunAs>,
+    ) -> impl FnMut() -> io::Result<()> + Send + 'static {
+        move || {
+            // SAFETY: post-fork child; every call below is async-signal-safe.
+            unsafe {
+                if libc::setsid() < 0 {
+                    return Err(io::Error::last_os_error());
+                }
+                if libc::ioctl(slave, libc::TIOCSCTTY, 0) != 0 {
+                    return Err(io::Error::last_os_error());
+                }
+                for fd in [libc::STDIN_FILENO, libc::STDOUT_FILENO, libc::STDERR_FILENO] {
+                    if libc::dup2(slave, fd) < 0 {
+                        return Err(io::Error::last_os_error());
+                    }
+                }
+                if slave > libc::STDERR_FILENO && libc::close(slave) != 0 {
+                    return Err(io::Error::last_os_error());
+                }
+                if let Some(RunAs { uid, gid }) = run_as {
+                    if libc::setgroups(1, &raw const gid) != 0
+                        || libc::setgid(gid) != 0
+                        || libc::setuid(uid) != 0
+                    {
+                        return Err(io::Error::last_os_error());
+                    }
+                }
+            }
+            Ok(())
+        }
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+        use std::io::{Read, Write};
+
+        #[test]
+        fn openpty_applies_initial_size_and_resize() {
+            let pty = openpty_sized(Some(WinSize { cols: 120, rows: 40 })).unwrap();
+            let mut ws = libc::winsize {
+                ws_col: 0,
+                ws_row: 0,
+                ws_xpixel: 0,
+                ws_ypixel: 0,
+            };
+            // SAFETY: live master fd; ws is a valid out-param.
+            unsafe { libc::ioctl(pty.master.as_raw_fd(), libc::TIOCGWINSZ, &mut ws) };
+            assert_eq!((ws.ws_col, ws.ws_row), (120, 40));
+
+            resize(&pty.master, WinSize { cols: 80, rows: 24 }).unwrap();
+            // SAFETY: as above.
+            unsafe { libc::ioctl(pty.master.as_raw_fd(), libc::TIOCGWINSZ, &mut ws) };
+            assert_eq!((ws.ws_col, ws.ws_row), (80, 24));
+        }
+
+        #[test]
+        fn pty_pair_round_trips_bytes() {
+            let pty = openpty_sized(None).unwrap();
+            let mut master = std::fs::File::from(pty.master);
+            let mut slave = std::fs::File::from(pty.slave);
+            master.write_all(b"ping\n").unwrap();
+            let mut buf = [0u8; 8];
+            let n = slave.read(&mut buf).unwrap();
+            assert_eq!(&buf[..n], b"ping\n");
+        }
+
+        #[test]
+        fn resolve_user_accepts_numeric_and_rejects_unknown() {
+            let run_as = resolve_user("1234").unwrap();
+            assert_eq!((run_as.uid, run_as.gid), (1234, 1234));
+            assert!(resolve_user("no-such-user-arcbox").is_err());
+        }
+    }
+}
+
+#[cfg(target_os = "linux")]
+pub use linux::{
+    PtyPair, RunAs, WinSize, child_terminal_setup, openpty_sized, resize, resolve_user,
+};

--- a/common/arcbox-pty/src/lib.rs
+++ b/common/arcbox-pty/src/lib.rs
@@ -159,7 +159,11 @@ mod linux {
 
         #[test]
         fn openpty_applies_initial_size_and_resize() {
-            let pty = openpty_sized(Some(WinSize { cols: 120, rows: 40 })).unwrap();
+            let pty = openpty_sized(Some(WinSize {
+                cols: 120,
+                rows: 40,
+            }))
+            .unwrap();
             let mut ws = libc::winsize {
                 ws_col: 0,
                 ws_row: 0,

--- a/guest/arcbox-agent/Cargo.toml
+++ b/guest/arcbox-agent/Cargo.toml
@@ -47,6 +47,7 @@ arcbox-logging.workspace = true
 
 # vsock and arcbox-vm are Linux-only
 [target.'cfg(target_os = "linux")'.dependencies]
+arcbox-pty = { version = "0.4.20", path = "../../common/arcbox-pty" } # x-release-please-version
 tokio-vsock = "0.5"
 arcbox-vm = { workspace = true }
 tonic.workspace = true

--- a/guest/arcbox-agent/src/agent/linux/machine_exec.rs
+++ b/guest/arcbox-agent/src/agent/linux/machine_exec.rs
@@ -2,19 +2,23 @@
 //!
 //! Handles [`MessageType::MachineExecRequest`] by spawning the command in the
 //! agent's own mount namespace — which for a distro machine is the machine's
-//! overlay root — and streaming stdout/stderr back as
-//! [`MessageType::MachineExecOutput`] frames. The final frame carries
-//! `done == true` and the exit code.
+//! overlay root.
 //!
-//! Non-interactive only: stdin is closed and `tty` requests are rejected. The
-//! interactive PTY session (stdin + resize) is the planned bidi follow-up —
-//! see `internal-docs/plans/machine-boot-shim.md`.
+//! Two modes share the entry point:
+//! - **piped** (`tty == false`): stdin closed, stdout/stderr streamed as
+//!   separate [`MessageType::MachineExecOutput`] frames;
+//! - **interactive** (`tty == true`): the command runs as a session leader on
+//!   a PTY (primitives from `arcbox-pty`); output is a single merged stream,
+//!   and the host feeds [`MessageType::MachineExecInput`] /
+//!   [`MessageType::MachineExecResize`] frames on the same connection.
+//!
+//! Both end with a `done == true` frame carrying the exit code.
 
 use std::process::Stdio;
 
 use anyhow::Context;
 use prost::Message;
-use tokio::io::{AsyncReadExt, AsyncWrite};
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite};
 use tokio::process::Command;
 
 use crate::rpc::{ErrorResponse, MessageType, write_message};
@@ -26,7 +30,7 @@ pub(super) async fn handle_machine_exec<S>(
     payload: &[u8],
 ) -> anyhow::Result<()>
 where
-    S: AsyncWrite + Unpin,
+    S: AsyncRead + AsyncWrite + Unpin,
 {
     let req = arcbox_protocol::MachineExecRequest::decode(payload)
         .context("failed to decode MachineExecRequest")?;
@@ -37,12 +41,7 @@ where
         return Ok(());
     }
     if req.tty {
-        let err = ErrorResponse::new(
-            400,
-            "interactive (tty) machine exec is not supported yet; run without a TTY",
-        );
-        write_message(stream, MessageType::Error, trace_id, &err.encode()).await?;
-        return Ok(());
+        return tty_session(stream, trace_id, &req).await;
     }
 
     let mut cmd = Command::new(&req.cmd[0]);
@@ -175,6 +174,211 @@ where
         &out.encode_to_vec(),
     )
     .await?;
+    Ok(())
+}
+
+/// Interactive PTY session on the current connection.
+///
+/// The command runs as a session leader with the PTY slave as its
+/// controlling terminal (child setup and privilege drop live in
+/// `arcbox-pty`). Output is pumped from the PTY master on a blocking thread
+/// (bounded channel); input/resize frames are read from the connection in
+/// the same select loop, so a single writer owns the stream.
+async fn tty_session<S>(
+    stream: &mut S,
+    trace_id: &str,
+    req: &arcbox_protocol::MachineExecRequest,
+) -> anyhow::Result<()>
+where
+    S: AsyncRead + AsyncWrite + Unpin,
+{
+    use std::io::{Read, Write};
+    use std::os::fd::AsRawFd;
+
+    let run_as = if req.user.is_empty() {
+        None
+    } else {
+        match arcbox_pty::resolve_user(&req.user) {
+            Ok(r) => Some(r),
+            Err(e) => {
+                let err = ErrorResponse::new(400, e.to_string());
+                write_message(stream, MessageType::Error, trace_id, &err.encode()).await?;
+                return Ok(());
+            }
+        }
+    };
+
+    let size = req.tty_size.as_ref().map(|s| arcbox_pty::WinSize {
+        cols: u16::try_from(s.width).unwrap_or(80),
+        rows: u16::try_from(s.height).unwrap_or(24),
+    });
+    let pty = match arcbox_pty::openpty_sized(size) {
+        Ok(pty) => pty,
+        Err(e) => {
+            let err = ErrorResponse::new(500, format!("openpty: {e}"));
+            write_message(stream, MessageType::Error, trace_id, &err.encode()).await?;
+            return Ok(());
+        }
+    };
+
+    let mut cmd = Command::new(&req.cmd[0]);
+    if req.cmd.len() > 1 {
+        cmd.args(&req.cmd[1..]);
+    }
+    if !req.working_dir.is_empty() {
+        cmd.current_dir(&req.working_dir);
+    }
+    for (k, v) in &req.env {
+        cmd.env(k, v);
+    }
+    // The pre_exec closure dup2s the slave over stdin/stdout/stderr, so the
+    // Command-level stdio configuration is irrelevant (pre_exec runs after
+    // it); null keeps no stray pipes open.
+    cmd.stdin(Stdio::null());
+    cmd.stdout(Stdio::null());
+    cmd.stderr(Stdio::null());
+    cmd.kill_on_drop(true);
+    // SAFETY: the closure runs post-fork pre-exec and only makes
+    // async-signal-safe calls; the slave stays open in the parent until
+    // after spawn.
+    unsafe {
+        cmd.pre_exec(arcbox_pty::child_terminal_setup(
+            pty.slave.as_raw_fd(),
+            run_as,
+        ));
+    }
+    let mut child = match cmd.spawn() {
+        Ok(c) => c,
+        Err(e) => {
+            let err = ErrorResponse::new(500, format!("failed to spawn process: {e}"));
+            write_message(stream, MessageType::Error, trace_id, &err.encode()).await?;
+            return Ok(());
+        }
+    };
+    // The child holds its own slave via the controlling-terminal dup2s; the
+    // parent copy must close so master read hits EOF when the child exits.
+    drop(pty.slave);
+
+    let mut master_write = std::fs::File::from(pty.master.try_clone()?);
+    let master_read = std::fs::File::from(pty.master.try_clone()?);
+    let master_resize = pty.master;
+
+    // Output pump: blocking PTY reads on a dedicated thread, handed to the
+    // session loop over a bounded channel (backpressure caps buffering).
+    let (out_tx, mut out_rx) = tokio::sync::mpsc::channel::<Vec<u8>>(16);
+    let reader = tokio::task::spawn_blocking(move || {
+        let mut master = master_read;
+        let mut buf = [0u8; 8192];
+        loop {
+            match master.read(&mut buf) {
+                // EIO is the normal PTY EOF once the child exits.
+                Ok(0) | Err(_) => break,
+                Ok(n) => {
+                    if out_tx.blocking_send(buf[..n].to_vec()).is_err() {
+                        break;
+                    }
+                }
+            }
+        }
+    });
+
+    let (mut conn_rd, mut conn_wr) = tokio::io::split(stream);
+    let mut host_gone = false;
+    loop {
+        tokio::select! {
+            chunk = out_rx.recv() => match chunk {
+                Some(data) => {
+                    let out = arcbox_protocol::MachineExecOutput {
+                        stream: "stdout".to_string(),
+                        data,
+                        ..Default::default()
+                    };
+                    if write_message(
+                        &mut conn_wr,
+                        MessageType::MachineExecOutput,
+                        trace_id,
+                        &out.encode_to_vec(),
+                    )
+                    .await
+                    .is_err()
+                    {
+                        host_gone = true;
+                        break;
+                    }
+                }
+                // Master EOF: the child exited and released the slave.
+                None => break,
+            },
+            frame = crate::rpc::read_message(&mut conn_rd) => match frame {
+                Ok((MessageType::MachineExecInput, _, payload)) => {
+                    // Empty payload signals stdin EOF; an interactive shell
+                    // ends via in-band ^D, so there is nothing to forward.
+                    if !payload.is_empty() {
+                        // Keystroke-sized writes into the kernel PTY buffer;
+                        // blocking only if the child stops draining input.
+                        if let Err(e) = master_write.write_all(&payload) {
+                            tracing::warn!(error = %e, "pty stdin write failed");
+                        }
+                    }
+                }
+                Ok((MessageType::MachineExecResize, _, payload)) => {
+                    if let Ok(ts) = arcbox_protocol::v1::TerminalSize::decode(&payload[..]) {
+                        let _ = arcbox_pty::resize(
+                            &master_resize,
+                            arcbox_pty::WinSize {
+                                cols: u16::try_from(ts.width).unwrap_or(80),
+                                rows: u16::try_from(ts.height).unwrap_or(24),
+                            },
+                        );
+                    }
+                }
+                Ok((other, _, _)) => {
+                    tracing::warn!(?other, "unexpected frame during machine exec session");
+                }
+                Err(_) => {
+                    host_gone = true;
+                    break;
+                }
+            },
+        }
+    }
+
+    if host_gone {
+        // Kill the whole session (the child is its leader after setsid), not
+        // just the direct child — an orphaned interactive shell must not
+        // keep its descendants running.
+        if let Some(pid) = child.id() {
+            // SAFETY: plain kill on a process group we created.
+            unsafe {
+                libc::kill(-(pid as libc::pid_t), libc::SIGKILL);
+            }
+        }
+    }
+
+    let exit_code = match child.wait().await {
+        Ok(status) => status.code().unwrap_or(-1),
+        Err(e) => {
+            tracing::warn!(error = %e, "failed to wait for exec child");
+            -1
+        }
+    };
+    let _ = reader.await;
+
+    if !host_gone {
+        let final_out = arcbox_protocol::MachineExecOutput {
+            done: true,
+            exit_code,
+            ..Default::default()
+        };
+        let _ = write_message(
+            &mut conn_wr,
+            MessageType::MachineExecOutput,
+            trace_id,
+            &final_out.encode_to_vec(),
+        )
+        .await;
+    }
+
     Ok(())
 }
 

--- a/rpc/arcbox-protocol/proto/common.proto
+++ b/rpc/arcbox-protocol/proto/common.proto
@@ -22,6 +22,14 @@ message Timestamp {
     int32 nanos = 2;
 }
 
+// Terminal dimensions in character cells.
+message TerminalSize {
+    // Columns.
+    uint32 width = 1;
+    // Rows.
+    uint32 height = 2;
+}
+
 // Key-value pair for labels, environment variables, etc.
 message KeyValue {
     string key = 1;

--- a/rpc/arcbox-protocol/proto/common.proto
+++ b/rpc/arcbox-protocol/proto/common.proto
@@ -22,14 +22,6 @@ message Timestamp {
     int32 nanos = 2;
 }
 
-// Terminal dimensions in character cells.
-message TerminalSize {
-    // Columns.
-    uint32 width = 1;
-    // Rows.
-    uint32 height = 2;
-}
-
 // Key-value pair for labels, environment variables, etc.
 message KeyValue {
     string key = 1;

--- a/rpc/arcbox-protocol/proto/machine.proto
+++ b/rpc/arcbox-protocol/proto/machine.proto
@@ -11,6 +11,7 @@ syntax = "proto3";
 
 package arcbox.v1;
 
+import "api.proto";
 import "common.proto";
 
 // MachineService manages Linux virtual machines. macOS guests are disposable,

--- a/rpc/arcbox-protocol/proto/machine.proto
+++ b/rpc/arcbox-protocol/proto/machine.proto
@@ -44,8 +44,13 @@ service MachineService {
     // discards free blocks so the host punches them out of the sparse image.
     rpc CompactDisk(MachineAgentRequest) returns (Empty);
 
-    // Executes a command in a machine.
+    // Executes a command in a machine (non-interactive: stdin closed).
     rpc Exec(MachineExecRequest) returns (stream MachineExecOutput);
+
+    // Interactive machine session: the first message must carry `init`;
+    // subsequent messages stream stdin bytes and terminal resizes. Output
+    // frames mirror Exec, with stdout/stderr merged by the PTY.
+    rpc ExecSession(stream MachineExecInput) returns (stream MachineExecOutput);
 
     // Gets the SSH connection info.
     rpc SSHInfo(SSHInfoRequest) returns (SSHInfoResponse);
@@ -284,6 +289,20 @@ message MachineExecRequest {
     map<string, string> env = 5;
     // Allocate TTY.
     bool tty = 6;
+    // Initial terminal size (interactive sessions).
+    TerminalSize tty_size = 7;
+}
+
+// One client message on an interactive machine session.
+message MachineExecInput {
+    oneof payload {
+        // Must be the first message: what to run.
+        MachineExecRequest init = 1;
+        // Raw stdin bytes; empty means stdin EOF.
+        bytes stdin = 2;
+        // Terminal resize.
+        TerminalSize resize = 3;
+    }
 }
 
 // Exec output from a machine.

--- a/rpc/arcbox-protocol/src/generated/arcbox.v1.rs
+++ b/rpc/arcbox-protocol/src/generated/arcbox.v1.rs
@@ -86,6 +86,991 @@ pub struct ResourceLimits {
     #[prost(int64, tag = "6")]
     pub memory_swap: i64,
 }
+/// Request to create a network.
+#[derive(serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct CreateNetworkRequest {
+    /// Network name.
+    #[prost(string, tag = "1")]
+    pub name: ::prost::alloc::string::String,
+    /// Driver (e.g., "bridge", "host", "none").
+    #[prost(string, tag = "2")]
+    pub driver: ::prost::alloc::string::String,
+    /// Internal network (not connected to external network).
+    #[prost(bool, tag = "3")]
+    pub internal: bool,
+    /// Labels.
+    #[prost(map = "string, string", tag = "4")]
+    pub labels:
+        ::std::collections::HashMap<::prost::alloc::string::String, ::prost::alloc::string::String>,
+    /// Enable IPv6.
+    #[prost(bool, tag = "5")]
+    pub enable_ipv6: bool,
+    /// IPAM configuration.
+    #[prost(message, optional, tag = "6")]
+    pub ipam: ::core::option::Option<IpamConfig>,
+}
+/// IPAM configuration.
+#[derive(serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct IpamConfig {
+    /// Driver name.
+    #[prost(string, tag = "1")]
+    pub driver: ::prost::alloc::string::String,
+    /// IPAM options.
+    #[prost(map = "string, string", tag = "2")]
+    pub options:
+        ::std::collections::HashMap<::prost::alloc::string::String, ::prost::alloc::string::String>,
+    /// Subnet configurations.
+    #[prost(message, repeated, tag = "3")]
+    pub subnets: ::prost::alloc::vec::Vec<IpamSubnet>,
+}
+/// IPAM subnet configuration.
+#[derive(serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct IpamSubnet {
+    /// Subnet in CIDR format.
+    #[prost(string, tag = "1")]
+    pub subnet: ::prost::alloc::string::String,
+    /// Gateway address.
+    #[prost(string, tag = "2")]
+    pub gateway: ::prost::alloc::string::String,
+    /// IP range for allocation.
+    #[prost(string, tag = "3")]
+    pub ip_range: ::prost::alloc::string::String,
+}
+/// Response to create network.
+#[derive(serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct CreateNetworkResponse {
+    /// Network ID.
+    #[prost(string, tag = "1")]
+    pub id: ::prost::alloc::string::String,
+    /// Warning messages.
+    #[prost(string, repeated, tag = "2")]
+    pub warnings: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
+}
+/// Request to remove a network.
+#[derive(serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct RemoveNetworkRequest {
+    /// Network ID or name.
+    #[prost(string, tag = "1")]
+    pub id: ::prost::alloc::string::String,
+}
+/// Request to list networks.
+#[derive(serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ListNetworksRequest {
+    /// Filter by labels.
+    #[prost(map = "string, string", tag = "1")]
+    pub filters:
+        ::std::collections::HashMap<::prost::alloc::string::String, ::prost::alloc::string::String>,
+}
+/// Response to list networks.
+#[derive(serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ListNetworksResponse {
+    /// List of networks.
+    #[prost(message, repeated, tag = "1")]
+    pub networks: ::prost::alloc::vec::Vec<NetworkSummary>,
+}
+/// Summary information about a network.
+#[derive(serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct NetworkSummary {
+    /// Network ID.
+    #[prost(string, tag = "1")]
+    pub id: ::prost::alloc::string::String,
+    /// Network name.
+    #[prost(string, tag = "2")]
+    pub name: ::prost::alloc::string::String,
+    /// Driver.
+    #[prost(string, tag = "3")]
+    pub driver: ::prost::alloc::string::String,
+    /// Scope (local, global).
+    #[prost(string, tag = "4")]
+    pub scope: ::prost::alloc::string::String,
+    /// Created timestamp (RFC3339).
+    #[prost(string, tag = "5")]
+    pub created: ::prost::alloc::string::String,
+    /// Internal network.
+    #[prost(bool, tag = "6")]
+    pub internal: bool,
+    /// Attachable.
+    #[prost(bool, tag = "7")]
+    pub attachable: bool,
+    /// Labels.
+    #[prost(map = "string, string", tag = "8")]
+    pub labels:
+        ::std::collections::HashMap<::prost::alloc::string::String, ::prost::alloc::string::String>,
+}
+/// Request to inspect a network.
+#[derive(serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct InspectNetworkRequest {
+    /// Network ID or name.
+    #[prost(string, tag = "1")]
+    pub id: ::prost::alloc::string::String,
+    /// Verbose output.
+    #[prost(bool, tag = "2")]
+    pub verbose: bool,
+}
+/// Detailed network information.
+#[derive(serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct NetworkInfo {
+    /// Network ID.
+    #[prost(string, tag = "1")]
+    pub id: ::prost::alloc::string::String,
+    /// Network name.
+    #[prost(string, tag = "2")]
+    pub name: ::prost::alloc::string::String,
+    /// Driver.
+    #[prost(string, tag = "3")]
+    pub driver: ::prost::alloc::string::String,
+    /// Scope.
+    #[prost(string, tag = "4")]
+    pub scope: ::prost::alloc::string::String,
+    /// Created timestamp (RFC3339).
+    #[prost(string, tag = "5")]
+    pub created: ::prost::alloc::string::String,
+    /// Internal network.
+    #[prost(bool, tag = "6")]
+    pub internal: bool,
+    /// Attachable.
+    #[prost(bool, tag = "7")]
+    pub attachable: bool,
+    /// Labels.
+    #[prost(map = "string, string", tag = "8")]
+    pub labels:
+        ::std::collections::HashMap<::prost::alloc::string::String, ::prost::alloc::string::String>,
+    /// IPAM configuration.
+    #[prost(message, optional, tag = "9")]
+    pub ipam: ::core::option::Option<IpamConfig>,
+    /// Connected containers.
+    #[prost(map = "string, message", tag = "10")]
+    pub containers: ::std::collections::HashMap<::prost::alloc::string::String, NetworkContainer>,
+    /// Driver options.
+    #[prost(map = "string, string", tag = "11")]
+    pub options:
+        ::std::collections::HashMap<::prost::alloc::string::String, ::prost::alloc::string::String>,
+}
+/// Container connected to a network.
+#[derive(serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct NetworkContainer {
+    /// Container name.
+    #[prost(string, tag = "1")]
+    pub name: ::prost::alloc::string::String,
+    /// Container endpoint ID.
+    #[prost(string, tag = "2")]
+    pub endpoint_id: ::prost::alloc::string::String,
+    /// IPv4 address.
+    #[prost(string, tag = "3")]
+    pub ipv4_address: ::prost::alloc::string::String,
+    /// IPv6 address.
+    #[prost(string, tag = "4")]
+    pub ipv6_address: ::prost::alloc::string::String,
+    /// MAC address.
+    #[prost(string, tag = "5")]
+    pub mac_address: ::prost::alloc::string::String,
+}
+/// The System VM's hypervisor backend.
+#[derive(serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct SystemVmBackendInfo {
+    #[prost(enumeration = "SystemVmBackend", tag = "1")]
+    pub backend: i32,
+}
+/// Request to switch the System VM's hypervisor backend.
+#[derive(serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct SetSystemVmBackendRequest {
+    #[prost(enumeration = "SystemVmBackend", tag = "1")]
+    pub backend: i32,
+}
+/// Request to resolve a container's filesystem layer directories.
+#[derive(serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct ResolveContainerFsRequest {
+    /// Full container ID.
+    #[prost(string, tag = "1")]
+    pub container_id: ::prost::alloc::string::String,
+}
+/// A container's filesystem layer directories, as guest paths under the
+/// containerd data mount.
+#[derive(serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct ResolveContainerFsResponse {
+    /// Writable layer directory. Empty for read-only snapshots.
+    #[prost(string, tag = "1")]
+    pub upper_dir: ::prost::alloc::string::String,
+    /// Read-only layer directories, top-most first.
+    #[prost(string, repeated, tag = "2")]
+    pub lower_dirs: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
+}
+/// Request to resolve an image's layer directories.
+#[derive(serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct ResolveImageFsRequest {
+    /// Chain ID of the image's top layer (`sha256:<64 hex>`).
+    #[prost(string, tag = "1")]
+    pub top_chain_id: ::prost::alloc::string::String,
+}
+/// An image's layer directories, as guest paths under the containerd data
+/// mount.
+#[derive(serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct ResolveImageFsResponse {
+    /// Read-only layer directories, top-most first.
+    #[prost(string, repeated, tag = "1")]
+    pub lower_dirs: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
+}
+/// Diagnostic snapshot of the System VM's virtio devices and vCPUs.
+#[derive(serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct VirtioDebugInfo {
+    #[prost(message, repeated, tag = "1")]
+    pub devices: ::prost::alloc::vec::Vec<VirtioDeviceDebug>,
+    /// Per-vCPU exit counters (custom-VMM backends; empty under VZ).
+    #[prost(message, repeated, tag = "2")]
+    pub vcpus: ::prost::alloc::vec::Vec<VcpuDebug>,
+    /// Times any component broadcast hv_vcpus_exit to ALL vCPUs.
+    #[prost(uint64, tag = "3")]
+    pub kick_broadcasts: u64,
+    /// Times the IRQ callback unparked ALL vCPU threads on an SPI assertion.
+    #[prost(uint64, tag = "4")]
+    pub unpark_broadcasts: u64,
+}
+/// Cumulative exit counters for one vCPU.
+#[derive(serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct VcpuDebug {
+    #[prost(uint32, tag = "1")]
+    pub vcpu: u32,
+    /// MMIO read exits.
+    #[prost(uint64, tag = "2")]
+    pub mmio_reads: u64,
+    /// MMIO write exits (includes every virtio QUEUE_NOTIFY doorbell).
+    #[prost(uint64, tag = "3")]
+    pub mmio_writes: u64,
+    /// WFI exits — the guest going idle.
+    #[prost(uint64, tag = "4")]
+    pub wfi: u64,
+    /// HVC exits (PSCI + ArcBox hypercalls).
+    #[prost(uint64, tag = "5")]
+    pub hvc: u64,
+    /// SMC exits.
+    #[prost(uint64, tag = "6")]
+    pub smc: u64,
+    /// Virtual-timer activations.
+    #[prost(uint64, tag = "7")]
+    pub vtimer: u64,
+    /// Times this vCPU was kicked out of hv_vcpu_run by hv_vcpus_exit.
+    #[prost(uint64, tag = "8")]
+    pub kicks_received: u64,
+    /// Trapped system-register accesses (treated RAZ/WI).
+    #[prost(uint64, tag = "9")]
+    pub sysreg: u64,
+    /// Unhandled exception classes and unknown exits.
+    #[prost(uint64, tag = "10")]
+    pub other: u64,
+}
+/// Snapshot of one virtio MMIO device.
+#[derive(serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct VirtioDeviceDebug {
+    /// Device ID within the VMM's device manager.
+    #[prost(uint32, tag = "1")]
+    pub id: u32,
+    /// Device type, e.g. "VirtioNet".
+    #[prost(string, tag = "2")]
+    pub device_type: ::prost::alloc::string::String,
+    /// Device name.
+    #[prost(string, tag = "3")]
+    pub name: ::prost::alloc::string::String,
+    /// MMIO device status register bits.
+    #[prost(uint32, tag = "4")]
+    pub status: u32,
+    /// Pending interrupt reasons not yet acknowledged by the guest.
+    #[prost(uint32, tag = "5")]
+    pub interrupt_status: u32,
+    /// Whether VIRTIO_F_EVENT_IDX was negotiated.
+    #[prost(bool, tag = "6")]
+    pub event_idx: bool,
+    /// Cumulative interrupts raised by the device.
+    #[prost(uint64, tag = "7")]
+    pub interrupts: u64,
+    /// Configured queues.
+    #[prost(message, repeated, tag = "8")]
+    pub queues: ::prost::alloc::vec::Vec<VirtioQueueDebug>,
+}
+/// Snapshot of one virtqueue. Ring fields are only present when the ring
+/// address was configured and lies inside guest RAM.
+#[derive(serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct VirtioQueueDebug {
+    /// Queue index within the device.
+    #[prost(uint32, tag = "1")]
+    pub index: u32,
+    /// Ring size negotiated by the driver.
+    #[prost(uint32, tag = "2")]
+    pub size: u32,
+    /// QUEUE_READY state.
+    #[prost(bool, tag = "3")]
+    pub ready: bool,
+    /// Cumulative guest kicks (QUEUE_NOTIFY writes).
+    #[prost(uint64, tag = "4")]
+    pub kicks: u64,
+    /// avail.idx — where the guest has published up to.
+    #[prost(uint32, optional, tag = "5")]
+    pub avail_idx: ::core::option::Option<u32>,
+    /// used.idx — where the device has completed up to. A persistent gap
+    /// behind avail_idx means the queue is wedged.
+    #[prost(uint32, optional, tag = "6")]
+    pub used_idx: ::core::option::Option<u32>,
+    /// avail.flags (bit 0 = VRING_AVAIL_F_NO_INTERRUPT).
+    #[prost(uint32, optional, tag = "7")]
+    pub avail_flags: ::core::option::Option<u32>,
+    /// used.flags (bit 0 = VRING_USED_F_NO_NOTIFY).
+    #[prost(uint32, optional, tag = "8")]
+    pub used_flags: ::core::option::Option<u32>,
+    /// used_event slot (guest → device kick threshold; EVENT_IDX only).
+    #[prost(uint32, optional, tag = "9")]
+    pub used_event: ::core::option::Option<u32>,
+    /// avail_event slot (device → guest interrupt threshold; EVENT_IDX only).
+    #[prost(uint32, optional, tag = "10")]
+    pub avail_event: ::core::option::Option<u32>,
+}
+/// Request to get system info.
+#[derive(serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct GetInfoRequest {}
+/// Response to get system info.
+#[derive(serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct GetInfoResponse {
+    /// Number of containers.
+    #[prost(int64, tag = "1")]
+    pub containers: i64,
+    /// Running containers.
+    #[prost(int64, tag = "2")]
+    pub containers_running: i64,
+    /// Paused containers.
+    #[prost(int64, tag = "3")]
+    pub containers_paused: i64,
+    /// Stopped containers.
+    #[prost(int64, tag = "4")]
+    pub containers_stopped: i64,
+    /// Number of images.
+    #[prost(int64, tag = "5")]
+    pub images: i64,
+    /// Number of machines.
+    #[prost(int64, tag = "6")]
+    pub machines: i64,
+    /// Running machines.
+    #[prost(int64, tag = "7")]
+    pub machines_running: i64,
+    /// Server version.
+    #[prost(string, tag = "8")]
+    pub server_version: ::prost::alloc::string::String,
+    /// Operating system.
+    #[prost(string, tag = "9")]
+    pub os: ::prost::alloc::string::String,
+    /// Architecture.
+    #[prost(string, tag = "10")]
+    pub arch: ::prost::alloc::string::String,
+    /// Total memory.
+    #[prost(int64, tag = "11")]
+    pub mem_total: i64,
+    /// Number of CPUs.
+    #[prost(int32, tag = "12")]
+    pub ncpu: i32,
+    /// Data directory.
+    #[prost(string, tag = "13")]
+    pub data_dir: ::prost::alloc::string::String,
+    /// Kernel version.
+    #[prost(string, tag = "14")]
+    pub kernel_version: ::prost::alloc::string::String,
+    /// Operating system type.
+    #[prost(string, tag = "15")]
+    pub os_type: ::prost::alloc::string::String,
+    /// Logging driver.
+    #[prost(string, tag = "16")]
+    pub logging_driver: ::prost::alloc::string::String,
+    /// Storage driver.
+    #[prost(string, tag = "17")]
+    pub storage_driver: ::prost::alloc::string::String,
+}
+/// Request to get version.
+#[derive(serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct GetVersionRequest {}
+/// Response to get version.
+#[derive(serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct GetVersionResponse {
+    /// Version string.
+    #[prost(string, tag = "1")]
+    pub version: ::prost::alloc::string::String,
+    /// API version.
+    #[prost(string, tag = "2")]
+    pub api_version: ::prost::alloc::string::String,
+    /// Minimum API version.
+    #[prost(string, tag = "3")]
+    pub min_api_version: ::prost::alloc::string::String,
+    /// Git commit.
+    #[prost(string, tag = "4")]
+    pub git_commit: ::prost::alloc::string::String,
+    /// Build time.
+    #[prost(string, tag = "5")]
+    pub build_time: ::prost::alloc::string::String,
+    /// OS.
+    #[prost(string, tag = "6")]
+    pub os: ::prost::alloc::string::String,
+    /// Architecture.
+    #[prost(string, tag = "7")]
+    pub arch: ::prost::alloc::string::String,
+    /// Go version (for compatibility).
+    #[prost(string, tag = "8")]
+    pub go_version: ::prost::alloc::string::String,
+}
+/// Request to ping the server.
+#[derive(serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct SystemPingRequest {}
+/// Response to ping.
+#[derive(serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct SystemPingResponse {
+    /// API version.
+    #[prost(string, tag = "1")]
+    pub api_version: ::prost::alloc::string::String,
+    /// Build version.
+    #[prost(string, tag = "2")]
+    pub build_version: ::prost::alloc::string::String,
+}
+/// Request to get events.
+#[derive(serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct EventsRequest {
+    /// Only events since this timestamp (Unix seconds).
+    #[prost(int64, tag = "1")]
+    pub since: i64,
+    /// Only events until this timestamp (Unix seconds).
+    #[prost(int64, tag = "2")]
+    pub until: i64,
+    /// Filters.
+    #[prost(map = "string, string", tag = "3")]
+    pub filters:
+        ::std::collections::HashMap<::prost::alloc::string::String, ::prost::alloc::string::String>,
+}
+/// System event.
+#[derive(serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Event {
+    /// Event type (container, image, network, volume, daemon).
+    #[prost(string, tag = "1")]
+    pub r#type: ::prost::alloc::string::String,
+    /// Action (create, start, stop, die, destroy, etc.).
+    #[prost(string, tag = "2")]
+    pub action: ::prost::alloc::string::String,
+    /// Actor that generated the event.
+    #[prost(message, optional, tag = "3")]
+    pub actor: ::core::option::Option<EventActor>,
+    /// Timestamp (Unix nanoseconds).
+    #[prost(int64, tag = "4")]
+    pub time_nano: i64,
+}
+/// Event actor.
+#[derive(serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct EventActor {
+    /// ID of the object.
+    #[prost(string, tag = "1")]
+    pub id: ::prost::alloc::string::String,
+    /// Attributes.
+    #[prost(map = "string, string", tag = "2")]
+    pub attributes:
+        ::std::collections::HashMap<::prost::alloc::string::String, ::prost::alloc::string::String>,
+}
+/// Request to prune resources.
+#[derive(serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct PruneRequest {
+    /// Types to prune: containers, images, networks, volumes, all.
+    #[prost(string, repeated, tag = "1")]
+    pub types: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
+    /// Remove all unused resources, not just dangling ones.
+    #[prost(bool, tag = "2")]
+    pub all: bool,
+    /// Filters.
+    #[prost(map = "string, string", tag = "3")]
+    pub filters:
+        ::std::collections::HashMap<::prost::alloc::string::String, ::prost::alloc::string::String>,
+}
+/// Response to prune.
+#[derive(serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct PruneResponse {
+    /// Space reclaimed in bytes.
+    #[prost(uint64, tag = "1")]
+    pub space_reclaimed: u64,
+    /// Deleted containers.
+    #[prost(string, repeated, tag = "2")]
+    pub containers_deleted: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
+    /// Deleted images.
+    #[prost(string, repeated, tag = "3")]
+    pub images_deleted: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
+    /// Deleted networks.
+    #[prost(string, repeated, tag = "4")]
+    pub networks_deleted: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
+    /// Deleted volumes.
+    #[prost(string, repeated, tag = "5")]
+    pub volumes_deleted: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
+}
+/// Request to get the icon URL for a container image.
+#[derive(serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct GetImageIconRequest {
+    /// Fully qualified image name (e.g., "nginx", "localstack/localstack", "ghcr.io/astral-sh/uv").
+    #[prost(string, tag = "1")]
+    pub fqin: ::prost::alloc::string::String,
+}
+/// Response containing the icon URL.
+#[derive(serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct GetImageIconResponse {
+    /// Icon URL, empty if not found.
+    #[prost(string, tag = "1")]
+    pub url: ::prost::alloc::string::String,
+    /// Icon source (e.g., "docker_hub_logo", "docker_official_image", "ghcr_avatar").
+    #[prost(string, tag = "2")]
+    pub source: ::prost::alloc::string::String,
+}
+/// Request to create a volume.
+#[derive(serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct CreateVolumeRequest {
+    /// Volume name.
+    #[prost(string, tag = "1")]
+    pub name: ::prost::alloc::string::String,
+    /// Driver name.
+    #[prost(string, tag = "2")]
+    pub driver: ::prost::alloc::string::String,
+    /// Driver options.
+    #[prost(map = "string, string", tag = "3")]
+    pub driver_opts:
+        ::std::collections::HashMap<::prost::alloc::string::String, ::prost::alloc::string::String>,
+    /// Labels.
+    #[prost(map = "string, string", tag = "4")]
+    pub labels:
+        ::std::collections::HashMap<::prost::alloc::string::String, ::prost::alloc::string::String>,
+}
+/// Response to create volume.
+#[derive(serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct CreateVolumeResponse {
+    /// Volume name.
+    #[prost(string, tag = "1")]
+    pub name: ::prost::alloc::string::String,
+    /// Driver.
+    #[prost(string, tag = "2")]
+    pub driver: ::prost::alloc::string::String,
+    /// Mountpoint.
+    #[prost(string, tag = "3")]
+    pub mountpoint: ::prost::alloc::string::String,
+}
+/// Request to remove a volume.
+#[derive(serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct RemoveVolumeRequest {
+    /// Volume name.
+    #[prost(string, tag = "1")]
+    pub name: ::prost::alloc::string::String,
+    /// Force removal.
+    #[prost(bool, tag = "2")]
+    pub force: bool,
+}
+/// Request to list volumes.
+#[derive(serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ListVolumesRequest {
+    /// Filters.
+    #[prost(map = "string, string", tag = "1")]
+    pub filters:
+        ::std::collections::HashMap<::prost::alloc::string::String, ::prost::alloc::string::String>,
+}
+/// Response to list volumes.
+#[derive(serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ListVolumesResponse {
+    /// List of volumes.
+    #[prost(message, repeated, tag = "1")]
+    pub volumes: ::prost::alloc::vec::Vec<VolumeInfo>,
+    /// Warnings.
+    #[prost(string, repeated, tag = "2")]
+    pub warnings: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
+}
+/// Request to inspect a volume.
+#[derive(serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct InspectVolumeRequest {
+    /// Volume name.
+    #[prost(string, tag = "1")]
+    pub name: ::prost::alloc::string::String,
+}
+/// Volume information.
+#[derive(serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct VolumeInfo {
+    /// Volume name.
+    #[prost(string, tag = "1")]
+    pub name: ::prost::alloc::string::String,
+    /// Driver.
+    #[prost(string, tag = "2")]
+    pub driver: ::prost::alloc::string::String,
+    /// Mountpoint.
+    #[prost(string, tag = "3")]
+    pub mountpoint: ::prost::alloc::string::String,
+    /// Created timestamp (RFC3339).
+    #[prost(string, tag = "4")]
+    pub created: ::prost::alloc::string::String,
+    /// Status.
+    #[prost(map = "string, string", tag = "5")]
+    pub status:
+        ::std::collections::HashMap<::prost::alloc::string::String, ::prost::alloc::string::String>,
+    /// Labels.
+    #[prost(map = "string, string", tag = "6")]
+    pub labels:
+        ::std::collections::HashMap<::prost::alloc::string::String, ::prost::alloc::string::String>,
+    /// Scope (local, global).
+    #[prost(string, tag = "7")]
+    pub scope: ::prost::alloc::string::String,
+    /// Driver options.
+    #[prost(map = "string, string", tag = "8")]
+    pub options:
+        ::std::collections::HashMap<::prost::alloc::string::String, ::prost::alloc::string::String>,
+    /// Usage data.
+    #[prost(message, optional, tag = "9")]
+    pub usage: ::core::option::Option<VolumeUsage>,
+}
+/// Volume usage data.
+#[derive(serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct VolumeUsage {
+    /// Size in bytes.
+    #[prost(int64, tag = "1")]
+    pub size: i64,
+    /// Reference count.
+    #[prost(int64, tag = "2")]
+    pub ref_count: i64,
+}
+/// Request to prepare a migration.
+#[derive(serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct PrepareMigrationRequest {
+    /// Stable source runtime identifier (for example, "docker-desktop" or "orbstack").
+    #[prost(string, tag = "1")]
+    pub source_kind: ::prost::alloc::string::String,
+    /// Optional override for the source Docker-compatible socket path.
+    #[prost(string, tag = "2")]
+    pub source_socket_path: ::prost::alloc::string::String,
+    /// Allow prepare to include replace actions in the plan.
+    #[prost(bool, tag = "3")]
+    pub allow_replacements: bool,
+}
+/// Prepared migration summary.
+#[derive(serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct PrepareMigrationResponse {
+    /// Opaque identifier for the prepared plan.
+    #[prost(string, tag = "1")]
+    pub plan_id: ::prost::alloc::string::String,
+    /// Source runtime identifier used for the plan.
+    #[prost(string, tag = "2")]
+    pub source_kind: ::prost::alloc::string::String,
+    /// Resolved source socket path used for the plan.
+    #[prost(string, tag = "3")]
+    pub source_socket_path: ::prost::alloc::string::String,
+    /// Number of images included in the plan.
+    #[prost(uint32, tag = "4")]
+    pub image_count: u32,
+    /// Number of volumes included in the plan.
+    #[prost(uint32, tag = "5")]
+    pub volume_count: u32,
+    /// Number of networks included in the plan.
+    #[prost(uint32, tag = "6")]
+    pub network_count: u32,
+    /// Number of containers included in the plan.
+    #[prost(uint32, tag = "7")]
+    pub container_count: u32,
+    /// Whether the plan would replace existing ArcBox resources (images, volumes,
+    /// networks, or containers that already exist on the target). When true,
+    /// RunMigrationRequest.allow_replacements must be set to confirm.
+    #[prost(bool, tag = "8")]
+    pub replacements_required: bool,
+    /// Non-fatal warnings discovered during preparation (for example, volume
+    /// blockers that will require stopping running source containers).
+    #[prost(string, repeated, tag = "9")]
+    pub warnings: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
+}
+/// Request to run a prepared migration.
+#[derive(serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct RunMigrationRequest {
+    /// Opaque identifier returned by PrepareMigration.
+    #[prost(string, tag = "1")]
+    pub plan_id: ::prost::alloc::string::String,
+    /// Confirms that the caller accepts any replace actions in the plan.
+    #[prost(bool, tag = "2")]
+    pub allow_replacements: bool,
+}
+/// Streaming migration progress event.
+#[derive(serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct RunMigrationEvent {
+    /// Opaque identifier of the plan being executed.
+    #[prost(string, tag = "1")]
+    pub plan_id: ::prost::alloc::string::String,
+    /// High-level execution phase (for example, "prepare", "images", or "containers").
+    #[prost(string, tag = "2")]
+    pub phase: ::prost::alloc::string::String,
+    /// Optional resource name currently being processed.
+    #[prost(string, tag = "3")]
+    pub resource: ::prost::alloc::string::String,
+    /// Human-readable progress detail.
+    #[prost(string, tag = "4")]
+    pub message: ::prost::alloc::string::String,
+    /// Number of completed work items in the current phase.
+    #[prost(uint32, tag = "5")]
+    pub completed: u32,
+    /// Total work items expected in the current phase.
+    #[prost(uint32, tag = "6")]
+    pub total: u32,
+    /// Indicates that no more events will follow for this run.
+    #[prost(bool, tag = "7")]
+    pub done: bool,
+    /// Indicates whether the run completed successfully.
+    #[prost(bool, tag = "8")]
+    pub success: bool,
+}
+/// Shell input for interactive sessions.
+#[derive(serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct ShellInput {
+    /// Input data.
+    #[prost(bytes = "vec", tag = "1")]
+    pub data: ::prost::alloc::vec::Vec<u8>,
+    /// Resize terminal.
+    #[prost(message, optional, tag = "2")]
+    pub resize: ::core::option::Option<TerminalSize>,
+}
+/// Shell output for interactive sessions.
+#[derive(serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct ShellOutput {
+    /// Output data.
+    #[prost(bytes = "vec", tag = "1")]
+    pub data: ::prost::alloc::vec::Vec<u8>,
+    /// Exit code (only set when done).
+    #[prost(int32, tag = "2")]
+    pub exit_code: i32,
+    /// Is this the final message.
+    #[prost(bool, tag = "3")]
+    pub done: bool,
+}
+/// Terminal size.
+#[derive(serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct TerminalSize {
+    /// Terminal width.
+    #[prost(uint32, tag = "1")]
+    pub width: u32,
+    /// Terminal height.
+    #[prost(uint32, tag = "2")]
+    pub height: u32,
+}
+/// Daemon startup progress and infrastructure health.
+/// Allows the desktop app (or any gRPC client) to observe daemon readiness
+/// without managing its lifecycle.
+#[derive(serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct SetupStatus {
+    /// Current daemon phase.
+    #[prost(enumeration = "setup_status::Phase", tag = "1")]
+    pub phase: i32,
+    /// Whether the DNS resolver file is installed.
+    #[prost(bool, tag = "2")]
+    pub dns_resolver_installed: bool,
+    /// Whether /var/run/docker.sock is symlinked to ArcBox.
+    #[prost(bool, tag = "3")]
+    pub docker_socket_linked: bool,
+    /// Whether the container subnet route is installed.
+    #[prost(bool, tag = "4")]
+    pub route_installed: bool,
+    /// Whether the default VM is running.
+    #[prost(bool, tag = "5")]
+    pub vm_running: bool,
+    /// Human-readable status message.
+    #[prost(string, tag = "6")]
+    pub message: ::prost::alloc::string::String,
+    /// Whether Docker CLI tools are installed.
+    #[prost(bool, tag = "7")]
+    pub docker_tools_installed: bool,
+    /// Fatal startup error description. Set only when phase == FAILED,
+    /// so streaming clients learn the cause instead of seeing a bare
+    /// disconnect when the daemon exits.
+    #[prost(string, tag = "8")]
+    pub error: ::prost::alloc::string::String,
+}
+/// Nested message and enum types in `SetupStatus`.
+pub mod setup_status {
+    /// Daemon startup phases, ordered by progression.
+    #[derive(serde::Serialize, serde::Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+    #[repr(i32)]
+    pub enum Phase {
+        Unspecified = 0,
+        Initializing = 1,
+        AssetsReady = 2,
+        VmStarting = 3,
+        VmReady = 4,
+        NetworkReady = 5,
+        Ready = 6,
+        Degraded = 7,
+        DownloadingAssets = 8,
+        CleaningUp = 9,
+        /// Startup failed fatally; the daemon exits shortly after
+        /// publishing this phase. See the `error` field for the cause.
+        Failed = 10,
+    }
+    impl Phase {
+        /// String value of the enum field names used in the ProtoBuf definition.
+        ///
+        /// The values are not transformed in any way and thus are considered stable
+        /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+        pub fn as_str_name(&self) -> &'static str {
+            match self {
+                Self::Unspecified => "PHASE_UNSPECIFIED",
+                Self::Initializing => "INITIALIZING",
+                Self::AssetsReady => "ASSETS_READY",
+                Self::VmStarting => "VM_STARTING",
+                Self::VmReady => "VM_READY",
+                Self::NetworkReady => "NETWORK_READY",
+                Self::Ready => "READY",
+                Self::Degraded => "DEGRADED",
+                Self::DownloadingAssets => "DOWNLOADING_ASSETS",
+                Self::CleaningUp => "CLEANING_UP",
+                Self::Failed => "FAILED",
+            }
+        }
+        /// Creates an enum from field names used in the ProtoBuf definition.
+        pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+            match value {
+                "PHASE_UNSPECIFIED" => Some(Self::Unspecified),
+                "INITIALIZING" => Some(Self::Initializing),
+                "ASSETS_READY" => Some(Self::AssetsReady),
+                "VM_STARTING" => Some(Self::VmStarting),
+                "VM_READY" => Some(Self::VmReady),
+                "NETWORK_READY" => Some(Self::NetworkReady),
+                "READY" => Some(Self::Ready),
+                "DEGRADED" => Some(Self::Degraded),
+                "DOWNLOADING_ASSETS" => Some(Self::DownloadingAssets),
+                "CLEANING_UP" => Some(Self::CleaningUp),
+                "FAILED" => Some(Self::Failed),
+                _ => None,
+            }
+        }
+    }
+}
+/// Hypervisor backend for the single System VM.
+#[derive(serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+#[repr(i32)]
+pub enum SystemVmBackend {
+    /// Unset; rejected by SetSystemVmBackend.
+    Unspecified = 0,
+    /// Hypervisor.framework — ArcBox's custom VMM (amd64 via FEX). macOS 15+.
+    Hv = 1,
+    /// Virtualization.framework — Apple-managed execution. The default.
+    Vz = 2,
+}
+impl SystemVmBackend {
+    /// String value of the enum field names used in the ProtoBuf definition.
+    ///
+    /// The values are not transformed in any way and thus are considered stable
+    /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+    pub fn as_str_name(&self) -> &'static str {
+        match self {
+            Self::Unspecified => "SYSTEM_VM_BACKEND_UNSPECIFIED",
+            Self::Hv => "SYSTEM_VM_BACKEND_HV",
+            Self::Vz => "SYSTEM_VM_BACKEND_VZ",
+        }
+    }
+    /// Creates an enum from field names used in the ProtoBuf definition.
+    pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+        match value {
+            "SYSTEM_VM_BACKEND_UNSPECIFIED" => Some(Self::Unspecified),
+            "SYSTEM_VM_BACKEND_HV" => Some(Self::Hv),
+            "SYSTEM_VM_BACKEND_VZ" => Some(Self::Vz),
+            _ => None,
+        }
+    }
+}
 /// Request to create a machine.
 #[derive(serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -435,6 +1420,34 @@ pub struct MachineExecRequest {
     /// Allocate TTY.
     #[prost(bool, tag = "6")]
     pub tty: bool,
+    /// Initial terminal size (interactive sessions).
+    #[prost(message, optional, tag = "7")]
+    pub tty_size: ::core::option::Option<TerminalSize>,
+}
+/// One client message on an interactive machine session.
+#[derive(serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct MachineExecInput {
+    #[prost(oneof = "machine_exec_input::Payload", tags = "1, 2, 3")]
+    pub payload: ::core::option::Option<machine_exec_input::Payload>,
+}
+/// Nested message and enum types in `MachineExecInput`.
+pub mod machine_exec_input {
+    #[derive(serde::Serialize, serde::Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    #[derive(Clone, PartialEq, ::prost::Oneof)]
+    pub enum Payload {
+        /// Must be the first message: what to run.
+        #[prost(message, tag = "1")]
+        Init(super::MachineExecRequest),
+        /// Raw stdin bytes; empty means stdin EOF.
+        #[prost(bytes, tag = "2")]
+        Stdin(::prost::alloc::vec::Vec<u8>),
+        /// Terminal resize.
+        #[prost(message, tag = "3")]
+        Resize(super::TerminalSize),
+    }
 }
 /// Exec output from a machine.
 #[derive(serde::Serialize, serde::Deserialize)]
@@ -2321,991 +3334,6 @@ pub struct ImageFsPathsResponse {
     /// Read-only layer directories, top-most first.
     #[prost(string, repeated, tag = "1")]
     pub lower_dirs: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
-}
-/// Request to create a network.
-#[derive(serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct CreateNetworkRequest {
-    /// Network name.
-    #[prost(string, tag = "1")]
-    pub name: ::prost::alloc::string::String,
-    /// Driver (e.g., "bridge", "host", "none").
-    #[prost(string, tag = "2")]
-    pub driver: ::prost::alloc::string::String,
-    /// Internal network (not connected to external network).
-    #[prost(bool, tag = "3")]
-    pub internal: bool,
-    /// Labels.
-    #[prost(map = "string, string", tag = "4")]
-    pub labels:
-        ::std::collections::HashMap<::prost::alloc::string::String, ::prost::alloc::string::String>,
-    /// Enable IPv6.
-    #[prost(bool, tag = "5")]
-    pub enable_ipv6: bool,
-    /// IPAM configuration.
-    #[prost(message, optional, tag = "6")]
-    pub ipam: ::core::option::Option<IpamConfig>,
-}
-/// IPAM configuration.
-#[derive(serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct IpamConfig {
-    /// Driver name.
-    #[prost(string, tag = "1")]
-    pub driver: ::prost::alloc::string::String,
-    /// IPAM options.
-    #[prost(map = "string, string", tag = "2")]
-    pub options:
-        ::std::collections::HashMap<::prost::alloc::string::String, ::prost::alloc::string::String>,
-    /// Subnet configurations.
-    #[prost(message, repeated, tag = "3")]
-    pub subnets: ::prost::alloc::vec::Vec<IpamSubnet>,
-}
-/// IPAM subnet configuration.
-#[derive(serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
-#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
-pub struct IpamSubnet {
-    /// Subnet in CIDR format.
-    #[prost(string, tag = "1")]
-    pub subnet: ::prost::alloc::string::String,
-    /// Gateway address.
-    #[prost(string, tag = "2")]
-    pub gateway: ::prost::alloc::string::String,
-    /// IP range for allocation.
-    #[prost(string, tag = "3")]
-    pub ip_range: ::prost::alloc::string::String,
-}
-/// Response to create network.
-#[derive(serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
-#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
-pub struct CreateNetworkResponse {
-    /// Network ID.
-    #[prost(string, tag = "1")]
-    pub id: ::prost::alloc::string::String,
-    /// Warning messages.
-    #[prost(string, repeated, tag = "2")]
-    pub warnings: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
-}
-/// Request to remove a network.
-#[derive(serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
-#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
-pub struct RemoveNetworkRequest {
-    /// Network ID or name.
-    #[prost(string, tag = "1")]
-    pub id: ::prost::alloc::string::String,
-}
-/// Request to list networks.
-#[derive(serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct ListNetworksRequest {
-    /// Filter by labels.
-    #[prost(map = "string, string", tag = "1")]
-    pub filters:
-        ::std::collections::HashMap<::prost::alloc::string::String, ::prost::alloc::string::String>,
-}
-/// Response to list networks.
-#[derive(serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct ListNetworksResponse {
-    /// List of networks.
-    #[prost(message, repeated, tag = "1")]
-    pub networks: ::prost::alloc::vec::Vec<NetworkSummary>,
-}
-/// Summary information about a network.
-#[derive(serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct NetworkSummary {
-    /// Network ID.
-    #[prost(string, tag = "1")]
-    pub id: ::prost::alloc::string::String,
-    /// Network name.
-    #[prost(string, tag = "2")]
-    pub name: ::prost::alloc::string::String,
-    /// Driver.
-    #[prost(string, tag = "3")]
-    pub driver: ::prost::alloc::string::String,
-    /// Scope (local, global).
-    #[prost(string, tag = "4")]
-    pub scope: ::prost::alloc::string::String,
-    /// Created timestamp (RFC3339).
-    #[prost(string, tag = "5")]
-    pub created: ::prost::alloc::string::String,
-    /// Internal network.
-    #[prost(bool, tag = "6")]
-    pub internal: bool,
-    /// Attachable.
-    #[prost(bool, tag = "7")]
-    pub attachable: bool,
-    /// Labels.
-    #[prost(map = "string, string", tag = "8")]
-    pub labels:
-        ::std::collections::HashMap<::prost::alloc::string::String, ::prost::alloc::string::String>,
-}
-/// Request to inspect a network.
-#[derive(serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
-#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
-pub struct InspectNetworkRequest {
-    /// Network ID or name.
-    #[prost(string, tag = "1")]
-    pub id: ::prost::alloc::string::String,
-    /// Verbose output.
-    #[prost(bool, tag = "2")]
-    pub verbose: bool,
-}
-/// Detailed network information.
-#[derive(serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct NetworkInfo {
-    /// Network ID.
-    #[prost(string, tag = "1")]
-    pub id: ::prost::alloc::string::String,
-    /// Network name.
-    #[prost(string, tag = "2")]
-    pub name: ::prost::alloc::string::String,
-    /// Driver.
-    #[prost(string, tag = "3")]
-    pub driver: ::prost::alloc::string::String,
-    /// Scope.
-    #[prost(string, tag = "4")]
-    pub scope: ::prost::alloc::string::String,
-    /// Created timestamp (RFC3339).
-    #[prost(string, tag = "5")]
-    pub created: ::prost::alloc::string::String,
-    /// Internal network.
-    #[prost(bool, tag = "6")]
-    pub internal: bool,
-    /// Attachable.
-    #[prost(bool, tag = "7")]
-    pub attachable: bool,
-    /// Labels.
-    #[prost(map = "string, string", tag = "8")]
-    pub labels:
-        ::std::collections::HashMap<::prost::alloc::string::String, ::prost::alloc::string::String>,
-    /// IPAM configuration.
-    #[prost(message, optional, tag = "9")]
-    pub ipam: ::core::option::Option<IpamConfig>,
-    /// Connected containers.
-    #[prost(map = "string, message", tag = "10")]
-    pub containers: ::std::collections::HashMap<::prost::alloc::string::String, NetworkContainer>,
-    /// Driver options.
-    #[prost(map = "string, string", tag = "11")]
-    pub options:
-        ::std::collections::HashMap<::prost::alloc::string::String, ::prost::alloc::string::String>,
-}
-/// Container connected to a network.
-#[derive(serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
-#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
-pub struct NetworkContainer {
-    /// Container name.
-    #[prost(string, tag = "1")]
-    pub name: ::prost::alloc::string::String,
-    /// Container endpoint ID.
-    #[prost(string, tag = "2")]
-    pub endpoint_id: ::prost::alloc::string::String,
-    /// IPv4 address.
-    #[prost(string, tag = "3")]
-    pub ipv4_address: ::prost::alloc::string::String,
-    /// IPv6 address.
-    #[prost(string, tag = "4")]
-    pub ipv6_address: ::prost::alloc::string::String,
-    /// MAC address.
-    #[prost(string, tag = "5")]
-    pub mac_address: ::prost::alloc::string::String,
-}
-/// The System VM's hypervisor backend.
-#[derive(serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
-#[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
-pub struct SystemVmBackendInfo {
-    #[prost(enumeration = "SystemVmBackend", tag = "1")]
-    pub backend: i32,
-}
-/// Request to switch the System VM's hypervisor backend.
-#[derive(serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
-#[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
-pub struct SetSystemVmBackendRequest {
-    #[prost(enumeration = "SystemVmBackend", tag = "1")]
-    pub backend: i32,
-}
-/// Request to resolve a container's filesystem layer directories.
-#[derive(serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
-#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
-pub struct ResolveContainerFsRequest {
-    /// Full container ID.
-    #[prost(string, tag = "1")]
-    pub container_id: ::prost::alloc::string::String,
-}
-/// A container's filesystem layer directories, as guest paths under the
-/// containerd data mount.
-#[derive(serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
-#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
-pub struct ResolveContainerFsResponse {
-    /// Writable layer directory. Empty for read-only snapshots.
-    #[prost(string, tag = "1")]
-    pub upper_dir: ::prost::alloc::string::String,
-    /// Read-only layer directories, top-most first.
-    #[prost(string, repeated, tag = "2")]
-    pub lower_dirs: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
-}
-/// Request to resolve an image's layer directories.
-#[derive(serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
-#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
-pub struct ResolveImageFsRequest {
-    /// Chain ID of the image's top layer (`sha256:<64 hex>`).
-    #[prost(string, tag = "1")]
-    pub top_chain_id: ::prost::alloc::string::String,
-}
-/// An image's layer directories, as guest paths under the containerd data
-/// mount.
-#[derive(serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
-#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
-pub struct ResolveImageFsResponse {
-    /// Read-only layer directories, top-most first.
-    #[prost(string, repeated, tag = "1")]
-    pub lower_dirs: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
-}
-/// Diagnostic snapshot of the System VM's virtio devices and vCPUs.
-#[derive(serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct VirtioDebugInfo {
-    #[prost(message, repeated, tag = "1")]
-    pub devices: ::prost::alloc::vec::Vec<VirtioDeviceDebug>,
-    /// Per-vCPU exit counters (custom-VMM backends; empty under VZ).
-    #[prost(message, repeated, tag = "2")]
-    pub vcpus: ::prost::alloc::vec::Vec<VcpuDebug>,
-    /// Times any component broadcast hv_vcpus_exit to ALL vCPUs.
-    #[prost(uint64, tag = "3")]
-    pub kick_broadcasts: u64,
-    /// Times the IRQ callback unparked ALL vCPU threads on an SPI assertion.
-    #[prost(uint64, tag = "4")]
-    pub unpark_broadcasts: u64,
-}
-/// Cumulative exit counters for one vCPU.
-#[derive(serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
-#[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
-pub struct VcpuDebug {
-    #[prost(uint32, tag = "1")]
-    pub vcpu: u32,
-    /// MMIO read exits.
-    #[prost(uint64, tag = "2")]
-    pub mmio_reads: u64,
-    /// MMIO write exits (includes every virtio QUEUE_NOTIFY doorbell).
-    #[prost(uint64, tag = "3")]
-    pub mmio_writes: u64,
-    /// WFI exits — the guest going idle.
-    #[prost(uint64, tag = "4")]
-    pub wfi: u64,
-    /// HVC exits (PSCI + ArcBox hypercalls).
-    #[prost(uint64, tag = "5")]
-    pub hvc: u64,
-    /// SMC exits.
-    #[prost(uint64, tag = "6")]
-    pub smc: u64,
-    /// Virtual-timer activations.
-    #[prost(uint64, tag = "7")]
-    pub vtimer: u64,
-    /// Times this vCPU was kicked out of hv_vcpu_run by hv_vcpus_exit.
-    #[prost(uint64, tag = "8")]
-    pub kicks_received: u64,
-    /// Trapped system-register accesses (treated RAZ/WI).
-    #[prost(uint64, tag = "9")]
-    pub sysreg: u64,
-    /// Unhandled exception classes and unknown exits.
-    #[prost(uint64, tag = "10")]
-    pub other: u64,
-}
-/// Snapshot of one virtio MMIO device.
-#[derive(serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct VirtioDeviceDebug {
-    /// Device ID within the VMM's device manager.
-    #[prost(uint32, tag = "1")]
-    pub id: u32,
-    /// Device type, e.g. "VirtioNet".
-    #[prost(string, tag = "2")]
-    pub device_type: ::prost::alloc::string::String,
-    /// Device name.
-    #[prost(string, tag = "3")]
-    pub name: ::prost::alloc::string::String,
-    /// MMIO device status register bits.
-    #[prost(uint32, tag = "4")]
-    pub status: u32,
-    /// Pending interrupt reasons not yet acknowledged by the guest.
-    #[prost(uint32, tag = "5")]
-    pub interrupt_status: u32,
-    /// Whether VIRTIO_F_EVENT_IDX was negotiated.
-    #[prost(bool, tag = "6")]
-    pub event_idx: bool,
-    /// Cumulative interrupts raised by the device.
-    #[prost(uint64, tag = "7")]
-    pub interrupts: u64,
-    /// Configured queues.
-    #[prost(message, repeated, tag = "8")]
-    pub queues: ::prost::alloc::vec::Vec<VirtioQueueDebug>,
-}
-/// Snapshot of one virtqueue. Ring fields are only present when the ring
-/// address was configured and lies inside guest RAM.
-#[derive(serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
-#[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
-pub struct VirtioQueueDebug {
-    /// Queue index within the device.
-    #[prost(uint32, tag = "1")]
-    pub index: u32,
-    /// Ring size negotiated by the driver.
-    #[prost(uint32, tag = "2")]
-    pub size: u32,
-    /// QUEUE_READY state.
-    #[prost(bool, tag = "3")]
-    pub ready: bool,
-    /// Cumulative guest kicks (QUEUE_NOTIFY writes).
-    #[prost(uint64, tag = "4")]
-    pub kicks: u64,
-    /// avail.idx — where the guest has published up to.
-    #[prost(uint32, optional, tag = "5")]
-    pub avail_idx: ::core::option::Option<u32>,
-    /// used.idx — where the device has completed up to. A persistent gap
-    /// behind avail_idx means the queue is wedged.
-    #[prost(uint32, optional, tag = "6")]
-    pub used_idx: ::core::option::Option<u32>,
-    /// avail.flags (bit 0 = VRING_AVAIL_F_NO_INTERRUPT).
-    #[prost(uint32, optional, tag = "7")]
-    pub avail_flags: ::core::option::Option<u32>,
-    /// used.flags (bit 0 = VRING_USED_F_NO_NOTIFY).
-    #[prost(uint32, optional, tag = "8")]
-    pub used_flags: ::core::option::Option<u32>,
-    /// used_event slot (guest → device kick threshold; EVENT_IDX only).
-    #[prost(uint32, optional, tag = "9")]
-    pub used_event: ::core::option::Option<u32>,
-    /// avail_event slot (device → guest interrupt threshold; EVENT_IDX only).
-    #[prost(uint32, optional, tag = "10")]
-    pub avail_event: ::core::option::Option<u32>,
-}
-/// Request to get system info.
-#[derive(serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
-#[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
-pub struct GetInfoRequest {}
-/// Response to get system info.
-#[derive(serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
-#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
-pub struct GetInfoResponse {
-    /// Number of containers.
-    #[prost(int64, tag = "1")]
-    pub containers: i64,
-    /// Running containers.
-    #[prost(int64, tag = "2")]
-    pub containers_running: i64,
-    /// Paused containers.
-    #[prost(int64, tag = "3")]
-    pub containers_paused: i64,
-    /// Stopped containers.
-    #[prost(int64, tag = "4")]
-    pub containers_stopped: i64,
-    /// Number of images.
-    #[prost(int64, tag = "5")]
-    pub images: i64,
-    /// Number of machines.
-    #[prost(int64, tag = "6")]
-    pub machines: i64,
-    /// Running machines.
-    #[prost(int64, tag = "7")]
-    pub machines_running: i64,
-    /// Server version.
-    #[prost(string, tag = "8")]
-    pub server_version: ::prost::alloc::string::String,
-    /// Operating system.
-    #[prost(string, tag = "9")]
-    pub os: ::prost::alloc::string::String,
-    /// Architecture.
-    #[prost(string, tag = "10")]
-    pub arch: ::prost::alloc::string::String,
-    /// Total memory.
-    #[prost(int64, tag = "11")]
-    pub mem_total: i64,
-    /// Number of CPUs.
-    #[prost(int32, tag = "12")]
-    pub ncpu: i32,
-    /// Data directory.
-    #[prost(string, tag = "13")]
-    pub data_dir: ::prost::alloc::string::String,
-    /// Kernel version.
-    #[prost(string, tag = "14")]
-    pub kernel_version: ::prost::alloc::string::String,
-    /// Operating system type.
-    #[prost(string, tag = "15")]
-    pub os_type: ::prost::alloc::string::String,
-    /// Logging driver.
-    #[prost(string, tag = "16")]
-    pub logging_driver: ::prost::alloc::string::String,
-    /// Storage driver.
-    #[prost(string, tag = "17")]
-    pub storage_driver: ::prost::alloc::string::String,
-}
-/// Request to get version.
-#[derive(serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
-#[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
-pub struct GetVersionRequest {}
-/// Response to get version.
-#[derive(serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
-#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
-pub struct GetVersionResponse {
-    /// Version string.
-    #[prost(string, tag = "1")]
-    pub version: ::prost::alloc::string::String,
-    /// API version.
-    #[prost(string, tag = "2")]
-    pub api_version: ::prost::alloc::string::String,
-    /// Minimum API version.
-    #[prost(string, tag = "3")]
-    pub min_api_version: ::prost::alloc::string::String,
-    /// Git commit.
-    #[prost(string, tag = "4")]
-    pub git_commit: ::prost::alloc::string::String,
-    /// Build time.
-    #[prost(string, tag = "5")]
-    pub build_time: ::prost::alloc::string::String,
-    /// OS.
-    #[prost(string, tag = "6")]
-    pub os: ::prost::alloc::string::String,
-    /// Architecture.
-    #[prost(string, tag = "7")]
-    pub arch: ::prost::alloc::string::String,
-    /// Go version (for compatibility).
-    #[prost(string, tag = "8")]
-    pub go_version: ::prost::alloc::string::String,
-}
-/// Request to ping the server.
-#[derive(serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
-#[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
-pub struct SystemPingRequest {}
-/// Response to ping.
-#[derive(serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
-#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
-pub struct SystemPingResponse {
-    /// API version.
-    #[prost(string, tag = "1")]
-    pub api_version: ::prost::alloc::string::String,
-    /// Build version.
-    #[prost(string, tag = "2")]
-    pub build_version: ::prost::alloc::string::String,
-}
-/// Request to get events.
-#[derive(serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct EventsRequest {
-    /// Only events since this timestamp (Unix seconds).
-    #[prost(int64, tag = "1")]
-    pub since: i64,
-    /// Only events until this timestamp (Unix seconds).
-    #[prost(int64, tag = "2")]
-    pub until: i64,
-    /// Filters.
-    #[prost(map = "string, string", tag = "3")]
-    pub filters:
-        ::std::collections::HashMap<::prost::alloc::string::String, ::prost::alloc::string::String>,
-}
-/// System event.
-#[derive(serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct Event {
-    /// Event type (container, image, network, volume, daemon).
-    #[prost(string, tag = "1")]
-    pub r#type: ::prost::alloc::string::String,
-    /// Action (create, start, stop, die, destroy, etc.).
-    #[prost(string, tag = "2")]
-    pub action: ::prost::alloc::string::String,
-    /// Actor that generated the event.
-    #[prost(message, optional, tag = "3")]
-    pub actor: ::core::option::Option<EventActor>,
-    /// Timestamp (Unix nanoseconds).
-    #[prost(int64, tag = "4")]
-    pub time_nano: i64,
-}
-/// Event actor.
-#[derive(serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct EventActor {
-    /// ID of the object.
-    #[prost(string, tag = "1")]
-    pub id: ::prost::alloc::string::String,
-    /// Attributes.
-    #[prost(map = "string, string", tag = "2")]
-    pub attributes:
-        ::std::collections::HashMap<::prost::alloc::string::String, ::prost::alloc::string::String>,
-}
-/// Request to prune resources.
-#[derive(serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct PruneRequest {
-    /// Types to prune: containers, images, networks, volumes, all.
-    #[prost(string, repeated, tag = "1")]
-    pub types: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
-    /// Remove all unused resources, not just dangling ones.
-    #[prost(bool, tag = "2")]
-    pub all: bool,
-    /// Filters.
-    #[prost(map = "string, string", tag = "3")]
-    pub filters:
-        ::std::collections::HashMap<::prost::alloc::string::String, ::prost::alloc::string::String>,
-}
-/// Response to prune.
-#[derive(serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
-#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
-pub struct PruneResponse {
-    /// Space reclaimed in bytes.
-    #[prost(uint64, tag = "1")]
-    pub space_reclaimed: u64,
-    /// Deleted containers.
-    #[prost(string, repeated, tag = "2")]
-    pub containers_deleted: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
-    /// Deleted images.
-    #[prost(string, repeated, tag = "3")]
-    pub images_deleted: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
-    /// Deleted networks.
-    #[prost(string, repeated, tag = "4")]
-    pub networks_deleted: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
-    /// Deleted volumes.
-    #[prost(string, repeated, tag = "5")]
-    pub volumes_deleted: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
-}
-/// Request to get the icon URL for a container image.
-#[derive(serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
-#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
-pub struct GetImageIconRequest {
-    /// Fully qualified image name (e.g., "nginx", "localstack/localstack", "ghcr.io/astral-sh/uv").
-    #[prost(string, tag = "1")]
-    pub fqin: ::prost::alloc::string::String,
-}
-/// Response containing the icon URL.
-#[derive(serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
-#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
-pub struct GetImageIconResponse {
-    /// Icon URL, empty if not found.
-    #[prost(string, tag = "1")]
-    pub url: ::prost::alloc::string::String,
-    /// Icon source (e.g., "docker_hub_logo", "docker_official_image", "ghcr_avatar").
-    #[prost(string, tag = "2")]
-    pub source: ::prost::alloc::string::String,
-}
-/// Request to create a volume.
-#[derive(serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct CreateVolumeRequest {
-    /// Volume name.
-    #[prost(string, tag = "1")]
-    pub name: ::prost::alloc::string::String,
-    /// Driver name.
-    #[prost(string, tag = "2")]
-    pub driver: ::prost::alloc::string::String,
-    /// Driver options.
-    #[prost(map = "string, string", tag = "3")]
-    pub driver_opts:
-        ::std::collections::HashMap<::prost::alloc::string::String, ::prost::alloc::string::String>,
-    /// Labels.
-    #[prost(map = "string, string", tag = "4")]
-    pub labels:
-        ::std::collections::HashMap<::prost::alloc::string::String, ::prost::alloc::string::String>,
-}
-/// Response to create volume.
-#[derive(serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
-#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
-pub struct CreateVolumeResponse {
-    /// Volume name.
-    #[prost(string, tag = "1")]
-    pub name: ::prost::alloc::string::String,
-    /// Driver.
-    #[prost(string, tag = "2")]
-    pub driver: ::prost::alloc::string::String,
-    /// Mountpoint.
-    #[prost(string, tag = "3")]
-    pub mountpoint: ::prost::alloc::string::String,
-}
-/// Request to remove a volume.
-#[derive(serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
-#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
-pub struct RemoveVolumeRequest {
-    /// Volume name.
-    #[prost(string, tag = "1")]
-    pub name: ::prost::alloc::string::String,
-    /// Force removal.
-    #[prost(bool, tag = "2")]
-    pub force: bool,
-}
-/// Request to list volumes.
-#[derive(serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct ListVolumesRequest {
-    /// Filters.
-    #[prost(map = "string, string", tag = "1")]
-    pub filters:
-        ::std::collections::HashMap<::prost::alloc::string::String, ::prost::alloc::string::String>,
-}
-/// Response to list volumes.
-#[derive(serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct ListVolumesResponse {
-    /// List of volumes.
-    #[prost(message, repeated, tag = "1")]
-    pub volumes: ::prost::alloc::vec::Vec<VolumeInfo>,
-    /// Warnings.
-    #[prost(string, repeated, tag = "2")]
-    pub warnings: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
-}
-/// Request to inspect a volume.
-#[derive(serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
-#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
-pub struct InspectVolumeRequest {
-    /// Volume name.
-    #[prost(string, tag = "1")]
-    pub name: ::prost::alloc::string::String,
-}
-/// Volume information.
-#[derive(serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct VolumeInfo {
-    /// Volume name.
-    #[prost(string, tag = "1")]
-    pub name: ::prost::alloc::string::String,
-    /// Driver.
-    #[prost(string, tag = "2")]
-    pub driver: ::prost::alloc::string::String,
-    /// Mountpoint.
-    #[prost(string, tag = "3")]
-    pub mountpoint: ::prost::alloc::string::String,
-    /// Created timestamp (RFC3339).
-    #[prost(string, tag = "4")]
-    pub created: ::prost::alloc::string::String,
-    /// Status.
-    #[prost(map = "string, string", tag = "5")]
-    pub status:
-        ::std::collections::HashMap<::prost::alloc::string::String, ::prost::alloc::string::String>,
-    /// Labels.
-    #[prost(map = "string, string", tag = "6")]
-    pub labels:
-        ::std::collections::HashMap<::prost::alloc::string::String, ::prost::alloc::string::String>,
-    /// Scope (local, global).
-    #[prost(string, tag = "7")]
-    pub scope: ::prost::alloc::string::String,
-    /// Driver options.
-    #[prost(map = "string, string", tag = "8")]
-    pub options:
-        ::std::collections::HashMap<::prost::alloc::string::String, ::prost::alloc::string::String>,
-    /// Usage data.
-    #[prost(message, optional, tag = "9")]
-    pub usage: ::core::option::Option<VolumeUsage>,
-}
-/// Volume usage data.
-#[derive(serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
-#[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
-pub struct VolumeUsage {
-    /// Size in bytes.
-    #[prost(int64, tag = "1")]
-    pub size: i64,
-    /// Reference count.
-    #[prost(int64, tag = "2")]
-    pub ref_count: i64,
-}
-/// Request to prepare a migration.
-#[derive(serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
-#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
-pub struct PrepareMigrationRequest {
-    /// Stable source runtime identifier (for example, "docker-desktop" or "orbstack").
-    #[prost(string, tag = "1")]
-    pub source_kind: ::prost::alloc::string::String,
-    /// Optional override for the source Docker-compatible socket path.
-    #[prost(string, tag = "2")]
-    pub source_socket_path: ::prost::alloc::string::String,
-    /// Allow prepare to include replace actions in the plan.
-    #[prost(bool, tag = "3")]
-    pub allow_replacements: bool,
-}
-/// Prepared migration summary.
-#[derive(serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
-#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
-pub struct PrepareMigrationResponse {
-    /// Opaque identifier for the prepared plan.
-    #[prost(string, tag = "1")]
-    pub plan_id: ::prost::alloc::string::String,
-    /// Source runtime identifier used for the plan.
-    #[prost(string, tag = "2")]
-    pub source_kind: ::prost::alloc::string::String,
-    /// Resolved source socket path used for the plan.
-    #[prost(string, tag = "3")]
-    pub source_socket_path: ::prost::alloc::string::String,
-    /// Number of images included in the plan.
-    #[prost(uint32, tag = "4")]
-    pub image_count: u32,
-    /// Number of volumes included in the plan.
-    #[prost(uint32, tag = "5")]
-    pub volume_count: u32,
-    /// Number of networks included in the plan.
-    #[prost(uint32, tag = "6")]
-    pub network_count: u32,
-    /// Number of containers included in the plan.
-    #[prost(uint32, tag = "7")]
-    pub container_count: u32,
-    /// Whether the plan would replace existing ArcBox resources (images, volumes,
-    /// networks, or containers that already exist on the target). When true,
-    /// RunMigrationRequest.allow_replacements must be set to confirm.
-    #[prost(bool, tag = "8")]
-    pub replacements_required: bool,
-    /// Non-fatal warnings discovered during preparation (for example, volume
-    /// blockers that will require stopping running source containers).
-    #[prost(string, repeated, tag = "9")]
-    pub warnings: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
-}
-/// Request to run a prepared migration.
-#[derive(serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
-#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
-pub struct RunMigrationRequest {
-    /// Opaque identifier returned by PrepareMigration.
-    #[prost(string, tag = "1")]
-    pub plan_id: ::prost::alloc::string::String,
-    /// Confirms that the caller accepts any replace actions in the plan.
-    #[prost(bool, tag = "2")]
-    pub allow_replacements: bool,
-}
-/// Streaming migration progress event.
-#[derive(serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
-#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
-pub struct RunMigrationEvent {
-    /// Opaque identifier of the plan being executed.
-    #[prost(string, tag = "1")]
-    pub plan_id: ::prost::alloc::string::String,
-    /// High-level execution phase (for example, "prepare", "images", or "containers").
-    #[prost(string, tag = "2")]
-    pub phase: ::prost::alloc::string::String,
-    /// Optional resource name currently being processed.
-    #[prost(string, tag = "3")]
-    pub resource: ::prost::alloc::string::String,
-    /// Human-readable progress detail.
-    #[prost(string, tag = "4")]
-    pub message: ::prost::alloc::string::String,
-    /// Number of completed work items in the current phase.
-    #[prost(uint32, tag = "5")]
-    pub completed: u32,
-    /// Total work items expected in the current phase.
-    #[prost(uint32, tag = "6")]
-    pub total: u32,
-    /// Indicates that no more events will follow for this run.
-    #[prost(bool, tag = "7")]
-    pub done: bool,
-    /// Indicates whether the run completed successfully.
-    #[prost(bool, tag = "8")]
-    pub success: bool,
-}
-/// Shell input for interactive sessions.
-#[derive(serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
-#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
-pub struct ShellInput {
-    /// Input data.
-    #[prost(bytes = "vec", tag = "1")]
-    pub data: ::prost::alloc::vec::Vec<u8>,
-    /// Resize terminal.
-    #[prost(message, optional, tag = "2")]
-    pub resize: ::core::option::Option<TerminalSize>,
-}
-/// Shell output for interactive sessions.
-#[derive(serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
-#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
-pub struct ShellOutput {
-    /// Output data.
-    #[prost(bytes = "vec", tag = "1")]
-    pub data: ::prost::alloc::vec::Vec<u8>,
-    /// Exit code (only set when done).
-    #[prost(int32, tag = "2")]
-    pub exit_code: i32,
-    /// Is this the final message.
-    #[prost(bool, tag = "3")]
-    pub done: bool,
-}
-/// Terminal size.
-#[derive(serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
-#[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
-pub struct TerminalSize {
-    /// Terminal width.
-    #[prost(uint32, tag = "1")]
-    pub width: u32,
-    /// Terminal height.
-    #[prost(uint32, tag = "2")]
-    pub height: u32,
-}
-/// Daemon startup progress and infrastructure health.
-/// Allows the desktop app (or any gRPC client) to observe daemon readiness
-/// without managing its lifecycle.
-#[derive(serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
-#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
-pub struct SetupStatus {
-    /// Current daemon phase.
-    #[prost(enumeration = "setup_status::Phase", tag = "1")]
-    pub phase: i32,
-    /// Whether the DNS resolver file is installed.
-    #[prost(bool, tag = "2")]
-    pub dns_resolver_installed: bool,
-    /// Whether /var/run/docker.sock is symlinked to ArcBox.
-    #[prost(bool, tag = "3")]
-    pub docker_socket_linked: bool,
-    /// Whether the container subnet route is installed.
-    #[prost(bool, tag = "4")]
-    pub route_installed: bool,
-    /// Whether the default VM is running.
-    #[prost(bool, tag = "5")]
-    pub vm_running: bool,
-    /// Human-readable status message.
-    #[prost(string, tag = "6")]
-    pub message: ::prost::alloc::string::String,
-    /// Whether Docker CLI tools are installed.
-    #[prost(bool, tag = "7")]
-    pub docker_tools_installed: bool,
-    /// Fatal startup error description. Set only when phase == FAILED,
-    /// so streaming clients learn the cause instead of seeing a bare
-    /// disconnect when the daemon exits.
-    #[prost(string, tag = "8")]
-    pub error: ::prost::alloc::string::String,
-}
-/// Nested message and enum types in `SetupStatus`.
-pub mod setup_status {
-    /// Daemon startup phases, ordered by progression.
-    #[derive(serde::Serialize, serde::Deserialize)]
-    #[serde(rename_all = "camelCase")]
-    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
-    #[repr(i32)]
-    pub enum Phase {
-        Unspecified = 0,
-        Initializing = 1,
-        AssetsReady = 2,
-        VmStarting = 3,
-        VmReady = 4,
-        NetworkReady = 5,
-        Ready = 6,
-        Degraded = 7,
-        DownloadingAssets = 8,
-        CleaningUp = 9,
-        /// Startup failed fatally; the daemon exits shortly after
-        /// publishing this phase. See the `error` field for the cause.
-        Failed = 10,
-    }
-    impl Phase {
-        /// String value of the enum field names used in the ProtoBuf definition.
-        ///
-        /// The values are not transformed in any way and thus are considered stable
-        /// (if the ProtoBuf definition does not change) and safe for programmatic use.
-        pub fn as_str_name(&self) -> &'static str {
-            match self {
-                Self::Unspecified => "PHASE_UNSPECIFIED",
-                Self::Initializing => "INITIALIZING",
-                Self::AssetsReady => "ASSETS_READY",
-                Self::VmStarting => "VM_STARTING",
-                Self::VmReady => "VM_READY",
-                Self::NetworkReady => "NETWORK_READY",
-                Self::Ready => "READY",
-                Self::Degraded => "DEGRADED",
-                Self::DownloadingAssets => "DOWNLOADING_ASSETS",
-                Self::CleaningUp => "CLEANING_UP",
-                Self::Failed => "FAILED",
-            }
-        }
-        /// Creates an enum from field names used in the ProtoBuf definition.
-        pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
-            match value {
-                "PHASE_UNSPECIFIED" => Some(Self::Unspecified),
-                "INITIALIZING" => Some(Self::Initializing),
-                "ASSETS_READY" => Some(Self::AssetsReady),
-                "VM_STARTING" => Some(Self::VmStarting),
-                "VM_READY" => Some(Self::VmReady),
-                "NETWORK_READY" => Some(Self::NetworkReady),
-                "READY" => Some(Self::Ready),
-                "DEGRADED" => Some(Self::Degraded),
-                "DOWNLOADING_ASSETS" => Some(Self::DownloadingAssets),
-                "CLEANING_UP" => Some(Self::CleaningUp),
-                "FAILED" => Some(Self::Failed),
-                _ => None,
-            }
-        }
-    }
-}
-/// Hypervisor backend for the single System VM.
-#[derive(serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
-#[repr(i32)]
-pub enum SystemVmBackend {
-    /// Unset; rejected by SetSystemVmBackend.
-    Unspecified = 0,
-    /// Hypervisor.framework — ArcBox's custom VMM (amd64 via FEX). macOS 15+.
-    Hv = 1,
-    /// Virtualization.framework — Apple-managed execution. The default.
-    Vz = 2,
-}
-impl SystemVmBackend {
-    /// String value of the enum field names used in the ProtoBuf definition.
-    ///
-    /// The values are not transformed in any way and thus are considered stable
-    /// (if the ProtoBuf definition does not change) and safe for programmatic use.
-    pub fn as_str_name(&self) -> &'static str {
-        match self {
-            Self::Unspecified => "SYSTEM_VM_BACKEND_UNSPECIFIED",
-            Self::Hv => "SYSTEM_VM_BACKEND_HV",
-            Self::Vz => "SYSTEM_VM_BACKEND_VZ",
-        }
-    }
-    /// Creates an enum from field names used in the ProtoBuf definition.
-    pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
-        match value {
-            "SYSTEM_VM_BACKEND_UNSPECIFIED" => Some(Self::Unspecified),
-            "SYSTEM_VM_BACKEND_HV" => Some(Self::Hv),
-            "SYSTEM_VM_BACKEND_VZ" => Some(Self::Vz),
-            _ => None,
-        }
-    }
 }
 /// Subscription request for machine stats.
 #[derive(serde::Serialize, serde::Deserialize)]


### PR DESCRIPTION
**Stacked on #436.** Completes the machine exec story: real interactive terminals.

## PTY 抽象(切面:共享原语层,不共享会话层)
- **`common/arcbox-pty`**: the security-relevant PTY steps in one home — `openpty_sized`/`resize`, `resolve_user`, and `child_terminal_setup` (a `pre_exec`-compatible closure fixing the load-bearing order: setsid → TIOCSCTTY → dup2 → setgroups→setgid→setuid). Linux-gated, no tokio; unit tests (PTY roundtrip, sizing, user resolution) run on Linux.
- Deliberately per-consumer: process reaping (vm-agent is PID 1 with a reaper registry; arcbox-agent waits its own child), sync vs async pumps, wire framing. **vm-agent migration onto the crate is a follow-up PR.**

## Protocol (additive)
- proto: `MachineExecRequest.tty_size`, bidi `MachineService.ExecSession(stream MachineExecInput)` with Init/Stdin/Resize payloads (reuses `arcbox.v1.TerminalSize`).
- wire: `MachineExecInput` 0x0051 (raw stdin, empty = EOF), `MachineExecResize` 0x0052.

## Guest session (arcbox-agent)
`tty: true` runs the command as a session leader on a PTY: master output pumped on a blocking thread through a bounded channel; the same select loop consumes stdin/resize frames (single stream writer); host disconnect kills the whole session process group; final frame carries the exit code. Piped path unchanged.

## Host bridge + CLI
- `AgentClient::machine_exec_session` mirrors `sandbox_exec` (split transport, dual pumps).
- `MachineService.ExecSession`: first message must be Init; agent 400s → `INVALID_ARGUMENT`.
- `machine ssh <name>`: raw-mode terminal, SIGWINCH → resize, `/bin/sh -l` in the machine root.

## Verification
Agent cross-checked for `aarch64-unknown-linux-musl`; 153 core + 11 constants tests green; clippy `-D warnings` + fmt clean. Real end-to-end terminal verification lands with the machine e2e suite (needs #434's boot assets).

Remaining in this series (separate PRs): `mounts` parameter, machine e2e suite, vm-agent → arcbox-pty migration.