### PR TITLE
chore(assets): bump boot assets to 0.6.6

### DIFF
--- a/assets.lock
+++ b/assets.lock
@@ -14,9 +14,9 @@
 # and the [boot] bump.
 
 [boot]
-version = "0.6.4"
+version = "0.6.5"
 cdn = "https://boot.arcboxcdn.com"
-manifest_sha256 = "bb7885c381c5b5e76a22c10437a168624069f623a4096d691d1e592f151abfea"
+manifest_sha256 = "e5ffc47a2ecfd9f07e80199ad43f2963058cdb3e0bfd790c8b13afd538a8da22"
 
 [[tools]]
 name = "docker"

--- a/assets.lock
+++ b/assets.lock
@@ -14,9 +14,9 @@
 # and the [boot] bump.
 
 [boot]
-version = "0.6.3"
+version = "0.6.4"
 cdn = "https://boot.arcboxcdn.com"
-manifest_sha256 = "80c04d681dcf8384f8e4c76160a3d72b84b1d57a7b5663cf89325382073a5256"
+manifest_sha256 = "bb7885c381c5b5e76a22c10437a168624069f623a4096d691d1e592f151abfea"
 
 [[tools]]
 name = "docker"

--- a/assets.lock
+++ b/assets.lock
@@ -14,9 +14,9 @@
 # and the [boot] bump.
 
 [boot]
-version = "0.6.5"
+version = "0.6.6"
 cdn = "https://boot.arcboxcdn.com"
-manifest_sha256 = "e5ffc47a2ecfd9f07e80199ad43f2963058cdb3e0bfd790c8b13afd538a8da22"
+manifest_sha256 = "76f5868c035873b0d08583feff171e4d9b3ef0c702636105c5a18763961b5a35"
 
 [[tools]]
 name = "docker"


### PR DESCRIPTION
Boot bundle → 0.6.6 ([release](https://github.com/arcboxlabs/boot-assets/releases/tag/v0.6.6)):
- kernel **v0.0.18** (Linux 6.12.95 + squashfs)
- machine boot shim that boots through to distro init — the devtmpfs/scratch/agent-stdin fixes (boot-assets#42)

Verified against the live CDN: manifest `source_ref: v0.0.18`, sha256 matches this lock entry, built from boot-assets `0f46144` (the #42 merge); the published arm64 EROFS carries the fixed shim. Supersedes the closed 0.6.5 PR. This is the version the machine e2e (#439) needs to pass against the published bundle.