### PR TITLE
fix(helper): use valid dynamic code-signing flags

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -646,7 +646,7 @@ dependencies = [
 
 [[package]]
 name = "arcbox-helper"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "arcbox-constants",
  "arcbox-logging",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -259,7 +259,7 @@ arcbox-fleet-control-proto = { version = "0.5.0", path = "fleet/arcbox-fleet-con
 arcbox-docker = { version = "0.5.0", path = "app/arcbox-docker" } # x-release-please-version
 # Pinned to app/arcbox-helper's own version (not workspace.package). Do not
 # attach x-release-please-version — helper releases are manual.
-arcbox-helper = { version = "1.0.0", path = "app/arcbox-helper" }
+arcbox-helper = { version = "1.0.1", path = "app/arcbox-helper" }
 arcbox-core = { version = "0.5.0", path = "app/arcbox-core" } # x-release-please-version
 arcbox-api = { version = "0.5.0", path = "app/arcbox-api" } # x-release-please-version
 arcbox-migration = { version = "0.5.0", path = "app/arcbox-migration" } # x-release-please-version

--- a/app/arcbox-helper/Cargo.toml
+++ b/app/arcbox-helper/Cargo.toml
@@ -3,10 +3,10 @@ name = "arcbox-helper"
 description = "Privileged helper daemon for host mutations (routes, DNS, sockets)"
 # Independent of workspace.package.version. Bump only when the on-disk
 # privileged binary must be replaced (RPC wire break, security fix in the
-# root helper, or behavior the current daemon hard-requires). Ordinary
-# arcbox 0.4.x runtime bumps must NOT change this, or every Desktop user
-# gets an admin-password reinstall prompt.
-version = "1.0.0"
+# root helper, or behavior the current daemon hard-requires). Ordinary runtime
+# bumps must NOT change this, or every Desktop user gets an admin-password
+# reinstall prompt.
+version = "1.0.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/app/arcbox-helper/src/server/peer_auth.rs
+++ b/app/arcbox-helper/src/server/peer_auth.rs
@@ -176,12 +176,13 @@ fn requirement_string(identifier: &str, team_id: &str) -> String {
 
 /// Flags accepted by `SecCodeCheckValidity` for a live process.
 ///
-/// Nested and strict validation flags are for static bundle validation and
-/// make the dynamic API fail with `errSecCSInvalidFlags`.
+/// Strict validation retains additional bundle-structure checks. Nested-code
+/// recursion is static-only and makes the dynamic API fail with
+/// `errSecCSInvalidFlags`.
 #[cfg(all(target_os = "macos", any(test, not(debug_assertions))))]
 fn dynamic_validation_flags() -> security_framework::os::macos::code_signing::Flags {
     use security_framework::os::macos::code_signing::Flags;
-    Flags::NONE
+    Flags::STRICT_VALIDATE
 }
 
 #[cfg(not(debug_assertions))]

--- a/app/arcbox-helper/src/server/peer_auth.rs
+++ b/app/arcbox-helper/src/server/peer_auth.rs
@@ -174,11 +174,14 @@ fn requirement_string(identifier: &str, team_id: &str) -> String {
     )
 }
 
-/// `kSecCSCheckNestedCode | kSecCSStrictValidate`.
-#[cfg(not(debug_assertions))]
-fn check_flags() -> security_framework::os::macos::code_signing::Flags {
+/// Flags accepted by `SecCodeCheckValidity` for a live process.
+///
+/// Nested and strict validation flags are for static bundle validation and
+/// make the dynamic API fail with `errSecCSInvalidFlags`.
+#[cfg(all(target_os = "macos", any(test, not(debug_assertions))))]
+fn dynamic_validation_flags() -> security_framework::os::macos::code_signing::Flags {
     use security_framework::os::macos::code_signing::Flags;
-    Flags::CHECK_NESTED_CODE | Flags::STRICT_VALIDATE
+    Flags::NONE
 }
 
 #[cfg(not(debug_assertions))]
@@ -193,7 +196,8 @@ fn check_code_signature_pid(pid: i32, identifier: &str, team_id: &str) -> bool {
     let Ok(req) = requirement_string(identifier, team_id).parse::<SecRequirement>() else {
         return false;
     };
-    code.check_validity(check_flags(), &req).is_ok()
+    code.check_validity(dynamic_validation_flags(), &req)
+        .is_ok()
 }
 
 #[cfg(not(debug_assertions))]
@@ -212,7 +216,8 @@ fn check_code_signature_audit(token: &AuditToken, identifier: &str, team_id: &st
     let Ok(req) = requirement_string(identifier, team_id).parse::<SecRequirement>() else {
         return false;
     };
-    code.check_validity(check_flags(), &req).is_ok()
+    code.check_validity(dynamic_validation_flags(), &req)
+        .is_ok()
 }
 
 #[cfg(test)]
@@ -230,11 +235,16 @@ mod tests {
     }
 
     #[test]
-    #[cfg(not(debug_assertions))]
-    fn check_flags_include_nested_and_strict() {
-        use security_framework::os::macos::code_signing::Flags;
-        let f = super::check_flags();
-        assert!(f.contains(Flags::CHECK_NESTED_CODE));
-        assert!(f.contains(Flags::STRICT_VALIDATE));
+    #[cfg(target_os = "macos")]
+    fn dynamic_validation_flags_are_accepted_by_security_framework() {
+        use security_framework::os::macos::code_signing::{Flags, SecCode, SecRequirement};
+
+        let code = SecCode::for_self(Flags::NONE).expect("test process should be inspectable");
+        let requirement = "true"
+            .parse::<SecRequirement>()
+            .expect("unconditional requirement should parse");
+
+        code.check_validity(super::dynamic_validation_flags(), &requirement)
+            .expect("dynamic code validation flags should be accepted");
     }
 }

--- a/app/arcbox-helper/tests/connection_test.rs
+++ b/app/arcbox-helper/tests/connection_test.rs
@@ -43,8 +43,9 @@ async fn mutation_client_rejects_an_old_wire_version() {
         client,
         Err(ClientError::IncompatibleVersion {
             installed,
-            required: "1.0.0"
+            required,
         }) if installed == "arcbox-helper 0.4.24"
+            && required == arcbox_constants::helper::MIN_HELPER_VERSION
     ));
 }
 
@@ -79,8 +80,8 @@ fn helper_version_pins_are_aligned() {
         "root Cargo.toml must pin arcbox-helper = {{ version = \"{pkg}\", ... }}"
     );
 
-    // Independent of workspace package version (0.4.x).
-    assert_eq!(pkg, "1.0.0");
+    // Independent of the workspace package version.
+    assert_eq!(pkg, "1.0.1");
 }
 
 #[tokio::test]

--- a/common/arcbox-constants/src/helper.rs
+++ b/common/arcbox-constants/src/helper.rs
@@ -2,7 +2,7 @@
 //! string format) the Desktop app.
 //!
 //! The helper crate (`arcbox-helper`) owns an **independent** Cargo version
-//! (currently `1.0.0`), not `workspace.package.version`. Compare that version
+//! (currently `1.0.1`), not `workspace.package.version`. Compare that version
 //! — never the daemon/workspace crate version — when deciding whether to
 //! reinstall the root binary.
 //!
@@ -19,7 +19,7 @@
 ///
 /// Must stay in sync with `app/arcbox-helper/Cargo.toml` `version` (and the
 /// workspace path-dep pin) whenever the floor moves.
-pub const MIN_HELPER_VERSION: &str = "1.0.0";
+pub const MIN_HELPER_VERSION: &str = "1.0.1";
 
 /// Strips the optional `arcbox-helper ` prefix and whitespace from a version line.
 #[must_use]

--- a/docs/helper.md
+++ b/docs/helper.md
@@ -64,7 +64,7 @@ signature verification on every accept (`peer_auth::verify`):
 1. Prefer `LOCAL_PEERTOKEN` (audit token) — binds to the live connecting process.
 2. Fall back to `LOCAL_PEERPID`.
 3. `SecCodeCopyGuestWithAttributes` → `SecCodeCheckValidity` with
-   default dynamic-validation flags and
+   strict dynamic-validation (without the static-only nested-code flag) and
    `identifier "…" and anchor apple generic and certificate leaf[subject.OU] = "TEAM"`.
 4. Allow-list: `com.arcboxlabs.desktop{,.dev}{,.daemon,.cli}`.
 

--- a/docs/helper.md
+++ b/docs/helper.md
@@ -7,19 +7,19 @@ perform: `/usr/local/bin` CLI symlinks, `/var/run/docker.sock`, `/etc/resolver`,
 ## Independent version
 
 `arcbox-helper` owns its **own** Cargo package version
-(`app/arcbox-helper/Cargo.toml`), currently `1.0.0`. It is **not** tied to
-`workspace.package.version` (`0.4.x`).
+(`app/arcbox-helper/Cargo.toml`), currently `1.0.1`. It is **not** tied to
+`workspace.package.version`.
 
 | Pin | Location |
 |-----|----------|
-| Helper package version | `app/arcbox-helper/Cargo.toml` → `version = "1.0.0"` |
-| Workspace path-dep | root `Cargo.toml` → `arcbox-helper = { version = "1.0.0", path = ... }` (**no** `x-release-please-version`) |
+| Helper package version | `app/arcbox-helper/Cargo.toml` → `version = "1.0.1"` |
+| Workspace path-dep | root `Cargo.toml` → `arcbox-helper = { version = "1.0.1", path = ... }` (**no** `x-release-please-version`) |
 | Daemon/CLI floor | `arcbox_constants::helper::MIN_HELPER_VERSION` |
 
 `arcbox-helper --version` and the tarpc `version` RPC both print:
 
 ```text
-arcbox-helper 1.0.0
+arcbox-helper 1.0.1
 ```
 
 Desktop and daemon parse that line with
@@ -64,6 +64,7 @@ signature verification on every accept (`peer_auth::verify`):
 1. Prefer `LOCAL_PEERTOKEN` (audit token) — binds to the live connecting process.
 2. Fall back to `LOCAL_PEERPID`.
 3. `SecCodeCopyGuestWithAttributes` → `SecCodeCheckValidity` with
+   default dynamic-validation flags and
    `identifier "…" and anchor apple generic and certificate leaf[subject.OU] = "TEAM"`.
 4. Allow-list: `com.arcboxlabs.desktop{,.dev}{,.daemon,.cli}`.
 


### PR DESCRIPTION
## Summary

- retain `STRICT_VALIDATE` for live-process `SecCodeCheckValidity` while removing the static-only `CHECK_NESTED_CODE` flag
- keep the existing audit-token/PID binding and identifier + Apple anchor + Team ID requirement
- bump the independently installed helper from `1.0.0` to `1.0.1` so Desktop replaces the broken production binary
- add a macOS Security.framework regression test and update the aligned version pins/docs

## Root cause

Desktop 1.29.0 installs a correctly signed helper, CLI, and daemon, but `arcbox-helper` passed `CHECK_NESTED_CODE | STRICT_VALIDATE` to dynamic `SecCodeCheckValidity`. macOS rejects `CHECK_NESTED_CODE` in this API with `-67070` (`errSecCSInvalidFlags`) before evaluating the requirement, so every legitimate helper RPC was dropped. That also prevented cold-start route reconciliation.

## Verification

- `make test-helper`
- `cargo test --release -p arcbox-helper --bin arcbox-helper dynamic_validation_flags_are_accepted_by_security_framework`
- `cargo clippy --release -p arcbox-helper -- -D warnings`
- `cargo check --locked -p arcbox-helper -p arcbox-daemon -p arcbox-cli`
- `cargo fmt --all -- --check`
- `git diff --check`
- on the installed 1.29.0 build, reproduced `-67070` with the shipped flag combination; `STRICT_VALIDATE` alone succeeds for the same allowed daemon PID + signing requirement, while a deliberately wrong identifier still fails with `-67050`
