### PR TITLE
feat(core,api): honor the machine mounts parameter

### DIFF
--- a/app/arcbox-api/src/grpc/machine.rs
+++ b/app/arcbox-api/src/grpc/machine.rs
@@ -144,6 +144,15 @@ impl machine_service_server::MachineService for MachineServiceImpl {
             },
             block_devices: Vec::new(),
             rootfs,
+            mounts: req
+                .mounts
+                .iter()
+                .map(|m| arcbox_core::machine::MachineMount {
+                    host_path: m.host_path.clone(),
+                    guest_path: m.guest_path.clone(),
+                    read_only: m.readonly,
+                })
+                .collect(),
             backend: arcbox_core::VmBackend::default(),
             enable_rosetta: false,
         };
@@ -311,7 +320,15 @@ impl machine_service_server::MachineService for MachineServiceImpl {
             }),
             created: Some(timestamp(machine.created_at)),
             started_at: machine.started_at.map(timestamp),
-            mounts: vec![],
+            mounts: machine
+                .mounts
+                .iter()
+                .map(|m| arcbox_protocol::v1::DirectoryMount {
+                    host_path: m.host_path.clone(),
+                    guest_path: m.guest_path.clone(),
+                    readonly: m.read_only,
+                })
+                .collect(),
         }))
     }
 

--- a/app/arcbox-core/src/machine.rs
+++ b/app/arcbox-core/src/machine.rs
@@ -308,13 +308,21 @@ impl MachineManager {
                 );
             }
 
-            // Reconstruct VmConfig from persisted data.
+            // Reconstruct VmConfig from persisted data, including the
+            // machine's own VirtioFS shares (tags must match what the
+            // persisted cmdline mount table references).
+            let mut vm_shared_dirs = shared_dirs.clone();
+            for (i, mount) in persisted.mounts.iter().enumerate() {
+                let mut share = SharedDirConfig::new(mount.host_path.clone(), mount_tag(i));
+                share.read_only = mount.read_only;
+                vm_shared_dirs.push(share);
+            }
             let vm_config = VmConfig {
                 cpus: persisted.cpus,
                 memory_mb: persisted.memory_mb,
                 kernel: persisted.kernel.clone(),
                 cmdline: persisted.cmdline.clone(),
-                shared_dirs: shared_dirs.clone(),
+                shared_dirs: vm_shared_dirs,
                 block_devices: persisted.block_devices.clone(),
                 backend: persisted.backend,
                 ..Default::default()

--- a/app/arcbox-core/src/machine.rs
+++ b/app/arcbox-core/src/machine.rs
@@ -98,6 +98,18 @@ pub struct BootShim {
     pub rootfs: PathBuf,
 }
 
+/// A host directory mounted into a machine (per-machine VirtioFS share).
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct MachineMount {
+    /// Host directory to share.
+    pub host_path: String,
+    /// Guest mount point (absolute; must not contain `,` or `=`, which the
+    /// cmdline mount table uses as separators).
+    pub guest_path: String,
+    /// Whether the share is read-only.
+    pub read_only: bool,
+}
+
 /// Machine configuration.
 #[derive(Debug, Clone)]
 pub struct MachineConfig {

--- a/app/arcbox-core/src/machine.rs
+++ b/app/arcbox-core/src/machine.rs
@@ -72,6 +72,8 @@ pub struct MachineInfo {
     pub created_at: DateTime<Utc>,
     /// Last successful start time.
     pub started_at: Option<DateTime<Utc>>,
+    /// Host directories shared into the machine (shim machines).
+    pub mounts: Vec<MachineMount>,
 }
 
 /// A pulled distro rootfs image a machine boots from.
@@ -132,6 +134,10 @@ pub struct MachineConfig {
     /// per-machine data disk after it, and defaults the kernel command line
     /// to mount it as root.
     pub rootfs: Option<MachineRootfs>,
+    /// Host directories mounted into the machine as per-machine VirtioFS
+    /// shares. Honored on shim machines (the shim mounts them into the new
+    /// root); ignored elsewhere.
+    pub mounts: Vec<MachineMount>,
     /// Distribution name (e.g., "alpine", "ubuntu").
     pub distro: Option<String>,
     /// Distribution version (e.g., "3.21", "24.04").
@@ -161,6 +167,7 @@ impl Default for MachineConfig {
             cmdline: None,
             block_devices: Vec::new(),
             rootfs: None,
+            mounts: Vec::new(),
             distro: None,
             distro_version: None,
             backend: arcbox_vmm::VmBackend::default(),
@@ -191,18 +198,64 @@ fn default_distro_cmdline(rootfs_format: &str) -> String {
 
 /// Kernel command line for the machine boot shim: the shim EROFS boots as
 /// root and stages the distro rootfs + data disk named by the `arcbox.*`
-/// keys (see `internal-docs/plans/machine-boot-shim.md`).
-fn machine_shim_cmdline(rootfs_format: &str) -> String {
+/// keys (see `internal-docs/plans/machine-boot-shim.md`). User mounts ride
+/// along as a `tag=guest_path[:ro]` table the shim replays.
+fn machine_shim_cmdline(rootfs_format: &str, mounts: &[MachineMount]) -> String {
     use arcbox_constants::cmdline::{
-        MACHINE_DATA_KEY, MACHINE_INIT_PATH, MACHINE_ROOTFS_KEY, MACHINE_ROOTFS_TYPE_KEY,
+        MACHINE_DATA_KEY, MACHINE_INIT_PATH, MACHINE_MOUNTS_KEY, MACHINE_ROOTFS_KEY,
+        MACHINE_ROOTFS_TYPE_KEY,
     };
     let console = boot_console();
-    format!(
+    let mut cmdline = format!(
         "console={console} root=/dev/vda ro rootfstype=erofs earlycon \
          init={MACHINE_INIT_PATH} \
          {MACHINE_ROOTFS_KEY}/dev/vdb {MACHINE_ROOTFS_TYPE_KEY}{rootfs_format} \
          {MACHINE_DATA_KEY}/dev/vdc"
-    )
+    );
+    if !mounts.is_empty() {
+        let table = mounts
+            .iter()
+            .enumerate()
+            .map(|(i, m)| {
+                let ro = if m.read_only { ":ro" } else { "" };
+                format!("{}={}{ro}", mount_tag(i), m.guest_path)
+            })
+            .collect::<Vec<_>>()
+            .join(",");
+        cmdline.push(' ');
+        cmdline.push_str(MACHINE_MOUNTS_KEY);
+        cmdline.push_str(&table);
+    }
+    cmdline
+}
+
+/// VirtioFS tag for the machine's `i`-th user mount.
+fn mount_tag(index: usize) -> String {
+    format!("m{index}")
+}
+
+/// Validates a user mount: the host path must exist and the guest path must
+/// be absolute and free of the cmdline table separators.
+fn validate_mount(mount: &MachineMount) -> Result<()> {
+    if !std::path::Path::new(&mount.host_path).is_dir() {
+        return Err(CoreError::config(format!(
+            "mount host path '{}' is not a directory",
+            mount.host_path
+        )));
+    }
+    if !mount.guest_path.starts_with('/') {
+        return Err(CoreError::config(format!(
+            "mount guest path '{}' must be absolute",
+            mount.guest_path
+        )));
+    }
+    if mount.guest_path.contains(',') || mount.guest_path.contains('=') {
+        return Err(CoreError::config(format!(
+            "mount guest path '{}' must not contain ',' or '='",
+            mount.guest_path
+        )));
+    }
+    Ok(())
 }
 
 /// Machine manager.
@@ -288,6 +341,7 @@ impl MachineManager {
                     backend: persisted.backend,
                     created_at: persisted.created_at,
                     started_at: persisted.started_at,
+                    mounts: persisted.mounts.clone(),
                 };
                 machines.insert(persisted.name.clone(), info);
             }
@@ -361,6 +415,24 @@ impl MachineManager {
             shared_dirs.push(SharedDirConfig::new(MOUNT_PRIVATE, TAG_PRIVATE));
         }
 
+        // User mounts become per-machine VirtioFS shares (tags m0, m1, …);
+        // the shim replays the cmdline mount table into the new root. Only
+        // meaningful behind the shim — reject elsewhere instead of silently
+        // dropping them.
+        if !config.mounts.is_empty() {
+            if config.rootfs.as_ref().is_none_or(|r| r.shim.is_none()) {
+                return Err(CoreError::config(
+                    "mounts require a shim-booted distro machine",
+                ));
+            }
+            for (i, mount) in config.mounts.iter().enumerate() {
+                validate_mount(mount)?;
+                let mut share = SharedDirConfig::new(mount.host_path.clone(), mount_tag(i));
+                share.read_only = mount.read_only;
+                shared_dirs.push(share);
+            }
+        }
+
         // Distro machines boot the pulled rootfs image (behind the boot shim
         // when configured) with a sparse per-machine data disk; plain VMs
         // keep the caller-provided kernel and block devices untouched.
@@ -407,7 +479,7 @@ impl MachineManager {
                 });
                 let cmdline = config.cmdline.clone().or_else(|| {
                     Some(match &rootfs.shim {
-                        Some(_) => machine_shim_cmdline(&rootfs.format),
+                        Some(_) => machine_shim_cmdline(&rootfs.format, &config.mounts),
                         None => default_distro_cmdline(&rootfs.format),
                     })
                 });
@@ -454,6 +526,7 @@ impl MachineManager {
             backend: config.backend,
             created_at: Utc::now(),
             started_at: None,
+            mounts: config.mounts,
         };
 
         // Persist the machine config
@@ -1133,6 +1206,7 @@ impl MachineManager {
             backend: arcbox_vmm::VmBackend::default(),
             created_at: Utc::now(),
             started_at: None,
+            mounts: Vec::new(),
         };
 
         machines.insert(name.to_string(), info);

--- a/app/arcbox-core/src/machine/tests.rs
+++ b/app/arcbox-core/src/machine/tests.rs
@@ -301,3 +301,90 @@ async fn test_assign_cid_skips_cids_held_by_other_machines() {
     let (_, cid) = machine_manager.assign_cid_for_start(&name).unwrap();
     assert_eq!(cid, 4, "lowest CID not held by another machine");
 }
+
+#[tokio::test]
+async fn test_create_with_mounts_extends_cmdline_and_persists() {
+    let temp_dir = tempdir().unwrap();
+    let machine_manager = test_machine_manager(temp_dir.path());
+
+    let rootfs_img = temp_dir.path().join("rootfs.squashfs");
+    std::fs::write(&rootfs_img, b"squash").unwrap();
+    let host_share = temp_dir.path().join("share");
+    std::fs::create_dir(&host_share).unwrap();
+
+    let shim = BootShim {
+        kernel: temp_dir.path().join("kernel"),
+        rootfs: temp_dir.path().join("shim.erofs"),
+    };
+    let mounts = vec![
+        MachineMount {
+            host_path: host_share.to_string_lossy().into_owned(),
+            guest_path: "/work".to_string(),
+            read_only: false,
+        },
+        MachineMount {
+            host_path: host_share.to_string_lossy().into_owned(),
+            guest_path: "/data".to_string(),
+            read_only: true,
+        },
+    ];
+
+    machine_manager
+        .create(MachineConfig {
+            name: "mounted".to_string(),
+            disk_gb: 1,
+            rootfs: Some(MachineRootfs {
+                path: rootfs_img.clone(),
+                format: "squashfs".to_string(),
+                shim: Some(shim.clone()),
+            }),
+            mounts: mounts.clone(),
+            ..Default::default()
+        })
+        .await
+        .unwrap();
+
+    let machine = machine_manager.get("mounted").unwrap();
+    let cmdline = machine.cmdline.as_deref().unwrap();
+    assert!(
+        cmdline.contains(&format!(
+            "{}m0=/work,m1=/data:ro",
+            arcbox_constants::cmdline::MACHINE_MOUNTS_KEY
+        )),
+        "{cmdline}"
+    );
+    assert_eq!(machine.mounts.len(), 2);
+    assert_eq!(machine.mounts[1].guest_path, "/data");
+    assert!(machine.mounts[1].read_only);
+
+    // Mounts are rejected off the shim path and validated for separators.
+    let err = machine_manager
+        .create(MachineConfig {
+            name: "no-shim-mounts".to_string(),
+            mounts: mounts.clone(),
+            ..Default::default()
+        })
+        .await
+        .unwrap_err();
+    assert!(err.to_string().contains("shim"), "{err}");
+
+    let err = machine_manager
+        .create(MachineConfig {
+            name: "bad-guest-path".to_string(),
+            disk_gb: 1,
+            rootfs: Some(MachineRootfs {
+                path: rootfs_img,
+                format: "squashfs".to_string(),
+                shim: Some(shim),
+            }),
+            mounts: vec![MachineMount {
+                host_path: host_share.to_string_lossy().into_owned(),
+                guest_path: "/with,comma".to_string(),
+                read_only: false,
+            }],
+            ..Default::default()
+        })
+        .await
+        .unwrap_err();
+    assert!(err.to_string().contains("','"), "{err}");
+}

--- a/app/arcbox-core/src/persistence.rs
+++ b/app/arcbox-core/src/persistence.rs
@@ -59,6 +59,9 @@ pub struct PersistedMachine {
     /// Last successful start timestamp.
     #[serde(default)]
     pub started_at: Option<DateTime<Utc>>,
+    /// Host directories shared into the machine.
+    #[serde(default)]
+    pub mounts: Vec<crate::machine::MachineMount>,
 }
 
 /// Default creation time for backward compatibility with old configs.
@@ -144,6 +147,7 @@ impl From<&MachineInfo> for PersistedMachine {
             backend: info.backend,
             created_at: info.created_at,
             started_at: info.started_at,
+            mounts: info.mounts.clone(),
         }
     }
 }
@@ -321,6 +325,7 @@ mod tests {
         let info = MachineInfo {
             name: "test-vm".to_string(),
             started_at: None,
+            mounts: Vec::new(),
             state: MachineState::Created,
             vm_id: VmId::new(),
             cpus: 4,
@@ -363,6 +368,7 @@ mod tests {
             let info = MachineInfo {
                 name: name.to_string(),
                 started_at: None,
+                mounts: Vec::new(),
                 state: MachineState::Created,
                 vm_id: VmId::new(),
                 cpus: 2,
@@ -398,6 +404,7 @@ mod tests {
         let info = MachineInfo {
             name: "test-vm".to_string(),
             started_at: None,
+            mounts: Vec::new(),
             state: MachineState::Created,
             vm_id: VmId::new(),
             cpus: 2,
@@ -431,6 +438,7 @@ mod tests {
         let info = MachineInfo {
             name: "test-vm".to_string(),
             started_at: None,
+            mounts: Vec::new(),
             state: MachineState::Created,
             vm_id: VmId::new(),
             cpus: 2,
@@ -479,6 +487,7 @@ mod tests {
         let info = MachineInfo {
             name: "crash-vm".to_string(),
             started_at: None,
+            mounts: Vec::new(),
             state: MachineState::Running,
             vm_id: VmId::new(),
             cpus: 2,

--- a/app/arcbox-core/src/vm_lifecycle/boot.rs
+++ b/app/arcbox-core/src/vm_lifecycle/boot.rs
@@ -377,6 +377,7 @@ impl LifecycleShared {
             cmdline: Some(boot.cmdline),
             block_devices,
             rootfs: None,
+            mounts: Vec::new(),
             distro: None,
             distro_version: None,
             backend: self.backend(),

--- a/app/arcbox-core/src/vm_lifecycle/tests.rs
+++ b/app/arcbox-core/src/vm_lifecycle/tests.rs
@@ -161,6 +161,7 @@ fn sample_machine(cpus: u32, memory_mb: u64, kernel: &str, cmdline: &str) -> Mac
         backend: arcbox_vmm::VmBackend::default(),
         created_at: chrono::Utc::now(),
         started_at: None,
+        mounts: Vec::new(),
     }
 }
 

--- a/common/arcbox-constants/src/cmdline.rs
+++ b/common/arcbox-constants/src/cmdline.rs
@@ -46,8 +46,9 @@ pub const MACHINE_DATA_KEY: &str = "arcbox.machine_data=";
 /// `arcbox-vmm` (`darwin_hv::pl011`), the crate that owns the emulator.
 pub const HV_EARLYCON_DIRECTIVE: &str = "earlycon=pl011,0x0b000000";
 
-/// Kernel cmdline key carrying the machine's user mounts as
-/// `tag=guest_path[:ro]` entries joined by commas (e.g.
+/// Kernel cmdline key carrying the machine's user mounts.
+///
+/// The value is `tag=guest_path[:ro]` entries joined by commas (e.g.
 /// `m0=/work,m1=/data:ro`). Each tag names a per-machine VirtioFS share the
 /// shim mounts into the new root after staging the overlay. Guest paths are
 /// validated host-side to contain neither `,` nor `=`.

--- a/common/arcbox-constants/src/cmdline.rs
+++ b/common/arcbox-constants/src/cmdline.rs
@@ -45,3 +45,10 @@ pub const MACHINE_DATA_KEY: &str = "arcbox.machine_data=";
 /// The address is verified against `PL011_BASE` by a drift-guard test in
 /// `arcbox-vmm` (`darwin_hv::pl011`), the crate that owns the emulator.
 pub const HV_EARLYCON_DIRECTIVE: &str = "earlycon=pl011,0x0b000000";
+
+/// Kernel cmdline key carrying the machine's user mounts as
+/// `tag=guest_path[:ro]` entries joined by commas (e.g.
+/// `m0=/work,m1=/data:ro`). Each tag names a per-machine VirtioFS share the
+/// shim mounts into the new root after staging the overlay. Guest paths are
+/// validated host-side to contain neither `,` nor `=`.
+pub const MACHINE_MOUNTS_KEY: &str = "arcbox.machine_mounts=";


### PR DESCRIPTION
**Stacked on #437.** `CreateMachineRequest.mounts` — parsed by the CLI since day one, silently dropped by the daemon — now works on shim machines:

- Each mount becomes a **per-machine VirtioFS share** (tags `m0`, `m1`, …) and rides the kernel cmdline as an `arcbox.machine_mounts=tag=guest_path[:ro],…` table (new `MACHINE_MOUNTS_KEY` in arcbox-constants) that the boot shim replays into the new root — boot-assets companion PR adds the replay.
- Validation instead of silent dropping: host dir must exist; guest path absolute and free of the table separators (`,`/`=`); mounts off the shim path are rejected.
- Persisted and **rebuilt into the VM config on daemon reload** (tags must keep matching the persisted cmdline), surfaced by `Inspect.mounts`.

Tests: assembly (cmdline table + ro flag + persistence via get), rejection paths (no shim, separator in guest path). 154 core tests green; clippy `-D warnings` + fmt clean.