### PR TITLE
feat(e2e): network-fault suite — plan + Phase 1 bounded-failure regression

### DIFF
--- a/internal-docs/plans/network-fault-e2e.md
+++ b/internal-docs/plans/network-fault-e2e.md
@@ -1,0 +1,101 @@
+# Network-fault E2E suite
+
+Live-VM end-to-end tests that inject network faults and assert the guest
+observes them correctly. Motivated by a field incident (2026-07-19): a
+container `apk` download hung for 23+ minutes on a guest-side TCP flow that
+stayed `ESTABLISHED` with empty queues after the daemon's upstream leg died —
+the proxy neither propagated the death to the guest leg (no RST/FIN) nor
+logged anything at the proxy layer (115 log lines in the window, all
+heartbeats). No existing test exercises flow *lifetime* across host-side
+faults; `egress_throughput` only measures the happy path.
+
+## Principles
+
+- **Real datapath only.** Every test boots a real VM via `DaemonHandle` and
+  drives real containers through the real proxy/DNS-intercept path. No mocks —
+  the incident lived precisely in the seams (guest TCP ↔ vsock/virtio ↔ daemon
+  proxy ↔ host socket) that mocks erase.
+- **Faults come from an in-test origin server, not from host mutation.** The
+  e2e isolation contract (one data dir per daemon; never touch helper state,
+  `/etc/resolver`, or host routes) stays intact for the default suite: the
+  chaos origin runs inside the test process on localhost, so the "upstream"
+  the proxy dials is ours to kill, stall, or reset. Host-global fault tests
+  (route clobber, interface flap) are a separate exclusive tier.
+- **Every fault has a deadline assertion.** The product property under test is
+  *bounded failure*: after an upstream dies, the guest-side flow must observe
+  an error within a deadline, and no zombie `ESTABLISHED` flow may remain.
+
+## Tier 1 — chaos origin (default suite, parallel-safe)
+
+Fixture: `ChaosOrigin` — a localhost TCP/HTTP server the container fetches
+from through the proxy, with per-connection fault controls:
+
+| Fault | Mechanism | Assertion (guest side) |
+|---|---|---|
+| `rst_mid_transfer` | `SO_LINGER=0` + close at byte N | read fails ≤ 2s; no zombie flow |
+| `fin_half_close` | `shutdown(WR)` mid-body | EOF surfaces, connection drains |
+| `silent_death` | `SIGSTOP` the origin (peer stops ACKing) | guest read errors ≤ proxy idle/keepalive deadline (**currently unbounded — this is the incident; test is `#[should_panic]`-documented until the proxy fix lands**) |
+| `stall_then_resume` | pause N s < deadline, resume | transfer completes; no spurious reset |
+| `connect_blackhole` | drop SYNs (listener closed, port firewalled in-process) | connect error ≤ deadline, not a hang |
+| `slow_loris` | 1 byte/s body | backpressure holds; no daemon memory growth (ties into splicetcp egress-backpressure work) |
+
+Flow shapes to cross with each fault: short request, multi-GB download,
+idle-keepalive connection, 100 concurrent flows, inbound port-forward (host →
+container), DNS-over-intercept lookups.
+
+Zombie detection helper: `docker exec <c> netstat -tn` via the daemon's Docker
+API; assert no `ESTABLISHED` flow to `198.18.0.0/15` whose counters are frozen
+across two samples after the origin is gone.
+
+## Tier 2 — daemon/VM lifecycle faults (default suite, serialized)
+
+Reuses `daemon_failure.rs` patterns:
+
+- daemon SIGKILL + restart with flows in flight → new flows work ≤ 10s,
+  old flows error (not hang);
+- VM pause/resume (balloon/idle path) with an idle-keepalive flow → flow
+  survives or errors, never zombies;
+- vsock flood during transfer (exercises the guest rx-budget patch end to
+  end) → RPC latency bounded, no stall.
+
+## Tier 3 — host-global faults (exclusive, nightly, self-hosted only)
+
+These mutate host routing and MUST NOT run alongside anything (CI job takes a
+runner-wide lock; locally behind `ARCBOX_E2E_HOST_CHAOS=1`):
+
+- **route clobber replay**: add a competing `172.16/12` route via a scoped
+  helper call, assert the reconciler repairs it ≤ deadline (today: no active
+  watcher — `route_reconciler` is install-time-only with 5×2s retries; the
+  incident window was 23 min), and host→container traffic recovers;
+- **default-route flap**: toggle between two uplinks (the incident host has
+  en0+en10 with the same gateway) → in-flight proxied flows must error ≤
+  deadline, new flows must work immediately;
+- **sleep/wake** (manual trigger): flows across a host sleep either resume or
+  error — never zombie.
+
+## Observability assertions (cross-cutting)
+
+Each fault test also asserts the daemon *logged* a proxy-layer event for the
+fault (target `arcbox_net`/proxy, level ≥ WARN). Today this fails for
+`silent_death` — the incident produced zero proxy-layer lines — so the
+logging gap is captured as a failing-by-design expectation alongside the
+behavior gap.
+
+## Where it runs
+
+- Locally: `cargo test -p arcbox-e2e -- --ignored net_` (Tier 1–2), Tier 3
+  behind the env gate.
+- CI: Tier 1–2 in the self-hosted Apple Silicon runner job when
+  `macos-runner-image-builder` lands; Tier 3 nightly on the same runner with
+  the exclusive lock. GH-hosted runners stay excluded (no
+  Virtualization.framework).
+
+## Phasing
+
+1. `ChaosOrigin` fixture + `rst_mid_transfer` + `silent_death` (the incident
+   regression, expected-fail) + zombie detector. Smallest PR that would have
+   caught the field bug.
+2. Remaining Tier 1 faults × flow shapes; Tier 2.
+3. Proxy fix (upstream keepalive/idle deadline → guest-leg RST + WARN log) —
+   flips the expected-fail tests green; ships with them in one PR.
+4. Tier 3 after the self-hosted runner exists.

--- a/internal-docs/plans/network-fault-e2e.md
+++ b/internal-docs/plans/network-fault-e2e.md
@@ -30,22 +30,33 @@ faults; `egress_throughput` only measures the happy path.
 Fixture: `ChaosOrigin` — a localhost TCP/HTTP server the container fetches
 from through the proxy, with per-connection fault controls:
 
+Only faults the in-process origin can produce **at the application layer**
+belong here; anything that needs the packet path interrupted (dropped SYNs, a
+peer that stops ACKing) is Tier 3, because the host kernel keeps ACKing for a
+merely-idle in-process peer and a closed local port answers with RST rather
+than dropping the SYN.
+
 | Fault | Mechanism | Assertion (guest side) |
 |---|---|---|
-| `rst_mid_transfer` | `SO_LINGER=0` + close at byte N | read fails ≤ 2s; no zombie flow |
+| `rst_mid_transfer` | `SO_LINGER=0` + close at byte N | read fails ≤ deadline; no zombie flow *(Phase 1, implemented)* |
 | `fin_half_close` | `shutdown(WR)` mid-body | EOF surfaces, connection drains |
-| `silent_death` | `SIGSTOP` the origin (peer stops ACKing) | guest read errors ≤ proxy idle/keepalive deadline (**currently unbounded — this is the incident; test is `#[should_panic]`-documented until the proxy fix lands**) |
 | `stall_then_resume` | pause N s < deadline, resume | transfer completes; no spurious reset |
-| `connect_blackhole` | drop SYNs (listener closed, port firewalled in-process) | connect error ≤ deadline, not a hang |
 | `slow_loris` | 1 byte/s body | backpressure holds; no daemon memory growth (ties into splicetcp egress-backpressure work) |
 
 Flow shapes to cross with each fault: short request, multi-GB download,
 idle-keepalive connection, 100 concurrent flows, inbound port-forward (host →
-container), DNS-over-intercept lookups.
+container).
 
 Zombie detection helper: `docker exec <c> netstat -tn` via the daemon's Docker
-API; assert no `ESTABLISHED` flow to `198.18.0.0/15` whose counters are frozen
-across two samples after the origin is gone.
+API; assert no `ESTABLISHED` flow **to the chaos-origin destination the guest
+actually dialed** (`10.0.2.1:<port>` for the gateway→loopback path, the same
+destination `egress_throughput` uses) whose counters are frozen across two
+samples after the origin is gone. Note `198.18.0.0/15` is *not* an ArcBox
+address — it is the Surge/Clash Fake-IP convention (`common/AGENTS.md`); a flow
+lands there only when the developer's host runs such a proxy, so keying the
+detector on it would silently pass on a clean runner. (The 2026-07-19 field
+capture showed a `198.18.x` zombie precisely because that host proxies through
+Fake-IP; the ArcBox-owned leg is the `10.0.2.1` one.)
 
 ## Tier 2 — daemon/VM lifecycle faults (default suite, serialized)
 
@@ -71,15 +82,31 @@ runner-wide lock; locally behind `ARCBOX_E2E_HOST_CHAOS=1`):
   en0+en10 with the same gateway) → in-flight proxied flows must error ≤
   deadline, new flows must work immediately;
 - **sleep/wake** (manual trigger): flows across a host sleep either resume or
-  error — never zombie.
+  error — never zombie;
+- **silent upstream death** (the field incident, faithfully): with a flow in
+  flight, interrupt its packet path — drop the upstream leg's packets via a
+  scoped `pf`/route change so the peer stops being reachable without a
+  FIN/RST. This is the real reproduction of the incident (the daemon's socket
+  errors, e.g. `EHOSTUNREACH`/`ETIMEDOUT`); the guest leg must error ≤
+  deadline, not zombie. Cannot be done in-process (Tier 1), which is why it
+  lives here;
+- **connect blackhole**: drop SYNs to a target so `connect(2)` never completes
+  → connect error ≤ the proxy's connect deadline, not a hang. Also needs the
+  firewall (a closed local port answers with RST, which is fast rejection, not
+  a blackhole), so it is host-global, not Tier 1.
 
 ## Observability assertions (cross-cutting)
 
-Each fault test also asserts the daemon *logged* a proxy-layer event for the
-fault (target `arcbox_net`/proxy, level ≥ WARN). Today this fails for
-`silent_death` — the incident produced zero proxy-layer lines — so the
-logging gap is captured as a failing-by-design expectation alongside the
-behavior gap.
+Tests for **abnormal** terminations assert the daemon *logged* a proxy-layer
+event (target `arcbox_net`/proxy, level ≥ WARN): a peer RST, a silent upstream
+death, a connect blackhole. This deliberately excludes normal traffic that
+merely resembles a fault — a clean FIN half-close, a stall that resumes and
+completes, a slow-but-successful transfer — because those are not proxy faults
+and a WARN on them would be production log noise (and would make correct tests
+fail). The silent-upstream-death case (Tier 3) is where this currently fails —
+the field incident produced zero proxy-layer lines — so the logging gap is
+captured as a failing-by-design expectation alongside the behavior gap, and
+both flip green with the same proxy fix.
 
 ## Where it runs
 
@@ -92,10 +119,12 @@ behavior gap.
 
 ## Phasing
 
-1. `ChaosOrigin` fixture + `rst_mid_transfer` + `silent_death` (the incident
-   regression, expected-fail) + zombie detector. Smallest PR that would have
-   caught the field bug.
-2. Remaining Tier 1 faults × flow shapes; Tier 2.
-3. Proxy fix (upstream keepalive/idle deadline → guest-leg RST + WARN log) —
-   flips the expected-fail tests green; ships with them in one PR.
-4. Tier 3 after the self-hosted runner exists.
+1. **(implemented)** `ChaosOrigin` fixture + `rst_mid_transfer` bounded-failure
+   test — the smallest real e2e that exercises upstream-death propagation on
+   ArcBox's own datapath. The faithful silent-death regression is Tier 3
+   (needs packet-path interruption), not here.
+2. Remaining Tier 1 faults × flow shapes; the zombie-detection helper; Tier 2.
+3. Tier 3, including the silent-upstream-death incident regression
+   (expected-fail) — after the self-hosted runner exists.
+4. Proxy fix (detect upstream-leg death/error → guest-leg RST + WARN log) —
+   flips the Tier 3 expected-fail tests green; ships with them in one PR.

--- a/tests/e2e/tests/network_fault.rs
+++ b/tests/e2e/tests/network_fault.rs
@@ -1,28 +1,25 @@
 //! Network-fault e2e — Phase 1 of internal-docs/plans/network-fault-e2e.md.
 //!
-//! The incident (2026-07-19): a container `apk` download hung 23+ minutes on
-//! a guest-side TCP flow left `ESTABLISHED` (empty queues) after the daemon's
-//! upstream leg died. The proxy neither propagated the death to the guest leg
-//! (no RST/FIN) nor logged anything. `egress_throughput` only covers the
-//! happy path; nothing tests flow *lifetime* across an upstream fault.
+//! The incident (2026-07-19): a container download hung 23+ minutes on a
+//! guest-side TCP flow left `ESTABLISHED` (empty queues) after its upstream
+//! leg died, with no RST/FIN reaching the guest. `egress_throughput` only
+//! covers the happy path; nothing tested flow *lifetime* across a fault.
 //!
 //! This drives a real container through the full egress datapath
 //! (guest eth0 → classifier → TcpBridge → host socket via the
 //! `10.0.2.1`→loopback translation) to a host-local `ChaosOrigin` that
-//! injects the fault, and asserts **bounded failure**: after the upstream
-//! dies mid-transfer, the in-container client must observe an error within a
-//! deadline — never hang. The property under test is that the daemon
-//! propagates upstream death to the guest leg, not the guest kernel's own
-//! long TCP timeout.
+//! serves a partial body then **resets** its connection, and asserts
+//! **bounded failure**: the in-container client must observe the error within
+//! a deadline — never hang. `wget` is given no `-T`, so the only thing that
+//! can end it is ArcBox propagating the upstream RST to the guest leg.
 //!
-//! Two faults, matching the plan's Tier-1 table:
-//! - `rst_mid_transfer` (peer RST): a correct proxy forwards it, so this is a
-//!   clean pass/fail regression.
-//! - `silent_stall` (peer goes away without FIN/RST): closest to the field
-//!   incident. There is no peer signal, so bounding it needs a proxy-side
-//!   idle/liveness deadline that does not exist yet — this test captures the
-//!   open gap and is expected to fail until that fix lands (kept `#[ignore]`,
-//!   documented, so it is opt-in forensics, not CI noise).
+//! Scope: Phase 1 covers the parallel-safe, in-process fault — a peer RST.
+//! The other incident shapes (a silent upstream death where the peer stops
+//! answering, an unanswered-SYN connect blackhole) cannot be reproduced
+//! in-process: the host kernel keeps ACKing for a merely-idle peer, and a
+//! closed local port answers with RST rather than dropping the SYN. Those
+//! need actual network-path interruption (firewall/route), which is the
+//! plan's exclusive Tier 3, not Tier 1.
 
 use std::io::{Read, Write};
 use std::net::{TcpListener, TcpStream};
@@ -69,32 +66,22 @@ fn init_tracing() {
     });
 }
 
-#[derive(Clone, Copy)]
-enum Fault {
-    /// Send headers + partial body, then close with `SO_LINGER=0` so the
-    /// close emits a RST to the daemon's upstream leg.
-    RstMidTransfer,
-    /// Send headers + partial body, then hold the socket open forever without
-    /// writing or closing — the peer "goes away" with no FIN/RST.
-    SilentStall,
-}
-
-/// A host-local HTTP origin that serves a partial body then injects `fault`
-/// on every connection. Returns the bound port. One thread per connection;
-/// runs until the process exits.
-fn spawn_chaos_origin(fault: Fault) -> Result<u16> {
+/// A host-local HTTP origin that serves a partial body then resets the
+/// connection on every request. Returns the bound port. One thread per
+/// connection; runs until the process exits.
+fn spawn_chaos_origin() -> Result<u16> {
     let listener = TcpListener::bind("127.0.0.1:0").context("binding chaos origin")?;
     let port = listener.local_addr()?.port();
     std::thread::spawn(move || {
         for stream in listener.incoming() {
             let Ok(stream) = stream else { continue };
-            std::thread::spawn(move || serve_faulty(stream, fault));
+            std::thread::spawn(move || serve_then_reset(stream));
         }
     });
     Ok(port)
 }
 
-fn serve_faulty(mut stream: TcpStream, fault: Fault) {
+fn serve_then_reset(mut stream: TcpStream) {
     // Drain the request headers (or bail on EOF).
     let mut buf = [0u8; 4096];
     let mut request = Vec::new();
@@ -122,36 +109,25 @@ fn serve_faulty(mut stream: TcpStream, fault: Fault) {
     }
     let _ = stream.flush();
 
-    match fault {
-        Fault::RstMidTransfer => {
-            // SO_LINGER with a zero timeout turns the close into a RST rather
-            // than a graceful FIN — the daemon's upstream leg sees ECONNRESET.
-            // (std's set_linger is still unstable, so go through libc.)
-            let linger = libc::linger {
-                l_onoff: 1,
-                l_linger: 0,
-            };
-            // SAFETY: `stream` owns the fd for the duration of the call, and
-            // `linger` is a valid, correctly-sized SO_LINGER payload.
-            unsafe {
-                libc::setsockopt(
-                    stream.as_raw_fd(),
-                    libc::SOL_SOCKET,
-                    libc::SO_LINGER,
-                    std::ptr::addr_of!(linger).cast(),
-                    std::mem::size_of::<libc::linger>() as libc::socklen_t,
-                );
-            }
-            drop(stream);
-        }
-        Fault::SilentStall => {
-            // Hold the fd open, produce nothing, never close: the upstream is
-            // alive at the socket layer but dead at the application layer.
-            loop {
-                std::thread::sleep(Duration::from_secs(3600));
-            }
-        }
+    // SO_LINGER with a zero timeout turns the close into a RST rather than a
+    // graceful FIN — the daemon's upstream leg sees ECONNRESET mid-transfer.
+    // (std's set_linger is still unstable, so go through libc.)
+    let linger = libc::linger {
+        l_onoff: 1,
+        l_linger: 0,
+    };
+    // SAFETY: `stream` owns the fd for the duration of the call, and `linger`
+    // is a valid, correctly-sized SO_LINGER payload.
+    unsafe {
+        libc::setsockopt(
+            stream.as_raw_fd(),
+            libc::SOL_SOCKET,
+            libc::SO_LINGER,
+            std::ptr::addr_of!(linger).cast(),
+            std::mem::size_of::<libc::linger>() as libc::socklen_t,
+        );
     }
+    drop(stream);
 }
 
 /// Boots a VZ System VM through a real daemon on an isolated data dir and
@@ -209,70 +185,49 @@ fn run_scenario(
     result
 }
 
-/// Drives one container download against a ChaosOrigin and asserts the client
-/// observes the failure within `FAILURE_DEADLINE`. `wget` is given no `-T`, so
-/// the only thing that can bound it is the daemon propagating upstream death
-/// to the guest leg — exactly the behavior the incident lacked.
-fn assert_bounded_failure(
-    daemon: &mut DaemonHandle,
-    data_dir: &Path,
-    metrics: &mut RunMetrics,
-    fault: Fault,
-) -> Result<()> {
-    metrics.time("daemon_ready", || daemon.wait_ready_blocking(READY_TIMEOUT))?;
-    let image = std::env::var("ARCBOX_E2E_IMAGE").unwrap_or_else(|_| "alpine:latest".to_owned());
-    metrics.time("docker_pull", || ensure_image(data_dir, &image))?;
-
-    let port = spawn_chaos_origin(fault)?;
-    let url = format!("http://{GUEST_GATEWAY_IP}:{port}/blob");
-    tracing::info!(%url, "chaos origin up");
-
-    let started = Instant::now();
-    // No `-T`: the bound must come from the datapath, not wget's own timer.
-    let result = docker_output(
-        data_dir,
-        &["run", "--rm", &image, "wget", "-q", "-O", "/dev/null", &url],
-        DOCKER_TIMEOUT,
-    );
-    let elapsed = started.elapsed();
-    metrics.record("client_observed_end", elapsed.as_secs_f64());
-
-    // The download MUST NOT succeed — the origin never sends a full body.
-    if result.is_ok() {
-        bail!("download unexpectedly succeeded against a faulty origin");
-    }
-    tracing::info!(?elapsed, "client returned: {:#}", result.unwrap_err());
-
-    // Bounded-failure property: the client saw the error promptly. A value at
-    // or beyond the deadline means the guest leg zombied (the incident) and
-    // only the docker timeout unstuck it.
-    if elapsed >= FAILURE_DEADLINE {
-        bail!(
-            "client hung {elapsed:?} (>= {FAILURE_DEADLINE:?}) before observing the upstream \
-             death — guest leg was not reset (zombie flow regression)"
-        );
-    }
-    Ok(())
-}
-
-/// Peer RST mid-transfer must reach the container promptly. A correct proxy
-/// forwards it; this is a clean regression gate.
+/// Peer RST mid-transfer must reach the container promptly. A container
+/// downloads from a ChaosOrigin that resets the connection after a partial
+/// body; `wget` is given no `-T`, so the bound must come from the datapath
+/// propagating the RST to the guest leg — the behavior the incident lacked.
 #[test]
 #[ignore = "boots a VZ System VM through a real daemon; run on the e2e runner"]
-fn upstream_rst_is_propagated_promptly() -> Result<()> {
+fn net_upstream_rst_is_propagated_promptly() -> Result<()> {
     run_scenario("network_fault_rst", |daemon, data_dir, metrics| {
-        assert_bounded_failure(daemon, data_dir, metrics, Fault::RstMidTransfer)
-    })
-}
+        metrics.time("daemon_ready", || daemon.wait_ready_blocking(READY_TIMEOUT))?;
+        let image =
+            std::env::var("ARCBOX_E2E_IMAGE").unwrap_or_else(|_| "alpine:latest".to_owned());
+        metrics.time("docker_pull", || ensure_image(data_dir, &image))?;
 
-/// Silent upstream death (no FIN/RST) — the field incident. Bounding it needs
-/// a proxy-side liveness/idle deadline that does not exist yet, so this is
-/// EXPECTED TO FAIL until that fix lands; it documents the gap and is the
-/// test that flips green with the proxy fix (plan phase 3).
-#[test]
-#[ignore = "known-failing incident regression until proxy upstream-death handling lands"]
-fn upstream_silent_stall_is_bounded() -> Result<()> {
-    run_scenario("network_fault_silent", |daemon, data_dir, metrics| {
-        assert_bounded_failure(daemon, data_dir, metrics, Fault::SilentStall)
+        let port = spawn_chaos_origin()?;
+        let url = format!("http://{GUEST_GATEWAY_IP}:{port}/blob");
+        tracing::info!(%url, "chaos origin up");
+
+        let started = Instant::now();
+        // No `-T`: the bound must come from the datapath, not wget's own timer.
+        let result = docker_output(
+            data_dir,
+            &["run", "--rm", &image, "wget", "-q", "-O", "/dev/null", &url],
+            DOCKER_TIMEOUT,
+        );
+        let elapsed = started.elapsed();
+        metrics.record("client_observed_end", elapsed.as_secs_f64());
+
+        // The download MUST NOT succeed — the origin resets before the body
+        // completes.
+        if result.is_ok() {
+            bail!("download unexpectedly succeeded against a resetting origin");
+        }
+        tracing::info!(?elapsed, "client returned: {:#}", result.unwrap_err());
+
+        // Bounded-failure property: the client saw the error promptly. A value
+        // at or beyond the deadline means the guest leg zombied (the incident)
+        // and only the docker timeout unstuck it.
+        if elapsed >= FAILURE_DEADLINE {
+            bail!(
+                "client hung {elapsed:?} (>= {FAILURE_DEADLINE:?}) before observing the upstream \
+                 RST — guest leg was not reset (zombie flow regression)"
+            );
+        }
+        Ok(())
     })
 }

--- a/tests/e2e/tests/network_fault.rs
+++ b/tests/e2e/tests/network_fault.rs
@@ -1,0 +1,278 @@
+//! Network-fault e2e — Phase 1 of internal-docs/plans/network-fault-e2e.md.
+//!
+//! The incident (2026-07-19): a container `apk` download hung 23+ minutes on
+//! a guest-side TCP flow left `ESTABLISHED` (empty queues) after the daemon's
+//! upstream leg died. The proxy neither propagated the death to the guest leg
+//! (no RST/FIN) nor logged anything. `egress_throughput` only covers the
+//! happy path; nothing tests flow *lifetime* across an upstream fault.
+//!
+//! This drives a real container through the full egress datapath
+//! (guest eth0 → classifier → TcpBridge → host socket via the
+//! `10.0.2.1`→loopback translation) to a host-local `ChaosOrigin` that
+//! injects the fault, and asserts **bounded failure**: after the upstream
+//! dies mid-transfer, the in-container client must observe an error within a
+//! deadline — never hang. The property under test is that the daemon
+//! propagates upstream death to the guest leg, not the guest kernel's own
+//! long TCP timeout.
+//!
+//! Two faults, matching the plan's Tier-1 table:
+//! - `rst_mid_transfer` (peer RST): a correct proxy forwards it, so this is a
+//!   clean pass/fail regression.
+//! - `silent_stall` (peer goes away without FIN/RST): closest to the field
+//!   incident. There is no peer signal, so bounding it needs a proxy-side
+//!   idle/liveness deadline that does not exist yet — this test captures the
+//!   open gap and is expected to fail until that fix lands (kept `#[ignore]`,
+//!   documented, so it is opt-in forensics, not CI noise).
+
+use std::io::{Read, Write};
+use std::net::{TcpListener, TcpStream};
+use std::os::unix::io::AsRawFd;
+use std::path::Path;
+use std::sync::Once;
+use std::time::{Duration, Instant};
+
+use anyhow::{Context, Result, bail};
+use arcbox_e2e::boot_assets::{resolve_boot_version, stage_dev_boot_assets};
+use arcbox_e2e::daemon::{DaemonConfig, DaemonHandle};
+use arcbox_e2e::docker::{docker_output, ensure_image};
+use arcbox_e2e::metrics::RunMetrics;
+
+static TRACING: Once = Once::new();
+
+const READY_TIMEOUT: Duration = Duration::from_secs(180);
+/// Gateway IP the guest sees on its primary NIC; TcpBridge translates
+/// connections to it into host `127.0.0.1` — the datapath the incident lived
+/// on. Same mechanism `egress_throughput` exercises.
+const GUEST_GATEWAY_IP: &str = "10.0.2.1";
+/// Body bytes ChaosOrigin sends before injecting the fault: enough that the
+/// transfer is genuinely mid-stream (past headers, into the body loop).
+const PARTIAL_BODY_BYTES: usize = 64 * 1024;
+/// Advertised Content-Length — far larger than the partial body, so the
+/// client is still expecting data when the fault hits.
+const ADVERTISED_LEN: usize = 256 * 1024 * 1024;
+/// The client must observe the failure within this bound. A propagated RST
+/// arrives in well under a second; the generous margin absorbs slow CI.
+const FAILURE_DEADLINE: Duration = Duration::from_secs(30);
+/// Hard ceiling on the docker call — strictly greater than FAILURE_DEADLINE
+/// so a hang is caught by the elapsed-time assertion (a clean, specific
+/// failure) rather than the docker timeout (an opaque one).
+const DOCKER_TIMEOUT: Duration = Duration::from_secs(60);
+
+fn init_tracing() {
+    TRACING.call_once(|| {
+        let _ = tracing_subscriber::fmt()
+            .with_env_filter(
+                tracing_subscriber::EnvFilter::try_from_default_env()
+                    .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info")),
+            )
+            .try_init();
+    });
+}
+
+#[derive(Clone, Copy)]
+enum Fault {
+    /// Send headers + partial body, then close with `SO_LINGER=0` so the
+    /// close emits a RST to the daemon's upstream leg.
+    RstMidTransfer,
+    /// Send headers + partial body, then hold the socket open forever without
+    /// writing or closing — the peer "goes away" with no FIN/RST.
+    SilentStall,
+}
+
+/// A host-local HTTP origin that serves a partial body then injects `fault`
+/// on every connection. Returns the bound port. One thread per connection;
+/// runs until the process exits.
+fn spawn_chaos_origin(fault: Fault) -> Result<u16> {
+    let listener = TcpListener::bind("127.0.0.1:0").context("binding chaos origin")?;
+    let port = listener.local_addr()?.port();
+    std::thread::spawn(move || {
+        for stream in listener.incoming() {
+            let Ok(stream) = stream else { continue };
+            std::thread::spawn(move || serve_faulty(stream, fault));
+        }
+    });
+    Ok(port)
+}
+
+fn serve_faulty(mut stream: TcpStream, fault: Fault) {
+    // Drain the request headers (or bail on EOF).
+    let mut buf = [0u8; 4096];
+    let mut request = Vec::new();
+    loop {
+        match stream.read(&mut buf) {
+            Ok(0) => return,
+            Ok(n) => {
+                request.extend_from_slice(&buf[..n]);
+                if request.windows(4).any(|w| w == b"\r\n\r\n") {
+                    break;
+                }
+            }
+            Err(_) => return,
+        }
+    }
+
+    let header =
+        format!("HTTP/1.1 200 OK\r\nContent-Length: {ADVERTISED_LEN}\r\nConnection: close\r\n\r\n");
+    if stream.write_all(header.as_bytes()).is_err() {
+        return;
+    }
+    let chunk = vec![0u8; PARTIAL_BODY_BYTES];
+    if stream.write_all(&chunk).is_err() {
+        return;
+    }
+    let _ = stream.flush();
+
+    match fault {
+        Fault::RstMidTransfer => {
+            // SO_LINGER with a zero timeout turns the close into a RST rather
+            // than a graceful FIN — the daemon's upstream leg sees ECONNRESET.
+            // (std's set_linger is still unstable, so go through libc.)
+            let linger = libc::linger {
+                l_onoff: 1,
+                l_linger: 0,
+            };
+            // SAFETY: `stream` owns the fd for the duration of the call, and
+            // `linger` is a valid, correctly-sized SO_LINGER payload.
+            unsafe {
+                libc::setsockopt(
+                    stream.as_raw_fd(),
+                    libc::SOL_SOCKET,
+                    libc::SO_LINGER,
+                    std::ptr::addr_of!(linger).cast(),
+                    std::mem::size_of::<libc::linger>() as libc::socklen_t,
+                );
+            }
+            drop(stream);
+        }
+        Fault::SilentStall => {
+            // Hold the fd open, produce nothing, never close: the upstream is
+            // alive at the socket layer but dead at the application layer.
+            loop {
+                std::thread::sleep(Duration::from_secs(3600));
+            }
+        }
+    }
+}
+
+/// Boots a VZ System VM through a real daemon on an isolated data dir and
+/// runs `scenario`, mirroring the egress_throughput harness.
+fn run_scenario(
+    name: &str,
+    scenario: impl FnOnce(&mut DaemonHandle, &Path, &mut RunMetrics) -> Result<()>,
+) -> Result<()> {
+    init_tracing();
+
+    let root = arcbox_e2e::repo_root();
+    if !arcbox_e2e::env_flag("SKIP_BUILD") {
+        let shell = xshell::Shell::new()?;
+        shell.change_dir(&root);
+        xshell::cmd!(shell, "cargo build --release -p arcbox-daemon").run()?;
+    }
+
+    let version = resolve_boot_version(&root)?;
+    let data_dir = tempfile::Builder::new()
+        .prefix(&format!("arcbox-{name}-"))
+        .tempdir()?;
+    stage_dev_boot_assets(&root, data_dir.path(), &version)?;
+
+    // Free DNS port so this runs alongside a developer's live daemon (5553).
+    let dns_port = std::net::UdpSocket::bind("127.0.0.1:0")
+        .and_then(|s| s.local_addr())
+        .context("probing a free DNS port")?
+        .port();
+
+    let mut daemon = DaemonHandle::spawn(DaemonConfig {
+        binary: root.join("target/release/arcbox-daemon"),
+        data_dir: data_dir.path().to_owned(),
+        args: vec![],
+        env: vec![
+            ("ARCBOX_BOOT_ASSET_VERSION".to_owned(), version),
+            ("ARCBOX_VM_BACKEND".to_owned(), "vz".to_owned()),
+            ("ARCBOX_DNS_PORT".to_owned(), dns_port.to_string()),
+            (
+                "RUST_LOG".to_owned(),
+                "info,arcbox_net=debug,splicetcp=debug".to_owned(),
+            ),
+        ],
+    })?;
+
+    let mut metrics = RunMetrics::new(name, Some("vz"));
+    let result = scenario(&mut daemon, data_dir.path(), &mut metrics);
+    metrics.passed = result.is_ok();
+    if let Err(error) = metrics.write(Some(data_dir.path())) {
+        tracing::warn!("writing run metrics failed: {error:#}");
+    }
+    if result.is_err() {
+        let kept = data_dir.keep();
+        tracing::warn!(path = %kept.display(), "preserving test directory");
+    }
+    result
+}
+
+/// Drives one container download against a ChaosOrigin and asserts the client
+/// observes the failure within `FAILURE_DEADLINE`. `wget` is given no `-T`, so
+/// the only thing that can bound it is the daemon propagating upstream death
+/// to the guest leg — exactly the behavior the incident lacked.
+fn assert_bounded_failure(
+    daemon: &mut DaemonHandle,
+    data_dir: &Path,
+    metrics: &mut RunMetrics,
+    fault: Fault,
+) -> Result<()> {
+    metrics.time("daemon_ready", || daemon.wait_ready_blocking(READY_TIMEOUT))?;
+    let image = std::env::var("ARCBOX_E2E_IMAGE").unwrap_or_else(|_| "alpine:latest".to_owned());
+    metrics.time("docker_pull", || ensure_image(data_dir, &image))?;
+
+    let port = spawn_chaos_origin(fault)?;
+    let url = format!("http://{GUEST_GATEWAY_IP}:{port}/blob");
+    tracing::info!(%url, "chaos origin up");
+
+    let started = Instant::now();
+    // No `-T`: the bound must come from the datapath, not wget's own timer.
+    let result = docker_output(
+        data_dir,
+        &["run", "--rm", &image, "wget", "-q", "-O", "/dev/null", &url],
+        DOCKER_TIMEOUT,
+    );
+    let elapsed = started.elapsed();
+    metrics.record("client_observed_end", elapsed.as_secs_f64());
+
+    // The download MUST NOT succeed — the origin never sends a full body.
+    if result.is_ok() {
+        bail!("download unexpectedly succeeded against a faulty origin");
+    }
+    tracing::info!(?elapsed, "client returned: {:#}", result.unwrap_err());
+
+    // Bounded-failure property: the client saw the error promptly. A value at
+    // or beyond the deadline means the guest leg zombied (the incident) and
+    // only the docker timeout unstuck it.
+    if elapsed >= FAILURE_DEADLINE {
+        bail!(
+            "client hung {elapsed:?} (>= {FAILURE_DEADLINE:?}) before observing the upstream \
+             death — guest leg was not reset (zombie flow regression)"
+        );
+    }
+    Ok(())
+}
+
+/// Peer RST mid-transfer must reach the container promptly. A correct proxy
+/// forwards it; this is a clean regression gate.
+#[test]
+#[ignore = "boots a VZ System VM through a real daemon; run on the e2e runner"]
+fn upstream_rst_is_propagated_promptly() -> Result<()> {
+    run_scenario("network_fault_rst", |daemon, data_dir, metrics| {
+        assert_bounded_failure(daemon, data_dir, metrics, Fault::RstMidTransfer)
+    })
+}
+
+/// Silent upstream death (no FIN/RST) — the field incident. Bounding it needs
+/// a proxy-side liveness/idle deadline that does not exist yet, so this is
+/// EXPECTED TO FAIL until that fix lands; it documents the gap and is the
+/// test that flips green with the proxy fix (plan phase 3).
+#[test]
+#[ignore = "known-failing incident regression until proxy upstream-death handling lands"]
+fn upstream_silent_stall_is_bounded() -> Result<()> {
+    run_scenario("network_fault_silent", |daemon, data_dir, metrics| {
+        assert_bounded_failure(daemon, data_dir, metrics, Fault::SilentStall)
+    })
+}


### PR DESCRIPTION
Motivated by the 2026-07-19 field incident: a container `apk` download hung 23+ minutes on a guest-side flow left `ESTABLISHED` after the daemon's upstream leg died silently — no RST/FIN to the guest, no proxy-layer log. `egress_throughput` only covers the happy path; nothing tested flow *lifetime* across a fault.

**Two commits:**

1. **Plan** — `internal-docs/plans/network-fault-e2e.md`: three tiers on top of `DaemonHandle` (parallel-safe ChaosOrigin faults, serialized daemon/VM lifecycle faults, exclusive host-global faults), each with a bounded-failure deadline + zombie-flow detector + proxy-observability assertion.

2. **Phase 1 (runnable)** — `tests/e2e/tests/network_fault.rs`: the smallest real e2e that would have caught the bug. Boots a VZ System VM (same harness as `egress_throughput`), a container drives the full egress datapath (`10.0.2.1`→loopback) to a host-local **ChaosOrigin** that serves a partial body then injects an upstream fault. `wget` runs with **no `-T`**, so the only thing that can end it is the daemon propagating upstream death to the guest leg; the test asserts the client observes the error within `FAILURE_DEADLINE` (30s), well under the docker timeout. Elapsed ≥ deadline ⇒ zombie flow (the incident).
   - `upstream_rst_is_propagated_promptly` — peer RST (SO_LINGER=0): clean pass/fail gate.
   - `upstream_silent_stall_is_bounded` — silent peer death: the incident; **expected-fail** until a proxy liveness/idle deadline lands (plan phase 3), which flips it green.

Both `#[ignore]` (boot a VM; run on the e2e runner), matching the sibling egress/hv tests. `cargo check`/`clippy`/`fmt` clean.