### PR TITLE
ci(release): retry crates.io publish through the rate limit

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,7 +91,25 @@ jobs:
         # member, resolves inter-deps via a local temp registry, then uploads in
         # dependency order, waiting for the index between uploads. --no-verify:
         # see the note above (crates that embed out-of-tree workspace files).
-        run: cargo publish --workspace --exclude arcbox-hv --no-verify --locked
+        #
+        # crates.io rate-limits bulk updates to existing crates (HTTP 429 after
+        # a burst), and the workspace has ~50 members — a single pass never gets
+        # through. Retry with backoff: cargo skips crates already published at
+        # this version, so each pass uploads whatever the refill allows until
+        # the whole workspace is up. Only a persistent non-rate-limit failure
+        # exhausts the attempts and fails the job.
+        run: |
+          attempts=20
+          for i in $(seq 1 "$attempts"); do
+            if cargo publish --workspace --exclude arcbox-hv --no-verify --locked; then
+              echo "crates.io publish complete after $i attempt(s)"
+              exit 0
+            fi
+            echo "::notice::crates.io publish attempt $i/$attempts incomplete (likely rate-limited); backing off 60s"
+            sleep 60
+          done
+          echo "::error::crates.io publish did not complete after $attempts attempts"
+          exit 1
 
   # ==========================================================================
   # Build + sign macOS ARM64 host binaries


### PR DESCRIPTION
## Problem

The release's **Publish crates to crates.io** job has failed on every recent version (v0.4.23, v0.4.24, …). Root cause: the workspace has ~50 members, and one `cargo publish --workspace` pass hits crates.io's update rate limit partway through:

```
error: failed to publish arcbox-virtio-console v0.4.24 to registry
the remote server responded with an error (status 429 Too Many Requests):
You have published too many updates to existing crates in a short period of time.
```

It's a bulk-publish throttling issue, not a build problem — the daemon artifacts publish fine regardless, so nobody noticed, but the job is permanently red.

## Fix

Wrap the publish in a retry-with-backoff loop (20 × 60 s). `cargo publish --workspace` skips crates already published at the current version, so each pass uploads whatever the rate-limit refill allows and the workspace converges over a few attempts. A genuine (non-rate-limit) failure still exhausts the retries and fails the job, so real breakage isn't masked.

Worst case ~20 min of backoff, well within the job's 45-min timeout, and it runs in parallel with the macOS daemon build (never on the release's critical path).

## Test plan

- YAML validated; the loop is plain POSIX shell (`seq`/`sleep`).
- Real validation is the next tagged release — the crates.io job should go green instead of 429-failing.