### PR TITLE
chore(assets): bump boot assets to 0.6.7 (kernel 6.18.38)

### DIFF
--- a/assets.lock
+++ b/assets.lock
@@ -14,9 +14,9 @@
 # and the [boot] bump.
 
 [boot]
-version = "0.6.6"
+version = "0.6.7"
 cdn = "https://boot.arcboxcdn.com"
-manifest_sha256 = "76f5868c035873b0d08583feff171e4d9b3ef0c702636105c5a18763961b5a35"
+manifest_sha256 = "bb395d37667d827e7e0f12a0cd1d3db627d528bda0bb1391d264077645a3489e"
 
 [[tools]]
 name = "docker"


### PR DESCRIPTION
Final step of the 6.18 release chain: kernel v0.0.19 (#12 over in arcboxlabs/kernel) → boot-assets v0.6.7 (kernel-release rebuild) → this pin.

- `[boot]` 0.6.6 → **0.6.7**, manifest sha256 updated
- dockerd in the bundle stays 29.6.1 → `[[tools]]` docker pin untouched (per the lockfile's divergence note)

**Verification**
- CDN manifest `asset/v0.6.7/manifest.json`: `source_ref = v0.0.19` ✓
- manifest kernel sha256 `94e8ba8a…` == kernel release `kernel-arm64.sha256` byte-for-byte ✓

Kernel payload: 6.18.38 LTS, PREEMPT_LAZY (arm64/x86), NETFILTER_XTABLES_LEGACY gates for the static iptables-legacy in the guest, vsock rx-budget patch, version-guarded arcbox_hvc_blk.