### PR TITLE
chore(assets): bump boot assets to 0.6.8 (mkfs.erofs + rootfs razor)

### DIFF
--- a/assets.lock
+++ b/assets.lock
@@ -14,9 +14,9 @@
 # and the [boot] bump.
 
 [boot]
-version = "0.6.7"
+version = "0.6.8"
 cdn = "https://boot.arcboxcdn.com"
-manifest_sha256 = "bb395d37667d827e7e0f12a0cd1d3db627d528bda0bb1391d264077645a3489e"
+manifest_sha256 = "4d9d0823fef856af03fb97fd5416185aceeeeade7762e8c96f71241497e92a35"
 
 [[tools]]
 name = "docker"


### PR DESCRIPTION
Follow-up to #445: pins boot-assets **v0.6.8**, which carries the same v0.0.19 kernel (6.18.38 + lazy preemption) plus the rootfs changes from boot-assets#39 and #43:

- static **mkfs.erofs 1.9.2** for the containerd erofs snapshotter
- **btrfs-progs v6.12 → v7.1** — new data disks get `block-group-tree` by default (faster mounts on large aged disks; needs kernel ≥ 6.1, safe across any plausible rollback)
- **iptables 1.8.11 → 1.8.13**
- **removed** the never-consumed `ebtables`/`ethtool`/`socat` trio (evidence in boot-assets#43)

Net: arm64 bundle **13.9 MB → 12.0 MB (−14%)** despite the mkfs.erofs addition. dockerd stays 29.6.1 → `[[tools]]` pin untouched.

**Verification**
- CDN `asset/v0.6.8/manifest.json`: `asset_version = 0.6.8`, `source_ref = v0.0.19` ✓
- manifest arm64 kernel sha `94e8ba8a…` == kernel v0.0.19 release asset, byte-for-byte ✓