### PR TITLE
feat(e2e): network-workload suite — plan + Phase 1 (found 3 datapath defects)

### DIFF
--- a/internal-docs/plans/network-workload-e2e.md
+++ b/internal-docs/plans/network-workload-e2e.md
@@ -114,12 +114,14 @@ the proxy, not to gate anything.
 
 ## First-run findings (2026-07-19, Phase 1 on master's datapath)
 
-The initial local run failed all five Phase-1 scenarios and pinned three
-datapath defects, all with **zero proxy-layer WARN/ERROR lines** — the fault
-plan's observability gap reproduced under plain workloads:
+The initial local runs (with and without hot-path debug logging) failed all
+five Phase-1 scenarios and pinned three datapath defects, all with **zero
+proxy-layer WARN/ERROR lines** — the fault plan's observability gap
+reproduced under plain workloads:
 
-1. **Uploads silently lose data** (W2, both variants: 256 MiB arrived
-   ~1-2.6 MB short while the in-container client exited 0). Mechanism, from
+1. **Uploads silently lose data** (W2, both variants, both runs: 256 MiB
+   arrived 1.3-3.2 MB short while the in-container client exited 0 — even
+   against a reader draining at full speed). Mechanism, from
    `common/splicetcp/src/tcp_bridge/fast_path.rs`:
    - `is_new_data` accepts any segment whose *end* extends `last_ack`, so
      after a `WouldBlock` drop the next in-flight segment is written and
@@ -129,8 +131,11 @@ plan's observability gap reproduced under plain workloads:
      full, losing the unwritten tail;
    - FIN handling runs `close_fast_path` unconditionally, so a
      close-after-write client kills gap recovery even where it would work.
-2. **Concurrent downloads wedge permanently** (W3: ~30 of 64 flows died on
-   a 60 s read timeout; W4 degraded until the 240 s ceiling). The download
+2. **Concurrent downloads wedge permanently, sequential ones degrade**
+   (W3: 18 of 64 single-container flows and 5 of 64 across-containers flows
+   died on a 60 s read timeout even with quiet logging; W4: sequential churn
+   slowed to ~2 s/request — 120 of 500 requests inside the 240 s ceiling).
+   The download
    direction sends with a hardcoded `window: 65535`, never reads the guest's
    advertised receive window, has no retransmission, and deliberately
    ignores pure ACKs — so a single guest-side window-overrun drop leaves a

--- a/internal-docs/plans/network-workload-e2e.md
+++ b/internal-docs/plans/network-workload-e2e.md
@@ -1,0 +1,131 @@
+# Network-workload E2E suite
+
+Companion to `network-fault-e2e.md`: that plan injects *faults*; this one
+asserts the datapath under the realistic *workloads* a developer generates
+every day — large pulls, uploads, dependency-install bursts, published ports,
+DNS, container-to-container traffic. Today only the happy-path download
+direction has any coverage (`egress_throughput`); everything else a developer
+does daily is untested end to end.
+
+## Principles
+
+- **Locally runnable is the bar.** Every default-suite test runs on any Apple
+  Silicon dev machine via `cargo test -p arcbox-e2e -- --ignored net_` with:
+  no external network (in-process origins/sinks on localhost), no privileged
+  helper, no vmnet, parallel-safe (isolated data dirs; only ephemeral host
+  ports). CI wiring inherits the fault plan's "Where it runs" unchanged — the
+  suite must not *depend* on it.
+- **Real datapath only** (same as the fault plan). `docker exec`/`logs`/`cp`
+  ride vsock, not eth0 (`app/arcbox-docker/src/proxy/connector.rs`), so they
+  are the out-of-band control channel for in-guest assertions even when the
+  network path under test is saturated or wedged.
+- **Behavioral bounds, not absolute throughput.** Assertions are deadlines,
+  zero-stall, latency-flatness ratios, and zombie-freedom; `RunMetrics`
+  records the absolute numbers as trend lines, they are never pass/fail.
+- **Workloads must be quiet.** The observability inverse of the fault plan:
+  after every workload scenario, the daemon log must contain no proxy-layer
+  ERROR, and a zombie sweep (the fault plan's detector, shared fixture) must
+  come back empty. Faults assert loud logs; workloads assert quiet ones.
+
+## Capability boundaries (source-verified 2026-07-19)
+
+What the datapath actually supports, hence what is testable in the default
+suite:
+
+- **Published ports work helper-free in isolated mode.** The primary NIC is a
+  socketpair-backed file-handle attachment created unconditionally
+  (`virt/arcbox-vmm/src/vmm/darwin.rs`), and `InboundListenerManager` binds
+  plain unprivileged sockets against it
+  (`common/arcbox-proxy/src/inbound_relay.rs`). The vmnet "bridge NIC" +
+  helper-installed `172.16/12` route is a separate mechanism for direct
+  container-IP L3 routing only — out of scope here (fault plan Tier 3
+  territory).
+- **Ephemeral publish (`-p 127.0.0.1::80`) resolves guest-side.** Guest
+  dockerd allocates the host port before `start` returns; ArcBox parses the
+  inspect JSON and binds that exact port
+  (`app/arcbox-docker/src/port_bindings.rs`,
+  `app/arcbox-core/src/runtime.rs::resolve_bind_ip` — `127.0.0.1` bind IPs
+  honored). `docker port` proxies the guest JSON verbatim. Never exercised by
+  a test — W6 is that assertion.
+- **UDP is a full per-flow proxy, not DNS-only.** Outbound non-DNS UDP gets a
+  real host socket per 4-tuple with gateway→loopback translation and 60 s
+  idle expiry (`common/arcbox-proxy/src/egress/udp.rs`); UDP publishing is
+  supported inbound (`inbound_relay.rs` synthesizes L2 frames).
+- **DNS:** containers query `10.0.2.1:53` directly (dockerd `daemon.json`,
+  `guest/arcbox-agent/src/init.rs`), intercepted in-VMM by `DnsForwarder`
+  sharing the host `DnsService` hosts table: `host.docker.internal` /
+  `gateway.docker.internal` → gateway IP, dynamic `<name>.arcbox.local`
+  registrations, NXDOMAIN for unregistered own-domain names, everything else
+  forwarded to the host's resolv.conf upstreams (`virt/arcbox-net/src/dns.rs`).
+  Own-domain behavior is fully local-testable; upstream forwarding is
+  environment-dependent (external phase only).
+- **Upload direction has no backpressure queue.** Guest→host payload writes
+  that hit `WouldBlock` are silently dropped without ACK; recovery is the
+  guest kernel's RTO retransmit
+  (`common/splicetcp/src/tcp_bridge/fast_path.rs:91-104`). Download has a
+  bounded-channel backpressure path (`common/splicetcp/src/direct_rx.rs`);
+  upload has nothing. Accepted-by-design per the module docs, but W2 must pin
+  the resulting behavior (eventual completion, no stall-forever) so a
+  regression from "slow" to "stuck" is caught.
+- **Container↔container traffic never leaves the guest kernel** (dockerd
+  bridges/veth; the host only proxies the API calls). W10 is therefore a
+  guest-kernel + dockerd regression test — exactly what the 6.18
+  iptables-legacy migration needs standing coverage for — not a proxy test.
+
+## The workload matrix
+
+Shared fixture work (Phase 0): lift the blob server (`egress_throughput`) and
+`ChaosOrigin` (`network_fault`) into `tests/e2e/src/net_fixtures.rs`; add a
+`SlowSink` (raw-TCP byte-counting reader with a scriptable mid-stream pause),
+a `UdpEcho`, a `published_host_port(data_dir, container, "80/tcp")` helper
+(reads `docker port`), and the fault plan's zombie detector — one
+implementation serving both suites. Scenarios within one test share a single
+booted daemon and aggregate failures (the `run_downloads` pattern), because
+boot time dominates.
+
+| # | Workload (daily behavior) | Mechanism | Assertions |
+|---|---|---|---|
+| W1 | sustained download (big-file pull) | exists: `egress_throughput` | unchanged |
+| W2 | sustained upload (push/POST) | `dd if=/dev/zero bs=1M count=256 \| nc 10.0.2.1 <port>` into `SlowSink`; variants: normal reader, reader pauses 5 s mid-stream | sink byte count exact; completion ≤ deadline in both variants — pause must slow it (RTO), never wedge it |
+| W3 | concurrency burst (npm/cargo install shape) | 64 parallel 4 MB downloads inside one container + 8 containers × 8 flows | all complete; slowest ≤ 4× median (straggler bound); zombie sweep clean |
+| W4 | connection churn (apk/git-HTTP shape) | 500 sequential GETs, fresh connection each | last-decile latency ≤ 3× first-decile (no per-flow leak/slowdown); no flow-table growth after |
+| W5 | keepalive reuse | 100 pipelined requests on one connection (`printf … \| nc`; fixture speaks keep-alive) | all responses arrive, per-request latency flat |
+| W6 | inbound publish TCP (dev serves a port) | `busybox httpd` + `-p 127.0.0.1::80`; discover port via `docker port` | (a) content correct from host `curl`; (b) 64 MB inbound download; (c) 32 concurrent host connections; (d) `docker stop` → host port stops accepting (listener lifecycle) |
+| W7 | inbound publish UDP | `nc -u -l` echo in container, `-p 127.0.0.1::<p>/udp` | host datagrams echo back; port released on stop |
+| W8 | UDP egress | container `nc -u 10.0.2.1 <port>` against `UdpEcho` | echo round-trip; after >60 s idle the flow re-establishes (expiry is invisible to the app) |
+| W9 | DNS daily paths | in-container `nslookup` via vsock exec | `host.docker.internal` → gateway IP; named container resolves as `<name>.arcbox.local` from another container; unregistered `.arcbox.local` NXDOMAINs ≤ 2 s (bounded, not forwarded) |
+| W10 | container↔container (compose shape) | user-defined network, `busybox httpd` server + client by service name and by IP | resolution + transfer work; regression net for guest bridge/iptables-legacy config (6.18) |
+| W11 | registry round-trip (push+pull compound) | `registry:2` in-guest publishing ephemeral port; host CLI pushes alpine to `host.docker.internal:<port>`, pulls back | full-loop egress+inbound with real dockerd traffic. **Blocked**: guest dockerd needs `insecure-registries` for plain-HTTP non-loopback — requires an agent-side knob first; Phase 3 |
+| W12 | long-lived idle flow across idle-shrink | keepalive flow held open past `ARCBOX_IDLE_TIMEOUT_SECS=20`, then reused | works or errors — never zombies (overlaps fault plan Tier 2; implement once, there) |
+
+## External phase (env-gated, never default, still local)
+
+`ARCBOX_E2E_EXTERNAL=1` (same spirit as `ARCBOX_E2E_EGRESS_URL`): real-tool
+runs on a dev machine with internet — the tools whose hangs started all this:
+
+- E1 `apk add` a real package (the 2026-07-19 incident's exact shape);
+- E2 `git clone` a small public repo over smart HTTP;
+- E3 `docker pull` a multi-layer image ≥ 500 MB (concurrent layer fetches);
+- E4 HTTPS ≥ 100 MB download (TLS through the datapath).
+
+Each with a hard deadline and the zombie sweep. Results are
+environment-dependent by nature; these exist to be run manually when touching
+the proxy, not to gate anything.
+
+## Runtime budget
+
+Default suite ≈ 4 test binaries (`network_workload` W2–W5, `network_inbound`
+W6–W8, `network_dns` W9–W10, plus existing `egress_throughput`/
+`network_fault`), one boot each ≈ 15–20 min serial on an M-series machine;
+parallel-safe if run concurrently (distinct data dirs, ephemeral ports only).
+
+## Phasing
+
+1. Fixture lift (`net_fixtures.rs`; no behavior change to existing tests).
+2. `network_workload.rs`: W2 upload (normal + paused-reader), W3 burst,
+   W4 churn — pure in-process, no new capability questions, and W2 pins the
+   datapath's weakest documented spot.
+3. `network_inbound.rs` (W6–W8) + `network_dns.rs` (W9–W10) — W6 doubles as
+   the missing e2e for ephemeral publish.
+4. W5, W12 (with fault-plan Tier 2), W11 behind the insecure-registry knob,
+   external phase E1–E4.

--- a/internal-docs/plans/network-workload-e2e.md
+++ b/internal-docs/plans/network-workload-e2e.md
@@ -112,6 +112,44 @@ Each with a hard deadline and the zombie sweep. Results are
 environment-dependent by nature; these exist to be run manually when touching
 the proxy, not to gate anything.
 
+## First-run findings (2026-07-19, Phase 1 on master's datapath)
+
+The initial local run failed all five Phase-1 scenarios and pinned three
+datapath defects, all with **zero proxy-layer WARN/ERROR lines** — the fault
+plan's observability gap reproduced under plain workloads:
+
+1. **Uploads silently lose data** (W2, both variants: 256 MiB arrived
+   ~1-2.6 MB short while the in-container client exited 0). Mechanism, from
+   `common/splicetcp/src/tcp_bridge/fast_path.rs`:
+   - `is_new_data` accepts any segment whose *end* extends `last_ack`, so
+     after a `WouldBlock` drop the next in-flight segment is written and
+     `set_last_ack(seq_end)` **ACKs across the hole** — the guest never
+     retransmits the dropped bytes (permanent gap, silently acknowledged);
+   - `Ok(_n)` ignores short writes: partially written segments are ACKed in
+     full, losing the unwritten tail;
+   - FIN handling runs `close_fast_path` unconditionally, so a
+     close-after-write client kills gap recovery even where it would work.
+2. **Concurrent downloads wedge permanently** (W3: ~30 of 64 flows died on
+   a 60 s read timeout; W4 degraded until the 240 s ceiling). The download
+   direction sends with a hardcoded `window: 65535`, never reads the guest's
+   advertised receive window, has no retransmission, and deliberately
+   ignores pure ACKs — so a single guest-side window-overrun drop leaves a
+   sequence gap no mechanism can fill; the guest dup-ACK storms (hundreds
+   to ~1.1k per flow in the daemon log) until the client times out. The
+   `guest-tx delivery counters` prove L2 delivery stayed lossless
+   (`lossy_dropped=0`, `enobufs` events blocked-not-dropped), placing the
+   loss at guest TCP window overrun.
+3. **Hot-path debug logging is an observer effect**: `splicetcp=debug` logs
+   every classified frame (~6k lines/s during a dup-ACK storm), distorting
+   the datapath under measurement. The workload suite therefore runs the
+   daemon at `info,arcbox_net=debug`.
+
+Status: W2–W4 are **red by design** until the TcpBridge fixes land (only
+ACK bytes actually written in-order; honor the guest's receive window or
+retransmit; make both loss paths log at WARN). Same convention as the fault
+plan's Tier 3: the suite is the regression net that flips green with the
+fix, and the strict assertions stay.
+
 ## Runtime budget
 
 Default suite ≈ 4 test binaries (`network_workload` W2–W5, `network_inbound`

--- a/tests/e2e/src/lib.rs
+++ b/tests/e2e/src/lib.rs
@@ -4,7 +4,9 @@ pub mod boot_assets;
 pub mod daemon;
 pub mod docker;
 pub mod metrics;
+pub mod net_fixtures;
 pub mod sandbox;
+pub mod scenario;
 pub mod signing;
 
 pub fn repo_root() -> PathBuf {

--- a/tests/e2e/src/net_fixtures.rs
+++ b/tests/e2e/src/net_fixtures.rs
@@ -1,0 +1,356 @@
+//! In-process network origins and sinks for the network workload and fault
+//! suites (`internal-docs/plans/network-workload-e2e.md`,
+//! `internal-docs/plans/network-fault-e2e.md`).
+//!
+//! Everything binds `127.0.0.1:0` and runs until the process exits; guests
+//! reach a fixture at `10.0.2.1:<port>` via the TcpBridge gateway→loopback
+//! translation, so tests exercise the full egress datapath with no external
+//! network and no fixed host ports (parallel-safe per the README contract).
+
+use std::io::{Read, Write};
+use std::net::{TcpListener, TcpStream};
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+use anyhow::{Context, Result, bail};
+
+use crate::docker::docker_output;
+
+/// Gateway IP the guest sees on its primary NIC. TcpBridge translates
+/// connections to it into host `127.0.0.1` — the `host.docker.internal`
+/// mechanism, and the datapath every fixture here sits behind.
+pub const GUEST_GATEWAY_IP: &str = "10.0.2.1";
+
+/// Reads request headers until the `\r\n\r\n` terminator. Returns false on
+/// EOF or error before the terminator.
+fn drain_request_headers(stream: &mut TcpStream) -> bool {
+    let mut buf = [0u8; 4096];
+    let mut request = Vec::new();
+    loop {
+        match stream.read(&mut buf) {
+            Ok(0) | Err(_) => return false,
+            Ok(n) => {
+                request.extend_from_slice(&buf[..n]);
+                if request.windows(4).any(|w| w == b"\r\n\r\n") {
+                    return true;
+                }
+            }
+        }
+    }
+}
+
+/// HTTP origin serving `blob_bytes` of zeroes per request.
+///
+/// Records one duration per connection: accept → the client closing its
+/// side after reading the full body. Client-close (not last-write) is the
+/// completion signal, so a flow whose tail stalls in flight shows up as a
+/// long duration even though the server buffered its final bytes early.
+pub struct BlobServer {
+    port: u16,
+    timings: Arc<Mutex<Vec<Duration>>>,
+}
+
+impl BlobServer {
+    pub fn port(&self) -> u16 {
+        self.port
+    }
+
+    /// Per-connection durations in completion order.
+    pub fn timings(&self) -> Vec<Duration> {
+        self.timings.lock().expect("timings poisoned").clone()
+    }
+
+    pub fn reset_timings(&self) {
+        self.timings.lock().expect("timings poisoned").clear();
+    }
+}
+
+pub fn spawn_blob_server(blob_bytes: usize) -> Result<BlobServer> {
+    let listener = TcpListener::bind("127.0.0.1:0").context("binding blob server")?;
+    let port = listener.local_addr()?.port();
+    let timings: Arc<Mutex<Vec<Duration>>> = Arc::default();
+    let recorded = Arc::clone(&timings);
+    std::thread::spawn(move || {
+        for stream in listener.incoming() {
+            let Ok(mut stream) = stream else { continue };
+            let recorded = Arc::clone(&recorded);
+            std::thread::spawn(move || {
+                let started = Instant::now();
+                if !drain_request_headers(&mut stream) {
+                    return;
+                }
+                let header = format!(
+                    "HTTP/1.1 200 OK\r\nContent-Length: {blob_bytes}\r\nConnection: close\r\n\r\n"
+                );
+                if stream.write_all(header.as_bytes()).is_err() {
+                    return;
+                }
+                let chunk = vec![0u8; 64 * 1024];
+                let mut remaining = blob_bytes;
+                while remaining > 0 {
+                    let n = remaining.min(chunk.len());
+                    if stream.write_all(&chunk[..n]).is_err() {
+                        return;
+                    }
+                    remaining -= n;
+                }
+                // Wait for the client's close so the timing covers actual
+                // receipt, not just our last buffered write.
+                let mut sink = [0u8; 1024];
+                while matches!(stream.read(&mut sink), Ok(n) if n > 0) {}
+                recorded
+                    .lock()
+                    .expect("timings poisoned")
+                    .push(started.elapsed());
+            });
+        }
+    });
+    Ok(BlobServer { port, timings })
+}
+
+/// HTTP origin that serves `partial_body` bytes of an `advertised_len`
+/// body, then turns its close into a RST (`SO_LINGER` zero).
+///
+/// The daemon's upstream leg sees ECONNRESET mid-transfer. One thread per
+/// connection.
+pub fn spawn_chaos_origin(partial_body: usize, advertised_len: usize) -> Result<u16> {
+    let listener = TcpListener::bind("127.0.0.1:0").context("binding chaos origin")?;
+    let port = listener.local_addr()?.port();
+    std::thread::spawn(move || {
+        for stream in listener.incoming() {
+            let Ok(stream) = stream else { continue };
+            std::thread::spawn(move || serve_then_reset(stream, partial_body, advertised_len));
+        }
+    });
+    Ok(port)
+}
+
+fn serve_then_reset(mut stream: TcpStream, partial_body: usize, advertised_len: usize) {
+    if !drain_request_headers(&mut stream) {
+        return;
+    }
+    let header =
+        format!("HTTP/1.1 200 OK\r\nContent-Length: {advertised_len}\r\nConnection: close\r\n\r\n");
+    if stream.write_all(header.as_bytes()).is_err() {
+        return;
+    }
+    let chunk = vec![0u8; partial_body];
+    if stream.write_all(&chunk).is_err() {
+        return;
+    }
+    let _ = stream.flush();
+
+    // SO_LINGER with a zero timeout turns the close into a RST rather than a
+    // graceful FIN. (std's set_linger is still unstable, so go through libc.)
+    let linger = libc::linger {
+        l_onoff: 1,
+        l_linger: 0,
+    };
+    // SAFETY: `stream` owns the fd for the duration of the call, and `linger`
+    // is a valid, correctly-sized SO_LINGER payload.
+    unsafe {
+        libc::setsockopt(
+            std::os::unix::io::AsRawFd::as_raw_fd(&stream),
+            libc::SOL_SOCKET,
+            libc::SO_LINGER,
+            std::ptr::addr_of!(linger).cast(),
+            std::mem::size_of::<libc::linger>() as libc::socklen_t,
+        );
+    }
+    drop(stream);
+}
+
+/// Mid-stream read pause for [`SlowSink`]: after `after_bytes` have been
+/// read, reading stops for `duration`.
+///
+/// With the client still pushing, the host socket buffers fill and the
+/// daemon's upload write hits `WouldBlock` — the no-backpressure-queue path
+/// (payload dropped, guest RTO recovers).
+#[derive(Clone, Copy)]
+pub struct SinkPause {
+    pub after_bytes: usize,
+    pub duration: Duration,
+}
+
+/// Raw-TCP upload sink: counts received bytes and closes once `expected`
+/// bytes have arrived (the client sees a clean EOF).
+///
+/// The receive side is the assertion surface for W2: exact byte count
+/// within a deadline, regardless of the in-guest client's own EOF-handling
+/// quirks.
+pub struct SlowSink {
+    port: u16,
+    received: Arc<AtomicUsize>,
+    done: Arc<AtomicBool>,
+    transfer: Arc<Mutex<Option<Duration>>>,
+}
+
+pub struct SinkReport {
+    pub received: usize,
+    /// Accept → the sink's read loop ending (byte count reached or client
+    /// hangup), measured sink-side. Includes any configured pause.
+    pub transfer: Duration,
+}
+
+impl SlowSink {
+    pub fn port(&self) -> u16 {
+        self.port
+    }
+
+    /// Blocks until the sink has received its expected byte count (or the
+    /// client hung up early), then returns the report. Errors on timeout
+    /// with the byte count reached so far.
+    pub fn wait_complete(&self, timeout: Duration) -> Result<SinkReport> {
+        let started = Instant::now();
+        while started.elapsed() < timeout {
+            if self.done.load(Ordering::Acquire) {
+                return Ok(SinkReport {
+                    received: self.received.load(Ordering::Acquire),
+                    transfer: self
+                        .transfer
+                        .lock()
+                        .expect("transfer poisoned")
+                        .unwrap_or_default(),
+                });
+            }
+            std::thread::sleep(Duration::from_millis(50));
+        }
+        bail!(
+            "sink did not complete within {timeout:?} ({} bytes received)",
+            self.received.load(Ordering::Acquire)
+        )
+    }
+}
+
+pub fn spawn_slow_sink(expected: usize, pause: Option<SinkPause>) -> Result<SlowSink> {
+    let listener = TcpListener::bind("127.0.0.1:0").context("binding slow sink")?;
+    let port = listener.local_addr()?.port();
+    let received = Arc::new(AtomicUsize::new(0));
+    let done = Arc::new(AtomicBool::new(false));
+    let transfer: Arc<Mutex<Option<Duration>>> = Arc::default();
+    let sink_received = Arc::clone(&received);
+    let sink_done = Arc::clone(&done);
+    let sink_transfer = Arc::clone(&transfer);
+    std::thread::spawn(move || {
+        for stream in listener.incoming() {
+            let Ok(mut stream) = stream else { continue };
+            let accepted = Instant::now();
+            let mut buf = vec![0u8; 64 * 1024];
+            let mut paused = false;
+            loop {
+                let count = sink_received.load(Ordering::Acquire);
+                if count >= expected {
+                    break;
+                }
+                if let Some(pause) = pause
+                    && !paused
+                    && count >= pause.after_bytes
+                {
+                    paused = true;
+                    std::thread::sleep(pause.duration);
+                }
+                match stream.read(&mut buf) {
+                    Ok(0) | Err(_) => break,
+                    Ok(n) => {
+                        sink_received.fetch_add(n, Ordering::AcqRel);
+                    }
+                }
+            }
+            drop(stream);
+            *sink_transfer.lock().expect("transfer poisoned") = Some(accepted.elapsed());
+            sink_done.store(true, Ordering::Release);
+        }
+    });
+    Ok(SlowSink {
+        port,
+        received,
+        done,
+        transfer,
+    })
+}
+
+/// Asserts no `ESTABLISHED` flow to `10.0.2.1:<port>` remains inside the
+/// container's netns.
+///
+/// Retries for `grace` so in-flight FIN teardown passes while a frozen flow
+/// — the 2026-07-19 incident shape — fails with the offending `netstat`
+/// lines. The exec rides vsock, not the datapath under test.
+pub fn assert_no_established_flows(
+    data_dir: &Path,
+    container: &str,
+    port: u16,
+    grace: Duration,
+) -> Result<()> {
+    let needle = format!("{GUEST_GATEWAY_IP}:{port}");
+    let started = Instant::now();
+    loop {
+        let out = docker_output(
+            data_dir,
+            &["exec", container, "netstat", "-tn"],
+            Duration::from_secs(20),
+        )
+        .context("netstat in workload container")?;
+        let zombies: Vec<&str> = out
+            .lines()
+            .filter(|l| l.contains("ESTABLISHED") && l.contains(&needle))
+            .collect();
+        if zombies.is_empty() {
+            return Ok(());
+        }
+        if started.elapsed() >= grace {
+            bail!(
+                "flows to {needle} still ESTABLISHED {:?} after the workload ended:\n{}",
+                started.elapsed(),
+                zombies.join("\n")
+            );
+        }
+        std::thread::sleep(Duration::from_secs(1));
+    }
+}
+
+/// Position marker into the daemon's JSON log (`<data_dir>/log/daemon.log`)
+/// for the workload suites' quiet-log assertion.
+///
+/// Normal traffic must not produce proxy-layer ERROR lines (the
+/// observability inverse of the fault plan, which asserts faults are loud).
+pub struct DaemonLogCursor {
+    path: PathBuf,
+    offset: u64,
+}
+
+pub fn daemon_log_cursor(data_dir: &Path) -> DaemonLogCursor {
+    let path = data_dir.join("log/daemon.log");
+    let offset = std::fs::metadata(&path).map_or(0, |m| m.len());
+    DaemonLogCursor { path, offset }
+}
+
+impl DaemonLogCursor {
+    /// Proxy-layer (`arcbox_net`/`splicetcp`/`arcbox_proxy`) ERROR lines
+    /// appended since the cursor was taken. Reads from the start if the log
+    /// rotated underneath the cursor.
+    pub fn proxy_errors(&self) -> Result<Vec<String>> {
+        let contents = std::fs::read(&self.path)
+            .with_context(|| format!("reading {}", self.path.display()))?;
+        let tail = if contents.len() as u64 >= self.offset {
+            &contents[self.offset as usize..]
+        } else {
+            contents.as_slice()
+        };
+        Ok(String::from_utf8_lossy(tail)
+            .lines()
+            .filter(|l| {
+                l.contains(r#""level":"ERROR""#)
+                    && [
+                        r#""target":"arcbox_net"#,
+                        r#""target":"splicetcp"#,
+                        r#""target":"arcbox_proxy"#,
+                    ]
+                    .iter()
+                    .any(|t| l.contains(t))
+            })
+            .map(str::to_owned)
+            .collect())
+    }
+}

--- a/tests/e2e/src/net_fixtures.rs
+++ b/tests/e2e/src/net_fixtures.rs
@@ -335,37 +335,75 @@ pub fn assert_no_established_flows(
 pub struct DaemonLogCursor {
     path: PathBuf,
     offset: u64,
+    /// Inode of the file the cursor was taken in — rotation renames the
+    /// file, so a changed inode (not a shorter length: the new file can
+    /// grow past the old offset) is the rotation signal.
+    ino: Option<u64>,
 }
 
 pub fn daemon_log_cursor(data_dir: &Path) -> DaemonLogCursor {
     let path = data_dir.join("log/daemon.log");
-    let offset = std::fs::metadata(&path).map_or(0, |m| m.len());
-    DaemonLogCursor { path, offset }
+    let meta = std::fs::metadata(&path).ok();
+    DaemonLogCursor {
+        offset: meta.as_ref().map_or(0, std::fs::Metadata::len),
+        ino: meta.map(|m| std::os::unix::fs::MetadataExt::ino(&m)),
+        path,
+    }
 }
 
 impl DaemonLogCursor {
     /// Proxy-layer (`arcbox_net`/`splicetcp`/`arcbox_proxy` and their
     /// submodules — the needles are prefixes) ERROR lines appended since
-    /// the cursor was taken. If the log rotated underneath the cursor, the
-    /// rotated generations (`daemon.log.N`, oldest first) are stitched
-    /// back in front of the current file so the cursor offset still lands
-    /// on the right byte and no window of the run escapes the scan.
+    /// the cursor was taken.
+    ///
+    /// Rotation is detected by inode identity, not length — after a
+    /// rotation the new `daemon.log` can grow past the old offset. When
+    /// the cursor's file has been renamed away, every generation from the
+    /// cursor's inode (`daemon.log.N`, oldest first) through the current
+    /// file is stitched into one stream so the offset still lands on the
+    /// cursor byte; if the cursor's generation already aged out of
+    /// retention, everything is scanned (over-matching boot-phase lines
+    /// beats silently dropping workload-phase ones).
     pub fn proxy_errors(&self) -> Result<Vec<String>> {
-        let mut contents = std::fs::read(&self.path)
+        let current = std::fs::read(&self.path)
             .with_context(|| format!("reading {}", self.path.display()))?;
-        if (contents.len() as u64) < self.offset {
-            let mut stitched = Vec::new();
+        let current_ino = std::fs::metadata(&self.path)
+            .ok()
+            .map(|m| std::os::unix::fs::MetadataExt::ino(&m));
+
+        let (contents, offset) = if self.ino.is_none() || current_ino == self.ino {
+            (current, self.offset)
+        } else {
+            // Oldest → newest: daemon.log.9 .. daemon.log.1, then current.
+            let mut generations: Vec<(Option<u64>, Vec<u8>)> = Vec::new();
             for n in (1..=9).rev() {
                 let rotated = self.path.with_extension(format!("log.{n}"));
                 if let Ok(bytes) = std::fs::read(&rotated) {
-                    stitched.extend_from_slice(&bytes);
+                    let ino = std::fs::metadata(&rotated)
+                        .ok()
+                        .map(|m| std::os::unix::fs::MetadataExt::ino(&m));
+                    generations.push((ino, bytes));
                 }
             }
-            stitched.append(&mut contents);
-            contents = stitched;
-        }
-        let tail = if contents.len() as u64 >= self.offset {
-            &contents[self.offset as usize..]
+            generations.push((current_ino, current));
+            let start = generations
+                .iter()
+                .position(|(ino, _)| *ino == self.ino)
+                .unwrap_or(0);
+            let offset = if generations[start].0 == self.ino {
+                self.offset
+            } else {
+                0
+            };
+            let stitched = generations
+                .drain(start..)
+                .flat_map(|(_, bytes)| bytes)
+                .collect();
+            (stitched, offset)
+        };
+
+        let tail = if contents.len() as u64 >= offset {
+            &contents[offset as usize..]
         } else {
             contents.as_slice()
         };
@@ -383,5 +421,63 @@ impl DaemonLogCursor {
             })
             .map(str::to_owned)
             .collect())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const ERR: &str = r#"{"level":"ERROR","fields":{"message":"x"},"target":"arcbox_net::darwin::datapath_loop::guest_tx"}"#;
+
+    fn write_log(dir: &Path, name: &str, lines: &[&str]) {
+        std::fs::write(dir.join("log").join(name), lines.join("\n") + "\n").unwrap();
+    }
+
+    #[test]
+    fn proxy_errors_sees_across_rotation_even_when_new_file_outgrows_offset() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(dir.path().join("log")).unwrap();
+        // Pre-cursor content, including an ERROR that must NOT be reported.
+        write_log(dir.path(), "daemon.log", &[ERR, "boot line"]);
+        let cursor = daemon_log_cursor(dir.path());
+
+        // Post-cursor ERROR lands in the same file, then the log rotates and
+        // the NEW current file grows well past the old cursor offset.
+        let mut f = std::fs::OpenOptions::new()
+            .append(true)
+            .open(dir.path().join("log/daemon.log"))
+            .unwrap();
+        std::io::Write::write_all(&mut f, format!("{ERR}\n").as_bytes()).unwrap();
+        drop(f);
+        std::fs::rename(
+            dir.path().join("log/daemon.log"),
+            dir.path().join("log/daemon.log.1"),
+        )
+        .unwrap();
+        let filler = vec!["info line"; 64].join("\n");
+        write_log(dir.path(), "daemon.log", &[&filler, ERR]);
+
+        let errors = cursor.proxy_errors().unwrap();
+        assert_eq!(
+            errors.len(),
+            2,
+            "one rotated-away post-cursor ERROR + one in the new file; \
+             the pre-cursor ERROR stays excluded: {errors:?}"
+        );
+    }
+
+    #[test]
+    fn proxy_errors_matches_module_qualified_targets() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(dir.path().join("log")).unwrap();
+        write_log(dir.path(), "daemon.log", &[]);
+        let cursor = daemon_log_cursor(dir.path());
+        write_log(dir.path(), "daemon.log", &[ERR]);
+        // Same inode (rewritten in place on most filesystems is not
+        // guaranteed, so re-take metadata semantics: the assertion is on
+        // needle matching, which is inode-independent).
+        let errors = cursor.proxy_errors().unwrap();
+        assert_eq!(errors.len(), 1, "submodule target must match: {errors:?}");
     }
 }

--- a/tests/e2e/src/net_fixtures.rs
+++ b/tests/e2e/src/net_fixtures.rs
@@ -62,6 +62,23 @@ impl BlobServer {
         self.timings.lock().expect("timings poisoned").clone()
     }
 
+    /// [`timings`](Self::timings), but waits up to `grace` for `expected`
+    /// recordings to land first. A recording is pushed only once the
+    /// fixture thread sees the client's TCP close, which races the
+    /// client command's own (vsock-delivered) completion — without the
+    /// wait, an exact-count check can miss the last flows despite every
+    /// client having succeeded.
+    pub fn wait_for_timings(&self, expected: usize, grace: Duration) -> Vec<Duration> {
+        let deadline = Instant::now() + grace;
+        loop {
+            let snapshot = self.timings();
+            if snapshot.len() >= expected || Instant::now() >= deadline {
+                return snapshot;
+            }
+            std::thread::sleep(Duration::from_millis(50));
+        }
+    }
+
     pub fn reset_timings(&self) {
         self.timings.lock().expect("timings poisoned").clear();
     }
@@ -327,12 +344,26 @@ pub fn daemon_log_cursor(data_dir: &Path) -> DaemonLogCursor {
 }
 
 impl DaemonLogCursor {
-    /// Proxy-layer (`arcbox_net`/`splicetcp`/`arcbox_proxy`) ERROR lines
-    /// appended since the cursor was taken. Reads from the start if the log
-    /// rotated underneath the cursor.
+    /// Proxy-layer (`arcbox_net`/`splicetcp`/`arcbox_proxy` and their
+    /// submodules — the needles are prefixes) ERROR lines appended since
+    /// the cursor was taken. If the log rotated underneath the cursor, the
+    /// rotated generations (`daemon.log.N`, oldest first) are stitched
+    /// back in front of the current file so the cursor offset still lands
+    /// on the right byte and no window of the run escapes the scan.
     pub fn proxy_errors(&self) -> Result<Vec<String>> {
-        let contents = std::fs::read(&self.path)
+        let mut contents = std::fs::read(&self.path)
             .with_context(|| format!("reading {}", self.path.display()))?;
+        if (contents.len() as u64) < self.offset {
+            let mut stitched = Vec::new();
+            for n in (1..=9).rev() {
+                let rotated = self.path.with_extension(format!("log.{n}"));
+                if let Ok(bytes) = std::fs::read(&rotated) {
+                    stitched.extend_from_slice(&bytes);
+                }
+            }
+            stitched.append(&mut contents);
+            contents = stitched;
+        }
         let tail = if contents.len() as u64 >= self.offset {
             &contents[self.offset as usize..]
         } else {

--- a/tests/e2e/src/scenario.rs
+++ b/tests/e2e/src/scenario.rs
@@ -1,0 +1,86 @@
+//! Shared daemon-boot scaffolding for datapath scenario tests.
+//!
+//! Used by `egress_throughput`, `network_fault`, and `network_workload`:
+//! build the release daemon, stage boot assets into an isolated data dir,
+//! spawn a VZ daemon on a free DNS port, run the scenario with metrics, and
+//! preserve the data dir on failure (or always with `KEEP_TEST_DIR`).
+
+use std::path::Path;
+use std::sync::Once;
+
+use anyhow::{Context, Result};
+
+use crate::boot_assets::{resolve_boot_version, stage_dev_boot_assets};
+use crate::daemon::{DaemonConfig, DaemonHandle};
+use crate::metrics::RunMetrics;
+
+static TRACING: Once = Once::new();
+
+pub fn init_tracing() {
+    TRACING.call_once(|| {
+        let _ = tracing_subscriber::fmt()
+            .with_env_filter(
+                tracing_subscriber::EnvFilter::try_from_default_env()
+                    .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info")),
+            )
+            .try_init();
+    });
+}
+
+pub fn run_vz_scenario(
+    name: &str,
+    scenario: impl FnOnce(&mut DaemonHandle, &Path, &mut RunMetrics) -> Result<()>,
+) -> Result<()> {
+    init_tracing();
+
+    let root = crate::repo_root();
+    if !crate::env_flag("SKIP_BUILD") {
+        let shell = xshell::Shell::new()?;
+        shell.change_dir(&root);
+        xshell::cmd!(shell, "cargo build --release -p arcbox-daemon").run()?;
+    }
+
+    let version = resolve_boot_version(&root)?;
+    let data_dir = tempfile::Builder::new()
+        .prefix(&format!("arcbox-{name}-"))
+        .tempdir()?;
+    stage_dev_boot_assets(&root, data_dir.path(), &version)?;
+
+    // Probe a free port for the daemon's host DNS service so this test can
+    // run alongside a developer's live daemon (fixed 5553) and parallel
+    // test runs. The bind is dropped before the daemon starts — a benign
+    // TOCTOU for a test harness.
+    let dns_port = std::net::UdpSocket::bind("127.0.0.1:0")
+        .and_then(|s| s.local_addr())
+        .context("probing a free DNS port")?
+        .port();
+
+    let mut daemon = DaemonHandle::spawn(DaemonConfig {
+        binary: root.join("target/release/arcbox-daemon"),
+        data_dir: data_dir.path().to_owned(),
+        args: vec![],
+        env: vec![
+            ("ARCBOX_BOOT_ASSET_VERSION".to_owned(), version),
+            ("ARCBOX_VM_BACKEND".to_owned(), "vz".to_owned()),
+            ("ARCBOX_DNS_PORT".to_owned(), dns_port.to_string()),
+            // Per-SYN datapath tracing: stall forensics need the gated-SYN,
+            // handshake-retransmit, and RST decisions, which log at debug.
+            (
+                "RUST_LOG".to_owned(),
+                "info,arcbox_net=debug,splicetcp=debug".to_owned(),
+            ),
+        ],
+    })?;
+
+    let mut metrics = RunMetrics::new(name, Some("vz"));
+    let result = scenario(&mut daemon, data_dir.path(), &mut metrics);
+    metrics.passed = result.is_ok();
+    if let Err(error) = metrics.write(Some(data_dir.path())) {
+        tracing::warn!("writing run metrics failed: {error:#}");
+    }
+    if result.is_err() || crate::env_flag("KEEP_TEST_DIR") {
+        let kept = data_dir.keep();
+        tracing::warn!(path = %kept.display(), "preserving test directory");
+    }
+    result
+}

--- a/tests/e2e/src/scenario.rs
+++ b/tests/e2e/src/scenario.rs
@@ -31,6 +31,21 @@ pub fn run_vz_scenario(
     name: &str,
     scenario: impl FnOnce(&mut DaemonHandle, &Path, &mut RunMetrics) -> Result<()>,
 ) -> Result<()> {
+    // Per-SYN datapath tracing: stall forensics need the gated-SYN,
+    // handshake-retransmit, and RST decisions, which log at debug.
+    run_vz_scenario_with_log(name, "info,arcbox_net=debug,splicetcp=debug", scenario)
+}
+
+/// [`run_vz_scenario`] with an explicit daemon `RUST_LOG`.
+///
+/// Workload tests pass a quieter filter: `splicetcp=debug` logs every
+/// classified frame, and at dup-ACK-storm rates the logging itself distorts
+/// the datapath under measurement (~6k lines/s observed).
+pub fn run_vz_scenario_with_log(
+    name: &str,
+    rust_log: &str,
+    scenario: impl FnOnce(&mut DaemonHandle, &Path, &mut RunMetrics) -> Result<()>,
+) -> Result<()> {
     init_tracing();
 
     let root = crate::repo_root();
@@ -63,12 +78,7 @@ pub fn run_vz_scenario(
             ("ARCBOX_BOOT_ASSET_VERSION".to_owned(), version),
             ("ARCBOX_VM_BACKEND".to_owned(), "vz".to_owned()),
             ("ARCBOX_DNS_PORT".to_owned(), dns_port.to_string()),
-            // Per-SYN datapath tracing: stall forensics need the gated-SYN,
-            // handshake-retransmit, and RST decisions, which log at debug.
-            (
-                "RUST_LOG".to_owned(),
-                "info,arcbox_net=debug,splicetcp=debug".to_owned(),
-            ),
+            ("RUST_LOG".to_owned(), rust_log.to_owned()),
         ],
     })?;
 

--- a/tests/e2e/tests/egress_throughput.rs
+++ b/tests/e2e/tests/egress_throughput.rs
@@ -23,19 +23,15 @@
 //! via the gateway-IP→loopback translation, which also regression-tests
 //! `host.docker.internal` staying direct under a configured system proxy.
 
-use std::io::{Read, Write};
-use std::net::TcpListener;
 use std::path::Path;
-use std::sync::Once;
 use std::time::Duration;
 
 use anyhow::{Context, Result};
-use arcbox_e2e::boot_assets::{resolve_boot_version, stage_dev_boot_assets};
-use arcbox_e2e::daemon::{DaemonConfig, DaemonHandle};
+use arcbox_e2e::daemon::DaemonHandle;
 use arcbox_e2e::docker::{docker_output, ensure_image};
 use arcbox_e2e::metrics::RunMetrics;
-
-static TRACING: Once = Once::new();
+use arcbox_e2e::net_fixtures::{GUEST_GATEWAY_IP, spawn_blob_server};
+use arcbox_e2e::scenario::run_vz_scenario;
 
 const READY_TIMEOUT: Duration = Duration::from_secs(180);
 /// Blob size per download. Large enough to sustain a multi-second transfer
@@ -47,123 +43,11 @@ const DOWNLOADS: usize = 6;
 /// Ceiling for one in-container download (loopback moves 64 MB in seconds;
 /// generous slack for slow CI hosts).
 const DOWNLOAD_TIMEOUT: Duration = Duration::from_secs(120);
-/// Gateway IP the guest sees on its primary (userspace-netstack) NIC.
-/// TcpBridge translates connections targeting it to host `127.0.0.1`
-/// (the `host.docker.internal` mechanism), which is exactly the datapath
-/// under test.
-const GUEST_GATEWAY_IP: &str = "10.0.2.1";
-
-fn init_tracing() {
-    TRACING.call_once(|| {
-        let _ = tracing_subscriber::fmt()
-            .with_env_filter(
-                tracing_subscriber::EnvFilter::try_from_default_env()
-                    .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info")),
-            )
-            .try_init();
-    });
-}
-
-/// Serves `BLOB_BYTES` of zeroes for any HTTP request, one thread per
-/// connection, until the process exits. Returns the bound port.
-fn spawn_blob_server() -> Result<u16> {
-    let listener = TcpListener::bind("127.0.0.1:0").context("binding blob server")?;
-    let port = listener.local_addr()?.port();
-    std::thread::spawn(move || {
-        for stream in listener.incoming() {
-            let Ok(mut stream) = stream else { continue };
-            std::thread::spawn(move || {
-                // Read the request until the header terminator (or EOF).
-                let mut buf = [0u8; 4096];
-                let mut request = Vec::new();
-                loop {
-                    match stream.read(&mut buf) {
-                        Ok(0) => return,
-                        Ok(n) => {
-                            request.extend_from_slice(&buf[..n]);
-                            if request.windows(4).any(|w| w == b"\r\n\r\n") {
-                                break;
-                            }
-                        }
-                        Err(_) => return,
-                    }
-                }
-                let header = format!(
-                    "HTTP/1.1 200 OK\r\nContent-Length: {BLOB_BYTES}\r\nConnection: close\r\n\r\n"
-                );
-                if stream.write_all(header.as_bytes()).is_err() {
-                    return;
-                }
-                let chunk = vec![0u8; 64 * 1024];
-                let mut remaining = BLOB_BYTES;
-                while remaining > 0 {
-                    let n = remaining.min(chunk.len());
-                    if stream.write_all(&chunk[..n]).is_err() {
-                        return;
-                    }
-                    remaining -= n;
-                }
-            });
-        }
-    });
-    Ok(port)
-}
 
 #[test]
 #[ignore = "boots a VZ System VM through a real daemon and drives sustained egress downloads"]
 fn sustained_egress_downloads_do_not_stall() -> Result<()> {
-    init_tracing();
-
-    let root = arcbox_e2e::repo_root();
-    if !arcbox_e2e::env_flag("SKIP_BUILD") {
-        let shell = xshell::Shell::new()?;
-        shell.change_dir(&root);
-        xshell::cmd!(shell, "cargo build --release -p arcbox-daemon").run()?;
-    }
-
-    let version = resolve_boot_version(&root)?;
-    let data_dir = tempfile::Builder::new()
-        .prefix("arcbox-egress-throughput-")
-        .tempdir()?;
-    stage_dev_boot_assets(&root, data_dir.path(), &version)?;
-
-    // Probe a free port for the daemon's host DNS service so this test can
-    // run alongside a developer's live daemon (fixed 5553) and parallel
-    // test runs. The bind is dropped before the daemon starts — a benign
-    // TOCTOU for a test harness.
-    let dns_port = std::net::UdpSocket::bind("127.0.0.1:0")
-        .and_then(|s| s.local_addr())
-        .context("probing a free DNS port")?
-        .port();
-
-    let mut daemon = DaemonHandle::spawn(DaemonConfig {
-        binary: root.join("target/release/arcbox-daemon"),
-        data_dir: data_dir.path().to_owned(),
-        args: vec![],
-        env: vec![
-            ("ARCBOX_BOOT_ASSET_VERSION".to_owned(), version),
-            ("ARCBOX_VM_BACKEND".to_owned(), "vz".to_owned()),
-            ("ARCBOX_DNS_PORT".to_owned(), dns_port.to_string()),
-            // Per-SYN datapath tracing: stall forensics need the gated-SYN,
-            // handshake-retransmit, and RST decisions, which log at debug.
-            (
-                "RUST_LOG".to_owned(),
-                "info,arcbox_net=debug,splicetcp=debug".to_owned(),
-            ),
-        ],
-    })?;
-
-    let mut metrics = RunMetrics::new("egress_throughput", Some("vz"));
-    let result = scenario(&mut daemon, data_dir.path(), &mut metrics);
-    metrics.passed = result.is_ok();
-    if let Err(error) = metrics.write(Some(data_dir.path())) {
-        tracing::warn!("writing run metrics failed: {error:#}");
-    }
-    if result.is_err() {
-        let kept = data_dir.keep();
-        tracing::warn!(path = %kept.display(), "preserving test directory");
-    }
-    result
+    run_vz_scenario("egress_throughput", scenario)
 }
 
 fn scenario(daemon: &mut DaemonHandle, data_dir: &Path, metrics: &mut RunMetrics) -> Result<()> {
@@ -172,8 +56,8 @@ fn scenario(daemon: &mut DaemonHandle, data_dir: &Path, metrics: &mut RunMetrics
     let image = std::env::var("ARCBOX_E2E_IMAGE").unwrap_or_else(|_| "alpine:latest".to_owned());
     metrics.time("docker_pull", || ensure_image(data_dir, &image))?;
 
-    let port = spawn_blob_server()?;
-    let url = format!("http://{GUEST_GATEWAY_IP}:{port}/blob");
+    let server = spawn_blob_server(BLOB_BYTES)?;
+    let url = format!("http://{GUEST_GATEWAY_IP}:{}/blob", server.port());
     tracing::info!(%url, blob_mb = BLOB_BYTES / (1024 * 1024), "blob server up");
 
     // ABX-423 experiment (ARCBOX_E2E_GUEST_SAMPLER): a persistent in-guest

--- a/tests/e2e/tests/network_fault.rs
+++ b/tests/e2e/tests/network_fault.rs
@@ -7,7 +7,7 @@
 //!
 //! This drives a real container through the full egress datapath
 //! (guest eth0 → classifier → TcpBridge → host socket via the
-//! `10.0.2.1`→loopback translation) to a host-local `ChaosOrigin` that
+//! `10.0.2.1`→loopback translation) to a host-local chaos origin that
 //! serves a partial body then **resets** its connection, and asserts
 //! **bounded failure**: the in-container client must observe the error within
 //! a deadline — never hang. `wget` is given no `-T`, so the only thing that
@@ -21,28 +21,16 @@
 //! need actual network-path interruption (firewall/route), which is the
 //! plan's exclusive Tier 3, not Tier 1.
 
-use std::io::{Read, Write};
-use std::net::{TcpListener, TcpStream};
-use std::os::unix::io::AsRawFd;
-use std::path::Path;
-use std::sync::Once;
 use std::time::{Duration, Instant};
 
-use anyhow::{Context, Result, bail};
-use arcbox_e2e::boot_assets::{resolve_boot_version, stage_dev_boot_assets};
-use arcbox_e2e::daemon::{DaemonConfig, DaemonHandle};
+use anyhow::{Result, bail};
 use arcbox_e2e::docker::{docker_output, ensure_image};
-use arcbox_e2e::metrics::RunMetrics;
-
-static TRACING: Once = Once::new();
+use arcbox_e2e::net_fixtures::{GUEST_GATEWAY_IP, spawn_chaos_origin};
+use arcbox_e2e::scenario::run_vz_scenario;
 
 const READY_TIMEOUT: Duration = Duration::from_secs(180);
-/// Gateway IP the guest sees on its primary NIC; TcpBridge translates
-/// connections to it into host `127.0.0.1` — the datapath the incident lived
-/// on. Same mechanism `egress_throughput` exercises.
-const GUEST_GATEWAY_IP: &str = "10.0.2.1";
-/// Body bytes ChaosOrigin sends before injecting the fault: enough that the
-/// transfer is genuinely mid-stream (past headers, into the body loop).
+/// Body bytes the chaos origin sends before injecting the fault: enough that
+/// the transfer is genuinely mid-stream (past headers, into the body loop).
 const PARTIAL_BODY_BYTES: usize = 64 * 1024;
 /// Advertised Content-Length — far larger than the partial body, so the
 /// client is still expecting data when the fault hits.
@@ -55,150 +43,20 @@ const FAILURE_DEADLINE: Duration = Duration::from_secs(30);
 /// failure) rather than the docker timeout (an opaque one).
 const DOCKER_TIMEOUT: Duration = Duration::from_secs(60);
 
-fn init_tracing() {
-    TRACING.call_once(|| {
-        let _ = tracing_subscriber::fmt()
-            .with_env_filter(
-                tracing_subscriber::EnvFilter::try_from_default_env()
-                    .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info")),
-            )
-            .try_init();
-    });
-}
-
-/// A host-local HTTP origin that serves a partial body then resets the
-/// connection on every request. Returns the bound port. One thread per
-/// connection; runs until the process exits.
-fn spawn_chaos_origin() -> Result<u16> {
-    let listener = TcpListener::bind("127.0.0.1:0").context("binding chaos origin")?;
-    let port = listener.local_addr()?.port();
-    std::thread::spawn(move || {
-        for stream in listener.incoming() {
-            let Ok(stream) = stream else { continue };
-            std::thread::spawn(move || serve_then_reset(stream));
-        }
-    });
-    Ok(port)
-}
-
-fn serve_then_reset(mut stream: TcpStream) {
-    // Drain the request headers (or bail on EOF).
-    let mut buf = [0u8; 4096];
-    let mut request = Vec::new();
-    loop {
-        match stream.read(&mut buf) {
-            Ok(0) => return,
-            Ok(n) => {
-                request.extend_from_slice(&buf[..n]);
-                if request.windows(4).any(|w| w == b"\r\n\r\n") {
-                    break;
-                }
-            }
-            Err(_) => return,
-        }
-    }
-
-    let header =
-        format!("HTTP/1.1 200 OK\r\nContent-Length: {ADVERTISED_LEN}\r\nConnection: close\r\n\r\n");
-    if stream.write_all(header.as_bytes()).is_err() {
-        return;
-    }
-    let chunk = vec![0u8; PARTIAL_BODY_BYTES];
-    if stream.write_all(&chunk).is_err() {
-        return;
-    }
-    let _ = stream.flush();
-
-    // SO_LINGER with a zero timeout turns the close into a RST rather than a
-    // graceful FIN — the daemon's upstream leg sees ECONNRESET mid-transfer.
-    // (std's set_linger is still unstable, so go through libc.)
-    let linger = libc::linger {
-        l_onoff: 1,
-        l_linger: 0,
-    };
-    // SAFETY: `stream` owns the fd for the duration of the call, and `linger`
-    // is a valid, correctly-sized SO_LINGER payload.
-    unsafe {
-        libc::setsockopt(
-            stream.as_raw_fd(),
-            libc::SOL_SOCKET,
-            libc::SO_LINGER,
-            std::ptr::addr_of!(linger).cast(),
-            std::mem::size_of::<libc::linger>() as libc::socklen_t,
-        );
-    }
-    drop(stream);
-}
-
-/// Boots a VZ System VM through a real daemon on an isolated data dir and
-/// runs `scenario`, mirroring the egress_throughput harness.
-fn run_scenario(
-    name: &str,
-    scenario: impl FnOnce(&mut DaemonHandle, &Path, &mut RunMetrics) -> Result<()>,
-) -> Result<()> {
-    init_tracing();
-
-    let root = arcbox_e2e::repo_root();
-    if !arcbox_e2e::env_flag("SKIP_BUILD") {
-        let shell = xshell::Shell::new()?;
-        shell.change_dir(&root);
-        xshell::cmd!(shell, "cargo build --release -p arcbox-daemon").run()?;
-    }
-
-    let version = resolve_boot_version(&root)?;
-    let data_dir = tempfile::Builder::new()
-        .prefix(&format!("arcbox-{name}-"))
-        .tempdir()?;
-    stage_dev_boot_assets(&root, data_dir.path(), &version)?;
-
-    // Free DNS port so this runs alongside a developer's live daemon (5553).
-    let dns_port = std::net::UdpSocket::bind("127.0.0.1:0")
-        .and_then(|s| s.local_addr())
-        .context("probing a free DNS port")?
-        .port();
-
-    let mut daemon = DaemonHandle::spawn(DaemonConfig {
-        binary: root.join("target/release/arcbox-daemon"),
-        data_dir: data_dir.path().to_owned(),
-        args: vec![],
-        env: vec![
-            ("ARCBOX_BOOT_ASSET_VERSION".to_owned(), version),
-            ("ARCBOX_VM_BACKEND".to_owned(), "vz".to_owned()),
-            ("ARCBOX_DNS_PORT".to_owned(), dns_port.to_string()),
-            (
-                "RUST_LOG".to_owned(),
-                "info,arcbox_net=debug,splicetcp=debug".to_owned(),
-            ),
-        ],
-    })?;
-
-    let mut metrics = RunMetrics::new(name, Some("vz"));
-    let result = scenario(&mut daemon, data_dir.path(), &mut metrics);
-    metrics.passed = result.is_ok();
-    if let Err(error) = metrics.write(Some(data_dir.path())) {
-        tracing::warn!("writing run metrics failed: {error:#}");
-    }
-    if result.is_err() {
-        let kept = data_dir.keep();
-        tracing::warn!(path = %kept.display(), "preserving test directory");
-    }
-    result
-}
-
 /// Peer RST mid-transfer must reach the container promptly. A container
-/// downloads from a ChaosOrigin that resets the connection after a partial
+/// downloads from a chaos origin that resets the connection after a partial
 /// body; `wget` is given no `-T`, so the bound must come from the datapath
 /// propagating the RST to the guest leg — the behavior the incident lacked.
 #[test]
 #[ignore = "boots a VZ System VM through a real daemon; run on the e2e runner"]
 fn net_upstream_rst_is_propagated_promptly() -> Result<()> {
-    run_scenario("network_fault_rst", |daemon, data_dir, metrics| {
+    run_vz_scenario("network_fault_rst", |daemon, data_dir, metrics| {
         metrics.time("daemon_ready", || daemon.wait_ready_blocking(READY_TIMEOUT))?;
         let image =
             std::env::var("ARCBOX_E2E_IMAGE").unwrap_or_else(|_| "alpine:latest".to_owned());
         metrics.time("docker_pull", || ensure_image(data_dir, &image))?;
 
-        let port = spawn_chaos_origin()?;
+        let port = spawn_chaos_origin(PARTIAL_BODY_BYTES, ADVERTISED_LEN)?;
         let url = format!("http://{GUEST_GATEWAY_IP}:{port}/blob");
         tracing::info!(%url, "chaos origin up");
 

--- a/tests/e2e/tests/network_workload.rs
+++ b/tests/e2e/tests/network_workload.rs
@@ -38,7 +38,7 @@ use arcbox_e2e::net_fixtures::{
     GUEST_GATEWAY_IP, SinkPause, assert_no_established_flows, daemon_log_cursor, spawn_blob_server,
     spawn_slow_sink,
 };
-use arcbox_e2e::scenario::run_vz_scenario;
+use arcbox_e2e::scenario::run_vz_scenario_with_log;
 
 const READY_TIMEOUT: Duration = Duration::from_secs(180);
 /// Long-lived workbench container: scenarios `docker exec` into it (vsock,
@@ -80,63 +80,70 @@ const SWEEP_GRACE: Duration = Duration::from_secs(10);
 #[test]
 #[ignore = "boots a VZ System VM through a real daemon; run on the e2e runner"]
 fn net_workload_egress_suite() -> Result<()> {
-    run_vz_scenario("network_workload", |daemon, data_dir, metrics| {
-        metrics.time("daemon_ready", || daemon.wait_ready_blocking(READY_TIMEOUT))?;
-        let image =
-            std::env::var("ARCBOX_E2E_IMAGE").unwrap_or_else(|_| "alpine:latest".to_owned());
-        metrics.time("docker_pull", || ensure_image(data_dir, &image))?;
-        docker_output(
-            data_dir,
-            &["run", "-d", "--name", BENCH, &image, "sleep", "2147483647"],
-            Duration::from_secs(60),
-        )
-        .context("starting workbench container")?;
+    // No splicetcp=debug: it logs every classified frame, and a dup-ACK
+    // storm turns that into ~6k lines/s of hot-path logging that distorts
+    // the very throughput under test.
+    run_vz_scenario_with_log(
+        "network_workload",
+        "info,arcbox_net=debug",
+        |daemon, data_dir, metrics| {
+            metrics.time("daemon_ready", || daemon.wait_ready_blocking(READY_TIMEOUT))?;
+            let image =
+                std::env::var("ARCBOX_E2E_IMAGE").unwrap_or_else(|_| "alpine:latest".to_owned());
+            metrics.time("docker_pull", || ensure_image(data_dir, &image))?;
+            docker_output(
+                data_dir,
+                &["run", "-d", "--name", BENCH, &image, "sleep", "2147483647"],
+                Duration::from_secs(60),
+            )
+            .context("starting workbench container")?;
 
-        // Taken after setup so image-pull noise is out of scope; covers
-        // every workload below.
-        let log = daemon_log_cursor(data_dir);
+            // Taken after setup so image-pull noise is out of scope; covers
+            // every workload below.
+            let log = daemon_log_cursor(data_dir);
 
-        let scenarios: [(&str, ScenarioFn); 5] = [
-            ("upload_steady", upload_steady),
-            ("upload_paused_reader", upload_paused_reader),
-            ("burst_single_container", burst_single_container),
-            ("burst_multi_container", burst_multi_container),
-            ("churn_sequential", churn_sequential),
-        ];
-        let mut failures = Vec::new();
-        for (name, scenario) in scenarios {
-            tracing::info!(scenario = name, "starting");
-            match scenario(data_dir, metrics, &image) {
-                Ok(()) => tracing::info!(scenario = name, "passed"),
-                Err(error) => {
-                    tracing::warn!(scenario = name, "failed: {error:#}");
-                    failures.push(format!("{name}: {error:#}"));
+            let scenarios: [(&str, ScenarioFn); 5] = [
+                ("upload_steady", upload_steady),
+                ("upload_paused_reader", upload_paused_reader),
+                ("burst_single_container", burst_single_container),
+                ("burst_multi_container", burst_multi_container),
+                ("churn_sequential", churn_sequential),
+            ];
+            let mut failures = Vec::new();
+            for (name, scenario) in scenarios {
+                tracing::info!(scenario = name, "starting");
+                match scenario(data_dir, metrics, &image) {
+                    Ok(()) => tracing::info!(scenario = name, "passed"),
+                    Err(error) => {
+                        tracing::warn!(scenario = name, "failed: {error:#}");
+                        failures.push(format!("{name}: {error:#}"));
+                    }
                 }
             }
-        }
 
-        match log.proxy_errors() {
-            Ok(errors) if !errors.is_empty() => failures.push(format!(
-                "quiet-log: {} proxy-layer ERROR line(s) during workloads:\n{}",
-                errors.len(),
-                errors.join("\n")
-            )),
-            Ok(_) => {}
-            Err(error) => failures.push(format!("quiet-log: unreadable: {error:#}")),
-        }
+            match log.proxy_errors() {
+                Ok(errors) if !errors.is_empty() => failures.push(format!(
+                    "quiet-log: {} proxy-layer ERROR line(s) during workloads:\n{}",
+                    errors.len(),
+                    errors.join("\n")
+                )),
+                Ok(_) => {}
+                Err(error) => failures.push(format!("quiet-log: unreadable: {error:#}")),
+            }
 
-        docker_ignore(data_dir, &["rm".into(), "-f".into(), BENCH.into()]);
-        if failures.is_empty() {
-            Ok(())
-        } else {
-            bail!(
-                "{} of {} workload checks failed:\n{}",
-                failures.len(),
-                scenarios.len() + 1,
-                failures.join("\n---\n")
-            )
-        }
-    })
+            docker_ignore(data_dir, &["rm".into(), "-f".into(), BENCH.into()]);
+            if failures.is_empty() {
+                Ok(())
+            } else {
+                bail!(
+                    "{} of {} workload checks failed:\n{}",
+                    failures.len(),
+                    scenarios.len() + 1,
+                    failures.join("\n---\n")
+                )
+            }
+        },
+    )
 }
 
 type ScenarioFn = fn(&Path, &mut RunMetrics, &str) -> Result<()>;
@@ -243,12 +250,17 @@ fn burst_single_container(data_dir: &Path, metrics: &mut RunMetrics, _image: &st
     let script = burst_script(&url, BURST_FLOWS);
 
     let started = Instant::now();
-    docker_output(
+    if let Err(error) = docker_output(
         data_dir,
         &["exec", BENCH, "sh", "-c", &script],
         BURST_DEADLINE + Duration::from_secs(60),
-    )
-    .context("burst_single: in-container burst")?;
+    ) {
+        bail!(
+            "burst_single: in-container burst failed ({} of {BURST_FLOWS} flows completed \
+             server-side): {error:#}",
+            server.timings().len()
+        );
+    }
     let elapsed = started.elapsed();
     metrics.record("burst_single_wall", elapsed.as_secs_f64());
     if elapsed >= BURST_DEADLINE {
@@ -295,7 +307,12 @@ fn burst_multi_container(data_dir: &Path, metrics: &mut RunMetrics, image: &str)
     for name in &names {
         docker_ignore(data_dir, &["rm".into(), "-f".into(), name.clone()]);
     }
-    result?;
+    if let Err(error) = result {
+        bail!(
+            "burst_multi failed ({} of {BURST_FLOWS} flows completed server-side): {error:#}",
+            server.timings().len()
+        );
+    }
     let elapsed = started.elapsed();
     metrics.record("burst_multi_wall", elapsed.as_secs_f64());
     if elapsed >= BURST_DEADLINE {
@@ -322,12 +339,17 @@ done"#
     );
 
     let started = Instant::now();
-    docker_output(
+    if let Err(error) = docker_output(
         data_dir,
         &["exec", BENCH, "sh", "-c", &script],
         CHURN_DEADLINE + Duration::from_secs(60),
-    )
-    .context("churn: in-container request loop")?;
+    ) {
+        bail!(
+            "churn: request loop failed ({} of {CHURN_REQUESTS} requests completed \
+             server-side): {error:#}",
+            server.timings().len()
+        );
+    }
     let elapsed = started.elapsed();
     metrics.record("churn_wall", elapsed.as_secs_f64());
     if elapsed >= CHURN_DEADLINE {

--- a/tests/e2e/tests/network_workload.rs
+++ b/tests/e2e/tests/network_workload.rs
@@ -266,7 +266,12 @@ fn burst_single_container(data_dir: &Path, metrics: &mut RunMetrics, _image: &st
     if elapsed >= BURST_DEADLINE {
         bail!("burst_single: took {elapsed:?} (>= {BURST_DEADLINE:?})");
     }
-    check_stragglers(&server.timings(), BURST_FLOWS, "burst_single", metrics)?;
+    check_stragglers(
+        &server.wait_for_timings(BURST_FLOWS, SWEEP_GRACE),
+        BURST_FLOWS,
+        "burst_single",
+        metrics,
+    )?;
     assert_no_established_flows(data_dir, BENCH, server.port(), SWEEP_GRACE)
 }
 
@@ -320,7 +325,12 @@ fn burst_multi_container(data_dir: &Path, metrics: &mut RunMetrics, image: &str)
     }
     // No netns sweep: the burst containers are gone, and with them their
     // guest-side flows; the quiet-log check still covers the daemon side.
-    check_stragglers(&server.timings(), BURST_FLOWS, "burst_multi", metrics)
+    check_stragglers(
+        &server.wait_for_timings(BURST_FLOWS, SWEEP_GRACE),
+        BURST_FLOWS,
+        "burst_multi",
+        metrics,
+    )
 }
 
 /// W4: 500 sequential fresh-connection requests. Flatness bound: the mean of
@@ -356,7 +366,7 @@ done"#
         bail!("churn: took {elapsed:?} (>= {CHURN_DEADLINE:?})");
     }
 
-    let timings = server.timings();
+    let timings = server.wait_for_timings(CHURN_REQUESTS, SWEEP_GRACE);
     if timings.len() != CHURN_REQUESTS {
         bail!(
             "churn: expected {CHURN_REQUESTS} completed requests, server saw {}",

--- a/tests/e2e/tests/network_workload.rs
+++ b/tests/e2e/tests/network_workload.rs
@@ -1,0 +1,391 @@
+//! Network-workload e2e — Phase 1 (W2–W4) of
+//! internal-docs/plans/network-workload-e2e.md.
+//!
+//! Where `network_fault` injects faults, this suite drives the datapath with
+//! the traffic shapes a developer generates daily and asserts they behave:
+//!
+//! - **W2 upload** (push/POST shape): 256 MiB guest→host, against a
+//!   normal reader and against one that pauses mid-stream. The upload
+//!   direction has *no* backpressure queue — a host-socket `WouldBlock`
+//!   silently drops the payload and recovery is the guest kernel's RTO
+//!   retransmit (`splicetcp/src/tcp_bridge/fast_path.rs`). The paused-reader
+//!   variant pins that behavior: slower is acceptable, wedged is a bug.
+//! - **W3 burst** (npm/cargo-install shape): 64 concurrent downloads, in one
+//!   container and spread across 8, with a straggler bound — one stalled
+//!   flow among many is exactly what per-flow zombie bugs look like.
+//! - **W4 churn** (apk/git-HTTP shape): 500 sequential fresh-connection
+//!   requests with a latency-flatness bound — per-flow state leaks show up
+//!   as monotonic slowdown.
+//!
+//! All scenarios share one booted daemon (boot dominates the runtime) and
+//! run inside a long-lived workbench container whose netns the zombie sweep
+//! inspects afterwards. Two cross-cutting assertions close each run: no
+//! `ESTABLISHED` flow to a fixture outlives its workload, and the daemon
+//! log stays free of proxy-layer ERRORs — workloads must be quiet, the
+//! observability inverse of the fault suite.
+//!
+//! Known issue: the VZ virtio-net freeze (ABX-420) intermittently stalls
+//! egress flows for ~60-75 s and can fail the burst/churn scenarios here,
+//! exactly as it does `egress_throughput`.
+
+use std::path::Path;
+use std::time::{Duration, Instant};
+
+use anyhow::{Context, Result, bail};
+use arcbox_e2e::docker::{docker_ignore, docker_output, ensure_image};
+use arcbox_e2e::metrics::RunMetrics;
+use arcbox_e2e::net_fixtures::{
+    GUEST_GATEWAY_IP, SinkPause, assert_no_established_flows, daemon_log_cursor, spawn_blob_server,
+    spawn_slow_sink,
+};
+use arcbox_e2e::scenario::run_vz_scenario;
+
+const READY_TIMEOUT: Duration = Duration::from_secs(180);
+/// Long-lived workbench container: scenarios `docker exec` into it (vsock,
+/// off-datapath), and its netns is where the zombie sweep looks.
+const BENCH: &str = "net-workload-bench";
+
+/// W2: upload volume. Large enough that buffers are a rounding error and the
+/// transfer is genuinely sustained.
+const UPLOAD_BYTES: usize = 256 * 1024 * 1024;
+const UPLOAD_MIB: usize = UPLOAD_BYTES / (1024 * 1024);
+/// W2 steady-reader deadline. Loopback-backed, so this is generous.
+const UPLOAD_DEADLINE: Duration = Duration::from_secs(180);
+/// W2 paused-reader deadline: steady bound + pause + RTO-backoff recovery
+/// slack (the guest's retransmit backoff can idle several seconds past the
+/// reader's resume).
+const UPLOAD_PAUSED_DEADLINE: Duration = Duration::from_secs(300);
+/// W2 paused variant: reader stops for this long once `PAUSE_AFTER_BYTES`
+/// have arrived, forcing the host socket buffers full and the daemon's
+/// upload write into `WouldBlock` while the client still pushes.
+const PAUSE_AFTER_BYTES: usize = 16 * 1024 * 1024;
+const PAUSE_DURATION: Duration = Duration::from_secs(5);
+
+/// W3: flows per burst and blob size per flow.
+const BURST_FLOWS: usize = 64;
+const BURST_BLOB_BYTES: usize = 4 * 1024 * 1024;
+const BURST_DEADLINE: Duration = Duration::from_secs(120);
+/// W3 multi-container variant: 8 containers × 8 flows = the same 64.
+const BURST_CONTAINERS: usize = 8;
+
+/// W4: request count and body size (dependency-index shape: small, many).
+const CHURN_REQUESTS: usize = 500;
+const CHURN_BLOB_BYTES: usize = 64 * 1024;
+const CHURN_DEADLINE: Duration = Duration::from_secs(180);
+
+/// Teardown grace for the zombie sweep: in-flight FIN handling passes, a
+/// frozen flow (the 2026-07-19 incident shape) fails.
+const SWEEP_GRACE: Duration = Duration::from_secs(10);
+
+#[test]
+#[ignore = "boots a VZ System VM through a real daemon; run on the e2e runner"]
+fn net_workload_egress_suite() -> Result<()> {
+    run_vz_scenario("network_workload", |daemon, data_dir, metrics| {
+        metrics.time("daemon_ready", || daemon.wait_ready_blocking(READY_TIMEOUT))?;
+        let image =
+            std::env::var("ARCBOX_E2E_IMAGE").unwrap_or_else(|_| "alpine:latest".to_owned());
+        metrics.time("docker_pull", || ensure_image(data_dir, &image))?;
+        docker_output(
+            data_dir,
+            &["run", "-d", "--name", BENCH, &image, "sleep", "2147483647"],
+            Duration::from_secs(60),
+        )
+        .context("starting workbench container")?;
+
+        // Taken after setup so image-pull noise is out of scope; covers
+        // every workload below.
+        let log = daemon_log_cursor(data_dir);
+
+        let scenarios: [(&str, ScenarioFn); 5] = [
+            ("upload_steady", upload_steady),
+            ("upload_paused_reader", upload_paused_reader),
+            ("burst_single_container", burst_single_container),
+            ("burst_multi_container", burst_multi_container),
+            ("churn_sequential", churn_sequential),
+        ];
+        let mut failures = Vec::new();
+        for (name, scenario) in scenarios {
+            tracing::info!(scenario = name, "starting");
+            match scenario(data_dir, metrics, &image) {
+                Ok(()) => tracing::info!(scenario = name, "passed"),
+                Err(error) => {
+                    tracing::warn!(scenario = name, "failed: {error:#}");
+                    failures.push(format!("{name}: {error:#}"));
+                }
+            }
+        }
+
+        match log.proxy_errors() {
+            Ok(errors) if !errors.is_empty() => failures.push(format!(
+                "quiet-log: {} proxy-layer ERROR line(s) during workloads:\n{}",
+                errors.len(),
+                errors.join("\n")
+            )),
+            Ok(_) => {}
+            Err(error) => failures.push(format!("quiet-log: unreadable: {error:#}")),
+        }
+
+        docker_ignore(data_dir, &["rm".into(), "-f".into(), BENCH.into()]);
+        if failures.is_empty() {
+            Ok(())
+        } else {
+            bail!(
+                "{} of {} workload checks failed:\n{}",
+                failures.len(),
+                scenarios.len() + 1,
+                failures.join("\n---\n")
+            )
+        }
+    })
+}
+
+type ScenarioFn = fn(&Path, &mut RunMetrics, &str) -> Result<()>;
+
+fn upload_steady(data_dir: &Path, metrics: &mut RunMetrics, image: &str) -> Result<()> {
+    upload(
+        data_dir,
+        metrics,
+        image,
+        "upload_steady",
+        None,
+        UPLOAD_DEADLINE,
+    )
+}
+
+fn upload_paused_reader(data_dir: &Path, metrics: &mut RunMetrics, image: &str) -> Result<()> {
+    upload(
+        data_dir,
+        metrics,
+        image,
+        "upload_paused",
+        Some(SinkPause {
+            after_bytes: PAUSE_AFTER_BYTES,
+            duration: PAUSE_DURATION,
+        }),
+        UPLOAD_PAUSED_DEADLINE,
+    )
+}
+
+/// W2: the workbench pipes `UPLOAD_BYTES` of zeroes into a raw TCP sink.
+/// The sink closing after the exact byte count is what ends the client, so
+/// the assertion surface is sink-side and immune to busybox `nc`'s
+/// stdin-EOF quirks. The kernel keeps delivering after a client-side close,
+/// so the sink count is authoritative either way.
+fn upload(
+    data_dir: &Path,
+    metrics: &mut RunMetrics,
+    _image: &str,
+    label: &str,
+    pause: Option<SinkPause>,
+    deadline: Duration,
+) -> Result<()> {
+    let sink = spawn_slow_sink(UPLOAD_BYTES, pause)?;
+    let command = format!(
+        "dd if=/dev/zero bs=1M count={UPLOAD_MIB} 2>/dev/null | nc {GUEST_GATEWAY_IP} {}",
+        sink.port()
+    );
+    let started = Instant::now();
+    docker_output(
+        data_dir,
+        &["exec", BENCH, "sh", "-c", &command],
+        deadline + Duration::from_secs(60),
+    )
+    .with_context(|| format!("{label}: in-container upload command"))?;
+    let report = sink.wait_complete(deadline.saturating_sub(started.elapsed()))?;
+    let elapsed = started.elapsed();
+    metrics.record(&format!("{label}_wall"), elapsed.as_secs_f64());
+    metrics.record(
+        &format!("{label}_sink_transfer"),
+        report.transfer.as_secs_f64(),
+    );
+    tracing::info!(
+        ?elapsed,
+        sink_transfer = ?report.transfer,
+        mib = UPLOAD_MIB,
+        "{label}: upload done"
+    );
+
+    if report.received != UPLOAD_BYTES {
+        bail!(
+            "{label}: sink received {} of {UPLOAD_BYTES} bytes",
+            report.received
+        );
+    }
+    if elapsed >= deadline {
+        bail!("{label}: upload took {elapsed:?} (>= {deadline:?})");
+    }
+    assert_no_established_flows(data_dir, BENCH, sink.port(), SWEEP_GRACE)
+}
+
+/// Burst worker script: `flows` parallel downloads, each failing the script
+/// if any flow fails. The per-flow `-T 60` turns a stalled flow into a
+/// clean nonzero exit instead of an opaque outer timeout.
+fn burst_script(url: &str, flows: usize) -> String {
+    format!(
+        r#"pids=""
+i=0
+while [ $i -lt {flows} ]; do
+  wget -q -O /dev/null -T 60 "{url}" &
+  pids="$pids $!"
+  i=$((i+1))
+done
+rc=0
+for p in $pids; do wait $p || rc=1; done
+exit $rc"#
+    )
+}
+
+/// W3a: 64 concurrent flows from one container. Server-side per-flow
+/// completion timings (accept → client close) feed the straggler bound.
+fn burst_single_container(data_dir: &Path, metrics: &mut RunMetrics, _image: &str) -> Result<()> {
+    let server = spawn_blob_server(BURST_BLOB_BYTES)?;
+    let url = format!("http://{GUEST_GATEWAY_IP}:{}/blob", server.port());
+    let script = burst_script(&url, BURST_FLOWS);
+
+    let started = Instant::now();
+    docker_output(
+        data_dir,
+        &["exec", BENCH, "sh", "-c", &script],
+        BURST_DEADLINE + Duration::from_secs(60),
+    )
+    .context("burst_single: in-container burst")?;
+    let elapsed = started.elapsed();
+    metrics.record("burst_single_wall", elapsed.as_secs_f64());
+    if elapsed >= BURST_DEADLINE {
+        bail!("burst_single: took {elapsed:?} (>= {BURST_DEADLINE:?})");
+    }
+    check_stragglers(&server.timings(), BURST_FLOWS, "burst_single", metrics)?;
+    assert_no_established_flows(data_dir, BENCH, server.port(), SWEEP_GRACE)
+}
+
+/// W3b: the same 64 flows spread across 8 containers — the multi-project
+/// shape, and container-count scaling for the daemon's flow table.
+fn burst_multi_container(data_dir: &Path, metrics: &mut RunMetrics, image: &str) -> Result<()> {
+    let server = spawn_blob_server(BURST_BLOB_BYTES)?;
+    let url = format!("http://{GUEST_GATEWAY_IP}:{}/blob", server.port());
+    let flows_each = BURST_FLOWS / BURST_CONTAINERS;
+    let script = burst_script(&url, flows_each);
+
+    let names: Vec<String> = (0..BURST_CONTAINERS)
+        .map(|i| format!("net-workload-burst-{i}"))
+        .collect();
+    let started = Instant::now();
+    let result = (|| {
+        for name in &names {
+            docker_output(
+                data_dir,
+                &["run", "-d", "--name", name, image, "sh", "-c", &script],
+                Duration::from_secs(60),
+            )
+            .with_context(|| format!("burst_multi: starting {name}"))?;
+        }
+        for name in &names {
+            let code = docker_output(
+                data_dir,
+                &["wait", name],
+                BURST_DEADLINE + Duration::from_secs(60),
+            )
+            .with_context(|| format!("burst_multi: waiting for {name}"))?;
+            if code.trim() != "0" {
+                bail!("burst_multi: {name} exited {}", code.trim());
+            }
+        }
+        Ok(())
+    })();
+    for name in &names {
+        docker_ignore(data_dir, &["rm".into(), "-f".into(), name.clone()]);
+    }
+    result?;
+    let elapsed = started.elapsed();
+    metrics.record("burst_multi_wall", elapsed.as_secs_f64());
+    if elapsed >= BURST_DEADLINE {
+        bail!("burst_multi: took {elapsed:?} (>= {BURST_DEADLINE:?})");
+    }
+    // No netns sweep: the burst containers are gone, and with them their
+    // guest-side flows; the quiet-log check still covers the daemon side.
+    check_stragglers(&server.timings(), BURST_FLOWS, "burst_multi", metrics)
+}
+
+/// W4: 500 sequential fresh-connection requests. Flatness bound: the mean of
+/// the last 50 server-side timings must stay within 3× the first 50 (with an
+/// absolute floor so a fast path isn't judged on noise) — per-flow state
+/// leaks show up as monotonic slowdown long before anything hard-fails.
+fn churn_sequential(data_dir: &Path, metrics: &mut RunMetrics, _image: &str) -> Result<()> {
+    let server = spawn_blob_server(CHURN_BLOB_BYTES)?;
+    let url = format!("http://{GUEST_GATEWAY_IP}:{}/blob", server.port());
+    let script = format!(
+        r#"i=0
+while [ $i -lt {CHURN_REQUESTS} ]; do
+  wget -q -O /dev/null -T 30 "{url}" || {{ echo "request $i failed" >&2; exit 1; }}
+  i=$((i+1))
+done"#
+    );
+
+    let started = Instant::now();
+    docker_output(
+        data_dir,
+        &["exec", BENCH, "sh", "-c", &script],
+        CHURN_DEADLINE + Duration::from_secs(60),
+    )
+    .context("churn: in-container request loop")?;
+    let elapsed = started.elapsed();
+    metrics.record("churn_wall", elapsed.as_secs_f64());
+    if elapsed >= CHURN_DEADLINE {
+        bail!("churn: took {elapsed:?} (>= {CHURN_DEADLINE:?})");
+    }
+
+    let timings = server.timings();
+    if timings.len() != CHURN_REQUESTS {
+        bail!(
+            "churn: expected {CHURN_REQUESTS} completed requests, server saw {}",
+            timings.len()
+        );
+    }
+    let decile = CHURN_REQUESTS / 10;
+    let mean =
+        |window: &[Duration]| -> Duration { window.iter().sum::<Duration>() / window.len() as u32 };
+    let first = mean(&timings[..decile]);
+    let last = mean(&timings[CHURN_REQUESTS - decile..]);
+    metrics.record("churn_first_decile_mean", first.as_secs_f64());
+    metrics.record("churn_last_decile_mean", last.as_secs_f64());
+    tracing::info!(?first, ?last, "churn decile means");
+    let bound = (first * 3).max(Duration::from_millis(500));
+    if last > bound {
+        bail!(
+            "churn: last-decile mean {last:?} exceeds flatness bound {bound:?} \
+             (first-decile mean {first:?}) — per-connection slowdown"
+        );
+    }
+    assert_no_established_flows(data_dir, BENCH, server.port(), SWEEP_GRACE)
+}
+
+/// Straggler bound: slowest flow ≤ max(4× median, 2 s). The absolute floor
+/// keeps sub-second medians from turning scheduler noise into a failure.
+fn check_stragglers(
+    timings: &[Duration],
+    expected: usize,
+    label: &str,
+    metrics: &mut RunMetrics,
+) -> Result<()> {
+    if timings.len() != expected {
+        bail!(
+            "{label}: expected {expected} completed flows, server saw {}",
+            timings.len()
+        );
+    }
+    let mut sorted = timings.to_vec();
+    sorted.sort();
+    let median = sorted[sorted.len() / 2];
+    let slowest = *sorted.last().expect("non-empty by the length check");
+    metrics.record(&format!("{label}_flow_median"), median.as_secs_f64());
+    metrics.record(&format!("{label}_flow_slowest"), slowest.as_secs_f64());
+    tracing::info!(?median, ?slowest, "{label} flow timings");
+    let bound = (median * 4).max(Duration::from_secs(2));
+    if slowest > bound {
+        bail!(
+            "{label}: slowest flow {slowest:?} exceeds straggler bound {bound:?} \
+             (median {median:?}) — a flow stalled while its peers completed"
+        );
+    }
+    Ok(())
+}


### PR DESCRIPTION
Follow-up to #447: the daily-developer-workload companion to the
network-fault plan, sharing its fixtures.

## What

`internal-docs/plans/network-workload-e2e.md` plus its Phase 1, locally
runnable today:

```
cargo test -p arcbox-e2e --test network_workload -- --ignored --nocapture
```

- **Fixture lift** (`src/net_fixtures.rs`): blob server and chaos origin move
  out of the test files; adds `SlowSink` (byte-counting upload reader with a
  scriptable mid-stream pause), the zombie-flow sweep, and a daemon-log
  cursor for the quiet-log assertion. `scenario::run_vz_scenario` extracts
  the boot scaffolding all three datapath tests now share.
- **`network_workload.rs`** — one booted daemon, five scenarios:
  W2 256 MiB uploads (steady + paused reader), W3 64-flow concurrency burst
  (single container + 8×8), W4 500-request fresh-connection churn. Behavioral
  bounds only (deadlines, straggler ≤ max(4×median, 2 s), last-decile ≤
  max(3×first-decile, 500 ms)); absolute numbers go to RunMetrics.

## What the first runs found (red by design until fixed)

All five scenarios fail against today's datapath, reproducibly, with **zero
proxy-layer WARN/ERROR lines**. Details with `file:line` in the plan's
findings section:

1. **Uploads silently lose data** — 256 MiB arrives 1.3–3.2 MB short while
   the client exits 0. `fast_path.rs` ACKs across `WouldBlock` holes
   (`is_new_data` checks only the segment *end* against `last_ack`), ACKs
   short writes in full (`Ok(_n)` ignored), and tears down on FIN
   unconditionally.
2. **Downloads have no loss recovery** — hardcoded `window: 65535`, guest
   rwnd never read, no retransmission, pure ACKs deliberately ignored → one
   guest-side window-overrun drop wedges the flow forever (18/64 and 5/64
   burst flows died on a 60 s read timeout; sequential churn degraded to
   ~2 s/request, 120 of 500 requests inside the 240 s ceiling).
   `guest-tx delivery counters` stayed lossless (`lossy_dropped=0`), placing
   the drops at guest TCP window overrun.
3. **Observer effect**: `splicetcp=debug` logs every classified frame
   (~6k lines/s during dup-ACK storms), so the workload suite runs the
   daemon at `info,arcbox_net=debug` via `run_vz_scenario_with_log`.

Per the fault plan's convention the strict assertions stay: this suite is the
regression net that flips green with the TcpBridge fixes (ACK only bytes
actually written in order; honor rwnd or retransmit; WARN on both loss
paths).

## Verification

Three full local runs (VZ backend, isolated daemon, alpine:latest): one with
debug logging, two without — failure numbers stable across runs; CI compiles
the suite but does not execute `#[ignore]` tests.