### PR TITLE
fix(vmm,agent,daemon): honor real HVC block capacity; fail loud on shrink

### DIFF
--- a/app/arcbox-daemon/src/startup/mod.rs
+++ b/app/arcbox-daemon/src/startup/mod.rs
@@ -139,6 +139,13 @@ async fn acquire_lock(early: EarlyContext) -> Result<DaemonContext> {
 /// On non-macOS this is a no-op (no XPC helpers).
 #[cfg(target_os = "macos")]
 async fn wait_for_resources(ctx: &DaemonContext) -> Result<()> {
+    // Remove a stale Docker socket from a previous session up front. It is
+    // otherwise (re)bound only in start_runtime_services, so if a later phase
+    // (e.g. VM boot) fails, a leftover socket makes clients hit "connection
+    // refused" against a dead listener instead of seeing the daemon as
+    // not-yet-ready. Mirrors the gRPC socket's early unlink-then-bind.
+    let _ = std::fs::remove_file(&ctx.layout.docker_socket);
+
     let docker_imgs = resource_cleanup::disk_image_paths(&ctx.layout.data_subdir);
     let decision = resource_cleanup::decide(
         ctx.daemon_lock.displaced_stale_daemon(),

--- a/guest/arcbox-agent/src/agent/linux/btrfs.rs
+++ b/guest/arcbox-agent/src/agent/linux/btrfs.rs
@@ -68,8 +68,7 @@ fn block_device_size(device: &str) -> Option<u64> {
 /// exposes a smaller disk than the one the filesystem was grown against (the
 /// VZ→HV capacity bug). The data is intact; switching the engine back recovers.
 fn check_device_fits_filesystem(device: &str) -> Result<(), String> {
-    let (Some(fs_bytes), Some(dev_bytes)) =
-        (btrfs_total_bytes(device), block_device_size(device))
+    let (Some(fs_bytes), Some(dev_bytes)) = (btrfs_total_bytes(device), block_device_size(device))
     else {
         return Ok(());
     };

--- a/guest/arcbox-agent/src/agent/linux/btrfs.rs
+++ b/guest/arcbox-agent/src/agent/linux/btrfs.rs
@@ -19,6 +19,9 @@ use super::cmdline::docker_data_device;
 /// `0x10040` (superblock starts at `0x10000`, magic at internal offset `0x40`).
 const BTRFS_MAGIC: [u8; 8] = [0x5f, 0x42, 0x48, 0x52, 0x66, 0x53, 0x5f, 0x4d];
 const BTRFS_MAGIC_OFFSET: u64 = 0x10040;
+/// Offset of the `total_bytes` field in the Btrfs superblock (superblock at
+/// 64 KiB + 0x70 within it).
+const BTRFS_TOTAL_BYTES_OFFSET: u64 = 0x10070;
 
 /// Temporary mount point for the raw Btrfs device before subvolume bind mounts.
 ///
@@ -39,6 +42,46 @@ fn has_btrfs_superblock(device: &str) -> bool {
         return false;
     }
     magic == BTRFS_MAGIC
+}
+
+/// Reads the Btrfs superblock's `total_bytes` (the device size the filesystem
+/// was last resized to). `None` if the field can't be read.
+fn btrfs_total_bytes(device: &str) -> Option<u64> {
+    let mut file = std::fs::File::open(device).ok()?;
+    file.seek(SeekFrom::Start(BTRFS_TOTAL_BYTES_OFFSET)).ok()?;
+    let mut buf = [0_u8; 8];
+    file.read_exact(&mut buf).ok()?;
+    Some(u64::from_le_bytes(buf))
+}
+
+/// Reads a block device's size in bytes by seeking to its end.
+fn block_device_size(device: &str) -> Option<u64> {
+    let mut file = std::fs::File::open(device).ok()?;
+    file.seek(SeekFrom::End(0)).ok()
+}
+
+/// Fails loudly when the block device is smaller than the Btrfs filesystem it
+/// carries. Btrfs refuses to mount (`open_ctree failed`) in that case, so a
+/// bare mount error would otherwise repeat every retry with no explanation.
+///
+/// The mismatch happens when the VM engine is switched to a backend that
+/// exposes a smaller disk than the one the filesystem was grown against (the
+/// VZ→HV capacity bug). The data is intact; switching the engine back recovers.
+fn check_device_fits_filesystem(device: &str) -> Result<(), String> {
+    let (Some(fs_bytes), Some(dev_bytes)) =
+        (btrfs_total_bytes(device), block_device_size(device))
+    else {
+        return Ok(());
+    };
+    if dev_bytes < fs_bytes {
+        return Err(format!(
+            "data disk is {dev_bytes} bytes but its Btrfs filesystem was grown to \
+             {fs_bytes} bytes; the block device shrank (VM engine switched to a \
+             backend exposing a smaller disk). Switch the engine back to VZ to \
+             recover — the data is intact."
+        ));
+    }
+    Ok(())
 }
 
 /// Formats the device as Btrfs if it does not already have a Btrfs superblock.
@@ -117,6 +160,10 @@ pub(super) fn ensure_data_mount() -> Result<String, String> {
         Ok(note) => tracing::info!("{}", note),
         Err(e) => return Err(e),
     }
+
+    // Step 1.5: Fail loudly if the device is smaller than its filesystem — Btrfs
+    // would otherwise reject the mount below with an opaque error on every retry.
+    check_device_fits_filesystem(&device)?;
 
     // Step 2: Mount raw Btrfs to temporary writable mount point.
     if !crate::mount::is_mounted(BTRFS_TEMP_MOUNT) {

--- a/virt/arcbox-vmm/src/vmm/darwin_hv/hvc_blk.rs
+++ b/virt/arcbox-vmm/src/vmm/darwin_hv/hvc_blk.rs
@@ -24,6 +24,10 @@ pub const ARCBOX_HVC_BLK_WRITE: u64 = 0xC200_0002;
 /// Returns X0 = 0 on success or negative errno.
 pub const ARCBOX_HVC_BLK_FLUSH: u64 = 0xC200_0003;
 
+/// HVC block capacity query. X1=dev_idx.
+/// Returns X0 = device capacity in 512-byte sectors, or negative errno.
+pub const ARCBOX_HVC_BLK_CAPACITY: u64 = 0xC200_0004;
+
 /// HVC block read or write.
 /// X1=device_idx, X2=sector, X3=buffer_gpa, X4=byte_length.
 /// `is_write`: false=pread, true=pwrite.
@@ -102,6 +106,22 @@ pub fn handle_hvc_blk_io(
         return (-libc::EIO as i64) as u64;
     }
     byte_len as u64
+}
+
+/// HVC block capacity query. X1=device_idx.
+///
+/// Returns the device's real capacity in 512-byte sectors so the guest driver
+/// can size the disk correctly instead of assuming a fixed placeholder. A wrong
+/// (too-small) size silently corrupts a Btrfs data disk whose metadata records
+/// the true size — see the VZ↔HV capacity mismatch this closes.
+pub fn handle_hvc_blk_capacity(vcpu: &arcbox_hv::HvVcpu, hvc_blk_fds: &[(i32, u32, u64)]) -> u64 {
+    let Ok(device_idx) = vcpu.get_reg(X1) else {
+        return (-libc::EINVAL as i64) as u64;
+    };
+    let Some(&(_, _, capacity_sectors)) = hvc_blk_fds.get(device_idx as usize) else {
+        return (-libc::ENODEV as i64) as u64;
+    };
+    capacity_sectors
 }
 
 /// HVC block flush (fsync). X1=device_idx.

--- a/virt/arcbox-vmm/src/vmm/darwin_hv/vcpu_loop.rs
+++ b/virt/arcbox-vmm/src/vmm/darwin_hv/vcpu_loop.rs
@@ -12,8 +12,8 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use arcbox_hv::{ExceptionClass, HvVcpu, MmioInfo, VcpuExit};
 
 use super::hvc_blk::{
-    ARCBOX_HVC_BLK_FLUSH, ARCBOX_HVC_BLK_READ, ARCBOX_HVC_BLK_WRITE, ARCBOX_HVC_PROBE,
-    handle_hvc_blk_flush, handle_hvc_blk_io,
+    ARCBOX_HVC_BLK_CAPACITY, ARCBOX_HVC_BLK_FLUSH, ARCBOX_HVC_BLK_READ, ARCBOX_HVC_BLK_WRITE,
+    ARCBOX_HVC_PROBE, handle_hvc_blk_capacity, handle_hvc_blk_flush, handle_hvc_blk_io,
 };
 use super::psci::{CpuPower, PsciExit, handle_psci};
 use super::{HvVcpuIds, Pl011, Pl031, VcpuThreadHandles};
@@ -562,6 +562,10 @@ pub(super) fn vcpu_run_loop(vcpu_id: u32, boot: VcpuBoot, ctx: VcpuContext) {
                         }
                         ARCBOX_HVC_BLK_FLUSH => {
                             let result = handle_hvc_blk_flush(&vcpu, &hvc_blk_fds);
+                            let _ = vcpu.set_reg(reg::X0, result);
+                        }
+                        ARCBOX_HVC_BLK_CAPACITY => {
+                            let result = handle_hvc_blk_capacity(&vcpu, &hvc_blk_fds);
                             let _ = vcpu.set_reg(reg::X0, result);
                         }
                         _ => {


### PR DESCRIPTION
## The bug (permanent Docker corruption on VZ→HV switch)

Switching the VM engine to the **HV backend** permanently breaks Docker for any existing user. Root cause is in the kernel (matching PR in arcboxlabs/kernel), this is the host/agent/daemon half:

- The guest HVC block driver hardcodes capacity to **512 GiB** (`set_capacity(disk, 1<<30)`), never querying the real size.
- `docker.img` is an **8 TiB** sparse file; the agent runs `btrfs resize max` each boot, so under VZ the Btrfs metadata records 8 TiB.
- Under HV the guest sees only 512 GiB → Btrfs refuses to mount (`open_ctree failed`, `total_bytes should be at most 549755813888 but found 8796093022208`) → dockerd never starts → daemon stalls in setup → `backend="hv"` is persisted so restart/reboot never self-heals.

100% reproducible; data itself is intact (recovered by switching back to VZ).

## This PR (host + defenses)

- **vmm/darwin_hv**: add `ARCBOX_HVC_BLK_CAPACITY` (0xC2000004) returning the device's real `capacity_sectors` (already tracked in `hvc_blk_fds`). The kernel driver queries this instead of guessing. Independently deployable: old-guest/new-host and new-guest/old-host both stay safe — the guest falls back to the previous fixed size when the call is unsupported.
- **agent/btrfs**: before mounting, compare the block-device size against the Btrfs superblock `total_bytes`; fail with a clear, actionable error ("switch the engine back to VZ … data is intact") when the device is smaller, instead of retrying an opaque mount failure every ~93 s.
- **daemon startup**: unlink a stale Docker socket early (in `release_stale_resources`, before VM boot) so a failed setup no longer leaves clients hitting connection-refused against a dead listener; mirrors the gRPC socket's early unlink-then-bind.

## Test plan

- `cargo build`/`clippy` clean for `arcbox-vmm`, `arcbox-daemon`, and `arcbox-agent` (aarch64-unknown-linux-musl).
- End-to-end HV boot verification requires the matching kernel driver (boot-assets release); tracked with that PR.

Paired with: arcboxlabs/kernel HVC blk capacity query. Interim user protection: arcbox-desktop guards the HV toggle until a boot bundle carrying both ships.