### PR TITLE
chore(assets): bump boot assets to 0.6.9 (kernel v0.0.20)

### DIFF
--- a/assets.lock
+++ b/assets.lock
@@ -14,9 +14,9 @@
 # and the [boot] bump.
 
 [boot]
-version = "0.6.8"
+version = "0.6.9"
 cdn = "https://boot.arcboxcdn.com"
-manifest_sha256 = "4d9d0823fef856af03fb97fd5416185aceeeeade7762e8c96f71241497e92a35"
+manifest_sha256 = "866ba781cd69fa85028683a27b5a4d8a8d81f2e96f34948e67930b0e1a746ef8"
 
 [[tools]]
 name = "docker"


### PR DESCRIPTION
Boot bundle **0.6.9** carries kernel **v0.0.20**, whose `arcbox_hvc_blk` driver queries the real HVC block-device capacity instead of hardcoding 512 GiB — the guest half of the VZ→HV data-disk corruption fix. Host handler + agent guard + daemon socket cleanup landed in #453.

`manifest_sha256` is the raw hash of the CDN-served `asset/v0.6.9/manifest.json` (the unified manifest the daemon fetches and verifies at startup) — verified `866ba781…` against the live CDN. Note the CDN manifest differs from the GitHub-release `manifest.json` asset; the daemon reads the CDN one.

Merging this + #453 lets release-please cut the daemon version that actually ships the fix. Then arcbox-desktop bumps `arcbox.version` to bundle it.