### PR TITLE
fix(helper): harden release compatibility

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -141,18 +141,22 @@ HELPER_SOCKET ?= /tmp/arcbox-helper.sock
 run-helper: build-helper
 	sudo ARCBOX_HELPER_SOCKET=$(HELPER_SOCKET) $(TARGET_DIR)/arcbox-helper
 
-# Install the helper into launchd (production-like). Requires sudo.
-install-helper: build-helper
-	sudo install -o root -g wheel -m 755 $(TARGET_DIR)/arcbox-helper /usr/local/libexec/arcbox-helper
+# Install the authenticated release helper into the world-connectable launchd
+# socket. Debug helpers skip peer authentication and must only use run-helper's
+# user-controlled development socket.
+install-helper:
+	$(MAKE) build-helper PROFILE=release
+	sudo install -o root -g wheel -m 755 target/release/arcbox-helper /usr/local/libexec/arcbox-helper
 	sudo cp bundle/com.arcboxlabs.desktop.helper.plist /Library/LaunchDaemons/
 	-sudo launchctl bootout system/com.arcboxlabs.desktop.helper 2>/dev/null
 	sudo launchctl bootstrap system /Library/LaunchDaemons/com.arcboxlabs.desktop.helper.plist
 	@echo "✓ arcbox-helper installed and registered with launchd"
 
-# Rebuild and hot-reload the helper in launchd (bootout → copy → bootstrap).
-reload-helper: build-helper
+# Rebuild and hot-reload the authenticated release helper.
+reload-helper:
+	$(MAKE) build-helper PROFILE=release
 	-sudo launchctl bootout system/com.arcboxlabs.desktop.helper 2>/dev/null
-	sudo cp $(TARGET_DIR)/arcbox-helper /usr/local/libexec/arcbox-helper
+	sudo cp target/release/arcbox-helper /usr/local/libexec/arcbox-helper
 	sudo launchctl bootstrap system /Library/LaunchDaemons/com.arcboxlabs.desktop.helper.plist
 	@echo "✓ arcbox-helper reloaded"
 

--- a/app/arcbox-cli/src/commands/doctor.rs
+++ b/app/arcbox-cli/src/commands/doctor.rs
@@ -235,7 +235,10 @@ async fn check_helper() -> CheckResult {
                 "unrecognized version {version:?}; run 'sudo abctl _install --no-daemon --no-shell'"
             )),
         },
-        Err(e) => CheckResult::Fail(format!("version check failed: {e}")),
+        Err(arcbox_helper::client::ClientError::Connection(e)) => {
+            CheckResult::Fail(format!("not reachable via launchd socket: {e}"))
+        }
+        Err(e) => CheckResult::Fail(format!("version RPC failed: {e}")),
     }
 }
 

--- a/app/arcbox-cli/src/commands/doctor.rs
+++ b/app/arcbox-cli/src/commands/doctor.rs
@@ -215,30 +215,27 @@ fn check_container_route() -> CheckResult {
 #[cfg(target_os = "macos")]
 async fn check_helper() -> CheckResult {
     let min = arcbox_constants::helper::MIN_HELPER_VERSION;
-    match arcbox_helper::client::Client::connect().await {
-        Ok(client) => match client.version().await {
-            Ok(version) => match arcbox_constants::helper::parse_helper_version(&version) {
-                Some(installed) => {
-                    let Some(minimum) = arcbox_constants::helper::parse_semver_triple(min) else {
-                        return CheckResult::Fail(format!(
-                            "invalid MIN_HELPER_VERSION constant {min:?}"
-                        ));
-                    };
-                    if arcbox_constants::helper::helper_version_satisfies(installed, minimum) {
-                        CheckResult::Pass(format!("reachable ({version})"))
-                    } else {
-                        CheckResult::Fail(format!(
-                            "{version} is older than required {min}; run 'sudo abctl _install --no-daemon --no-shell'"
-                        ))
-                    }
+    match arcbox_helper::client::Client::probe_version().await {
+        Ok(version) => match arcbox_constants::helper::parse_helper_version(&version) {
+            Some(installed) => {
+                let Some(minimum) = arcbox_constants::helper::parse_semver_triple(min) else {
+                    return CheckResult::Fail(format!(
+                        "invalid MIN_HELPER_VERSION constant {min:?}"
+                    ));
+                };
+                if arcbox_constants::helper::helper_version_satisfies(installed, minimum) {
+                    CheckResult::Pass(format!("reachable ({version})"))
+                } else {
+                    CheckResult::Fail(format!(
+                        "{version} is older than required {min}; run 'sudo abctl _install --no-daemon --no-shell'"
+                    ))
                 }
-                None => CheckResult::Fail(format!(
-                    "unrecognized version {version:?}; run 'sudo abctl _install --no-daemon --no-shell'"
-                )),
-            },
-            Err(e) => CheckResult::Fail(format!("version check failed: {e}")),
+            }
+            None => CheckResult::Fail(format!(
+                "unrecognized version {version:?}; run 'sudo abctl _install --no-daemon --no-shell'"
+            )),
         },
-        Err(e) => CheckResult::Fail(format!("not reachable via launchd socket: {e}")),
+        Err(e) => CheckResult::Fail(format!("version check failed: {e}")),
     }
 }
 

--- a/app/arcbox-cli/src/commands/internal.rs
+++ b/app/arcbox-cli/src/commands/internal.rs
@@ -123,9 +123,10 @@ async fn brew_uninstall() -> Result<()> {
     // 4. Remove `/usr/local/bin/docker*` via the helper. The helper plist
     //    survives this hook (its full removal belongs to `sudo abctl _uninstall`),
     //    so its launchd-activated socket is still reachable here. Best-effort:
-    //    if the helper was never installed (app never launched), the connect
-    //    fails and we leave nothing to clean up anyway. The helper's `cli_unlink`
-    //    is gated on `is_arcbox_owned`, so foreign symlinks are left alone.
+    //    a missing or incompatible helper makes the checked connection fail;
+    //    the full sudo uninstall removes any remaining owned links directly.
+    //    The helper's `cli_unlink` is gated on `is_arcbox_owned`, so foreign
+    //    symlinks are left alone.
     if let Ok(client) = arcbox_helper::client::Client::connect().await {
         for name in DOCKER_CLI_TOOLS {
             let _ = client.cli_unlink(name).await;

--- a/app/arcbox-core/src/route_reconciler.rs
+++ b/app/arcbox-core/src/route_reconciler.rs
@@ -43,9 +43,10 @@ pub enum RouteError {
 impl From<ClientError> for RouteError {
     fn from(e: ClientError) -> Self {
         match e {
-            ClientError::Connection(_) | ClientError::Rpc(_) => {
-                Self::HelperUnavailable(e.to_string())
-            }
+            ClientError::Connection(_)
+            | ClientError::Rpc(_)
+            | ClientError::UnrecognizedVersion(_)
+            | ClientError::IncompatibleVersion { .. } => Self::HelperUnavailable(e.to_string()),
             ClientError::Helper(err) => Self::RouteFailed(err.to_string()),
         }
     }

--- a/app/arcbox-daemon/src/self_setup.rs
+++ b/app/arcbox-daemon/src/self_setup.rs
@@ -40,22 +40,19 @@ pub trait SetupTask: Send + Sync {
 /// If the helper is unreachable **or older than
 /// [`arcbox_constants::helper::MIN_HELPER_VERSION`]**, all tasks are skipped so
 /// we never drive new RPCs (e.g. `hosts_alias_*`) into a legacy binary that
-/// misdecodes tarpc ordinals.
+/// misdecodes tarpc ordinals. [`Client::connect`] enforces that invariant for
+/// every helper consumer, including route reconciliation.
 pub async fn run(tasks: &[&dyn SetupTask]) {
     let client = match Client::connect().await {
         Ok(c) => c,
         Err(e) => {
             tracing::debug!(
                 error = %e,
-                "arcbox-helper not reachable, skipping self-setup"
+                "arcbox-helper unavailable or incompatible, skipping self-setup"
             );
             return;
         }
     };
-
-    if !helper_version_ok(&client).await {
-        return;
-    }
 
     for task in tasks {
         let name = task.name();
@@ -73,50 +70,5 @@ pub async fn run(tasks: &[&dyn SetupTask]) {
                 "failed (run 'sudo abctl _install --no-daemon --no-shell' to fix)"
             ),
         }
-    }
-}
-
-/// Returns `true` when the connected helper meets
-/// [`arcbox_constants::helper::MIN_HELPER_VERSION`].
-///
-/// On failure logs a warning and returns `false` so callers skip privileged
-/// tasks rather than hammering an incompatible helper.
-async fn helper_version_ok(client: &Client) -> bool {
-    let min = arcbox_constants::helper::MIN_HELPER_VERSION;
-    let Ok(version) = client.version().await else {
-        tracing::warn!("failed to check arcbox-helper version; skipping self-setup");
-        return false;
-    };
-
-    let Some(installed) = arcbox_constants::helper::parse_helper_version(&version) else {
-        tracing::warn!(
-            helper_version = %version,
-            "unrecognized arcbox-helper version; run 'sudo abctl _install --no-daemon --no-shell'"
-        );
-        return false;
-    };
-
-    let Some(minimum) = arcbox_constants::helper::parse_semver_triple(min) else {
-        tracing::warn!(
-            min_helper_version = min,
-            "invalid MIN_HELPER_VERSION constant"
-        );
-        return false;
-    };
-
-    if arcbox_constants::helper::helper_version_satisfies(installed, minimum) {
-        tracing::debug!(
-            helper_version = %version,
-            min_helper_version = min,
-            "arcbox-helper version ok"
-        );
-        true
-    } else {
-        tracing::warn!(
-            helper_version = %version,
-            min_helper_version = min,
-            "arcbox-helper too old; skipping self-setup — run 'sudo abctl _install --no-daemon --no-shell'"
-        );
-        false
     }
 }

--- a/app/arcbox-daemon/src/self_setup.rs
+++ b/app/arcbox-daemon/src/self_setup.rs
@@ -45,10 +45,28 @@ pub trait SetupTask: Send + Sync {
 pub async fn run(tasks: &[&dyn SetupTask]) {
     let client = match Client::connect().await {
         Ok(c) => c,
+        Err(ClientError::UnrecognizedVersion(version)) => {
+            tracing::warn!(
+                version = %version,
+                "arcbox-helper returned an unrecognized version; run 'sudo abctl _install --no-daemon --no-shell' to replace it"
+            );
+            return;
+        }
+        Err(ClientError::IncompatibleVersion {
+            installed,
+            required,
+        }) => {
+            tracing::warn!(
+                installed = %installed,
+                required,
+                "arcbox-helper is incompatible; run 'sudo abctl _install --no-daemon --no-shell' to replace it"
+            );
+            return;
+        }
         Err(e) => {
             tracing::debug!(
                 error = %e,
-                "arcbox-helper unavailable or incompatible, skipping self-setup"
+                "arcbox-helper unavailable, skipping self-setup"
             );
             return;
         }

--- a/app/arcbox-helper/src/client.rs
+++ b/app/arcbox-helper/src/client.rs
@@ -16,6 +16,17 @@ pub enum ClientError {
     /// tarpc transport or RPC-level failure.
     #[error("helper rpc failed: {0}")]
     Rpc(#[from] tarpc::client::RpcError),
+    /// The helper returned a version string that cannot be interpreted safely.
+    #[error("unrecognized helper version {0:?}")]
+    UnrecognizedVersion(String),
+    /// The helper's RPC wire major or minimum version is incompatible.
+    #[error("helper {installed} is incompatible; required {required}")]
+    IncompatibleVersion {
+        /// Version line returned by the helper.
+        installed: String,
+        /// Minimum compatible helper version.
+        required: &'static str,
+    },
     /// The helper executed the operation but it returned a structured error.
     #[error(transparent)]
     Helper(#[from] HelperError),
@@ -30,16 +41,21 @@ impl Client {
     /// Connects to the helper daemon via Unix socket.
     ///
     /// Uses launchd-managed socket by default (`/var/run/arcbox-helper.sock`),
-    /// overridable via `ARCBOX_HELPER_SOCKET` env var.
+    /// overridable via `ARCBOX_HELPER_SOCKET` env var. The connection is
+    /// rejected before any mutation when the helper wire version is
+    /// incompatible with this client.
     pub async fn connect() -> Result<Self, ClientError> {
         let inner = crate::connect().await?;
-        Ok(Self { inner })
+        let client = Self { inner };
+        client.ensure_compatible().await?;
+        Ok(client)
     }
 
     /// Connects to the helper daemon at an explicit socket path.
     ///
     /// Unlike [`connect()`](Self::connect), this does not read the
-    /// `ARCBOX_HELPER_SOCKET` env var, making it safe for parallel tests.
+    /// `ARCBOX_HELPER_SOCKET` env var, making it safe for parallel tests. It
+    /// enforces the same wire-version check as [`connect()`](Self::connect).
     pub async fn connect_to(path: &str) -> Result<Self, ClientError> {
         let transport = tarpc::serde_transport::unix::connect(
             path,
@@ -48,7 +64,19 @@ impl Client {
         .await?;
         let inner =
             crate::HelperServiceClient::new(tarpc::client::Config::default(), transport).spawn();
-        Ok(Self { inner })
+        let client = Self { inner };
+        client.ensure_compatible().await?;
+        Ok(client)
+    }
+
+    /// Connects only long enough to report the installed helper version.
+    ///
+    /// This intentionally skips compatibility enforcement so diagnostics can
+    /// explain why an old helper must be replaced. It never exposes a client
+    /// capable of sending mutation RPCs.
+    pub async fn probe_version() -> Result<String, ClientError> {
+        let inner = crate::connect().await?;
+        Self { inner }.version().await
     }
 
     /// Adds a host route for `subnet` via `iface`.
@@ -150,5 +178,23 @@ impl Client {
     /// Returns the helper daemon version.
     pub async fn version(&self) -> Result<String, ClientError> {
         Ok(self.inner.version(tarpc::context::current()).await?)
+    }
+
+    async fn ensure_compatible(&self) -> Result<(), ClientError> {
+        let version = self.version().await?;
+        let installed = arcbox_constants::helper::parse_helper_version(&version)
+            .ok_or_else(|| ClientError::UnrecognizedVersion(version.clone()))?;
+        let required = arcbox_constants::helper::MIN_HELPER_VERSION;
+        let minimum = arcbox_constants::helper::parse_semver_triple(required)
+            .expect("MIN_HELPER_VERSION is covered by a unit test");
+
+        if arcbox_constants::helper::helper_version_satisfies(installed, minimum) {
+            Ok(())
+        } else {
+            Err(ClientError::IncompatibleVersion {
+                installed: version,
+                required,
+            })
+        }
     }
 }

--- a/app/arcbox-helper/src/main.rs
+++ b/app/arcbox-helper/src/main.rs
@@ -20,7 +20,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 return Ok(());
             }
             "--version" | "-V" => {
-                eprintln!("arcbox-helper {}", env!("CARGO_PKG_VERSION"));
+                println!("arcbox-helper {}", env!("CARGO_PKG_VERSION"));
                 return Ok(());
             }
             "--idle-exit" => idle_exit = true,

--- a/app/arcbox-helper/tests/common/mod.rs
+++ b/app/arcbox-helper/tests/common/mod.rs
@@ -13,7 +13,9 @@ use tarpc::server::{BaseChannel, Channel};
 use tarpc::tokio_serde::formats::Bincode;
 
 #[derive(Clone)]
-pub struct MockHelperServer;
+pub struct MockHelperServer {
+    version: String,
+}
 
 impl HelperService for MockHelperServer {
     async fn route_add(
@@ -107,18 +109,33 @@ impl HelperService for MockHelperServer {
     }
 
     async fn version(self, _: tarpc::context::Context) -> String {
-        format!("arcbox-helper {}", env!("CARGO_PKG_VERSION"))
+        self.version
     }
 }
 
 /// Starts a mock server on a temp socket and returns a connected `Client`.
 pub async fn setup() -> (Client, tempfile::TempDir) {
+    let version = format!("arcbox-helper {}", env!("CARGO_PKG_VERSION"));
+    let (client, dir) = setup_with_version(&version).await;
+    (client.unwrap(), dir)
+}
+
+/// Starts a mock server with a caller-selected version response.
+pub async fn setup_with_version(
+    version: &str,
+) -> (
+    Result<Client, arcbox_helper::client::ClientError>,
+    tempfile::TempDir,
+) {
     let dir = tempfile::tempdir().unwrap();
     let sock_path = dir.path().join("helper.sock");
     let sock_str = sock_path.to_str().unwrap().to_string();
 
     let listener = tokio::net::UnixListener::bind(&sock_path).unwrap();
     let codec = tarpc::tokio_util::codec::length_delimited::LengthDelimitedCodec::builder();
+    let server = MockHelperServer {
+        version: version.to_owned(),
+    };
 
     tokio::spawn(async move {
         loop {
@@ -128,7 +145,7 @@ pub async fn setup() -> (Client, tempfile::TempDir) {
             let transport = tarpc::serde_transport::new(codec.new_framed(conn), Bincode::default());
             tokio::spawn(
                 BaseChannel::with_defaults(transport)
-                    .execute(MockHelperServer.serve())
+                    .execute(server.clone().serve())
                     .for_each(|resp| async {
                         tokio::spawn(resp);
                     }),
@@ -136,6 +153,6 @@ pub async fn setup() -> (Client, tempfile::TempDir) {
         }
     });
 
-    let client = Client::connect_to(&sock_str).await.unwrap();
+    let client = Client::connect_to(&sock_str).await;
     (client, dir)
 }

--- a/app/arcbox-helper/tests/connection_test.rs
+++ b/app/arcbox-helper/tests/connection_test.rs
@@ -2,7 +2,24 @@
 
 mod common;
 
+use std::process::Command;
+
 use arcbox_helper::client::{Client, ClientError};
+
+#[test]
+fn version_flag_reports_the_helper_version_on_stdout() {
+    let output = Command::new(env!("CARGO_BIN_EXE_arcbox-helper"))
+        .arg("--version")
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    assert_eq!(
+        String::from_utf8(output.stdout).unwrap(),
+        format!("arcbox-helper {}\n", env!("CARGO_PKG_VERSION"))
+    );
+    assert!(output.stderr.is_empty());
+}
 
 #[tokio::test]
 async fn version_returns_helper_crate_version() {

--- a/app/arcbox-helper/tests/connection_test.rs
+++ b/app/arcbox-helper/tests/connection_test.rs
@@ -35,6 +35,29 @@ async fn version_returns_helper_crate_version() {
     );
 }
 
+#[tokio::test]
+async fn mutation_client_rejects_an_old_wire_version() {
+    let (client, _dir) = common::setup_with_version("arcbox-helper 0.4.24").await;
+
+    assert!(matches!(
+        client,
+        Err(ClientError::IncompatibleVersion {
+            installed,
+            required: "1.0.0"
+        }) if installed == "arcbox-helper 0.4.24"
+    ));
+}
+
+#[tokio::test]
+async fn mutation_client_rejects_an_unrecognized_version() {
+    let (client, _dir) = common::setup_with_version("arcbox-helper broken").await;
+
+    assert!(matches!(
+        client,
+        Err(ClientError::UnrecognizedVersion(version)) if version == "arcbox-helper broken"
+    ));
+}
+
 /// Package version, workspace path-dep pin, and MIN_HELPER_VERSION must move
 /// together. Catches "bumped Cargo.toml but forgot MIN" before release.
 #[test]

--- a/docs/helper.md
+++ b/docs/helper.md
@@ -86,11 +86,18 @@ Rejected peers are dropped before any tarpc dispatch; logs include
 anything outside `/Applications/` or `/Users/` without a
 `.app/Contents/MacOS/xbin/` segment.
 
-### Daemon compatibility gate
+### Client-wide compatibility gate
 
-If the helper is unreachable, unparseable, or older than
-`MIN_HELPER_VERSION`, daemon `self_setup` **skips all privileged tasks** so it
-never drives new tarpc ordinals into a legacy binary.
+Every mutation-capable `Client::connect` / `Client::connect_to` call checks the
+helper's `version` RPC before returning a client. If the helper is unreachable,
+unparseable, outside the supported wire major, or older than
+`MIN_HELPER_VERSION`, no mutation client is returned. This protects every
+consumer—including daemon `self_setup`, route reconciliation, and CLI helper
+operations—from driving new tarpc ordinals into a legacy binary.
+
+Diagnostics use the non-mutating `Client::probe_version` path so `abctl doctor`
+can still report the version of an incompatible helper without exposing a
+client capable of sending privileged mutations.
 
 ## Local E2E (no root)
 


### PR DESCRIPTION
## Summary

- report `arcbox-helper --version` on stdout and cover the real binary contract
- enforce helper wire compatibility in the shared client while preserving unchecked doctor diagnostics
- build and install only authenticated release helpers into the system-wide launchd path

## Validation

- `make test-helper`
- `cargo test -p arcbox-core -p arcbox-daemon -p arcbox-cli --lib --bins`
- `cargo check -p arcbox-helper -p arcbox-core -p arcbox-daemon -p arcbox-cli`
- `cargo clippy -p arcbox-helper -p arcbox-core -p arcbox-daemon -p arcbox-cli -- -D warnings`
- `cargo fmt --all -- --check`