### PR TITLE
docs(macos): refresh stale CLI name and image-version examples

### DIFF
--- a/app/arcbox-cli/src/commands/macos.rs
+++ b/app/arcbox-cli/src/commands/macos.rs
@@ -2,7 +2,7 @@
 //!
 //! Disposable, single-purpose macOS VMs: pull a pre-baked base image once,
 //! then copy-on-write clone it to boot clean, throwaway guests. This is a
-//! distinct noun from `arcbox machine` (Linux) and talks to its own
+//! distinct noun from `abctl machine` (Linux) and talks to its own
 //! `MacosService`.
 
 use anyhow::{Context, Result};
@@ -104,7 +104,7 @@ pub struct RemoveArgs {
 /// macOS base image commands.
 #[derive(Subcommand)]
 pub enum ImageCommands {
-    /// Pull a published base image (e.g. tahoe-base or tahoe-base@2026.07.02)
+    /// Pull a published base image (e.g. tahoe-base or tahoe-base@2026.07.03)
     Pull(SourceArgs),
     /// Resolve a reference against the published index without downloading:
     /// what version a pull would land, and what is installed locally
@@ -122,7 +122,7 @@ pub enum ImageCommands {
 #[derive(Args)]
 pub struct SourceArgs {
     /// Image reference: stream name with optional pinned version
-    /// (e.g. "tahoe-base" or "tahoe-base@2026.07.02").
+    /// (e.g. "tahoe-base" or "tahoe-base@2026.07.03").
     #[arg(required_unless_present = "manifest", conflicts_with = "manifest")]
     pub reference: Option<String>,
     /// Use a manifest directly (URL or daemon-local path), bypassing the
@@ -197,7 +197,7 @@ async fn execute_create(args: CreateArgs) -> Result<()> {
     println!("  Memory: {} MiB", args.memory);
     println!();
     println!("To start it, run:");
-    println!("  arcbox macos start {}", args.name);
+    println!("  abctl macos start {}", args.name);
     Ok(())
 }
 
@@ -253,7 +253,7 @@ async fn execute_list() -> Result<()> {
         println!("No macOS guests found.");
         println!();
         println!("To create one, run:");
-        println!("  arcbox macos create <name> --image <base>");
+        println!("  abctl macos create <name> --image <base>");
         return Ok(());
     }
 
@@ -359,7 +359,7 @@ async fn execute_image(cmd: ImageCommands) -> Result<()> {
                 println!("No macOS images found.");
                 println!();
                 println!("To pull one, run:");
-                println!("  arcbox macos image pull tahoe-base");
+                println!("  abctl macos image pull tahoe-base");
                 return Ok(());
             }
 

--- a/app/arcbox-core/src/macos/image.rs
+++ b/app/arcbox-core/src/macos/image.rs
@@ -35,7 +35,7 @@ pub struct MacImageMeta {
     /// Stream the image was pulled from (e.g. `tahoe-base`), if pulled.
     #[serde(default)]
     pub stream: Option<String>,
-    /// Published version label (e.g. `2026.07.02`), if pulled.
+    /// Published version label (e.g. `2026.07.03`), if pulled.
     #[serde(default)]
     pub version: Option<String>,
     /// Guest macOS product version (e.g. `26.5`), if known.

--- a/app/arcbox-core/src/macos/pull.rs
+++ b/app/arcbox-core/src/macos/pull.rs
@@ -49,7 +49,7 @@ pub enum RemoteSource {
 pub struct ResolvedImage {
     /// Stream name (`tahoe-base`).
     pub name: String,
-    /// Concrete version a pull would land (`2026.07.02`), even when the
+    /// Concrete version a pull would land (`2026.07.03`), even when the
     /// source reference floats.
     pub version: String,
     /// Guest macOS product version (e.g. `26.5`).
@@ -398,7 +398,7 @@ mod tests {
         let manifest = serde_json::json!({
             "schema_version": 2,
             "name": "tahoe-base",
-            "version": "2026.07.02",
+            "version": "2026.07.03",
             "variant": "base",
             "built_at": "2026-07-02T00:00:00Z",
             "source_image": "ghcr.io/cirruslabs/macos-tahoe-base@sha256:abc",
@@ -425,7 +425,7 @@ mod tests {
         let image = mgr.pull_remote(source.clone(), |_, _| {}).await.unwrap();
 
         assert_eq!(image.meta.name, "tahoe-base");
-        assert_eq!(image.meta.version.as_deref(), Some("2026.07.02"));
+        assert_eq!(image.meta.version.as_deref(), Some("2026.07.03"));
         assert_eq!(image.meta.os_version.as_deref(), Some("26.5"));
         assert_eq!(std::fs::read(image.disk_path()).unwrap(), disk);
         assert_eq!(std::fs::read(image.aux_path()).unwrap(), aux);
@@ -448,7 +448,7 @@ mod tests {
         let manifest = serde_json::json!({
             "schema_version": 2,
             "name": "../evil",
-            "version": "2026.07.02",
+            "version": "2026.07.03",
             "os": { "product_version": "26.5" },
             "hardware_model": REAL_HARDWARE_MODEL_B64,
             "machine_id": REAL_MACHINE_ID_B64,
@@ -484,7 +484,7 @@ mod tests {
         let manifest = serde_json::json!({
             "schema_version": 2,
             "name": "tahoe-base",
-            "version": "2026.07.02",
+            "version": "2026.07.03",
             "os": { "product_version": "26.5" },
             "hardware_model": REAL_HARDWARE_MODEL_B64,
             "machine_id": REAL_MACHINE_ID_B64,
@@ -528,7 +528,7 @@ mod tests {
         let manifest = serde_json::json!({
             "schema_version": 2,
             "name": "tahoe-base",
-            "version": "2026.07.02",
+            "version": "2026.07.03",
             "os": { "product_version": "26.5", "build": "25F71" },
             "runner_version": "2.334.0",
             "hardware_model": REAL_HARDWARE_MODEL_B64,
@@ -551,7 +551,7 @@ mod tests {
 
         let resolved = mgr.resolve_remote(&source).await.unwrap();
         assert_eq!(resolved.name, "tahoe-base");
-        assert_eq!(resolved.version, "2026.07.02");
+        assert_eq!(resolved.version, "2026.07.03");
         assert_eq!(resolved.os_version, "26.5");
         assert_eq!(resolved.os_build.as_deref(), Some("25F71"));
         assert_eq!(resolved.runner_version.as_deref(), Some("2.334.0"));
@@ -563,7 +563,7 @@ mod tests {
 
         mgr.pull_remote(source.clone(), |_, _| {}).await.unwrap();
         let resolved = mgr.resolve_remote(&source).await.unwrap();
-        assert_eq!(resolved.installed_version.as_deref(), Some("2026.07.02"));
+        assert_eq!(resolved.installed_version.as_deref(), Some("2026.07.03"));
     }
 
     #[tokio::test]
@@ -583,7 +583,7 @@ mod tests {
         let manifest = serde_json::json!({
             "schema_version": 2,
             "name": "tahoe-base",
-            "version": "2026.07.02",
+            "version": "2026.07.03",
             "os": { "product_version": "26.5" },
             "hardware_model": REAL_HARDWARE_MODEL_B64,
             "machine_id": REAL_MACHINE_ID_B64,

--- a/app/arcbox-core/src/remote_image.rs
+++ b/app/arcbox-core/src/remote_image.rs
@@ -273,10 +273,10 @@ mod tests {
         assert_eq!(r.stream, "tahoe-base");
         assert_eq!(r.version, None);
 
-        let r: ImageReference = "tahoe-base@2026.07.02".parse().unwrap();
+        let r: ImageReference = "tahoe-base@2026.07.03".parse().unwrap();
         assert_eq!(r.stream, "tahoe-base");
-        assert_eq!(r.version.as_deref(), Some("2026.07.02"));
-        assert_eq!(r.to_string(), "tahoe-base@2026.07.02");
+        assert_eq!(r.version.as_deref(), Some("2026.07.03"));
+        assert_eq!(r.to_string(), "tahoe-base@2026.07.03");
     }
 
     #[test]
@@ -294,9 +294,9 @@ mod tests {
                 "schema_version": 1,
                 "images": {
                     "tahoe-base": {
-                        "latest": "2026.07.02",
+                        "latest": "2026.07.03",
                         "versions": {
-                            "2026.07.02": { "manifest": "tahoe-base/2026.07.02/manifest.json" },
+                            "2026.07.03": { "manifest": "tahoe-base/2026.07.03/manifest.json" },
                             "2026.06.01": { "manifest": "tahoe-base/2026.06.01/manifest.json" }
                         }
                     }
@@ -306,8 +306,8 @@ mod tests {
         .unwrap();
 
         let latest = index.resolve(&"tahoe-base".parse().unwrap()).unwrap();
-        assert_eq!(latest.0, "2026.07.02");
-        assert_eq!(latest.1, "tahoe-base/2026.07.02/manifest.json");
+        assert_eq!(latest.0, "2026.07.03");
+        assert_eq!(latest.1, "tahoe-base/2026.07.03/manifest.json");
 
         let pinned = index
             .resolve(&"tahoe-base@2026.06.01".parse().unwrap())
@@ -330,12 +330,12 @@ mod tests {
 
         let manifest = base
             .as_dir()
-            .join("tahoe-base/2026.07.02/manifest.json")
+            .join("tahoe-base/2026.07.03/manifest.json")
             .unwrap();
         let disk = manifest.join("disk.img.zst").unwrap();
         assert_eq!(
             disk.to_string(),
-            "https://images.arcbox.dev/tahoe-base/2026.07.02/disk.img.zst"
+            "https://images.arcbox.dev/tahoe-base/2026.07.03/disk.img.zst"
         );
 
         let manifest = RemoteLocation::parse("/tmp/out/manifest.json");
@@ -347,7 +347,7 @@ mod tests {
     fn validate_name_accepts_plain_and_dotted_components() {
         for ok in [
             "tahoe-base",
-            "tahoe-base@2026.07.02",
+            "tahoe-base@2026.07.03",
             "ubuntu-noble-arm64",
             ".pull-x",
             ".create-ci-1",

--- a/docs/macos-guest.md
+++ b/docs/macos-guest.md
@@ -26,15 +26,15 @@ and they are a **Machine-tier** capability (no Container or Sandbox tier).
 
 ## Startup Path Shape
 
-macOS guests are a separate noun end to end: the `arcbox macos` CLI talks to a dedicated
-`MacosService`, distinct from the Linux `arcbox machine` / `MachineService`. The two share
+macOS guests are a separate noun end to end: the `abctl macos` CLI talks to a dedicated
+`MacosService`, distinct from the Linux `abctl machine` / `MachineService`. The two share
 no request types and no routing — only the daemon process, the gRPC socket, and the reused
 `arcbox-vz` device configuration. The macOS lower half is an independent chain through
 `arcbox-vz` into Apple's framework, and never touches `arcbox-vmm` / HV / the vsock
 guest agent.
 
 ```text
-arcbox machine ...               arcbox macos ...            (CLI, separate nouns)
+abctl machine ...                abctl macos ...             (CLI, separate nouns)
         │  gRPC                          │  gRPC
         ▼                               ▼
 MachineService (machine.rs)      MacosService (macos.rs, macOS-only)
@@ -58,7 +58,7 @@ VmManager::start                 macos::MacVm
    `macos-runner-image-builder` repo for the format spec):
 
    ```text
-   arcbox macos image pull tahoe-base[@version]   (or --manifest <url|path>)
+   abctl macos image pull tahoe-base[@version]    (or --manifest <url|path>)
      → resolve via index.json → fetch manifest
      → validate hardware model support BEFORE the multi-GB download
      → stream disk.img.zst: socket → zstd decode → zero-skipping sparse writes
@@ -75,7 +75,7 @@ VmManager::start                 macos::MacVm
 2. **Per-VM create (fast, CoW).**
 
    ```text
-   arcbox macos create <n> --image <base> [--cpus N --memory MiB]
+   abctl macos create <n> --image <base> [--cpus N --memory MiB]
      → reject if --cpus / --memory are below the image's published minimums
      → assemble in a staging dir, then rename it into place atomically
        (concurrent creates of the same name cannot corrupt each other)
@@ -88,7 +88,7 @@ VmManager::start                 macos::MacVm
 3. **Per-VM start (hot path).**
 
    ```text
-   arcbox macos start <n>
+   abctl macos start <n>
      → MacVm.build → arcbox-vz VirtualMachineConfiguration
           boot_loader = MacOSBootLoader
           platform    = MacPlatform{ hardware_model, machine_id, aux_storage }
@@ -106,7 +106,7 @@ VmManager::start                 macos::MacVm
    persisted in its record, and pinned to the NAT interface at boot. vmnet's
    DHCP server (`bootpd`) writes leases to `/var/db/dhcpd_leases`; the daemon
    resolves the machine's lease by that MAC (`app/arcbox-core/src/macos/lease.rs`)
-   and reports the address via `Inspect`. `arcbox macos ip <n> [--wait <secs>]`
+   and reports the address via `Inspect`. `abctl macos ip <n> [--wait <secs>]`
    prints it — the handle callers (e.g. a CI driver) use to `ssh` into the
    guest and run work directly, with no in-guest agent or provisioning channel.
 
@@ -152,10 +152,10 @@ Teardown for the disposable loop: `request_stop` (graceful) -> delete the per-VM
 | guest IP from DHCP lease | `app/arcbox-core/src/macos/lease.rs` |
 | daemon wiring | `app/arcbox-core/src/runtime.rs` (`mac_machine_manager()`) |
 | daemon gRPC (macOS-only) | `app/arcbox-api/src/grpc/macos.rs` (`MacosServiceImpl`) |
-| CLI | `app/arcbox-cli/src/commands/macos.rs` (`arcbox macos`) |
+| CLI | `app/arcbox-cli/src/commands/macos.rs` (`abctl macos`) |
 
 `MacosService` is a wholly separate gRPC service from the Linux `MachineService`: its own
-request types (macOS-shaped, in MiB/GiB, no Linux fields), its own `arcbox macos` CLI noun,
+request types (macOS-shaped, in MiB/GiB, no Linux fields), its own `abctl macos` CLI noun,
 and it delegates straight to `mac_machine_manager()` — no `guest_os` discriminator and no
 ownership-probe routing. The service is registered and the CLI noun exists only on Apple
 Silicon hosts. macOS VM operations are `!Send` (ObjC handles + the VM dispatch queue across
@@ -166,21 +166,21 @@ current-thread runtime inside `spawn_blocking` (`grpc::run_macos_blocking`).
 
 ```sh
 # 1. Pull a published base image (multi-GB download; progress streams to the CLI):
-arcbox macos image pull tahoe-base            # latest per the published index
-arcbox macos image pull tahoe-base@2026.07.02 # pinned version
-arcbox macos image pull --manifest <url|path> # dev: bypass the index
-arcbox macos image resolve tahoe-base        # what a pull would land, without downloading
-arcbox macos image ls
+abctl macos image pull tahoe-base             # latest per the published index
+abctl macos image pull tahoe-base@2026.07.03  # pinned version
+abctl macos image pull --manifest <url|path>  # dev: bypass the index
+abctl macos image resolve tahoe-base          # what a pull would land, without downloading
+abctl macos image ls
 
 # 2. Create a disposable guest by copy-on-write cloning the base (instant):
-arcbox macos create ci-1 --image tahoe-base --cpus 4 --memory 8192
+abctl macos create ci-1 --image tahoe-base --cpus 4 --memory 8192
 
 # 3. Start / list / stop / remove:
-arcbox macos start ci-1
-arcbox macos ls
-arcbox macos stop ci-1
-arcbox macos rm ci-1
-arcbox macos image rm tahoe-base
+abctl macos start ci-1
+abctl macos ls
+abctl macos stop ci-1
+abctl macos rm ci-1
+abctl macos image rm tahoe-base
 ```
 
 ## Verification status
@@ -205,8 +205,8 @@ arcbox macos image rm tahoe-base
 - The CLI → daemon → manager surface is implemented and clippy-clean, but the daemon
   binary does not link under the devenv/nix toolchain (its SDK lacks the macOS 15+
   `hv_gic_*` Hypervisor.framework symbols `arcbox-hv`'s GIC backend needs — a
-  pre-existing limitation unrelated to this feature). A real `arcbox macos image pull`
-  → `arcbox macos create` → `arcbox macos start` run uses the project's
+  pre-existing limitation unrelated to this feature). A real `abctl macos image pull`
+  → `abctl macos create` → `abctl macos start` run uses the project's
   normal (system-SDK) build path, with the daemon Developer-ID-signed.
 
 ## Security model (zero-trust): what's achievable

--- a/fleet/arcbox-fleet-agent/src/control/image.rs
+++ b/fleet/arcbox-fleet-agent/src/control/image.rs
@@ -285,7 +285,7 @@ mod tests {
     #[tokio::test]
     async fn prepare_without_vm_backend_promotes_macos_target() {
         let state = AgentState::new(&seed());
-        state.set_macos_runner_image_target("tahoe-base@2026.07.02");
+        state.set_macos_runner_image_target("tahoe-base@2026.07.03");
         let service = ImageService::new(state.clone(), None, None);
 
         let mut stream = service

--- a/fleet/arcbox-fleet-agent/src/main.rs
+++ b/fleet/arcbox-fleet-agent/src/main.rs
@@ -199,7 +199,7 @@ enum SettingsCommand {
         #[arg(long)]
         participate: Option<bool>,
         /// macOS base-image stream darwin VM jobs boot from (e.g.
-        /// "tahoe-base" or "tahoe-base@2026.07.02").
+        /// "tahoe-base" or "tahoe-base@2026.07.03").
         #[arg(long)]
         macos_runner_image: Option<String>,
         /// "auto" | "enabled" | "disabled".

--- a/fleet/arcbox-fleet-agent/src/state.rs
+++ b/fleet/arcbox-fleet-agent/src/state.rs
@@ -743,11 +743,11 @@ mod tests {
     #[test]
     fn macos_runner_image_current_and_target_are_independent() {
         let state = AgentState::new(&seed());
-        state.set_macos_runner_image_target("tahoe-base@2026.07.02");
+        state.set_macos_runner_image_target("tahoe-base@2026.07.03");
         assert_eq!(state.macos_runner_image_current(), "tahoe-base");
-        assert_eq!(state.macos_runner_image_target(), "tahoe-base@2026.07.02");
+        assert_eq!(state.macos_runner_image_target(), "tahoe-base@2026.07.03");
 
-        state.set_macos_runner_image_current("tahoe-base@2026.07.02");
+        state.set_macos_runner_image_current("tahoe-base@2026.07.03");
         assert_eq!(
             state.macos_runner_image_current(),
             state.macos_runner_image_target()

--- a/fleet/arcbox-fleet-agent/src/vm.rs
+++ b/fleet/arcbox-fleet-agent/src/vm.rs
@@ -69,7 +69,7 @@ pub struct RunSpec<'a> {
     pub runner_image: &'a str,
 }
 
-/// The stream part of an image reference: `"tahoe-base@2026.07.02"` →
+/// The stream part of an image reference: `"tahoe-base@2026.07.03"` →
 /// `"tahoe-base"`. Installed images are registered under their stream name.
 fn stream_name(reference: &str) -> &str {
     reference.split_once('@').map_or(reference, |(s, _)| s)
@@ -105,7 +105,7 @@ impl VmRunner {
         if !images.iter().any(|i| i.name == stream_name(default_image)) {
             bail!(
                 "macOS runner image '{default_image}' is not installed in the daemon — \
-                 run `arcbox-fleet-agent prepare macos-runner-image` (or `arcbox macos \
+                 run `arcbox-fleet-agent prepare macos-runner-image` (or `abctl macos \
                  image pull {default_image}`) first"
             );
         }
@@ -476,12 +476,12 @@ mod tests {
     #[test]
     fn stream_name_strips_pinned_version() {
         assert_eq!(stream_name("tahoe-base"), "tahoe-base");
-        assert_eq!(stream_name("tahoe-base@2026.07.02"), "tahoe-base");
+        assert_eq!(stream_name("tahoe-base@2026.07.03"), "tahoe-base");
     }
 
     /// Full provision→ssh→exec→destroy cycle against a live daemon.
     /// Requires `arcbox-daemon` running with the default image pulled
-    /// (`arcbox macos image pull tahoe-base`); run manually:
+    /// (`abctl macos image pull tahoe-base`); run manually:
     /// `cargo test -p arcbox-fleet-agent vm_round_trip -- --ignored`.
     #[tokio::test]
     #[ignore = "needs a live arcbox-daemon with the tahoe-base image installed"]

--- a/rpc/arcbox-protocol/proto/macos.proto
+++ b/rpc/arcbox-protocol/proto/macos.proto
@@ -139,7 +139,7 @@ message MacosMachineInfo {
 // characteristics come from the published manifest, not the request.
 message MacosImagePullRequest {
     // Image reference: a stream name with an optional pinned version,
-    // e.g. "tahoe-base" or "tahoe-base@2026.07.02".
+    // e.g. "tahoe-base" or "tahoe-base@2026.07.03".
     string reference = 1;
     // Manifest override (URL or daemon-local path); bypasses the published
     // index. Intended for development and pinning escapes.
@@ -199,7 +199,7 @@ message MacosImageSummary {
     int64 created = 5;
     // Source (manifest location), if known.
     string source = 6;
-    // Published version label (e.g. "2026.07.02"), if pulled.
+    // Published version label (e.g. "2026.07.03"), if pulled.
     string version = 7;
     // Guest macOS product version (e.g. "26.5"), if known.
     string os_version = 8;

--- a/rpc/arcbox-protocol/src/generated/arcbox.v1.rs
+++ b/rpc/arcbox-protocol/src/generated/arcbox.v1.rs
@@ -1665,7 +1665,7 @@ pub struct MacosMachineInfo {
 #[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct MacosImagePullRequest {
     /// Image reference: a stream name with an optional pinned version,
-    /// e.g. "tahoe-base" or "tahoe-base@2026.07.02".
+    /// e.g. "tahoe-base" or "tahoe-base@2026.07.03".
     #[prost(string, tag = "1")]
     pub reference: ::prost::alloc::string::String,
     /// Manifest override (URL or daemon-local path); bypasses the published
@@ -1753,7 +1753,7 @@ pub struct MacosImageSummary {
     /// Source (manifest location), if known.
     #[prost(string, tag = "6")]
     pub source: ::prost::alloc::string::String,
-    /// Published version label (e.g. "2026.07.02"), if pulled.
+    /// Published version label (e.g. "2026.07.03"), if pulled.
     #[prost(string, tag = "7")]
     pub version: ::prost::alloc::string::String,
     /// Guest macOS product version (e.g. "26.5"), if known.


### PR DESCRIPTION
## Summary
- Rename `arcbox <cmd>` to `abctl <cmd>` across the macOS guest surface (CLI help/hints, module/doc comments, `docs/macos-guest.md`, fleet-agent error message and doc comment). Historical `CHANGELOG.md` entries are left as-is since they refer to commits made before the CLI rename.
- Replace the non-existent example version `2026.07.02` with the actual initial published version `2026.07.03` in docs, rustdoc examples, proto comments (`macos.proto` + regenerated `arcbox.v1.rs`), CLI help text, and synthetic manifest/version fixtures used by unit tests.

## Test plan
- [x] `cargo check -p arcbox-cli -p arcbox-core -p arcbox-fleet-agent -p arcbox-protocol`
- [x] `cargo test -p arcbox-core -p arcbox-fleet-agent` (test fixtures were updated in lockstep with their assertions)
- [x] `cargo fmt --check` (generated proto file was hand-edited comment-only; a `build.rs` regen should produce an identical file)
- [x] Skim `docs/macos-guest.md` for any remaining `arcbox <cmd>` occurrences