### PR TITLE
fix(net): TcpBridge sender-side correctness — lossless uploads, download retransmission, idle-loop latency

### DIFF
--- a/common/splicetcp/src/direct_rx.rs
+++ b/common/splicetcp/src/direct_rx.rs
@@ -257,9 +257,11 @@ async fn read_promoted_conn(
     let mut buf = vec![0u8; 32 * 1024];
     loop {
         // Never read (hence send) beyond the guest's advertised receive
-        // window — see `tcp_bridge::send_budget`. When window-limited, the
-        // guest's next ACK reopens the budget; 1 ms polling caps the wait
-        // while still sustaining multi-GB/s at an 8 MiB window. Unread
+        // window (capped at `HONORED_WINDOW_CAP`, 256 KiB) — see
+        // `tcp_bridge::send_budget`. When window-limited, the guest's next
+        // ACK reopens the budget; 1 ms polling bounds the wait, a
+        // ~256 MiB/s per-flow ceiling in that regime — ACK-driven wakeups
+        // take over long before it binds. Unread
         // bytes stay in the host socket buffer (kernel backpressure).
         let budget = crate::tcp_bridge::send_budget(
             conn.our_seq.load(Ordering::Relaxed),

--- a/common/splicetcp/src/direct_rx.rs
+++ b/common/splicetcp/src/direct_rx.rs
@@ -82,6 +82,12 @@ pub struct PromotedConn {
     /// Last ACK from guest (shared with the datapath via atomic so the
     /// inject thread and fast-path intercept stay in sync).
     pub last_ack: std::sync::Arc<std::sync::atomic::AtomicU32>,
+    /// Highest ACK the guest has sent for OUR stream, maintained by the
+    /// fast-path intercept. With `guest_window` it bounds how far ahead of
+    /// the guest this reader may send (`tcp_bridge::send_budget`).
+    pub guest_acked: std::sync::Arc<std::sync::atomic::AtomicU32>,
+    /// The guest's most recent advertised receive window, already scaled.
+    pub guest_window: std::sync::Arc<std::sync::atomic::AtomicU32>,
     /// Host→guest byte counter, present only when a flow observer is installed —
     /// `None` ⇒ no accounting and no per-connection allocation. The inline inject
     /// path reads the host socket outside the bridge's `poll_fast_path`, so this
@@ -183,6 +189,8 @@ impl ConnSink for TokioFrameConnSink {
             peer_mss,
             our_seq,
             last_ack,
+            guest_acked,
+            guest_window,
             down_bytes,
             gw_mac,
             guest_mac,
@@ -200,6 +208,8 @@ impl ConnSink for TokioFrameConnSink {
             guest_port,
             our_seq,
             last_ack,
+            guest_acked,
+            guest_window,
             down_bytes,
             dead,
             gw_mac,
@@ -223,6 +233,8 @@ struct AsyncPromotedConn {
     guest_port: u16,
     our_seq: Arc<std::sync::atomic::AtomicU32>,
     last_ack: Arc<std::sync::atomic::AtomicU32>,
+    guest_acked: Arc<std::sync::atomic::AtomicU32>,
+    guest_window: Arc<std::sync::atomic::AtomicU32>,
     down_bytes: Option<Arc<std::sync::atomic::AtomicU64>>,
     dead: Arc<std::sync::atomic::AtomicBool>,
     gw_mac: [u8; 6],
@@ -244,7 +256,22 @@ async fn read_promoted_conn(
 ) {
     let mut buf = vec![0u8; 32 * 1024];
     loop {
-        match stream.read(&mut buf).await {
+        // Never read (hence send) beyond the guest's advertised receive
+        // window — see `tcp_bridge::send_budget`. When window-limited, the
+        // guest's next ACK reopens the budget; 1 ms polling caps the wait
+        // while still sustaining multi-GB/s at an 8 MiB window. Unread
+        // bytes stay in the host socket buffer (kernel backpressure).
+        let budget = crate::tcp_bridge::send_budget(
+            conn.our_seq.load(Ordering::Relaxed),
+            conn.guest_acked.load(Ordering::Relaxed),
+            conn.guest_window.load(Ordering::Relaxed),
+        ) as usize;
+        if budget == 0 {
+            tokio::time::sleep(std::time::Duration::from_millis(1)).await;
+            continue;
+        }
+        let cap = budget.min(buf.len());
+        match stream.read(&mut buf[..cap]).await {
             Ok(0) => {
                 let seq_now = conn.our_seq.load(Ordering::Relaxed);
                 let fin = build_tcp_fin_frame(&TcpFrameParams {
@@ -300,8 +327,9 @@ async fn read_promoted_conn(
                 // let the guest mistake a truncated stream for a complete
                 // one — and never drop the upstream silently: without a
                 // guest-bound frame the guest socket stays ESTABLISHED
-                // forever (ABX-431).
-                tracing::debug!(
+                // forever (ABX-431). WARN: an abnormal flow termination must
+                // be visible in the daemon log (once per flow, no storm).
+                tracing::warn!(
                     "promoted conn {}:{} → {}:{} read error, RST to guest: {e}",
                     conn.remote_ip,
                     conn.remote_port,
@@ -363,6 +391,8 @@ mod tests {
             peer_mss: 1460,
             our_seq: our_seq.clone(),
             last_ack,
+            guest_acked: Arc::new(AtomicU32::new(1000)),
+            guest_window: Arc::new(AtomicU32::new(65535)),
             down_bytes: Some(down.clone()),
             gw_mac: [0x02, 0, 0, 0, 0, 1],
             guest_mac: [0x02, 0, 0, 0, 0, 2],
@@ -411,6 +441,8 @@ mod tests {
             peer_mss: 9000, // jumbo → the configured 4000 MTU drives sizing
             our_seq: our_seq.clone(),
             last_ack: Arc::new(AtomicU32::new(2000)),
+            guest_acked: Arc::new(AtomicU32::new(1000)),
+            guest_window: Arc::new(AtomicU32::new(65535)),
             down_bytes: None,
             gw_mac: [0x02, 0, 0, 0, 0, 1],
             guest_mac: [0x02, 0, 0, 0, 0, 2],
@@ -461,6 +493,8 @@ mod tests {
             peer_mss: 1460,
             our_seq: Arc::new(AtomicU32::new(1000)),
             last_ack: Arc::new(AtomicU32::new(2000)),
+            guest_acked: Arc::new(AtomicU32::new(1000)),
+            guest_window: Arc::new(AtomicU32::new(65535)),
             down_bytes: None,
             gw_mac: [0x02, 0, 0, 0, 0, 1],
             guest_mac: [0x02, 0, 0, 0, 0, 2],
@@ -520,6 +554,8 @@ mod tests {
             peer_mss: 1460,
             our_seq: Arc::new(AtomicU32::new(1000)),
             last_ack: Arc::new(AtomicU32::new(2000)),
+            guest_acked: Arc::new(AtomicU32::new(1000)),
+            guest_window: Arc::new(AtomicU32::new(65535)),
             down_bytes: None,
             gw_mac: [0x02, 0, 0, 0, 0, 1],
             guest_mac: [0x02, 0, 0, 0, 0, 2],
@@ -566,6 +602,8 @@ mod tests {
             peer_mss: 1460,
             our_seq: our_seq.clone(),
             last_ack: Arc::new(AtomicU32::new(2000)),
+            guest_acked: Arc::new(AtomicU32::new(1000)),
+            guest_window: Arc::new(AtomicU32::new(65535)),
             down_bytes: None,
             gw_mac: [0x02, 0, 0, 0, 0, 1],
             guest_mac: [0x02, 0, 0, 0, 0, 2],

--- a/common/splicetcp/src/direct_rx.rs
+++ b/common/splicetcp/src/direct_rx.rs
@@ -264,7 +264,9 @@ async fn read_promoted_conn(
         let budget = crate::tcp_bridge::send_budget(
             conn.our_seq.load(Ordering::Relaxed),
             conn.guest_acked.load(Ordering::Relaxed),
-            conn.guest_window.load(Ordering::Relaxed),
+            conn.guest_window
+                .load(Ordering::Relaxed)
+                .min(crate::tcp_bridge::HONORED_WINDOW_CAP),
         ) as usize;
         if budget == 0 {
             tokio::time::sleep(std::time::Duration::from_millis(1)).await;

--- a/common/splicetcp/src/tcp_bridge/fast_path.rs
+++ b/common/splicetcp/src/tcp_bridge/fast_path.rs
@@ -2,6 +2,72 @@ use super::{FastPathConn, GSO_SEGMENT_MSS, SynFlowKey, TCP_MIN_MSS, TcpBridge};
 use crate::ethernet::ETH_HEADER_LEN;
 use std::net::Ipv4Addr;
 
+/// Frame-construction context shared by the first-transmission and
+/// retransmission paths of `poll_fast_path`.
+struct FrameCtx {
+    large_frames: bool,
+    guest_mss: usize,
+    gw_mac: [u8; 6],
+    guest_mac: [u8; 6],
+}
+
+/// Builds guest-bound TCP data frames for `data` starting at `seq_start`:
+/// one GSO-style frame when enabled and the peer accepts 1460-byte
+/// segments, MSS-clamped segmentation otherwise (each emitted IP packet
+/// must fit every link on the path — e.g. a 1500-MTU docker bridge behind
+/// a 4000-MTU eth0). Does NOT advance `conn.our_seq` — retransmissions
+/// re-emit already-consumed sequence space.
+fn emit_data_frames(
+    ctx: &FrameCtx,
+    conn: &FastPathConn,
+    seq_start: u32,
+    data: &[u8],
+    frames: &mut Vec<Vec<u8>>,
+) {
+    if ctx.large_frames && conn.peer_mss >= GSO_SEGMENT_MSS {
+        let large = ETH_HEADER_LEN + 40 + data.len() > 1500;
+        let params = crate::ethernet::TcpFrameParams {
+            src_ip: conn.remote_ip,
+            dst_ip: conn.guest_ip,
+            src_port: conn.remote_port,
+            dst_port: conn.guest_port,
+            seq: seq_start,
+            ack: conn.last_ack,
+            window: 65535,
+            src_mac: ctx.gw_mac,
+            dst_mac: ctx.guest_mac,
+        };
+        frames.push(if large {
+            crate::ethernet::build_tcp_data_frame_partial_csum(&params, data)
+        } else {
+            crate::ethernet::build_tcp_data_frame(&params, data)
+        });
+        return;
+    }
+    let seg = ctx
+        .guest_mss
+        .min(usize::from(conn.peer_mss.max(TCP_MIN_MSS)));
+    let mut offset = 0;
+    while offset < data.len() {
+        let chunk_end = (offset + seg).min(data.len());
+        frames.push(crate::ethernet::build_tcp_data_frame(
+            &crate::ethernet::TcpFrameParams {
+                src_ip: conn.remote_ip,
+                dst_ip: conn.guest_ip,
+                src_port: conn.remote_port,
+                dst_port: conn.guest_port,
+                seq: seq_start.wrapping_add(offset as u32),
+                ack: conn.last_ack,
+                window: 65535,
+                src_mac: ctx.gw_mac,
+                dst_mac: ctx.guest_mac,
+            },
+            &data[offset..chunk_end],
+        ));
+        offset = chunk_end;
+    }
+}
+
 impl TcpBridge {
     /// Checks if a TCP frame matches a fast-path connection.
     ///
@@ -65,32 +131,6 @@ impl TcpBridge {
             return Some(Vec::new()); // Intercepted, no reply frame.
         }
 
-        // Download flow control: every guest frame carrying ACK updates our
-        // view of how much of OUR stream it received and how much receive
-        // window it advertises. Monotonic on the ack (a reordered frame
-        // must not regress it); the window rides along with the newest ack,
-        // and an equal ack still applies it (pure window updates).
-        if flags & 0x10 != 0 {
-            let guest_ack = u32::from_be_bytes([
-                frame[l4_start + 8],
-                frame[l4_start + 9],
-                frame[l4_start + 10],
-                frame[l4_start + 11],
-            ]);
-            let current = conn.guest_acked.load(std::sync::atomic::Ordering::Relaxed);
-            if guest_ack.wrapping_sub(current) < 0x8000_0000 {
-                let raw_win = u32::from(u16::from_be_bytes([
-                    frame[l4_start + 14],
-                    frame[l4_start + 15],
-                ]));
-                conn.guest_acked
-                    .store(guest_ack, std::sync::atomic::Ordering::Relaxed);
-                conn.guest_window.store(
-                    raw_win << conn.guest_wscale,
-                    std::sync::atomic::Ordering::Relaxed,
-                );
-            }
-        }
         // Extract payload using IPv4 total_length to exclude Ethernet padding.
         // NOTE: FIN check is deferred until after payload write — RFC 793
         // allows FIN segments to carry data.
@@ -100,6 +140,54 @@ impl TcpBridge {
         let payload_start = l4_start + tcp_data_offset;
         let payload_end = ip_end.min(frame.len());
         let payload_len = payload_end.saturating_sub(payload_start);
+
+        // Download flow control: every guest frame carrying ACK updates our
+        // view of how much of OUR stream it received and how much receive
+        // window it advertises. Monotonic on the ack (a reordered frame
+        // must not regress it); the window rides along with the newest ack,
+        // and an equal ack still applies it (pure window updates). A pure
+        // ACK repeating the same ack AND window while our data is in flight
+        // is a duplicate ACK — three of them mean the guest is missing a
+        // frame and triggers fast retransmit in `poll_fast_path`.
+        if flags & 0x10 != 0 {
+            let guest_ack = u32::from_be_bytes([
+                frame[l4_start + 8],
+                frame[l4_start + 9],
+                frame[l4_start + 10],
+                frame[l4_start + 11],
+            ]);
+            let current = conn.guest_acked.load(std::sync::atomic::Ordering::Relaxed);
+            let advance = guest_ack.wrapping_sub(current);
+            if advance < 0x8000_0000 {
+                let scaled_win = u32::from(u16::from_be_bytes([
+                    frame[l4_start + 14],
+                    frame[l4_start + 15],
+                ])) << conn.guest_wscale;
+                // FIN|SYN|RST all clear — `trailing_zeros` (clippy's
+                // suggestion) would obscure that this is a flag test.
+                let plain_ack = flags & (0x01 | 0x02 | 0x04) == 0;
+                if advance == 0
+                    && payload_len == 0
+                    && plain_ack
+                    && scaled_win == conn.guest_window.load(std::sync::atomic::Ordering::Relaxed)
+                {
+                    let sent = conn.our_seq.load(std::sync::atomic::Ordering::Relaxed);
+                    let in_flight = sent.wrapping_sub(guest_ack);
+                    if in_flight > 0 && in_flight < 0x8000_0000 {
+                        conn.dup_acks = conn.dup_acks.saturating_add(1);
+                        if conn.dup_acks >= 3 {
+                            conn.fast_retransmit = true;
+                        }
+                    }
+                } else if advance > 0 {
+                    conn.dup_acks = 0;
+                }
+                conn.guest_acked
+                    .store(guest_ack, std::sync::atomic::Ordering::Relaxed);
+                conn.guest_window
+                    .store(scaled_win, std::sync::atomic::Ordering::Relaxed);
+            }
+        }
 
         // Write payload to host stream (if any). The invariant that keeps
         // uploads lossless with no shim-side buffering: `last_ack` advances
@@ -253,6 +341,13 @@ impl TcpBridge {
         let mut to_remove = Vec::new();
         let guest_mac = self.fast_path_guest_mac.unwrap_or([0xFF; 6]);
         let gw_mac = self.fast_path_gateway_mac;
+        let ctx = FrameCtx {
+            large_frames: self.large_frames_enabled,
+            guest_mss: self.fast_path_guest_mss,
+            gw_mac,
+            guest_mac,
+        };
+        let now = std::time::Instant::now();
 
         for (key, conn) in &mut self.fast_path_conns {
             if conn.inline_owned {
@@ -273,23 +368,117 @@ impl TcpBridge {
                 }
                 continue;
             }
+            // ---- Sender-side loss recovery (runs for host_eof flows too:
+            // in-flight data and the FIN itself still need repair) ----
+            let acked = conn.guest_acked.load(std::sync::atomic::Ordering::Relaxed);
+            let drained = acked.wrapping_sub(conn.retransmit_seq);
+            if drained > 0 && drained < 0x8000_0000 {
+                // The guest ACKed more of our stream — release the buffered
+                // prefix and reset the loss-recovery clocks.
+                let n = (drained as usize).min(conn.retransmit_buf.len());
+                conn.retransmit_buf.drain(..n);
+                conn.retransmit_seq = acked;
+                conn.last_progress = now;
+                conn.rto = super::INITIAL_RTO;
+                conn.dup_acks = 0;
+            }
+            let sent = conn.our_seq.load(std::sync::atomic::Ordering::Relaxed);
+            let in_flight = sent.wrapping_sub(acked);
+            if in_flight > 0 && in_flight < 0x8000_0000 {
+                let timed_out = now.duration_since(conn.last_progress) >= conn.rto;
+                if conn.fast_retransmit || timed_out {
+                    // Resend everything from the guest's ack point: buffered
+                    // data first, then the FIN if it is still unACKed. The
+                    // path beyond guest eth0 (bridge → veth → container
+                    // backlog) drops under burst; without this a single
+                    // dropped frame wedges the flow forever.
+                    let offset = acked.wrapping_sub(conn.retransmit_seq) as usize;
+                    if offset < conn.retransmit_buf.len() {
+                        let data: Vec<u8> =
+                            conn.retransmit_buf.iter().skip(offset).copied().collect();
+                        emit_data_frames(&ctx, conn, acked, &data, &mut frames);
+                    }
+                    if let Some(fin_seq) = conn.fin_seq
+                        && sent.wrapping_sub(fin_seq) < 0x8000_0000
+                        && fin_seq.wrapping_sub(acked) < 0x8000_0000
+                    {
+                        frames.push(crate::ethernet::build_tcp_fin_frame(
+                            &crate::ethernet::TcpFrameParams {
+                                src_ip: conn.remote_ip,
+                                dst_ip: conn.guest_ip,
+                                src_port: conn.remote_port,
+                                dst_port: conn.guest_port,
+                                seq: fin_seq,
+                                ack: conn.last_ack,
+                                window: 65535,
+                                src_mac: gw_mac,
+                                dst_mac: guest_mac,
+                            },
+                        ));
+                    }
+                    tracing::debug!(
+                        "Fast path retransmit {}:{} → {}:{} ({} bytes from seq={acked}, cause={}, rto={:?})",
+                        conn.remote_ip,
+                        conn.remote_port,
+                        conn.guest_ip,
+                        conn.guest_port,
+                        in_flight,
+                        if conn.fast_retransmit {
+                            "dup-acks"
+                        } else {
+                            "rto"
+                        },
+                        conn.rto,
+                    );
+                    conn.fast_retransmit = false;
+                    conn.dup_acks = 0;
+                    conn.retransmits += 1;
+                    conn.last_progress = now;
+                    conn.rto = (conn.rto * 2).min(super::MAX_RTO);
+                }
+            } else {
+                // Nothing in flight — keep the RTO clock parked so the next
+                // send starts a fresh timeout window.
+                conn.last_progress = now;
+                conn.fast_retransmit = false;
+            }
+
             if conn.host_eof {
                 continue;
             }
 
             // Never read (hence send) beyond the guest's advertised receive
-            // window: within the budget the guest kernel guarantees
-            // buffering, and the local link is lossless, so no gap can form
-            // that this retransmission-free path could never repair. Unread
-            // bytes stay in the host socket buffer — kernel-level
-            // backpressure toward the upstream.
-            let budget = super::send_budget(
-                conn.our_seq.load(std::sync::atomic::Ordering::Relaxed),
-                conn.guest_acked.load(std::sync::atomic::Ordering::Relaxed),
-                conn.guest_window.load(std::sync::atomic::Ordering::Relaxed),
-            ) as usize;
+            // window (capped: the cap bounds both the retransmission buffer
+            // and the burst a flow can throw at the guest's bridge/veth
+            // backlog). Unread bytes stay in the host socket buffer —
+            // kernel-level backpressure toward the upstream.
+            let window = conn
+                .guest_window
+                .load(std::sync::atomic::Ordering::Relaxed)
+                .min(super::HONORED_WINDOW_CAP);
+            let budget = super::send_budget(sent, acked, window) as usize;
             if budget == 0 {
+                if !conn.window_stalled {
+                    conn.window_stalled = true;
+                    tracing::debug!(
+                        "Fast path window stall {}:{} → {}:{} (sent={sent}, acked={acked}, window={window})",
+                        conn.remote_ip,
+                        conn.remote_port,
+                        conn.guest_ip,
+                        conn.guest_port,
+                    );
+                }
                 continue;
+            }
+            if conn.window_stalled {
+                conn.window_stalled = false;
+                tracing::debug!(
+                    "Fast path window reopened {}:{} → {}:{} (sent={sent}, acked={acked}, window={window})",
+                    conn.remote_ip,
+                    conn.remote_port,
+                    conn.guest_ip,
+                    conn.guest_port,
+                );
             }
             let cap = budget.min(conn.read_buf.len());
 
@@ -311,7 +500,9 @@ impl TcpBridge {
                             src_mac: gw_mac,
                             dst_mac: guest_mac,
                         });
-                    // FIN consumes 1 SEQ.
+                    // FIN consumes 1 SEQ; remember its position so a lost
+                    // FIN is retransmitted like any other in-flight byte.
+                    conn.fin_seq = Some(seq_now);
                     conn.our_seq
                         .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
                     frames.push(fin);
@@ -321,72 +512,11 @@ impl TcpBridge {
                 }
                 Ok(n) => {
                     conn.down_bytes += n as u64;
-                    // Channel/inject path: send the entire read as one large
-                    // frame (the inject thread's GSO hint lets the guest
-                    // re-segment at MSS). Gated on the peer accepting the fixed
-                    // 1460-byte GSO segments; a smaller-MSS peer falls through to
-                    // the clamped segmentation below.
-                    let data = &conn.read_buf[..n];
-                    if self.large_frames_enabled && conn.peer_mss >= GSO_SEGMENT_MSS {
-                        let large = ETH_HEADER_LEN + 40 + data.len() > 1500;
-                        let seq_now = conn.our_seq.load(std::sync::atomic::Ordering::Relaxed);
-                        let params = crate::ethernet::TcpFrameParams {
-                            src_ip: conn.remote_ip,
-                            dst_ip: conn.guest_ip,
-                            src_port: conn.remote_port,
-                            dst_port: conn.guest_port,
-                            seq: seq_now,
-                            ack: conn.last_ack,
-                            window: 65535,
-                            src_mac: gw_mac,
-                            dst_mac: guest_mac,
-                        };
-                        let data_frame = if large {
-                            crate::ethernet::build_tcp_data_frame_partial_csum(&params, data)
-                        } else {
-                            crate::ethernet::build_tcp_data_frame(&params, data)
-                        };
-                        conn.our_seq
-                            .fetch_add(data.len() as u32, std::sync::atomic::Ordering::Relaxed);
-                        frames.push(data_frame);
-                    } else {
-                        // Non-GSO path: segment at the smaller of the configured
-                        // guest MSS and the MSS the peer advertised, so each
-                        // emitted IP packet fits every link on the path to the
-                        // guest endpoint — including a 1500-MTU docker bridge
-                        // behind a 4000-MTU eth0. Without the peer_mss bound a
-                        // container silently drops these oversized frames and
-                        // Host→VM stalls.
-                        let seg = self
-                            .fast_path_guest_mss
-                            .min(conn.peer_mss.max(TCP_MIN_MSS) as usize);
-                        let mut offset = 0;
-                        while offset < data.len() {
-                            let chunk_end = (offset + seg).min(data.len());
-                            let chunk = &data[offset..chunk_end];
-                            let seq_now = conn.our_seq.load(std::sync::atomic::Ordering::Relaxed);
-                            let data_frame = crate::ethernet::build_tcp_data_frame(
-                                &crate::ethernet::TcpFrameParams {
-                                    src_ip: conn.remote_ip,
-                                    dst_ip: conn.guest_ip,
-                                    src_port: conn.remote_port,
-                                    dst_port: conn.guest_port,
-                                    seq: seq_now,
-                                    ack: conn.last_ack,
-                                    window: 65535,
-                                    src_mac: gw_mac,
-                                    dst_mac: guest_mac,
-                                },
-                                chunk,
-                            );
-                            conn.our_seq.fetch_add(
-                                chunk.len() as u32,
-                                std::sync::atomic::Ordering::Relaxed,
-                            );
-                            frames.push(data_frame);
-                            offset = chunk_end;
-                        }
-                    }
+                    let seq_now = conn.our_seq.load(std::sync::atomic::Ordering::Relaxed);
+                    conn.retransmit_buf.extend(&conn.read_buf[..n]);
+                    emit_data_frames(&ctx, conn, seq_now, &conn.read_buf[..n], &mut frames);
+                    conn.our_seq
+                        .fetch_add(n as u32, std::sync::atomic::Ordering::Relaxed);
                 }
                 Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => {
                     // No data available — expected for non-blocking.
@@ -434,9 +564,10 @@ impl TcpBridge {
         let Some(conn) = self.fast_path_conns.remove(key) else {
             return;
         };
-        if conn.up_would_block + conn.up_short_writes + conn.up_out_of_order > 0 {
+        if conn.up_would_block + conn.up_short_writes + conn.up_out_of_order + conn.retransmits > 0
+        {
             tracing::debug!(
-                "Fast path close {}:{} → {}:{}: upload recovered via guest retransmit (would_block={}, short_writes={}, out_of_order={})",
+                "Fast path close {}:{} → {}:{}: loss recovery (up: would_block={}, short_writes={}, out_of_order={}; down: retransmits={})",
                 key.src_ip,
                 key.src_port,
                 key.dst_ip,
@@ -444,6 +575,7 @@ impl TcpBridge {
                 conn.up_would_block,
                 conn.up_short_writes,
                 conn.up_out_of_order,
+                conn.retransmits,
             );
         }
         if let Some(ref obs) = self.observer {
@@ -581,6 +713,15 @@ impl TcpBridge {
                 up_would_block: 0,
                 up_short_writes: 0,
                 up_out_of_order: 0,
+                window_stalled: false,
+                retransmit_buf: std::collections::VecDeque::new(),
+                retransmit_seq: our_seq,
+                last_progress: std::time::Instant::now(),
+                rto: super::INITIAL_RTO,
+                dup_acks: 0,
+                fast_retransmit: false,
+                fin_seq: None,
+                retransmits: 0,
                 read_buf: if inline_owned {
                     Vec::new()
                 } else {

--- a/common/splicetcp/src/tcp_bridge/fast_path.rs
+++ b/common/splicetcp/src/tcp_bridge/fast_path.rs
@@ -64,6 +64,33 @@ impl TcpBridge {
             self.close_fast_path(&key);
             return Some(Vec::new()); // Intercepted, no reply frame.
         }
+
+        // Download flow control: every guest frame carrying ACK updates our
+        // view of how much of OUR stream it received and how much receive
+        // window it advertises. Monotonic on the ack (a reordered frame
+        // must not regress it); the window rides along with the newest ack,
+        // and an equal ack still applies it (pure window updates).
+        if flags & 0x10 != 0 {
+            let guest_ack = u32::from_be_bytes([
+                frame[l4_start + 8],
+                frame[l4_start + 9],
+                frame[l4_start + 10],
+                frame[l4_start + 11],
+            ]);
+            let current = conn.guest_acked.load(std::sync::atomic::Ordering::Relaxed);
+            if guest_ack.wrapping_sub(current) < 0x8000_0000 {
+                let raw_win = u32::from(u16::from_be_bytes([
+                    frame[l4_start + 14],
+                    frame[l4_start + 15],
+                ]));
+                conn.guest_acked
+                    .store(guest_ack, std::sync::atomic::Ordering::Relaxed);
+                conn.guest_window.store(
+                    raw_win << conn.guest_wscale,
+                    std::sync::atomic::Ordering::Relaxed,
+                );
+            }
+        }
         // Extract payload using IPv4 total_length to exclude Ethernet padding.
         // NOTE: FIN check is deferred until after payload write — RFC 793
         // allows FIN segments to carry data.
@@ -74,99 +101,130 @@ impl TcpBridge {
         let payload_end = ip_end.min(frame.len());
         let payload_len = payload_end.saturating_sub(payload_start);
 
-        // Write payload to host stream (if any). Handle retransmits by
-        // only advancing `last_ack` when the segment extends previously
-        // acknowledged data; re-writing already-ACKed bytes to the host
-        // would corrupt the TLS stream on the peer side.
+        // Write payload to host stream (if any). The invariant that keeps
+        // uploads lossless with no shim-side buffering: `last_ack` advances
+        // ONLY over bytes actually written, in order, to the host socket.
+        // Everything else (out-of-order arrival, WouldBlock, the unwritten
+        // tail of a short write) stays un-ACKed, so the guest's own
+        // fast-retransmit/RTO machinery repairs the stream — dup-ACKs from
+        // the fall-through below are the recovery signal. ACKing past
+        // unwritten bytes is how uploads silently lost data (2026-07-19).
         if payload_len > 0 {
             use std::io::Write;
             let seq_end = guest_seq.wrapping_add(payload_len as u32);
-            // seq_end > conn.last_ack (wrap-safe) means "segment carries
-            // at least one new byte". Otherwise the entire segment is a
-            // retransmit of data we already ACKed.
-            let is_new_data = seq_end.wrapping_sub(conn.last_ack) > 0
-                && seq_end.wrapping_sub(conn.last_ack) < 0x8000_0000;
-            if is_new_data {
-                let payload = &frame[payload_start..payload_start + payload_len];
-                match conn.stream.write(payload) {
-                    Ok(_n) => {
-                        conn.up_bytes += payload_len as u64;
-                        conn.set_last_ack(seq_end);
-                        tracing::trace!(
-                            "Fast path TX: {src_ip}:{src_port}→{dst_ip}:{dst_port} wrote {payload_len} bytes"
-                        );
-                    }
-                    Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => {
-                        tracing::trace!(
-                            "Fast path TX: {src_ip}:{src_port}→{dst_ip}:{dst_port} WouldBlock"
-                        );
-                        return Some(Vec::new());
-                    }
-                    Err(e) if e.kind() == std::io::ErrorKind::BrokenPipe => {
-                        // Peer closed; inject already relayed FIN. ACK at
-                        // TCP layer so the guest stops retransmitting.
-                        conn.set_last_ack(seq_end);
-                        tracing::debug!(
-                            "Fast path TX: {src_ip}:{src_port}→{dst_ip}:{dst_port} Broken pipe, draining {payload_len} bytes"
-                        );
-                    }
-                    Err(e) => {
-                        tracing::warn!("Fast path TX write error, RST to guest: {e}");
-                        // Mirror the RX-error path: the host stream is dead,
-                        // so tear the guest side down with RST instead of
-                        // leaving it ESTABLISHED forever (ABX-431).
-                        let rst = crate::ethernet::build_tcp_rst_frame(
-                            &crate::ethernet::TcpFrameParams {
-                                src_ip: conn.remote_ip,
-                                dst_ip: conn.guest_ip,
-                                src_port: conn.remote_port,
-                                dst_port: conn.guest_port,
-                                seq: conn.our_seq.load(std::sync::atomic::Ordering::Relaxed),
-                                ack: conn.last_ack,
-                                window: 0,
-                                src_mac: self.fast_path_gateway_mac,
-                                dst_mac: self.fast_path_guest_mac.unwrap_or([0xFF; 6]),
-                            },
-                        );
-                        self.close_fast_path(&key);
-                        return Some(rst);
-                    }
-                }
-            } else {
-                // Duplicate/already-ACKed segment — skip write, re-ACK.
+            // Bytes this segment extends past our contiguous cursor.
+            let extends = seq_end.wrapping_sub(conn.last_ack);
+            if extends == 0 || extends >= 0x8000_0000 {
+                // Entirely at or behind the cursor — a retransmit of data
+                // we already ACKed. Skip the write, fall through to re-ACK.
                 tracing::trace!(
                     "Fast path TX: {src_ip}:{src_port}→{dst_ip}:{dst_port} retransmit (guest_seq={guest_seq}, last_ack={}, payload={payload_len})",
                     conn.last_ack
                 );
+            } else {
+                // Leading bytes already ACKed (partial retransmit overlap).
+                let overlap = conn.last_ack.wrapping_sub(guest_seq);
+                if overlap >= 0x8000_0000 {
+                    // guest_seq is ahead of the cursor: a hole precedes this
+                    // segment. Writing it would corrupt the byte stream and
+                    // ACKing it would bury the hole forever. Leave last_ack
+                    // alone — the ACK below is a dup-ACK, which is exactly
+                    // what makes the guest fast-retransmit the gap.
+                    conn.up_out_of_order += 1;
+                } else {
+                    let fresh = &frame[payload_start + overlap as usize..payload_end];
+                    match conn.stream.write(fresh) {
+                        Ok(n) => {
+                            conn.up_bytes += n as u64;
+                            conn.set_last_ack(conn.last_ack.wrapping_add(n as u32));
+                            if n < fresh.len() {
+                                // Host socket buffer filled mid-segment: ACK
+                                // covers only what was written; the guest
+                                // retransmits the tail.
+                                conn.up_short_writes += 1;
+                            }
+                        }
+                        Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => {
+                            // Nothing written, nothing ACKed. Fall through to
+                            // the dup-ACK so the guest fast-retransmits once
+                            // the socket drains, instead of waiting out RTO.
+                            conn.up_would_block += 1;
+                        }
+                        Err(e) if e.kind() == std::io::ErrorKind::BrokenPipe => {
+                            // Peer closed; inject already relayed FIN. ACK at
+                            // TCP layer so the guest stops retransmitting.
+                            conn.set_last_ack(seq_end);
+                            tracing::debug!(
+                                "Fast path TX: {src_ip}:{src_port}→{dst_ip}:{dst_port} Broken pipe, draining {payload_len} bytes"
+                            );
+                        }
+                        Err(e) => {
+                            tracing::warn!("Fast path TX write error, RST to guest: {e}");
+                            // Mirror the RX-error path: the host stream is dead,
+                            // so tear the guest side down with RST instead of
+                            // leaving it ESTABLISHED forever (ABX-431).
+                            let rst = crate::ethernet::build_tcp_rst_frame(
+                                &crate::ethernet::TcpFrameParams {
+                                    src_ip: conn.remote_ip,
+                                    dst_ip: conn.guest_ip,
+                                    src_port: conn.remote_port,
+                                    dst_port: conn.guest_port,
+                                    seq: conn.our_seq.load(std::sync::atomic::Ordering::Relaxed),
+                                    ack: conn.last_ack,
+                                    window: 0,
+                                    src_mac: self.fast_path_gateway_mac,
+                                    dst_mac: self.fast_path_guest_mac.unwrap_or([0xFF; 6]),
+                                },
+                            );
+                            self.close_fast_path(&key);
+                            return Some(rst);
+                        }
+                    }
+                }
             }
         }
 
-        // FIN handling — after payload has been forwarded to host.
+        // FIN handling — only once every byte before it has been written and
+        // ACKed. A FIN whose sequence position is beyond `last_ack` (data
+        // still missing, or its own payload only partially written) must not
+        // tear anything down: closing here would cut off the retransmissions
+        // that repair the gap, truncating the upload. The guest re-sends the
+        // gap and the FIN; until then it gets the dup-ACK below.
         if flags & 0x01 != 0 {
-            tracing::debug!("Fast path: FIN from guest {src_ip}:{src_port}→{dst_ip}:{dst_port}");
-            // FIN consumes 1 sequence number (in addition to any data bytes
-            // already accounted for above).
-            conn.set_last_ack(conn.last_ack.wrapping_add(1));
-            let guest_mac = self.fast_path_guest_mac.unwrap_or([0xFF; 6]);
-            let fin_ack = crate::ethernet::build_tcp_fin_frame(&crate::ethernet::TcpFrameParams {
-                src_ip: conn.remote_ip,
-                dst_ip: conn.guest_ip,
-                src_port: conn.remote_port,
-                dst_port: conn.guest_port,
-                seq: conn.our_seq.load(std::sync::atomic::Ordering::Relaxed),
-                ack: conn.last_ack,
-                window: 65535,
-                src_mac: self.fast_path_gateway_mac,
-                dst_mac: guest_mac,
-            });
-            self.close_fast_path(&key);
-            return Some(fin_ack);
+            let fin_seq = guest_seq.wrapping_add(payload_len as u32);
+            if fin_seq == conn.last_ack {
+                tracing::debug!(
+                    "Fast path: FIN from guest {src_ip}:{src_port}→{dst_ip}:{dst_port}"
+                );
+                // FIN consumes 1 sequence number (in addition to any data
+                // bytes already accounted for above).
+                conn.set_last_ack(conn.last_ack.wrapping_add(1));
+                let guest_mac = self.fast_path_guest_mac.unwrap_or([0xFF; 6]);
+                let fin_ack =
+                    crate::ethernet::build_tcp_fin_frame(&crate::ethernet::TcpFrameParams {
+                        src_ip: conn.remote_ip,
+                        dst_ip: conn.guest_ip,
+                        src_port: conn.remote_port,
+                        dst_port: conn.guest_port,
+                        seq: conn.our_seq.load(std::sync::atomic::Ordering::Relaxed),
+                        ack: conn.last_ack,
+                        window: 65535,
+                        src_mac: self.fast_path_gateway_mac,
+                        dst_mac: guest_mac,
+                    });
+                self.close_fast_path(&key);
+                return Some(fin_ack);
+            }
+            tracing::debug!(
+                "Fast path: FIN from guest {src_ip}:{src_port}→{dst_ip}:{dst_port} deferred (fin_seq={fin_seq}, last_ack={})",
+                conn.last_ack
+            );
         }
 
-        // Only ACK if the guest sent data — replying to a pure ACK
-        // would create a dup-ACK loop that triggers fast retransmits on
-        // the peer and tanks host→VM throughput.
-        if payload_len == 0 {
+        // Only ACK frames that carried payload or a deferred FIN — replying
+        // to a pure ACK would create a dup-ACK loop that triggers fast
+        // retransmits on the peer and tanks host→VM throughput.
+        if payload_len == 0 && flags & 0x01 == 0 {
             return Some(Vec::new());
         }
 
@@ -219,8 +277,24 @@ impl TcpBridge {
                 continue;
             }
 
+            // Never read (hence send) beyond the guest's advertised receive
+            // window: within the budget the guest kernel guarantees
+            // buffering, and the local link is lossless, so no gap can form
+            // that this retransmission-free path could never repair. Unread
+            // bytes stay in the host socket buffer — kernel-level
+            // backpressure toward the upstream.
+            let budget = super::send_budget(
+                conn.our_seq.load(std::sync::atomic::Ordering::Relaxed),
+                conn.guest_acked.load(std::sync::atomic::Ordering::Relaxed),
+                conn.guest_window.load(std::sync::atomic::Ordering::Relaxed),
+            ) as usize;
+            if budget == 0 {
+                continue;
+            }
+            let cap = budget.min(conn.read_buf.len());
+
             use std::io::Read;
-            match conn.stream.read(&mut conn.read_buf) {
+            match conn.stream.read(&mut conn.read_buf[..cap]) {
                 Ok(0) => {
                     // Host EOF — send FIN to guest.
                     conn.host_eof = true;
@@ -360,6 +434,18 @@ impl TcpBridge {
         let Some(conn) = self.fast_path_conns.remove(key) else {
             return;
         };
+        if conn.up_would_block + conn.up_short_writes + conn.up_out_of_order > 0 {
+            tracing::debug!(
+                "Fast path close {}:{} → {}:{}: upload recovered via guest retransmit (would_block={}, short_writes={}, out_of_order={})",
+                key.src_ip,
+                key.src_port,
+                key.dst_ip,
+                key.dst_port,
+                conn.up_would_block,
+                conn.up_short_writes,
+                conn.up_out_of_order,
+            );
+        }
         if let Some(ref obs) = self.observer {
             let down = conn.down_bytes
                 + conn
@@ -391,6 +477,7 @@ impl TcpBridge {
         our_seq: u32,
         last_ack: u32,
         peer_mss: u16,
+        peer_wscale: Option<u8>,
     ) {
         // Set non-blocking for polling in the event loop.
         stream.set_nonblocking(true).ok();
@@ -398,6 +485,12 @@ impl TcpBridge {
 
         let last_ack_atomic = std::sync::Arc::new(std::sync::atomic::AtomicU32::new(last_ack));
         let our_seq_atomic = std::sync::Arc::new(std::sync::atomic::AtomicU32::new(our_seq));
+        // Download flow-control state: nothing of ours is unACKed yet, and
+        // until the guest's first post-handshake ACK arrives we assume one
+        // unscaled window (SYN windows are unscaled per RFC 7323) — the
+        // first real ACK replaces it within a round trip.
+        let guest_acked = std::sync::Arc::new(std::sync::atomic::AtomicU32::new(our_seq));
+        let guest_window = std::sync::Arc::new(std::sync::atomic::AtomicU32::new(65535));
         // Shared host→guest byte counter — allocated ONLY when a flow observer is
         // installed, so an un-observed consumer (e.g. the VMM datapath) pays no
         // per-connection allocation or atomic. The inline inject thread increments
@@ -433,6 +526,8 @@ impl TcpBridge {
                         peer_mss,
                         our_seq: std::sync::Arc::clone(&our_seq_atomic),
                         last_ack: std::sync::Arc::clone(&last_ack_atomic),
+                        guest_acked: std::sync::Arc::clone(&guest_acked),
+                        guest_window: std::sync::Arc::clone(&guest_window),
                         down_bytes: down_shared.clone(),
                         gw_mac,
                         guest_mac,
@@ -480,6 +575,12 @@ impl TcpBridge {
                 remote_port: key.dst_port,
                 guest_port: key.src_port,
                 peer_mss,
+                guest_wscale: peer_wscale.unwrap_or(0),
+                guest_acked,
+                guest_window,
+                up_would_block: 0,
+                up_short_writes: 0,
+                up_out_of_order: 0,
                 read_buf: if inline_owned {
                     Vec::new()
                 } else {

--- a/common/splicetcp/src/tcp_bridge/fast_path.rs
+++ b/common/splicetcp/src/tcp_bridge/fast_path.rs
@@ -158,7 +158,15 @@ impl TcpBridge {
             ]);
             let current = conn.guest_acked.load(std::sync::atomic::Ordering::Relaxed);
             let advance = guest_ack.wrapping_sub(current);
-            if advance < 0x8000_0000 {
+            // Reject an ACK beyond what we actually sent (RFC 793: an ACK
+            // must not cover data past SND.NXT). Accepting one would let
+            // poll_fast_path drain retransmit_buf past real in-flight bytes
+            // and move retransmit_seq beyond our_seq, so those bytes could
+            // never be retransmitted — the flow would truncate or wedge.
+            let sent = conn.our_seq.load(std::sync::atomic::Ordering::Relaxed);
+            let beyond_sent =
+                guest_ack.wrapping_sub(sent) != 0 && guest_ack.wrapping_sub(sent) < 0x8000_0000;
+            if advance < 0x8000_0000 && !beyond_sent {
                 let scaled_win = u32::from(u16::from_be_bytes([
                     frame[l4_start + 14],
                     frame[l4_start + 15],
@@ -171,7 +179,6 @@ impl TcpBridge {
                     && plain_ack
                     && scaled_win == conn.guest_window.load(std::sync::atomic::Ordering::Relaxed)
                 {
-                    let sent = conn.our_seq.load(std::sync::atomic::Ordering::Relaxed);
                     let in_flight = sent.wrapping_sub(guest_ack);
                     if in_flight > 0 && in_flight < 0x8000_0000 {
                         conn.dup_acks = conn.dup_acks.saturating_add(1);

--- a/common/splicetcp/src/tcp_bridge/handshake.rs
+++ b/common/splicetcp/src/tcp_bridge/handshake.rs
@@ -415,10 +415,11 @@ impl TcpBridge {
                 let our_seq = conn.our_isn.wrapping_add(1);
                 let last_ack = conn.peer_isn.wrapping_add(1);
                 let peer_mss = conn.peer_mss;
+                let peer_wscale = conn.peer_wscale;
                 let Some(stream) = conn.host_stream else {
                     return Some(Vec::new());
                 };
-                self.promote_to_fast_path(key, stream, our_seq, last_ack, peer_mss);
+                self.promote_to_fast_path(key, stream, our_seq, last_ack, peer_mss, peer_wscale);
                 Some(Vec::new())
             }
             HandshakeRole::ActiveOpen => {
@@ -471,10 +472,11 @@ impl TcpBridge {
                     });
 
                 let peer_mss = conn.peer_mss;
+                let peer_wscale = conn.peer_wscale;
                 let Some(stream) = conn.host_stream else {
                     return Some(vec![ack_frame]);
                 };
-                self.promote_to_fast_path(key, stream, our_seq, last_ack, peer_mss);
+                self.promote_to_fast_path(key, stream, our_seq, last_ack, peer_mss, peer_wscale);
                 Some(vec![ack_frame])
             }
         }

--- a/common/splicetcp/src/tcp_bridge/handshake.rs
+++ b/common/splicetcp/src/tcp_bridge/handshake.rs
@@ -109,6 +109,22 @@ impl TcpBridge {
             dst_port,
             domain,
         });
+        // Wake the datapath loop the moment the connect resolves: on an
+        // idle loop nothing else fires until the next guest frame or the
+        // 1 s timer tick, and that tick otherwise dominates every fresh
+        // connection's latency (sequential fetches ran at ~2 s/request).
+        let result_rx = if let Some(waker) = &self.handshake_waker {
+            let waker = std::sync::Arc::clone(waker);
+            let (tx, rx) = oneshot::channel();
+            tokio::spawn(async move {
+                let value = result_rx.await.unwrap_or(None);
+                let _ = tx.send(value);
+                waker.notify_one();
+            });
+            rx
+        } else {
+            result_rx
+        };
 
         let our_isn = next_isn();
         self.handshake_conns.insert(

--- a/common/splicetcp/src/tcp_bridge/mod.rs
+++ b/common/splicetcp/src/tcp_bridge/mod.rs
@@ -19,12 +19,16 @@
 //!   contiguous cursor stays un-ACKed and the guest sees dup-ACKs — its
 //!   own fast-retransmit/RTO machinery repairs the stream. ACKing past
 //!   unwritten bytes is how uploads silently lost data.
-//! - **Download (host→guest)**: sends never exceed the receive window the
-//!   guest advertises (tracked from its ACKs, scaled by its SYN wscale).
-//!   Within that window the guest kernel guarantees buffering, and the
-//!   local L2 link is lossless by contract — so no gap can form that the
-//!   (retransmission-free) shim could never repair. Overrunning the window
-//!   is how concurrent downloads wedged permanently.
+//! - **Download (host→guest)**: the shim is the *sender-side* TCP for this
+//!   direction, and the path beyond guest `eth0` (bridge → veth → container
+//!   netns backlog) drops frames under burst like any real network — so it
+//!   keeps the two sender duties a real stack cannot delegate: it never
+//!   sends beyond the guest's advertised receive window (tracked from its
+//!   ACKs, scaled by its SYN wscale, capped at [`HONORED_WINDOW_CAP`]),
+//!   and it buffers in-flight bytes for retransmission (triple-dup-ACK
+//!   fast retransmit, RTO backoff otherwise). Without these, one dropped
+//!   frame wedged a flow forever and window overrun made that routine
+//!   under concurrency.
 
 use std::collections::HashMap;
 use std::net::Ipv4Addr;
@@ -88,6 +92,18 @@ const SHIM_MSS: u16 = 1460;
 /// IPv4 minimum (576-byte MTU − 40), so it is always safe to send; it also
 /// guards against a missing or malformed MSS option collapsing segments to 0.
 pub(crate) const TCP_MIN_MSS: u16 = 536;
+
+/// Cap on the guest receive window the download path honors. Bounds both
+/// the per-flow retransmission buffer and the burst a single flow can
+/// inject toward the guest's bridge/veth backlog. 256 KiB sustains
+/// multi-GB/s at sub-millisecond local RTTs.
+pub(crate) const HONORED_WINDOW_CAP: u32 = 256 * 1024;
+
+/// Initial retransmission timeout for unACKed download bytes; doubles per
+/// retransmission up to [`MAX_RTO`]. Local RTTs are sub-millisecond, so
+/// 200 ms only ever fires on actual loss, not reordering.
+pub(crate) const INITIAL_RTO: std::time::Duration = std::time::Duration::from_millis(200);
+pub(crate) const MAX_RTO: std::time::Duration = std::time::Duration::from_secs(2);
 
 /// Fixed segment size the GSO/inline injection paths let the guest re-segment
 /// at (the `gso_size` stamped by `arcbox-net-inject`'s `write_inline_headers`
@@ -215,6 +231,11 @@ pub struct TcpBridge {
     /// TCP handshakes being synthesized. Each entry is promoted to
     /// `fast_path_conns` once the 3-way completes.
     handshake_conns: HashMap<SynFlowKey, HandshakeConn>,
+    /// Notified when a pending handshake's async host connect resolves, so
+    /// the datapath loop can emit the SYN-ACK immediately instead of
+    /// waiting for the next guest frame or timer tick (an idle loop
+    /// otherwise adds up to a full tick of connect latency).
+    handshake_waker: Option<std::sync::Arc<tokio::sync::Notify>>,
 }
 
 /// A TCP connection promoted to the fast path — bypasses any TCP state
@@ -264,6 +285,31 @@ pub(super) struct FastPathConn {
     up_would_block: u64,
     up_short_writes: u64,
     up_out_of_order: u64,
+    /// True while the flow sits at a zero send budget — transition
+    /// logging only, so a stuck window is visible in the daemon log
+    /// without per-poll noise.
+    window_stalled: bool,
+    /// Sender-side retransmission buffer: every download byte from
+    /// `retransmit_seq` (== the last drained `guest_acked`) up to `our_seq`,
+    /// bounded by [`HONORED_WINDOW_CAP`]. Non-inline flows only.
+    retransmit_buf: std::collections::VecDeque<u8>,
+    /// Sequence number of `retransmit_buf[0]`.
+    retransmit_seq: u32,
+    /// Last time `guest_acked` advanced (RTO clock, armed while in flight).
+    last_progress: StdInstant,
+    /// Current retransmission timeout (backs off per retransmission).
+    rto: std::time::Duration,
+    /// Consecutive duplicate ACKs at the same `guest_acked` while data is
+    /// in flight — three trigger fast retransmit.
+    dup_acks: u8,
+    /// Set by the intercept when the dup-ACK threshold fires; consumed by
+    /// the next poll pass.
+    fast_retransmit: bool,
+    /// Sequence number of our FIN when `host_eof` (the FIN needs
+    /// retransmission too — a lost FIN wedges the close the same way).
+    fin_seq: Option<u32>,
+    /// Download retransmissions performed (diagnostics, logged at close).
+    retransmits: u64,
     /// Read buffer for host → guest data (reused across polls).
     read_buf: Vec<u8>,
     /// True if host stream has reached EOF.
@@ -332,7 +378,15 @@ impl TcpBridge {
             conn_sink: None,
             observer: None,
             handshake_conns: HashMap::new(),
+            handshake_waker: None,
         }
+    }
+
+    /// Installs a waker notified whenever an async host connect for a
+    /// pending handshake resolves. Must be set from within a Tokio runtime
+    /// context (`handle_outbound_syn` spawns the forwarding task).
+    pub fn set_handshake_waker(&mut self, waker: std::sync::Arc<tokio::sync::Notify>) {
+        self.handshake_waker = Some(waker);
     }
 
     /// Enables large frame mode (no MSS segmentation).

--- a/common/splicetcp/src/tcp_bridge/mod.rs
+++ b/common/splicetcp/src/tcp_bridge/mod.rs
@@ -10,7 +10,21 @@
 //! No congestion control, retransmission, reordering, or TIME_WAIT state
 //! is implemented here — both endpoints (guest Linux kernel, host macOS
 //! kernel) own their own TCP stacks end-to-end; any state machine work in
-//! the middle would be duplication.
+//! the middle would be duplication. Two sender-side disciplines make that
+//! stance sound (2026-07-19, found by the network-workload e2e):
+//!
+//! - **Upload (guest→host)**: a segment is ACKed only for the bytes
+//!   actually written, in order, to the host socket. Anything the socket
+//!   didn't take (`WouldBlock`, short write) or that arrived beyond the
+//!   contiguous cursor stays un-ACKed and the guest sees dup-ACKs — its
+//!   own fast-retransmit/RTO machinery repairs the stream. ACKing past
+//!   unwritten bytes is how uploads silently lost data.
+//! - **Download (host→guest)**: sends never exceed the receive window the
+//!   guest advertises (tracked from its ACKs, scaled by its SYN wscale).
+//!   Within that window the guest kernel guarantees buffering, and the
+//!   local L2 link is lossless by contract — so no gap can form that the
+//!   (retransmission-free) shim could never repair. Overrunning the window
+//!   is how concurrent downloads wedged permanently.
 
 use std::collections::HashMap;
 use std::net::Ipv4Addr;
@@ -232,6 +246,24 @@ pub(super) struct FastPathConn {
     /// path the guest can forward them over (e.g. a 1500-MTU docker bridge
     /// behind a 4000-MTU `eth0`). See `poll_fast_path`.
     peer_mss: u16,
+    /// Window-scale shift the guest advertised in its SYN / SYN-ACK
+    /// (0 when it offered none — scaling is then off per RFC 7323).
+    guest_wscale: u8,
+    /// Highest ACK the guest has sent for OUR stream. Shared with the
+    /// inline inject thread — the "sent and acknowledged" cursor of
+    /// download flow control.
+    guest_acked: std::sync::Arc<std::sync::atomic::AtomicU32>,
+    /// Receive window from the guest's most recent ACK, already scaled by
+    /// `guest_wscale`. Together with `guest_acked` it bounds host→guest
+    /// in-flight bytes (see [`send_budget`]).
+    guest_window: std::sync::Arc<std::sync::atomic::AtomicU32>,
+    /// Upload-path recovery counters (reported at flow close): segments
+    /// the host socket wouldn't take, segments it took partially, and
+    /// segments that arrived beyond the contiguous cursor. All three
+    /// recover via guest retransmission; they quantify backpressure, not loss.
+    up_would_block: u64,
+    up_short_writes: u64,
+    up_out_of_order: u64,
     /// Read buffer for host → guest data (reused across polls).
     read_buf: Vec<u8>,
     /// True if host stream has reached EOF.
@@ -263,6 +295,22 @@ impl FastPathConn {
             shared.store(ack, std::sync::atomic::Ordering::Relaxed);
         }
     }
+}
+
+/// Bytes the shim may still send host→guest without exceeding the guest's
+/// advertised receive window: `window − (sent − acked)`, wrap-safe.
+///
+/// The guest kernel guarantees buffering only inside this budget; staying
+/// inside it (on a lossless local link) is what lets the shim carry no
+/// retransmission machinery at all.
+pub(crate) fn send_budget(our_seq: u32, guest_acked: u32, guest_window: u32) -> u32 {
+    let in_flight = our_seq.wrapping_sub(guest_acked);
+    if in_flight >= 0x8000_0000 {
+        // Transiently stale snapshot ("acked ahead of sent") from racing
+        // atomics — treat as nothing in flight rather than stalling.
+        return guest_window;
+    }
+    guest_window.saturating_sub(in_flight)
 }
 
 impl TcpBridge {

--- a/common/splicetcp/src/tcp_bridge/tests.rs
+++ b/common/splicetcp/src/tcp_bridge/tests.rs
@@ -1172,3 +1172,72 @@ async fn triple_dup_ack_triggers_fast_retransmit() {
     ]);
     assert_eq!(first_seq, 1, "fast retransmit restarts at the ack cursor");
 }
+
+/// An ACK beyond what the shim actually sent (SND.NXT) must be ignored:
+/// accepting it would drain the retransmission buffer past real in-flight
+/// bytes and strand them (unretransmittable → truncation/wedge).
+#[tokio::test]
+async fn download_ack_beyond_sent_is_ignored() {
+    use tokio::io::AsyncWriteExt;
+
+    let mut bridge = TcpBridge::new(GW_IP);
+    bridge.set_fast_path_macs(GW_MAC, GUEST_MAC);
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let connect = tokio::net::TcpStream::connect(addr);
+    let (client, accepted) = tokio::join!(connect, listener.accept());
+    let client = client.unwrap();
+    let (mut accepted, _) = accepted.unwrap();
+
+    let dst_ip = Ipv4Addr::new(198, 18, 30, 102);
+    let key = SynFlowKey {
+        src_ip: GUEST_IP,
+        src_port: 40027,
+        dst_ip,
+        dst_port: 443,
+    };
+    bridge.promote_to_fast_path(key, client.into_std().unwrap(), 1, 1, 1460, None);
+
+    // Send 2920 bytes downstream (our_seq goes 1 → 2921).
+    accepted.write_all(&[0xF0; 2920]).await.unwrap();
+    let mut sent = 0usize;
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(2);
+    while sent < 2920 && std::time::Instant::now() < deadline {
+        sent += bridge
+            .poll_fast_path()
+            .iter()
+            .map(|f| f.len().saturating_sub(ETH_HEADER_LEN + 40))
+            .sum::<usize>();
+        tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+    }
+    assert_eq!(sent, 2920);
+
+    // Impossible ACK: acks seq 9999, far beyond our_seq (2921). Must be
+    // ignored — a later RTO must still retransmit from the real cursor (1),
+    // not from the bogus 9999.
+    let bogus = make_guest_segment((40027, dst_ip, 443), 1, 9999, 65535, 0x10, &[]);
+    bridge.try_fast_path_intercept(&bogus).expect("intercepted");
+
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(3);
+    let mut retransmitted = Vec::new();
+    while retransmitted.is_empty() && std::time::Instant::now() < deadline {
+        retransmitted = bridge.poll_fast_path();
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+    }
+    assert!(
+        !retransmitted.is_empty(),
+        "the impossible ACK must not have drained the retransmit buffer"
+    );
+    let tcp = ETH_HEADER_LEN + 20;
+    let first_seq = u32::from_be_bytes([
+        retransmitted[0][tcp + 4],
+        retransmitted[0][tcp + 5],
+        retransmitted[0][tcp + 6],
+        retransmitted[0][tcp + 7],
+    ]);
+    assert_eq!(
+        first_seq, 1,
+        "retransmit from the real cursor, not the bogus ACK"
+    );
+}

--- a/common/splicetcp/src/tcp_bridge/tests.rs
+++ b/common/splicetcp/src/tcp_bridge/tests.rs
@@ -345,7 +345,7 @@ async fn poll_fast_path_segments_frames_for_unix_dgram_limit() {
         dst_port: 443,
     };
     // Jumbo peer MSS so the dgram limit — not the peer bound — drives sizing.
-    bridge.promote_to_fast_path(key, client.into_std().unwrap(), 1, 1, 9000);
+    bridge.promote_to_fast_path(key, client.into_std().unwrap(), 1, 1, 9000, None);
 
     let payload = vec![0xAB; FAST_PATH_GUEST_MSS * 2 + 128];
     accepted.write_all(&payload).await.unwrap();
@@ -409,7 +409,7 @@ async fn poll_fast_path_segments_frames_for_configured_mtu() {
         dst_port: 443,
     };
     // Jumbo peer MSS so the configured MTU — not the peer bound — drives sizing.
-    bridge.promote_to_fast_path(key, client.into_std().unwrap(), 1, 1, 9000);
+    bridge.promote_to_fast_path(key, client.into_std().unwrap(), 1, 1, 9000, None);
 
     let payload = vec![0xAB; 5000];
     accepted.write_all(&payload).await.unwrap();
@@ -468,7 +468,7 @@ async fn poll_fast_path_clamps_segments_to_peer_mss() {
         dst_port: 443,
     };
     // …but the peer (a 1500-MTU bridged container) advertised MSS 1460.
-    bridge.promote_to_fast_path(key, client.into_std().unwrap(), 1, 1, 1460);
+    bridge.promote_to_fast_path(key, client.into_std().unwrap(), 1, 1, 1460, None);
 
     let payload = vec![0xAB; 5000];
     accepted.write_all(&payload).await.unwrap();
@@ -534,7 +534,7 @@ async fn large_frames_below_gso_mss_falls_back_to_clamped_segmentation() {
         dst_port: 443,
     };
     // …but the peer advertised MSS 1400, below the 1460 GSO segment size.
-    bridge.promote_to_fast_path(key, client.into_std().unwrap(), 1, 1, 1400);
+    bridge.promote_to_fast_path(key, client.into_std().unwrap(), 1, 1, 1400, None);
 
     let payload = vec![0xAB; 5000];
     accepted.write_all(&payload).await.unwrap();
@@ -593,7 +593,7 @@ async fn poll_fast_path_read_error_emits_rst_and_removes_flow() {
         dst_ip: Ipv4Addr::new(198, 18, 30, 95),
         dst_port: 443,
     };
-    bridge.promote_to_fast_path(key, client.into_std().unwrap(), 1000, 2000, 1460);
+    bridge.promote_to_fast_path(key, client.into_std().unwrap(), 1000, 2000, 1460, None);
     assert_eq!(bridge.fast_path_count(), 1);
 
     // Abortive close: SO_LINGER(0) turns the peer's close into a RST, so
@@ -655,7 +655,7 @@ async fn inline_dead_flag_reaps_bridge_entry() {
         dst_port: 443,
     };
     // peer_mss ≥ GSO_SEGMENT_MSS → inline-eligible, handed to the sink.
-    bridge.promote_to_fast_path(key, client.into_std().unwrap(), 1000, 2000, 9000);
+    bridge.promote_to_fast_path(key, client.into_std().unwrap(), 1000, 2000, 9000, None);
     assert_eq!(bridge.fast_path_count(), 1);
     let promoted = sink
         .0
@@ -720,4 +720,333 @@ async fn handshake_ttl_abort_emits_rst() {
         rst[ETH_HEADER_LEN + 20 + 11],
     ]);
     assert_eq!(ack, 7778);
+}
+
+// -------- Upload in-order ACK discipline / download window tests --------
+// Regression net for the 2026-07-19 findings: uploads ACKed across
+// WouldBlock holes and short writes (silent data loss), downloads overran
+// the guest's receive window with no retransmission to repair the gap.
+
+/// Builds a guest TCP segment with explicit flags, window, and payload.
+/// `flow` is the guest-side (src_port, dst_ip, dst_port) tuple.
+fn make_guest_segment(
+    flow: (u16, Ipv4Addr, u16),
+    seq: u32,
+    ack: u32,
+    window: u16,
+    flags: u8,
+    payload: &[u8],
+) -> Vec<u8> {
+    let (src_port, dst_ip, dst_port) = flow;
+    let ip_total = 40 + payload.len();
+    let mut frame = vec![0u8; ETH_HEADER_LEN + ip_total];
+    frame[0..6].copy_from_slice(&GW_MAC);
+    frame[6..12].copy_from_slice(&GUEST_MAC);
+    frame[12..14].copy_from_slice(&0x0800u16.to_be_bytes());
+    let ip = 14;
+    frame[ip] = 0x45;
+    frame[ip + 2..ip + 4].copy_from_slice(&(ip_total as u16).to_be_bytes());
+    frame[ip + 8] = 64;
+    frame[ip + 9] = 6;
+    frame[ip + 12..ip + 16].copy_from_slice(&GUEST_IP.octets());
+    frame[ip + 16..ip + 20].copy_from_slice(&dst_ip.octets());
+    let tcp = 34;
+    frame[tcp..tcp + 2].copy_from_slice(&src_port.to_be_bytes());
+    frame[tcp + 2..tcp + 4].copy_from_slice(&dst_port.to_be_bytes());
+    frame[tcp + 4..tcp + 8].copy_from_slice(&seq.to_be_bytes());
+    frame[tcp + 8..tcp + 12].copy_from_slice(&ack.to_be_bytes());
+    frame[tcp + 12] = 0x50;
+    frame[tcp + 13] = flags;
+    frame[tcp + 14..tcp + 16].copy_from_slice(&window.to_be_bytes());
+    frame[tcp + 20..].copy_from_slice(payload);
+    frame
+}
+
+fn tcp_flags_of(frame: &[u8]) -> u8 {
+    frame[ETH_HEADER_LEN + 20 + 13]
+}
+
+fn tcp_ack_of(frame: &[u8]) -> u32 {
+    let tcp = ETH_HEADER_LEN + 20;
+    u32::from_be_bytes([
+        frame[tcp + 8],
+        frame[tcp + 9],
+        frame[tcp + 10],
+        frame[tcp + 11],
+    ])
+}
+
+/// A segment arriving beyond the contiguous cursor (a hole precedes it)
+/// must not be written to the host socket and must not advance the ACK —
+/// the reply is a dup-ACK at the cursor. Filling the hole in order then
+/// delivers everything, bytes in the right order.
+#[tokio::test]
+async fn upload_hole_is_never_acked_or_written() {
+    use std::io::Read;
+
+    let mut bridge = TcpBridge::new(GW_IP);
+    bridge.set_fast_path_macs(GW_MAC, GUEST_MAC);
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let connect = tokio::net::TcpStream::connect(addr);
+    let (client, accepted) = tokio::join!(connect, listener.accept());
+    let client = client.unwrap();
+    let (accepted, _) = accepted.unwrap();
+
+    let dst_ip = Ipv4Addr::new(198, 18, 30, 96);
+    let key = SynFlowKey {
+        src_ip: GUEST_IP,
+        src_port: 40021,
+        dst_ip,
+        dst_port: 443,
+    };
+    bridge.promote_to_fast_path(key, client.into_std().unwrap(), 1000, 2000, 1460, None);
+
+    // Out-of-order segment: 2000..2100 is missing.
+    let ooo = make_guest_segment((40021, dst_ip, 443), 2100, 1000, 65535, 0x18, &[0xBB; 50]);
+    let reply = bridge.try_fast_path_intercept(&ooo).expect("intercepted");
+    assert_eq!(
+        tcp_ack_of(&reply),
+        2000,
+        "hole ahead of the segment: reply must be a dup-ACK at the cursor"
+    );
+
+    // Fill the hole in order, then retransmit the tail.
+    let fill = make_guest_segment((40021, dst_ip, 443), 2000, 1000, 65535, 0x18, &[0xAA; 100]);
+    let reply = bridge.try_fast_path_intercept(&fill).expect("intercepted");
+    assert_eq!(tcp_ack_of(&reply), 2100);
+    let tail = make_guest_segment((40021, dst_ip, 443), 2100, 1000, 65535, 0x18, &[0xBB; 50]);
+    let reply = bridge.try_fast_path_intercept(&tail).expect("intercepted");
+    assert_eq!(tcp_ack_of(&reply), 2150);
+
+    // The host socket saw the contiguous stream in order — no 0xBB bytes
+    // written ahead of the hole.
+    let mut server = accepted.into_std().unwrap();
+    server.set_nonblocking(false).unwrap();
+    server
+        .set_read_timeout(Some(std::time::Duration::from_secs(2)))
+        .unwrap();
+    let mut got = [0u8; 150];
+    server.read_exact(&mut got).unwrap();
+    assert!(got[..100].iter().all(|&b| b == 0xAA));
+    assert!(got[100..].iter().all(|&b| b == 0xBB));
+}
+
+/// A FIN whose sequence position lies beyond the cursor (its stream still
+/// has a gap) must not tear the flow down — teardown would cut off the
+/// retransmissions that repair the gap (the silent-truncation bug). Once
+/// the gap is filled, the retransmitted FIN completes the close.
+#[tokio::test]
+async fn upload_fin_with_gap_defers_teardown() {
+    let mut bridge = TcpBridge::new(GW_IP);
+    bridge.set_fast_path_macs(GW_MAC, GUEST_MAC);
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let connect = tokio::net::TcpStream::connect(addr);
+    let (client, accepted) = tokio::join!(connect, listener.accept());
+    let client = client.unwrap();
+    let (_accepted, _) = accepted.unwrap();
+
+    let dst_ip = Ipv4Addr::new(198, 18, 30, 97);
+    let key = SynFlowKey {
+        src_ip: GUEST_IP,
+        src_port: 40022,
+        dst_ip,
+        dst_port: 443,
+    };
+    bridge.promote_to_fast_path(key, client.into_std().unwrap(), 1000, 2000, 1460, None);
+
+    // FIN at 2100 while the cursor is still 2000: 100 bytes are missing.
+    let early_fin = make_guest_segment((40022, dst_ip, 443), 2100, 1000, 65535, 0x11, &[]);
+    let reply = bridge
+        .try_fast_path_intercept(&early_fin)
+        .expect("intercepted");
+    assert_eq!(
+        tcp_flags_of(&reply) & 0x01,
+        0,
+        "deferred FIN must be answered with a plain dup-ACK, not FIN-ACK"
+    );
+    assert_eq!(tcp_ack_of(&reply), 2000);
+    assert_eq!(
+        bridge.fast_path_count(),
+        1,
+        "flow must survive a FIN that precedes its missing data"
+    );
+
+    // Gap filled, FIN retransmitted → normal close.
+    let fill = make_guest_segment((40022, dst_ip, 443), 2000, 1000, 65535, 0x18, &[0xAA; 100]);
+    let reply = bridge.try_fast_path_intercept(&fill).expect("intercepted");
+    assert_eq!(tcp_ack_of(&reply), 2100);
+    let fin = make_guest_segment((40022, dst_ip, 443), 2100, 1000, 65535, 0x11, &[]);
+    let reply = bridge.try_fast_path_intercept(&fin).expect("intercepted");
+    assert_ne!(tcp_flags_of(&reply) & 0x01, 0, "in-order FIN gets FIN-ACK");
+    assert_eq!(tcp_ack_of(&reply), 2101, "FIN consumes one sequence number");
+    assert_eq!(bridge.fast_path_count(), 0);
+}
+
+/// Property: the ACK returned for a data segment never covers bytes the
+/// host socket did not take. Driven by writing far more than a shrunken
+/// send buffer accepts, then retransmitting from the ACK cursor until the
+/// whole payload lands — every byte must reach the server exactly once.
+#[tokio::test]
+async fn upload_ack_never_exceeds_host_writable() {
+    use std::io::Read;
+
+    let mut bridge = TcpBridge::new(GW_IP);
+    bridge.set_fast_path_macs(GW_MAC, GUEST_MAC);
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let connect = tokio::net::TcpStream::connect(addr);
+    let (client, accepted) = tokio::join!(connect, listener.accept());
+    let std_client = client.unwrap().into_std().unwrap();
+    // Shrink both socket buffers so segments outrun what the kernel will
+    // take and the write path must report partial/zero takes.
+    socket2::SockRef::from(&std_client)
+        .set_send_buffer_size(4096)
+        .unwrap();
+    let (accepted, _) = accepted.unwrap();
+    socket2::SockRef::from(&accepted)
+        .set_recv_buffer_size(4096)
+        .unwrap();
+
+    let dst_ip = Ipv4Addr::new(198, 18, 30, 98);
+    let key = SynFlowKey {
+        src_ip: GUEST_IP,
+        src_port: 40023,
+        dst_ip,
+        dst_port: 443,
+    };
+    bridge.promote_to_fast_path(key, std_client, 1000, 2000, 1460, None);
+
+    let mut server = accepted.into_std().unwrap();
+    server.set_nonblocking(false).unwrap();
+    server
+        .set_read_timeout(Some(std::time::Duration::from_millis(500)))
+        .unwrap();
+
+    // Segments stay MTU-plausible (an IP packet's total length is u16);
+    // the volume, not the segment size, is what outruns the buffers.
+    const SEGMENT: usize = 8 * 1024;
+    let payload = vec![0xCC; 256 * 1024];
+    let base: u32 = 2000;
+    let mut cursor: u32 = base;
+    let mut server_received = 0usize;
+    let mut short_takes = 0usize;
+    let mut read_buf = vec![0u8; 64 * 1024];
+
+    for _ in 0..2000 {
+        let offset = cursor.wrapping_sub(base) as usize;
+        if offset >= payload.len() {
+            break;
+        }
+        let chunk = &payload[offset..(offset + SEGMENT).min(payload.len())];
+        let segment = make_guest_segment((40023, dst_ip, 443), cursor, 1000, 65535, 0x18, chunk);
+        let reply = bridge
+            .try_fast_path_intercept(&segment)
+            .expect("intercepted");
+        let acked = tcp_ack_of(&reply);
+        let advance = acked.wrapping_sub(cursor) as usize;
+        assert!(advance <= chunk.len(), "ACK beyond the offered bytes");
+        if advance < chunk.len() {
+            short_takes += 1;
+        }
+        cursor = acked;
+
+        // Drain whatever reached the server; every ACKed byte must
+        // eventually be readable.
+        while server_received < cursor.wrapping_sub(base) as usize {
+            match server.read(&mut read_buf) {
+                Ok(0) => panic!("server EOF mid-transfer"),
+                Ok(n) => {
+                    assert!(read_buf[..n].iter().all(|&b| b == 0xCC));
+                    server_received += n;
+                }
+                Err(e) => panic!("ACKed bytes never reached the server: {e}"),
+            }
+        }
+    }
+
+    assert_eq!(
+        cursor.wrapping_sub(base) as usize,
+        payload.len(),
+        "retransmit-from-cursor must eventually deliver the whole payload"
+    );
+    assert_eq!(server_received, payload.len());
+    assert!(
+        short_takes > 0,
+        "test must actually exercise the partial-take path (send buffer 4 KiB, payload 64 KiB)"
+    );
+}
+
+/// The download side must never send beyond the guest's advertised receive
+/// window: with no ACKs after promotion at most one unscaled window goes
+/// out; a window-opening ACK releases the next tranche.
+#[tokio::test]
+async fn poll_fast_path_respects_guest_window() {
+    use tokio::io::AsyncWriteExt;
+
+    let mut bridge = TcpBridge::new(GW_IP);
+    bridge.set_fast_path_macs(GW_MAC, GUEST_MAC);
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let connect = tokio::net::TcpStream::connect(addr);
+    let (client, accepted) = tokio::join!(connect, listener.accept());
+    let client = client.unwrap();
+    let (mut accepted, _) = accepted.unwrap();
+
+    let dst_ip = Ipv4Addr::new(198, 18, 30, 99);
+    let key = SynFlowKey {
+        src_ip: GUEST_IP,
+        src_port: 40024,
+        dst_ip,
+        dst_port: 443,
+    };
+    bridge.promote_to_fast_path(key, client.into_std().unwrap(), 1, 1, 1460, None);
+
+    accepted.write_all(&vec![0xDD; 100_000]).await.unwrap();
+
+    async fn drain(bridge: &mut TcpBridge) -> usize {
+        let mut sent = 0usize;
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(2);
+        let mut idle = 0;
+        while std::time::Instant::now() < deadline && idle < 10 {
+            let batch = bridge.poll_fast_path();
+            if batch.is_empty() {
+                idle += 1;
+                tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+            } else {
+                idle = 0;
+                sent += batch
+                    .iter()
+                    .map(|f| f.len().saturating_sub(ETH_HEADER_LEN + 40))
+                    .sum::<usize>();
+            }
+        }
+        sent
+    }
+
+    let first = drain(&mut bridge).await;
+    assert!(
+        first <= 65535,
+        "no guest ACK yet: at most one unscaled window may be sent, got {first}"
+    );
+    assert!(
+        first >= 65535 - 1460,
+        "the initial window should be filled, got {first}"
+    );
+
+    // Guest ACKs everything and re-opens a 65535 window.
+    let ack = make_guest_segment((40024, dst_ip, 443), 1, 1 + first as u32, 65535, 0x10, &[]);
+    bridge.try_fast_path_intercept(&ack).expect("intercepted");
+
+    let second = drain(&mut bridge).await;
+    assert!(second > 0, "an opening ACK must release more data");
+    assert!(
+        second <= 65535,
+        "second tranche must respect the re-advertised window, got {second}"
+    );
 }

--- a/common/splicetcp/src/tcp_bridge/tests.rs
+++ b/common/splicetcp/src/tcp_bridge/tests.rs
@@ -1050,3 +1050,125 @@ async fn poll_fast_path_respects_guest_window() {
         "second tranche must respect the re-advertised window, got {second}"
     );
 }
+
+/// In-flight download bytes that never get ACKed must be retransmitted
+/// after the RTO — the path beyond guest eth0 drops under burst, and
+/// without sender-side retransmission one dropped frame wedges the flow.
+#[tokio::test]
+async fn poll_retransmits_unacked_data_after_rto() {
+    use tokio::io::AsyncWriteExt;
+
+    let mut bridge = TcpBridge::new(GW_IP);
+    bridge.set_fast_path_macs(GW_MAC, GUEST_MAC);
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let connect = tokio::net::TcpStream::connect(addr);
+    let (client, accepted) = tokio::join!(connect, listener.accept());
+    let client = client.unwrap();
+    let (mut accepted, _) = accepted.unwrap();
+
+    let dst_ip = Ipv4Addr::new(198, 18, 30, 100);
+    let key = SynFlowKey {
+        src_ip: GUEST_IP,
+        src_port: 40025,
+        dst_ip,
+        dst_port: 443,
+    };
+    bridge.promote_to_fast_path(key, client.into_std().unwrap(), 1, 1, 1460, None);
+
+    accepted.write_all(&[0xEE; 4096]).await.unwrap();
+
+    // First transmission (pretend every frame is lost — we just drop them).
+    let mut sent = 0usize;
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(2);
+    while sent < 4096 && std::time::Instant::now() < deadline {
+        sent += bridge
+            .poll_fast_path()
+            .iter()
+            .map(|f| f.len().saturating_sub(ETH_HEADER_LEN + 40))
+            .sum::<usize>();
+        tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+    }
+    assert_eq!(sent, 4096, "initial transmission");
+
+    // No guest ACK ever arrives. After the RTO the same sequence space
+    // must be re-emitted, starting at the un-ACKed cursor (seq=1).
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(3);
+    let mut retransmitted = Vec::new();
+    while retransmitted.is_empty() && std::time::Instant::now() < deadline {
+        retransmitted = bridge.poll_fast_path();
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+    }
+    assert!(
+        !retransmitted.is_empty(),
+        "RTO must re-emit un-ACKed data with no guest ACKs at all"
+    );
+    let tcp = ETH_HEADER_LEN + 20;
+    let first_seq = u32::from_be_bytes([
+        retransmitted[0][tcp + 4],
+        retransmitted[0][tcp + 5],
+        retransmitted[0][tcp + 6],
+        retransmitted[0][tcp + 7],
+    ]);
+    assert_eq!(first_seq, 1, "retransmission restarts at the ack cursor");
+}
+
+/// Three duplicate ACKs (same ack, same window, no payload, data in
+/// flight) must trigger an immediate fast retransmit from the ack point.
+#[tokio::test]
+async fn triple_dup_ack_triggers_fast_retransmit() {
+    use tokio::io::AsyncWriteExt;
+
+    let mut bridge = TcpBridge::new(GW_IP);
+    bridge.set_fast_path_macs(GW_MAC, GUEST_MAC);
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let connect = tokio::net::TcpStream::connect(addr);
+    let (client, accepted) = tokio::join!(connect, listener.accept());
+    let client = client.unwrap();
+    let (mut accepted, _) = accepted.unwrap();
+
+    let dst_ip = Ipv4Addr::new(198, 18, 30, 101);
+    let key = SynFlowKey {
+        src_ip: GUEST_IP,
+        src_port: 40026,
+        dst_ip,
+        dst_port: 443,
+    };
+    bridge.promote_to_fast_path(key, client.into_std().unwrap(), 1, 1, 1460, None);
+
+    accepted.write_all(&[0xEF; 2920]).await.unwrap();
+    let mut sent = 0usize;
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(2);
+    while sent < 2920 && std::time::Instant::now() < deadline {
+        sent += bridge
+            .poll_fast_path()
+            .iter()
+            .map(|f| f.len().saturating_sub(ETH_HEADER_LEN + 40))
+            .sum::<usize>();
+        tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+    }
+    assert_eq!(sent, 2920, "initial transmission");
+
+    // Guest signals a gap: three dup-ACKs at the initial cursor with the
+    // (unchanged) initial window.
+    for _ in 0..3 {
+        let dup = make_guest_segment((40026, dst_ip, 443), 1, 1, 65535, 0x10, &[]);
+        bridge.try_fast_path_intercept(&dup).expect("intercepted");
+    }
+    let retransmitted = bridge.poll_fast_path();
+    assert!(
+        !retransmitted.is_empty(),
+        "three dup-ACKs must fast-retransmit without waiting for the RTO"
+    );
+    let tcp = ETH_HEADER_LEN + 20;
+    let first_seq = u32::from_be_bytes([
+        retransmitted[0][tcp + 4],
+        retransmitted[0][tcp + 5],
+        retransmitted[0][tcp + 6],
+        retransmitted[0][tcp + 7],
+    ]);
+    assert_eq!(first_seq, 1, "fast retransmit restarts at the ack cursor");
+}

--- a/internal-docs/plans/network-workload-e2e.md
+++ b/internal-docs/plans/network-workload-e2e.md
@@ -149,11 +149,29 @@ reproduced under plain workloads:
    the datapath under measurement. The workload suite therefore runs the
    daemon at `info,arcbox_net=debug`.
 
-Status: W2–W4 are **red by design** until the TcpBridge fixes land (only
-ACK bytes actually written in-order; honor the guest's receive window or
-retransmit; make both loss paths log at WARN). Same convention as the fault
-plan's Tier 3: the suite is the regression net that flips green with the
-fix, and the strict assertions stay.
+**Resolved 2026-07-20** — the suite runs green end to end. Three product
+fixes, each accepted by these scenarios:
+
+1. Upload in-order ACK discipline (`last_ack` advances only over bytes
+   actually written; dup-ACKs solicit guest fast retransmit; FIN defers
+   past gaps) — W2 byte-exact.
+2. Guest-window flow control **plus sender-side retransmission** (in-flight
+   bytes buffered, window capped at 256 KiB, triple-dup-ACK fast retransmit,
+   200 ms–2 s RTO, FIN retransmitted too). The deeper finding: the lossless
+   L2 contract ends at guest `eth0` — the bridge→veth→container-netns
+   backlog drops under burst (64 flows through one veth wedged 61/64;
+   spread across 8 containers only 5/64), so the shim, as the download
+   direction's sender-side TCP, must retransmit. Window gating alone made
+   bursts *worse* by turning each drop into a full-window deadlock — W3.
+3. Idle-datapath wakeups (connect-resolved waker + 20 ms poll tick while
+   flows exist): a quiet loop only woke on guest frames or a 1 s tick, so
+   every fresh connection paid up to a second twice (SYN-ACK, then first
+   response bytes) — invisible under sustained transfer, ~2 s/request when
+   sequential. Churn went from 127-of-500-in-240 s to 19 ms/request — W4.
+
+The strict assertions stay as the permanent regression net; only the
+observability WARNs from the original finding list remain future work
+(loss-recovery events currently log at debug).
 
 ## Runtime budget
 

--- a/tests/e2e/src/scenario.rs
+++ b/tests/e2e/src/scenario.rs
@@ -47,6 +47,9 @@ pub fn run_vz_scenario_with_log(
     scenario: impl FnOnce(&mut DaemonHandle, &Path, &mut RunMetrics) -> Result<()>,
 ) -> Result<()> {
     init_tracing();
+    // Diagnostic override for the daemon under test, e.g.
+    // ARCBOX_E2E_DAEMON_LOG="info,splicetcp::tcp_bridge=debug".
+    let rust_log = std::env::var("ARCBOX_E2E_DAEMON_LOG").unwrap_or_else(|_| rust_log.to_owned());
 
     let root = crate::repo_root();
     if !crate::env_flag("SKIP_BUILD") {
@@ -78,7 +81,7 @@ pub fn run_vz_scenario_with_log(
             ("ARCBOX_BOOT_ASSET_VERSION".to_owned(), version),
             ("ARCBOX_VM_BACKEND".to_owned(), "vz".to_owned()),
             ("ARCBOX_DNS_PORT".to_owned(), dns_port.to_string()),
-            ("RUST_LOG".to_owned(), rust_log.to_owned()),
+            ("RUST_LOG".to_owned(), rust_log),
         ],
     })?;
 

--- a/tests/e2e/tests/network_workload.rs
+++ b/tests/e2e/tests/network_workload.rs
@@ -109,8 +109,16 @@ fn net_workload_egress_suite() -> Result<()> {
                 ("burst_multi_container", burst_multi_container),
                 ("churn_sequential", churn_sequential),
             ];
+            // Diagnostic filter: run only the named scenario, e.g.
+            // ARCBOX_E2E_WORKLOAD_ONLY=burst_single_container.
+            let only = std::env::var("ARCBOX_E2E_WORKLOAD_ONLY").ok();
             let mut failures = Vec::new();
             for (name, scenario) in scenarios {
+                if let Some(ref only) = only
+                    && only != name
+                {
+                    continue;
+                }
                 tracing::info!(scenario = name, "starting");
                 match scenario(data_dir, metrics, &image) {
                     Ok(()) => tracing::info!(scenario = name, "passed"),

--- a/virt/arcbox-net-inject/src/inject.rs
+++ b/virt/arcbox-net-inject/src/inject.rs
@@ -254,6 +254,17 @@ impl RxInjectThread {
                     break;
                 }
 
+                // Never send beyond the guest's advertised receive window:
+                // outside that budget the guest kernel drops what it can't
+                // buffer, and this path has no retransmission to repair the
+                // gap — the flow would wedge permanently (2026-07-19). A
+                // window-limited conn is revisited next pass, once the
+                // guest's ACKs (via the datapath intercept) reopen it.
+                let budget = conn.send_budget() as usize;
+                if budget == 0 {
+                    break;
+                }
+
                 // Gather up to MAX_MERGE buffers into the scratch arrays.
                 // The pops advance the avail cursor speculatively; guest
                 // memory stays untouched, and the cursor is rewound to
@@ -335,8 +346,16 @@ impl RxInjectThread {
                     // Placeholder — overwritten below for slots < count.
                     IoSliceMut::new(&mut [])
                 });
+                // Clamp iovec capacities to the window budget so a single
+                // readv can never pull more than the guest may receive. The
+                // clamped capacities also drive the per-descriptor byte
+                // distribution below — readv fills iovs in order at exactly
+                // these sizes.
+                let mut iov_caps = [0usize; MAX_MERGE];
+                let mut budget_left = budget;
+                let mut iov_count = 0usize;
                 for i in 0..count {
-                    let (start, cap) = if i == 0 {
+                    let (start, full_cap) = if i == 0 {
                         (
                             inline_conn::TOTAL_HDR_LEN,
                             desc_lens[i] - inline_conn::TOTAL_HDR_LEN,
@@ -344,6 +363,12 @@ impl RxInjectThread {
                     } else {
                         (0, desc_lens[i])
                     };
+                    let cap = full_cap.min(budget_left);
+                    if cap == 0 {
+                        break;
+                    }
+                    budget_left -= cap;
+                    iov_caps[i] = cap;
                     // SAFETY: desc_ptrs[i] points into the VM-lifetime
                     // guest mmap (bounds checked by gpa_to_offset above).
                     // The buffer is device-owned until we advance used_idx,
@@ -351,9 +376,10 @@ impl RxInjectThread {
                     let slice =
                         unsafe { std::slice::from_raw_parts_mut(desc_ptrs[i].add(start), cap) };
                     iovs[i] = IoSliceMut::new(slice);
+                    iov_count = i + 1;
                 }
 
-                let read_result = conn.stream.read_vectored(&mut iovs[..count]);
+                let read_result = conn.stream.read_vectored(&mut iovs[..iov_count]);
                 match read_result {
                     Ok(0) => {
                         tracing::debug!(
@@ -387,16 +413,11 @@ impl RxInjectThread {
                         let mut remaining = n;
                         let mut num_used = 0usize;
                         let mut per_desc_len = [0usize; MAX_MERGE];
-                        for i in 0..count {
+                        for i in 0..iov_count {
                             if remaining == 0 {
                                 break;
                             }
-                            let cap = if i == 0 {
-                                desc_lens[i] - inline_conn::TOTAL_HDR_LEN
-                            } else {
-                                desc_lens[i]
-                            };
-                            let filled = remaining.min(cap);
+                            let filled = remaining.min(iov_caps[i]);
                             per_desc_len[i] = filled;
                             remaining -= filled;
                             num_used = i + 1;
@@ -603,6 +624,8 @@ mod tests {
             guest_port: 50000,
             our_seq: Arc::new(AtomicU32::new(1000)),
             last_ack: Arc::new(AtomicU32::new(2000)),
+            guest_acked: Arc::new(AtomicU32::new(1000)),
+            guest_window: Arc::new(AtomicU32::new(u32::MAX)),
             gw_mac: [0x02, 0, 0, 0, 0, 1],
             guest_mac: [0x02, 0, 0, 0, 0, 2],
             host_eof: false,

--- a/virt/arcbox-net-inject/src/inline_conn.rs
+++ b/virt/arcbox-net-inject/src/inline_conn.rs
@@ -65,6 +65,12 @@ pub struct InlineConn {
 // SAFETY: TcpStream is Send, all other fields are Send+Sync.
 unsafe impl Send for InlineConn {}
 
+/// Cap on the guest window this thread honors — bounds the burst a flow
+/// can throw at the guest-internal bridge/veth backlog. Keep in sync with
+/// `splicetcp::tcp_bridge::HONORED_WINDOW_CAP` (this crate must not
+/// depend on splicetcp).
+const HONORED_WINDOW_CAP: u32 = 256 * 1024;
+
 impl InlineConn {
     /// Bytes this thread may still send without exceeding the guest's
     /// advertised receive window: `window − (sent − acked)`, wrap-safe.
@@ -75,7 +81,10 @@ impl InlineConn {
     pub fn send_budget(&self) -> u32 {
         let sent = self.our_seq.load(Ordering::Relaxed);
         let acked = self.guest_acked.load(Ordering::Relaxed);
-        let window = self.guest_window.load(Ordering::Relaxed);
+        let window = self
+            .guest_window
+            .load(Ordering::Relaxed)
+            .min(HONORED_WINDOW_CAP);
         let in_flight = sent.wrapping_sub(acked);
         if in_flight >= 0x8000_0000 {
             // Transiently stale snapshot from racing atomics.

--- a/virt/arcbox-net-inject/src/inline_conn.rs
+++ b/virt/arcbox-net-inject/src/inline_conn.rs
@@ -41,6 +41,13 @@ pub struct InlineConn {
     pub our_seq: Arc<AtomicU32>,
     /// Last ACK from guest (shared with datapath loop via atomic).
     pub last_ack: Arc<AtomicU32>,
+    /// Highest ACK the guest has sent for OUR stream, maintained by the
+    /// datapath's fast-path intercept. With `guest_window` it bounds how
+    /// far ahead of the guest this thread may send.
+    pub guest_acked: Arc<AtomicU32>,
+    /// The guest's most recent advertised receive window, already scaled
+    /// by its SYN window-scale option.
+    pub guest_window: Arc<AtomicU32>,
     /// Gateway MAC for Ethernet source.
     pub gw_mac: [u8; 6],
     /// Guest MAC for Ethernet destination.
@@ -57,6 +64,26 @@ pub struct InlineConn {
 
 // SAFETY: TcpStream is Send, all other fields are Send+Sync.
 unsafe impl Send for InlineConn {}
+
+impl InlineConn {
+    /// Bytes this thread may still send without exceeding the guest's
+    /// advertised receive window: `window − (sent − acked)`, wrap-safe.
+    /// Within the budget the guest kernel guarantees buffering, and the
+    /// inject path is lossless — so staying inside it means no gap can
+    /// form that this retransmission-free path could never repair.
+    /// (Mirrors `splicetcp::tcp_bridge::send_budget`.)
+    pub fn send_budget(&self) -> u32 {
+        let sent = self.our_seq.load(Ordering::Relaxed);
+        let acked = self.guest_acked.load(Ordering::Relaxed);
+        let window = self.guest_window.load(Ordering::Relaxed);
+        let in_flight = sent.wrapping_sub(acked);
+        if in_flight >= 0x8000_0000 {
+            // Transiently stale snapshot from racing atomics.
+            return window;
+        }
+        window.saturating_sub(in_flight)
+    }
+}
 
 /// Writes 66 bytes of headers (12 virtio-net + 54 Eth/IP/TCP) directly
 /// into a guest descriptor buffer. Returns the number of header bytes

--- a/virt/arcbox-net/src/darwin/datapath_loop/mod.rs
+++ b/virt/arcbox-net/src/darwin/datapath_loop/mod.rs
@@ -244,6 +244,22 @@ impl NetworkDatapath {
         let mut maintenance = tokio::time::interval(Duration::from_secs(30));
         maintenance.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
 
+        // Wakes the loop when a pending handshake's host connect resolves,
+        // so the SYN-ACK goes out immediately (an idle loop otherwise sits
+        // in select! until the next guest frame or the 1 s tick — that tick
+        // dominated fresh-connection latency at ~2 s per sequential fetch).
+        let handshake_waker = std::sync::Arc::new(tokio::sync::Notify::new());
+        tcp_bridge.set_handshake_waker(handshake_waker.clone());
+
+        // Fast poll cadence while fast-path connections exist: their host
+        // sockets have no readiness registration (they are polled), so
+        // without this an idle connection's first response bytes wait for
+        // the next guest frame or the 1 s tick. 20 ms bounds first-byte
+        // latency at negligible idle cost (50 polls/s only while flows
+        // are open); sustained transfers self-sustain via guest ACK frames.
+        let mut fastpath_tick = tokio::time::interval(Duration::from_millis(20));
+        fastpath_tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+
         tracing::info!("Network datapath started (TCP shim + socket proxy mode)");
 
         loop {
@@ -417,6 +433,15 @@ impl NetworkDatapath {
                     egress.maintenance();
                     guest_tx.log_stats(rx_frames);
                 }
+
+                // A pending handshake's host connect resolved — fall through
+                // so poll_handshakes() in the common tail emits the SYN-ACK
+                // right away.
+                () = handshake_waker.notified() => {}
+
+                // Bounded first-byte latency for polled fast-path sockets;
+                // the common tail's poll_fast_path() does the actual work.
+                _ = fastpath_tick.tick(), if tcp_bridge.fast_path_count() > 0 => {}
             }
 
             // ── Common tail: run on every iteration regardless of which
@@ -447,9 +472,9 @@ impl NetworkDatapath {
             //    backlog is pending. Skipping the poll leaves host-socket
             //    data in the host kernel's receive buffer, closing the
             //    host-side TCP window so the remote sender throttles instead
-            //    of the datapath dropping frames (lossless backpressure; the
-            //    shim has no retransmission, so a dropped data frame would
-            //    stall the connection permanently).
+            //    of the datapath dropping frames (lossless backpressure —
+            //    preferable even though the bridge can retransmit, since
+            //    retransmission costs a round trip per loss).
             if guest_tx.has_backlog() {
                 guest_tx.stats.gated_polls += 1;
             } else {

--- a/virt/arcbox-vmm/src/vmm/darwin_hv/inline_sink.rs
+++ b/virt/arcbox-vmm/src/vmm/darwin_hv/inline_sink.rs
@@ -20,6 +20,8 @@ impl arcbox_net::direct_rx::ConnSink for InlineConnSinkAdapter {
             guest_port: conn.guest_port,
             our_seq: conn.our_seq,
             last_ack: conn.last_ack,
+            guest_acked: conn.guest_acked,
+            guest_window: conn.guest_window,
             gw_mac: conn.gw_mac,
             guest_mac: conn.guest_mac,
             host_eof: false,


### PR DESCRIPTION
Stacked on #450 (its W2–W4 scenarios are this change's acceptance net;
retarget to master once #450 merges).

## The three fixes

1. **Uploads no longer lose data.** `last_ack` advances only over bytes
   actually written, in order, to the host socket: out-of-order segments
   are no longer written-and-ACKed across a `WouldBlock` hole, short
   writes ACK only the written prefix, WouldBlock falls through to a
   dup-ACK (guest fast-retransmits instead of waiting out its RTO), and a
   FIN beyond the contiguous cursor defers teardown until the gap is
   repaired. Before: 256 MiB uploads arrived 1.3–3.2 MB short with the
   client exiting 0.

2. **Downloads get real sender-side TCP: window flow control + retransmission.**
   The shim tracks the guest's ACK and advertised window (scaled by its
   SYN wscale) and never sends beyond the budget — in `poll_fast_path`,
   the tokio `direct_rx` task, and the HV inline inject thread (iovec
   capacities clamped). The deeper finding from the burst scenarios: the
   lossless-delivery contract ends at guest `eth0`; the
   bridge→veth→container-netns backlog drops frames under burst (64 flows
   through one veth: 61/64 wedged; across 8 containers: 5/64), so the
   bridge now buffers in-flight bytes (window capped at 256 KiB),
   fast-retransmits on three duplicate ACKs, backs off on a 200 ms–2 s
   RTO, and retransmits the FIN. Window gating alone made bursts *worse*
   (each drop became a full-window deadlock — dup-ACKs into the void).

3. **Idle-datapath latency.** A quiet loop only woke on guest frames or
   the 1 s timer tick, so every fresh connection paid up to a second
   twice: the SYN-ACK waited for a wakeup after the async connect
   resolved, and the first response bytes of a polled flow waited for the
   next tick. `handle_outbound_syn` now notifies a datapath waker when
   the connect resolves, and the loop polls at 20 ms while fast-path
   connections exist. Sequential fetches: ~2 s/request → 19 ms/request.

## Verification

- `cargo test -p splicetcp --all-features`: 64 tests (6 new: out-of-order
  hole never ACKed, FIN-with-gap deferred, ACK-never-exceeds-writable
  property, window respected, RTO retransmit, triple-dup-ACK fast
  retransmit).
- **Workload suite (#450) fully green** on a real VZ VM: uploads
  byte-exact both variants; burst 64/64 single-container (median 1.45 s,
  slowest 2.72 s) and 64/64 across containers (median 268 ms); churn 500
  requests at 19.0 ms first-decile / 19.1 ms last-decile; zombie sweeps
  clean; zero proxy-layer errors.
- **No regression**: `egress_throughput` 6/6 sequential 64 MiB downloads
  (~1.4 s each), `network_fault` RST propagation still prompt.

Known gap (documented in the plan): the HV inline inject path and the
tokio `direct_rx` task have window gating but not retransmission; the
loss-recovery events log at debug, not WARN, pending the fault plan's
observability pass.