### PR TITLE
feat(api): MachineService.Events lifecycle stream

### DIFF
--- a/app/arcbox-api/src/grpc/machine.rs
+++ b/app/arcbox-api/src/grpc/machine.rs
@@ -574,9 +574,13 @@ impl machine_service_server::MachineService for MachineServiceImpl {
                         }
                         yield Ok(machine_event);
                     }
-                    // Dropped events under load: the client re-lists on the next
-                    // event it sees, so a gap only delays convergence.
-                    Err(RecvError::Lagged(_)) => {}
+                    // Dropped events under load: emit a resync signal so the
+                    // client re-lists even if the missed event would have been
+                    // filtered out here (otherwise a filtered `stopped` could be
+                    // lost with no later matching event to recover from).
+                    Err(RecvError::Lagged(_)) => {
+                        yield Ok(resync_event());
+                    }
                     Err(RecvError::Closed) => break,
                 }
             }
@@ -584,6 +588,13 @@ impl machine_service_server::MachineService for MachineServiceImpl {
 
         Ok(Response::new(Box::pin(stream)))
     }
+}
+
+/// Current wall-clock time as Unix nanoseconds (saturating).
+fn now_unix_nanos() -> i64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map_or(0, |d| i64::try_from(d.as_nanos()).unwrap_or(i64::MAX))
 }
 
 /// Maps a system event to its machine-lifecycle wire form, or `None` for
@@ -596,22 +607,31 @@ fn to_machine_event(event: &arcbox_core::event::Event) -> Option<MachineEvent> {
         Event::MachineStarted { name } => (name, "started"),
         Event::MachineIdle { name } => (name, "idle"),
         Event::MachineStopped { name } => (name, "stopped"),
+        Event::MachineRemoved { name } => (name, "removed"),
         _ => return None,
     };
-    let timestamp = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .map_or(0, |d| i64::try_from(d.as_nanos()).unwrap_or(i64::MAX));
     Some(MachineEvent {
         name: name.clone(),
         action: action.to_owned(),
-        timestamp,
+        timestamp: now_unix_nanos(),
         attributes: std::collections::HashMap::new(),
     })
 }
 
+/// A filter-independent signal that the client should re-list because events
+/// were dropped. Carries no machine name and the reserved `resync` action.
+fn resync_event() -> MachineEvent {
+    MachineEvent {
+        name: String::new(),
+        action: "resync".to_owned(),
+        timestamp: now_unix_nanos(),
+        attributes: std::collections::HashMap::new(),
+    }
+}
+
 #[cfg(test)]
 mod tests {
-    use super::to_machine_event;
+    use super::{resync_event, to_machine_event};
     use arcbox_core::event::Event;
 
     #[test]
@@ -621,6 +641,7 @@ mod tests {
             (Event::MachineStarted { name: "m".into() }, "started"),
             (Event::MachineIdle { name: "m".into() }, "idle"),
             (Event::MachineStopped { name: "m".into() }, "stopped"),
+            (Event::MachineRemoved { name: "m".into() }, "removed"),
         ];
         for (event, action) in cases {
             let mapped = to_machine_event(&event).expect("machine event maps");
@@ -633,5 +654,12 @@ mod tests {
     fn ignores_non_machine_events() {
         assert!(to_machine_event(&Event::VmStarted { id: "vm".into() }).is_none());
         assert!(to_machine_event(&Event::ContainerRouteInstalled { name: "m".into() }).is_none());
+    }
+
+    #[test]
+    fn resync_event_carries_no_name() {
+        let event = resync_event();
+        assert_eq!(event.action, "resync");
+        assert!(event.name.is_empty());
     }
 }

--- a/app/arcbox-api/src/grpc/machine.rs
+++ b/app/arcbox-api/src/grpc/machine.rs
@@ -7,10 +7,10 @@ use arcbox_core::machine_image;
 use arcbox_grpc::v1::machine_service_server;
 use arcbox_protocol::v1::{
     CreateMachineRequest, CreateMachineResponse, Empty, InspectMachineRequest, ListMachinesRequest,
-    ListMachinesResponse, MachineAgentRequest, MachineExecInput, MachineExecOutput,
-    MachineExecRequest, MachineInfo, MachineNetwork, MachinePingResponse, MachineSummary,
-    MachineSystemInfo, RemoveMachineRequest, StartMachineRequest, StopMachineRequest,
-    machine_exec_input,
+    ListMachinesResponse, MachineAgentRequest, MachineEvent, MachineEventsRequest,
+    MachineExecInput, MachineExecOutput, MachineExecRequest, MachineInfo, MachineNetwork,
+    MachinePingResponse, MachineSummary, MachineSystemInfo, RemoveMachineRequest,
+    StartMachineRequest, StopMachineRequest, machine_exec_input,
 };
 use tokio_stream::Stream;
 use tokio_stream::StreamExt as _;
@@ -546,5 +546,92 @@ impl machine_service_server::MachineService for MachineServiceImpl {
             }
         };
         Ok(Response::new(Box::pin(out_stream)))
+    }
+
+    type EventsStream = Pin<Box<dyn Stream<Item = Result<MachineEvent, Status>> + Send + 'static>>;
+
+    async fn events(
+        &self,
+        request: Request<MachineEventsRequest>,
+    ) -> Result<Response<Self::EventsStream>, Status> {
+        use tokio::sync::broadcast::error::RecvError;
+
+        let req = request.into_inner();
+        let mut rx = self.runtime.ready()?.event_bus().subscribe();
+
+        let stream = async_stream::stream! {
+            loop {
+                match rx.recv().await {
+                    Ok(event) => {
+                        let Some(machine_event) = to_machine_event(&event) else {
+                            continue;
+                        };
+                        if !req.id.is_empty() && machine_event.name != req.id {
+                            continue;
+                        }
+                        if !req.action.is_empty() && machine_event.action != req.action {
+                            continue;
+                        }
+                        yield Ok(machine_event);
+                    }
+                    // Dropped events under load: the client re-lists on the next
+                    // event it sees, so a gap only delays convergence.
+                    Err(RecvError::Lagged(_)) => {}
+                    Err(RecvError::Closed) => break,
+                }
+            }
+        };
+
+        Ok(Response::new(Box::pin(stream)))
+    }
+}
+
+/// Maps a system event to its machine-lifecycle wire form, or `None` for
+/// events that are not machine lifecycle transitions.
+fn to_machine_event(event: &arcbox_core::event::Event) -> Option<MachineEvent> {
+    use arcbox_core::event::Event;
+
+    let (name, action) = match event {
+        Event::MachineCreated { name } => (name, "created"),
+        Event::MachineStarted { name } => (name, "started"),
+        Event::MachineIdle { name } => (name, "idle"),
+        Event::MachineStopped { name } => (name, "stopped"),
+        _ => return None,
+    };
+    let timestamp = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map_or(0, |d| i64::try_from(d.as_nanos()).unwrap_or(i64::MAX));
+    Some(MachineEvent {
+        name: name.clone(),
+        action: action.to_owned(),
+        timestamp,
+        attributes: std::collections::HashMap::new(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::to_machine_event;
+    use arcbox_core::event::Event;
+
+    #[test]
+    fn maps_each_machine_lifecycle_event() {
+        let cases = [
+            (Event::MachineCreated { name: "m".into() }, "created"),
+            (Event::MachineStarted { name: "m".into() }, "started"),
+            (Event::MachineIdle { name: "m".into() }, "idle"),
+            (Event::MachineStopped { name: "m".into() }, "stopped"),
+        ];
+        for (event, action) in cases {
+            let mapped = to_machine_event(&event).expect("machine event maps");
+            assert_eq!(mapped.name, "m");
+            assert_eq!(mapped.action, action);
+        }
+    }
+
+    #[test]
+    fn ignores_non_machine_events() {
+        assert!(to_machine_event(&Event::VmStarted { id: "vm".into() }).is_none());
+        assert!(to_machine_event(&Event::ContainerRouteInstalled { name: "m".into() }).is_none());
     }
 }

--- a/app/arcbox-core/src/event.rs
+++ b/app/arcbox-core/src/event.rs
@@ -17,6 +17,8 @@ pub enum Event {
     MachineIdle { name: String },
     /// Machine stopped.
     MachineStopped { name: String },
+    /// Machine removed (record and disks deleted).
+    MachineRemoved { name: String },
     /// Container subnet route installed on the host for a machine's bridge NIC.
     ContainerRouteInstalled { name: String },
 }

--- a/app/arcbox-core/src/machine.rs
+++ b/app/arcbox-core/src/machine.rs
@@ -269,6 +269,10 @@ pub struct MachineManager {
     machines_dir: PathBuf,
     /// Shared DNS hosts table from NetworkManager, passed to VMM on start.
     shared_dns_hosts: Option<std::sync::Arc<arcbox_dns::LocalHostsTable>>,
+    /// System-wide event bus. User-machine lifecycle events are published here
+    /// so watchers (`MachineService.Events`) see them; the default System VM's
+    /// events are published by its own lifecycle actor instead.
+    event_bus: crate::event::EventBus,
 }
 
 impl MachineManager {
@@ -278,6 +282,7 @@ impl MachineManager {
         vm_manager: Arc<VmManager>,
         data_dir: PathBuf,
         shared_dns_hosts: Option<std::sync::Arc<arcbox_dns::LocalHostsTable>>,
+        event_bus: crate::event::EventBus,
     ) -> Self {
         let machines_dir = data_dir.join("machines");
         let persistence = MachinePersistence::new(&machines_dir);
@@ -376,6 +381,16 @@ impl MachineManager {
             data_dir,
             machines_dir,
             shared_dns_hosts,
+            event_bus,
+        }
+    }
+
+    /// Publish a lifecycle event for user machine `name`. The default System VM
+    /// is skipped: its lifecycle actor publishes the same events, so emitting
+    /// here too would double them.
+    fn publish_event(&self, name: &str, event: crate::event::Event) {
+        if name != crate::vm_lifecycle::DEFAULT_MACHINE_NAME {
+            self.event_bus.publish(event);
         }
     }
 
@@ -542,6 +557,12 @@ impl MachineManager {
 
         machines.insert(config.name.clone(), info);
 
+        self.publish_event(
+            &config.name,
+            crate::event::Event::MachineCreated {
+                name: config.name.clone(),
+            },
+        );
         Ok(config.name)
     }
 
@@ -602,6 +623,12 @@ impl MachineManager {
             })?;
         }
 
+        self.publish_event(
+            name,
+            crate::event::Event::MachineStarted {
+                name: name.to_string(),
+            },
+        );
         Ok(())
     }
 
@@ -971,6 +998,12 @@ impl MachineManager {
             );
         }
 
+        self.publish_event(
+            name,
+            crate::event::Event::MachineStopped {
+                name: name.to_string(),
+            },
+        );
         Ok(())
     }
 
@@ -1097,6 +1130,13 @@ impl MachineManager {
                         e
                     );
                 }
+                drop(machines);
+                self.publish_event(
+                    name,
+                    crate::event::Event::MachineStopped {
+                        name: name.to_string(),
+                    },
+                );
                 Ok(true)
             }
             Ok(false) => {
@@ -1192,6 +1232,13 @@ impl MachineManager {
         // restart even though VM and in-memory state are already gone.
         self.persistence.remove(name)?;
 
+        drop(machines);
+        self.publish_event(
+            name,
+            crate::event::Event::MachineRemoved {
+                name: name.to_string(),
+            },
+        );
         tracing::info!("Removed machine '{}'", name);
         Ok(())
     }

--- a/app/arcbox-core/src/machine/tests.rs
+++ b/app/arcbox-core/src/machine/tests.rs
@@ -2,8 +2,51 @@ use super::*;
 use tempfile::tempdir;
 
 fn test_machine_manager(data_dir: &std::path::Path) -> MachineManager {
+    test_machine_manager_with_bus(data_dir, crate::event::EventBus::new())
+}
+
+fn test_machine_manager_with_bus(
+    data_dir: &std::path::Path,
+    event_bus: crate::event::EventBus,
+) -> MachineManager {
     let vm_manager = Arc::new(VmManager::new(data_dir.join("snapshots")));
-    MachineManager::new(vm_manager, data_dir.to_path_buf(), None)
+    MachineManager::new(vm_manager, data_dir.to_path_buf(), None, event_bus)
+}
+
+#[tokio::test]
+async fn create_publishes_machine_created_for_user_machines_only() {
+    use crate::event::{Event, EventBus};
+
+    let temp_dir = tempdir().unwrap();
+    let bus = EventBus::new();
+    let mut rx = bus.subscribe();
+    let manager = test_machine_manager_with_bus(temp_dir.path(), bus);
+
+    manager
+        .create(MachineConfig {
+            name: "work".to_string(),
+            ..Default::default()
+        })
+        .await
+        .unwrap();
+    assert!(
+        matches!(rx.try_recv(), Ok(Event::MachineCreated { name }) if name == "work"),
+        "creating a user machine must publish MachineCreated"
+    );
+
+    // The default System VM's lifecycle events come from its own lifecycle
+    // actor; MachineManager must not double-publish for it.
+    manager
+        .create(MachineConfig {
+            name: "default".to_string(),
+            ..Default::default()
+        })
+        .await
+        .unwrap();
+    assert!(
+        rx.try_recv().is_err(),
+        "creating the default machine must not publish from MachineManager"
+    );
 }
 
 #[tokio::test]

--- a/app/arcbox-core/src/runtime.rs
+++ b/app/arcbox-core/src/runtime.rs
@@ -201,6 +201,7 @@ impl Runtime {
             Arc::clone(&vm_manager),
             config.data_dir.clone(),
             shared_dns_table,
+            event_bus.clone(),
         ));
 
         // Build the single System VM. The daemon runs one utility VM (default

--- a/rpc/arcbox-protocol/proto/machine.proto
+++ b/rpc/arcbox-protocol/proto/machine.proto
@@ -55,6 +55,11 @@ service MachineService {
 
     // Gets the SSH connection info.
     rpc SSHInfo(SSHInfoRequest) returns (SSHInfoResponse);
+
+    // Subscribes to machine lifecycle events. The stream stays open until the
+    // client disconnects. Emitted actions:
+    //   "created" | "started" | "idle" | "stopped"
+    rpc Events(MachineEventsRequest) returns (stream MachineEvent);
 }
 
 // Request to create a machine.
@@ -336,4 +341,28 @@ message SSHInfoResponse {
     string identity_file = 4;
     // SSH command string.
     string command = 5;
+}
+
+// Request to subscribe to machine lifecycle events.
+message MachineEventsRequest {
+    // Filter by machine ID/name (empty = all machines).
+    string id = 1;
+    // Filter by event action (empty = all actions).
+    string action = 2;
+}
+
+// A machine lifecycle event.
+message MachineEvent {
+    // Machine name.
+    string name = 1;
+    // Action:
+    //   "created" — machine record created
+    //   "started" — VM reached the running state
+    //   "idle"    — running VM entered the idle (reduced-resource) state
+    //   "stopped" — VM shut down
+    string action = 2;
+    // Unix nanoseconds.
+    int64 timestamp = 3;
+    // Additional context (reserved; e.g. error detail on future actions).
+    map<string, string> attributes = 4;
 }

--- a/rpc/arcbox-protocol/proto/machine.proto
+++ b/rpc/arcbox-protocol/proto/machine.proto
@@ -58,7 +58,9 @@ service MachineService {
 
     // Subscribes to machine lifecycle events. The stream stays open until the
     // client disconnects. Emitted actions:
-    //   "created" | "started" | "idle" | "stopped"
+    //   "created" | "started" | "idle" | "stopped" | "removed"
+    // plus "resync" (empty name) when the server dropped events under load and
+    // the client should re-list. Events for the default System VM are included.
     rpc Events(MachineEventsRequest) returns (stream MachineEvent);
 }
 
@@ -353,13 +355,15 @@ message MachineEventsRequest {
 
 // A machine lifecycle event.
 message MachineEvent {
-    // Machine name.
+    // Machine name (empty for "resync").
     string name = 1;
     // Action:
     //   "created" — machine record created
     //   "started" — VM reached the running state
     //   "idle"    — running VM entered the idle (reduced-resource) state
     //   "stopped" — VM shut down
+    //   "removed" — machine deleted
+    //   "resync"  — events were dropped under load; re-list to recover
     string action = 2;
     // Unix nanoseconds.
     int64 timestamp = 3;

--- a/rpc/arcbox-protocol/src/generated/arcbox.v1.rs
+++ b/rpc/arcbox-protocol/src/generated/arcbox.v1.rs
@@ -1497,6 +1497,41 @@ pub struct SshInfoResponse {
     #[prost(string, tag = "5")]
     pub command: ::prost::alloc::string::String,
 }
+/// Request to subscribe to machine lifecycle events.
+#[derive(serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct MachineEventsRequest {
+    /// Filter by machine ID/name (empty = all machines).
+    #[prost(string, tag = "1")]
+    pub id: ::prost::alloc::string::String,
+    /// Filter by event action (empty = all actions).
+    #[prost(string, tag = "2")]
+    pub action: ::prost::alloc::string::String,
+}
+/// A machine lifecycle event.
+#[derive(serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct MachineEvent {
+    /// Machine name.
+    #[prost(string, tag = "1")]
+    pub name: ::prost::alloc::string::String,
+    /// Action:
+    ///    "created" — machine record created
+    ///    "started" — VM reached the running state
+    ///    "idle"    — running VM entered the idle (reduced-resource) state
+    ///    "stopped" — VM shut down
+    #[prost(string, tag = "2")]
+    pub action: ::prost::alloc::string::String,
+    /// Unix nanoseconds.
+    #[prost(int64, tag = "3")]
+    pub timestamp: i64,
+    /// Additional context (reserved; e.g. error detail on future actions).
+    #[prost(map = "string, string", tag = "4")]
+    pub attributes:
+        ::std::collections::HashMap<::prost::alloc::string::String, ::prost::alloc::string::String>,
+}
 /// Request to create a macOS guest from a base image.
 #[derive(serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]

--- a/rpc/arcbox-protocol/src/generated/arcbox.v1.rs
+++ b/rpc/arcbox-protocol/src/generated/arcbox.v1.rs
@@ -1514,7 +1514,7 @@ pub struct MachineEventsRequest {
 #[serde(rename_all = "camelCase")]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct MachineEvent {
-    /// Machine name.
+    /// Machine name (empty for "resync").
     #[prost(string, tag = "1")]
     pub name: ::prost::alloc::string::String,
     /// Action:
@@ -1522,6 +1522,8 @@ pub struct MachineEvent {
     ///    "started" — VM reached the running state
     ///    "idle"    — running VM entered the idle (reduced-resource) state
     ///    "stopped" — VM shut down
+    ///    "removed" — machine deleted
+    ///    "resync"  — events were dropped under load; re-list to recover
     #[prost(string, tag = "2")]
     pub action: ::prost::alloc::string::String,
     /// Unix nanoseconds.

--- a/rpc/arcbox-protocol/src/lib.rs
+++ b/rpc/arcbox-protocol/src/lib.rs
@@ -53,10 +53,10 @@ pub mod common {
 pub mod machine {
     pub use super::v1::{
         CreateMachineRequest, CreateMachineResponse, DirectoryMount, InspectMachineRequest,
-        ListMachinesRequest, ListMachinesResponse, MachineExecOutput, MachineExecRequest,
-        MachineHardware, MachineInfo, MachineNetwork, MachineOs, MachineStorage, MachineSummary,
-        RemoveMachineRequest, SshInfoRequest, SshInfoResponse, StartMachineRequest,
-        StopMachineRequest,
+        ListMachinesRequest, ListMachinesResponse, MachineEvent, MachineEventsRequest,
+        MachineExecOutput, MachineExecRequest, MachineHardware, MachineInfo, MachineNetwork,
+        MachineOs, MachineStorage, MachineSummary, RemoveMachineRequest, SshInfoRequest,
+        SshInfoResponse, StartMachineRequest, StopMachineRequest,
     };
 }
 
@@ -161,9 +161,10 @@ pub use v1::{Empty, KeyValue, Mount, PortBinding, ResourceLimits, Timestamp};
 // Machine types
 pub use v1::{
     CreateMachineRequest, CreateMachineResponse, DirectoryMount, InspectMachineRequest,
-    ListMachinesRequest, ListMachinesResponse, MachineExecOutput, MachineExecRequest,
-    MachineHardware, MachineInfo, MachineNetwork, MachineOs, MachineStorage, MachineSummary,
-    RemoveMachineRequest, SshInfoRequest, SshInfoResponse, StartMachineRequest, StopMachineRequest,
+    ListMachinesRequest, ListMachinesResponse, MachineEvent, MachineEventsRequest,
+    MachineExecOutput, MachineExecRequest, MachineHardware, MachineInfo, MachineNetwork, MachineOs,
+    MachineStorage, MachineSummary, RemoveMachineRequest, SshInfoRequest, SshInfoResponse,
+    StartMachineRequest, StopMachineRequest,
 };
 
 // Container types


### PR DESCRIPTION
## Why

The desktop Machines tab has no way to observe machine lifecycle, so it polls `List` every few seconds (arcbox-desktop #304). `ContainerService` and `SandboxService` both expose an event stream; `MachineService` didn't. This adds one so the desktop can push-update instead of poll.

## What

`rpc Events(MachineEventsRequest) returns (stream MachineEvent)`.

The handler subscribes the existing `runtime.event_bus()` and maps the machine lifecycle variants already published by the vm-lifecycle actor / boot path — `MachineCreated`/`MachineStarted`/`MachineIdle`/`MachineStopped` — to a wire `MachineEvent { name, action, timestamp, attributes }`. Optional `id` / `action` filters; lagged broadcast slots are skipped (a gap only delays convergence — the client re-lists on the next event it sees). Stream ends when the client disconnects or the bus closes.

No new event *sources*: those events already flow (the daemon itself consumes `MachineStopped`/`MachineIdle` for host route management). This only exposes them over gRPC. `MachineRemoved` isn't emitted today (removal is client-initiated); a `removed` action can be added later if multi-client removal visibility is wanted.

## Test plan

- `cargo build -p arcbox-api` (regenerates the tonic service trait + prost messages); `cargo clippy -p arcbox-api` clean.
- New unit tests: `to_machine_event` maps each lifecycle variant to its action and returns `None` for non-machine events.
- Proto change is purely additive (new RPC + two messages) → `buf breaking` compatible.

Follow-up: arcbox-desktop `MachineEventMonitor` (mirrors `SandboxEventMonitor`) consumes this and drops the interim poll, once a daemon carrying this ships.