### PR TITLE
feat(fleet): live VM backend activation — re-probe, re-attach, Prepare bootstrap

### DIFF
--- a/fleet/arcbox-fleet-agent/src/attach.rs
+++ b/fleet/arcbox-fleet-agent/src/attach.rs
@@ -6,6 +6,7 @@
 //! reconnect keeps running, and its terminal event is forwarded to whichever
 //! stream is live instead of being lost into the dropped connection's channel.
 
+use std::sync::Arc;
 use std::time::Duration;
 
 use anyhow::{Context, Result};
@@ -22,9 +23,9 @@ use tonic::Request;
 use tonic::metadata::MetadataValue;
 use tracing::{info, warn};
 
+use crate::backends::Backends;
 use crate::config::AgentConfig;
 use crate::credentials::Credential;
-use crate::docker;
 use crate::host;
 use crate::runner::RunnerSupervisor;
 use crate::state::AgentState;
@@ -122,22 +123,12 @@ fn telemetry_to_control(t: &HostTelemetry) -> control_proto::HostTelemetry {
 /// its own task.
 pub fn spawn_supervisor(
     config: &AgentConfig,
-    docker: Option<docker::DockerRunner>,
-    vm: Option<crate::vm::VmRunner>,
-    interop: Option<crate::interop::InteropRunner>,
-    capabilities: Vec<Capability>,
+    backends: Arc<Backends>,
     state: AgentState,
 ) -> (RunnerSupervisor, mpsc::Receiver<AttachRequest>) {
     let (egress_tx, egress_rx) = mpsc::channel::<AttachRequest>(OUTBOUND_CAPACITY);
-    let supervisor = RunnerSupervisor::new(
-        egress_tx,
-        config.runner_script.clone(),
-        docker,
-        vm,
-        interop,
-        capabilities,
-        state,
-    );
+    let supervisor =
+        RunnerSupervisor::new(egress_tx, config.runner_script.clone(), backends, state);
     (supervisor, egress_rx)
 }
 
@@ -688,8 +679,11 @@ mod tests {
             machine_id: "fltm_parked".to_owned(),
             machine_token: "flt_revoked".to_owned(),
         };
-        let (supervisor, egress_rx) =
-            spawn_supervisor(&config, None, None, None, Vec::new(), state.clone());
+        let (supervisor, egress_rx) = spawn_supervisor(
+            &config,
+            Backends::fixed(Vec::new(), state.clone()),
+            state.clone(),
+        );
         let shutdown = CancellationToken::new();
         let run = tokio::spawn(run(
             config,
@@ -813,16 +807,7 @@ mod tests {
             gateway: gateway.clone(),
             ..seed()
         });
-        let (events, _rx) = mpsc::channel(1);
-        let supervisor = RunnerSupervisor::new(
-            events,
-            None,
-            None,
-            None,
-            None,
-            Vec::new(),
-            AgentState::new(&seed()),
-        );
+        let supervisor = supervisor();
         let (_egress_tx, mut egress_rx) = mpsc::channel::<AttachRequest>(1);
         let mut pending = None;
         let mut backoff = INITIAL_BACKOFF;
@@ -869,18 +854,8 @@ mod tests {
     /// handle) for the life of the process.
     #[tokio::test]
     async fn verdict_resend_task_exits_when_shutdown_fires() {
-        let (events, _rx) = mpsc::channel(1);
-        let supervisor = RunnerSupervisor::new(
-            events,
-            None,
-            None,
-            None,
-            None,
-            Vec::new(),
-            AgentState::new(&seed()),
-        );
         let shutdown = CancellationToken::new();
-        let handle = spawn_verdict_resend(supervisor, shutdown.clone());
+        let handle = spawn_verdict_resend(supervisor(), shutdown.clone());
 
         shutdown.cancel();
         tokio::time::timeout(Duration::from_secs(1), handle)
@@ -917,6 +892,20 @@ mod tests {
         }
     }
 
+    /// A minimal supervisor over an empty fixed-capability registry, with
+    /// its own observable state — for tests that only need the handle and
+    /// never route a verdict through it (the egress receiver is dropped).
+    fn supervisor() -> RunnerSupervisor {
+        let (events, _rx) = mpsc::channel(1);
+        let state = AgentState::new(&seed());
+        RunnerSupervisor::new(
+            events,
+            None,
+            Backends::fixed(Vec::new(), state.clone()),
+            state,
+        )
+    }
+
     /// The connect + Attach-RPC handshake has no cancellation awareness of
     /// its own (see this fn's own doc in the non-test code above) — without
     /// racing it against `shutdown`, a reconnect attempt could complete the
@@ -926,16 +915,7 @@ mod tests {
     #[tokio::test]
     async fn connect_and_serve_bails_out_immediately_when_already_cancelled() {
         let state = AgentState::new(&seed());
-        let (events, _rx) = mpsc::channel(1);
-        let supervisor = RunnerSupervisor::new(
-            events,
-            None,
-            None,
-            None,
-            None,
-            Vec::new(),
-            AgentState::new(&seed()),
-        );
+        let supervisor = supervisor();
         let (_egress_tx, mut egress_rx) = mpsc::channel::<AttachRequest>(1);
         let mut pending = None;
         let mut backoff = INITIAL_BACKOFF;

--- a/fleet/arcbox-fleet-agent/src/attach.rs
+++ b/fleet/arcbox-fleet-agent/src/attach.rs
@@ -13,9 +13,9 @@ use anyhow::{Context, Result};
 use arcbox_fleet_control_proto::v1 as control_proto;
 use arcbox_fleet_proto::v1::fleet_gateway_service_client::FleetGatewayServiceClient;
 use arcbox_fleet_proto::v1::{
-    Attach, AttachRequest, Capability, Heartbeat, HostTelemetry, attach_request, attach_response,
+    Attach, AttachRequest, Heartbeat, HostTelemetry, attach_request, attach_response,
 };
-use tokio::sync::mpsc;
+use tokio::sync::{mpsc, watch};
 use tokio_stream::wrappers::ReceiverStream;
 use tokio_util::sync::CancellationToken;
 use tokio_util::task::AbortOnDropHandle;
@@ -100,6 +100,17 @@ fn is_unauthenticated(error: &anyhow::Error) -> bool {
     })
 }
 
+/// Why one connection's serve loop ended without an error.
+enum StreamEnd {
+    /// The gateway closed the stream; reconnect after backoff.
+    Closed,
+    /// The backend registry changed, so the capability set this stream
+    /// declared is stale — re-attach immediately (no backoff): the gateway
+    /// rewrites the machine's capability pools from each `Attach`
+    /// handshake, so the reconnect is what propagates the change.
+    Reattach,
+}
+
 /// Convert a gateway-facing telemetry reading into its control-plane
 /// counterpart. A plain function, not `From`: both `HostTelemetry` types
 /// are generated in other crates, so Rust's orphan rule blocks implementing
@@ -143,19 +154,22 @@ pub fn spawn_supervisor(
 #[allow(
     clippy::too_many_arguments,
     reason = "the reconnect loop genuinely needs all of: endpoint config, credential, the \
-              persistent supervisor, the cross-reconnect egress queue, advertised \
-              capabilities, the shutdown token, and the observable state handle"
+              persistent supervisor, the cross-reconnect egress queue, the backend \
+              registry, the shutdown token, and the observable state handle"
 )]
 pub async fn run(
     config: AgentConfig,
     credential: Credential,
     supervisor: RunnerSupervisor,
     mut egress_rx: mpsc::Receiver<AttachRequest>,
-    capabilities: Vec<Capability>,
+    backends: Arc<Backends>,
     shutdown: CancellationToken,
     state: AgentState,
 ) -> Result<()> {
     let mut backoff = INITIAL_BACKOFF;
+    // Activation notifications; each connection marks the current value
+    // seen before it snapshots the capability set it declares.
+    let mut backends_rx = backends.subscribe();
     // An event pulled from the egress queue but not yet delivered when the
     // connection dropped; re-sent first on the next connection so a terminal
     // event is never lost to a closed stream.
@@ -181,7 +195,8 @@ pub async fn run(
             &mut egress_rx,
             &mut pending,
             &mut backoff,
-            &capabilities,
+            &backends,
+            &mut backends_rx,
             &shutdown,
             &state,
             &mut drained_for_update,
@@ -193,7 +208,11 @@ pub async fn run(
             break;
         }
         match outcome {
-            Ok(()) => info!("attach stream closed by gateway; reconnecting"),
+            Ok(StreamEnd::Reattach) => {
+                info!("backend registry changed; re-attaching with the fresh capability set");
+                continue;
+            }
+            Ok(StreamEnd::Closed) => info!("attach stream closed by gateway; reconnecting"),
             Err(e) if is_unauthenticated(&e) => {
                 // The gateway definitively rejected the credential — the
                 // machine was decommissioned server-side (RUN-40), whether
@@ -315,11 +334,12 @@ async fn connect_and_serve(
     egress_rx: &mut mpsc::Receiver<AttachRequest>,
     pending: &mut Option<AttachRequest>,
     backoff: &mut Duration,
-    capabilities: &[Capability],
+    backends: &Backends,
+    backends_rx: &mut watch::Receiver<()>,
     shutdown: &CancellationToken,
     state: &AgentState,
     drained_for_update: &mut bool,
-) -> Result<()> {
+) -> Result<StreamEnd> {
     // The desired (`target`) gateway, not `config.gateway` directly —
     // `AgentSupervisor` seeds it from config, and an `Enroll` gateway
     // override can have moved it from there. It cannot move while this
@@ -330,20 +350,29 @@ async fn connect_and_serve(
     let gateway = state.gateway_target();
     let (req_tx, req_rx) = mpsc::channel::<AttachRequest>(OUTBOUND_CAPACITY);
 
+    // Mark the current registry generation seen BEFORE snapshotting the
+    // capability set: an activation racing this window still trips the
+    // re-attach arm below, which is harmless — the set it re-declares is
+    // already fresh. The reverse order could declare a stale set and eat
+    // the notification.
+    backends_rx.mark_unchanged();
+    let capabilities = backends.capabilities();
+
     // Send `Attach` as the very first outbound message, buffered on `req_tx`
     // before the gRPC call runs. Three reasons: it's the handshake message
     // the gateway checks agent_version against; it declares the capabilities
-    // and host facts that are constant for this process's lifetime (so
-    // Heartbeat can carry only what actually changes); and it satisfies the
-    // PLAT-34 "speak first" property — the gateway (or a proxy in front)
-    // will not release its response headers until it sees the client say
-    // something, and if the client waits for the response before sending
-    // anything the whole stream idle-times-out. The mpsc buffer holds the
-    // message until tonic drains it once the stream opens.
+    // and host facts for this connection (the gateway treats them as
+    // per-attachment declarative state and Heartbeat carries only what
+    // changes mid-stream — a capability change re-attaches instead); and it
+    // satisfies the PLAT-34 "speak first" property — the gateway (or a
+    // proxy in front) will not release its response headers until it sees
+    // the client say something, and if the client waits for the response
+    // before sending anything the whole stream idle-times-out. The mpsc
+    // buffer holds the message until tonic drains it once the stream opens.
     let attach_msg = AttachRequest {
         msg: Some(attach_request::Msg::Attach(Attach {
             agent_version: env!("CARGO_PKG_VERSION").to_owned(),
-            capabilities: capabilities.to_vec(),
+            capabilities,
             host_info_json: host::host_info_json(),
             host_os: host::host_os(),
             host_arch: host::host_arch(),
@@ -382,7 +411,7 @@ async fn connect_and_serve(
     };
     let mut inbound = tokio::select! {
         biased;
-        () = shutdown.cancelled() => return Ok(()),
+        () = shutdown.cancelled() => return Ok(StreamEnd::Closed),
         result = connect => result?,
     };
 
@@ -437,11 +466,23 @@ async fn connect_and_serve(
 
     loop {
         tokio::select! {
-            () = shutdown.cancelled() => break Ok(()),
+            () = shutdown.cancelled() => break Ok(StreamEnd::Closed),
             () = supervisor.settled(), if pending_update.is_some() => {
                 break Err(anyhow::Error::new(
                     pending_update.take().expect("guarded by is_some"),
                 ));
+            }
+            // A backend activated: leave cleanly so the reconnect declares
+            // the fresh capability set. In-flight jobs survive (they live
+            // in the supervisor), and a pending mid-stream update is safe
+            // to abandon — the next handshake re-derives it (AttachRejected
+            // or a re-pushed HeartbeatAck). Err means the registry dropped,
+            // which only happens at process teardown.
+            result = backends_rx.changed() => {
+                break Ok(match result {
+                    Ok(()) => StreamEnd::Reattach,
+                    Err(_) => StreamEnd::Closed,
+                });
             }
             event = egress_rx.recv() => match event {
                 Some(msg) => {
@@ -453,7 +494,7 @@ async fn connect_and_serve(
                 }
                 // The supervisor holds the only egress sender, so this cannot
                 // happen while the agent runs; treat it as a clean shutdown.
-                None => break Ok(()),
+                None => break Ok(StreamEnd::Closed),
             },
             message = inbound.message() => match message {
                 Ok(Some(message)) => {
@@ -475,7 +516,7 @@ async fn connect_and_serve(
                     }
                     dispatch(supervisor, message.msg);
                 }
-                Ok(None) => break Ok(()),
+                Ok(None) => break Ok(StreamEnd::Closed),
                 Err(status) => break Err(anyhow::Error::from(status)),
             },
         }
@@ -555,8 +596,9 @@ fn spawn_verdict_resend(
 /// Heartbeats are connection-scoped: the task is spawned per connection and
 /// aborted when it drops, so a momentary disconnect does not leave stale
 /// heartbeats queued for the next stream. Capability set and host facts are
-/// declared once per stream in the `Attach` handshake (they're constant for
-/// the process lifetime), so this loop carries only what actually changes.
+/// declared once per stream in the `Attach` handshake (a capability change
+/// re-attaches instead — see [`StreamEnd::Reattach`]), so this loop carries
+/// only what actually changes mid-stream.
 fn spawn_heartbeat(
     outbound: mpsc::Sender<AttachRequest>,
     state: AgentState,
@@ -679,18 +721,16 @@ mod tests {
             machine_id: "fltm_parked".to_owned(),
             machine_token: "flt_revoked".to_owned(),
         };
-        let (supervisor, egress_rx) = spawn_supervisor(
-            &config,
-            Backends::fixed(Vec::new(), state.clone()),
-            state.clone(),
-        );
+        let backends = Backends::fixed(Vec::new(), state.clone());
+        let (supervisor, egress_rx) =
+            spawn_supervisor(&config, Arc::clone(&backends), state.clone());
         let shutdown = CancellationToken::new();
         let run = tokio::spawn(run(
             config,
             credential,
             supervisor,
             egress_rx,
-            Vec::new(),
+            backends,
             shutdown.clone(),
             state.clone(),
         ));
@@ -808,6 +848,8 @@ mod tests {
             ..seed()
         });
         let supervisor = supervisor();
+        let backends = Backends::fixed(Vec::new(), AgentState::new(&seed()));
+        let mut backends_rx = backends.subscribe();
         let (_egress_tx, mut egress_rx) = mpsc::channel::<AttachRequest>(1);
         let mut pending = None;
         let mut backoff = INITIAL_BACKOFF;
@@ -832,7 +874,8 @@ mod tests {
                 &mut egress_rx,
                 &mut pending,
                 &mut backoff,
-                &[],
+                &backends,
+                &mut backends_rx,
                 &shutdown,
                 &state,
                 &mut drained_for_update,
@@ -846,6 +889,154 @@ mod tests {
             state.current().enrollment,
             control_proto::Enrollment::Attached as i32,
         );
+    }
+
+    /// A gateway that accepts every `Attach`, records each handshake's
+    /// capability set, and holds the stream open (draining inbound so
+    /// heartbeats don't backpressure) until the client leaves.
+    struct RecordingGateway {
+        attaches: Arc<tokio::sync::Mutex<Vec<Vec<arcbox_fleet_proto::v1::Capability>>>>,
+    }
+
+    #[tonic::async_trait]
+    impl arcbox_fleet_proto::v1::fleet_gateway_service_server::FleetGatewayService
+        for RecordingGateway
+    {
+        async fn enroll(
+            &self,
+            _: Request<arcbox_fleet_proto::v1::EnrollRequest>,
+        ) -> Result<tonic::Response<arcbox_fleet_proto::v1::EnrollResponse>, tonic::Status>
+        {
+            Err(tonic::Status::unimplemented("not used by this test"))
+        }
+
+        type AttachStream = tokio_stream::wrappers::ReceiverStream<
+            Result<arcbox_fleet_proto::v1::AttachResponse, tonic::Status>,
+        >;
+
+        async fn attach(
+            &self,
+            request: Request<tonic::Streaming<AttachRequest>>,
+        ) -> Result<tonic::Response<Self::AttachStream>, tonic::Status> {
+            let mut inbound = request.into_inner();
+            let first = inbound
+                .message()
+                .await
+                .map_err(|e| tonic::Status::internal(e.to_string()))?
+                .ok_or_else(|| tonic::Status::internal("closed before Attach"))?;
+            let Some(attach_request::Msg::Attach(attach)) = first.msg else {
+                return Err(tonic::Status::internal("first message was not Attach"));
+            };
+            self.attaches.lock().await.push(attach.capabilities);
+
+            let (tx, rx) = mpsc::channel(4);
+            let _ = tx
+                .send(Ok(arcbox_fleet_proto::v1::AttachResponse {
+                    msg: Some(attach_response::Msg::AttachAccepted(
+                        arcbox_fleet_proto::v1::AttachAccepted {},
+                    )),
+                }))
+                .await;
+            tokio::spawn(async move {
+                // Keep the response stream open while draining heartbeats;
+                // dropping `tx` when the client hangs up closes it.
+                let _hold = tx;
+                while let Ok(Some(_)) = inbound.message().await {}
+            });
+            Ok(tonic::Response::new(
+                tokio_stream::wrappers::ReceiverStream::new(rx),
+            ))
+        }
+
+        async fn unenroll(
+            &self,
+            _: Request<arcbox_fleet_proto::v1::UnenrollRequest>,
+        ) -> Result<tonic::Response<arcbox_fleet_proto::v1::UnenrollResponse>, tonic::Status>
+        {
+            Err(tonic::Status::unimplemented("not used by this test"))
+        }
+    }
+
+    /// The re-attach contract end to end: a backend activating mid-stream
+    /// must make the attach loop leave its live stream and re-attach, with
+    /// the fresh handshake declaring the grown capability set — that
+    /// reconnect is what propagates a capability change to the gateway.
+    #[tokio::test]
+    async fn backend_activation_reattaches_with_fresh_capabilities() {
+        use arcbox_fleet_proto::v1::fleet_gateway_service_server::FleetGatewayServiceServer;
+
+        let attaches = Arc::new(tokio::sync::Mutex::new(Vec::new()));
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let gateway = format!("http://{}", listener.local_addr().unwrap());
+        tokio::spawn(
+            tonic::transport::Server::builder()
+                .add_service(FleetGatewayServiceServer::new(RecordingGateway {
+                    attaches: Arc::clone(&attaches),
+                }))
+                .serve_with_incoming(tokio_stream::wrappers::TcpListenerStream::new(listener)),
+        );
+
+        let state = AgentState::new(&PersistedSettings {
+            gateway: gateway.clone(),
+            ..seed()
+        });
+        let config = AgentConfig {
+            gateway,
+            ..config()
+        };
+        let backends = Backends::new(false, None, None, None, state.clone());
+        let (supervisor, egress_rx) =
+            spawn_supervisor(&config, Arc::clone(&backends), state.clone());
+        let shutdown = CancellationToken::new();
+        let run_task = tokio::spawn(run(
+            config,
+            credential(),
+            supervisor,
+            egress_rx,
+            Arc::clone(&backends),
+            shutdown.clone(),
+            state,
+        ));
+
+        async fn wait_for_attaches(
+            attaches: &tokio::sync::Mutex<Vec<Vec<arcbox_fleet_proto::v1::Capability>>>,
+            n: usize,
+        ) {
+            tokio::time::timeout(Duration::from_secs(5), async {
+                while attaches.lock().await.len() < n {
+                    tokio::time::sleep(Duration::from_millis(10)).await;
+                }
+            })
+            .await
+            .unwrap_or_else(|_| panic!("gateway never saw {n} Attach handshakes"));
+        }
+
+        // First attach declares the empty startup set.
+        wait_for_attaches(&attaches, 1).await;
+        assert!(attaches.lock().await[0].is_empty());
+
+        // Activate the VM backend mid-stream; the loop must re-attach and
+        // declare it.
+        let daemon = crate::mock_daemon::MockDaemon::spawn(&["tahoe-base"]).await;
+        let vm = crate::vm::VmRunner::new(&daemon.socket, "tahoe-base")
+            .await
+            .expect("probe against the mock daemon");
+        backends.activate_vm(vm);
+
+        wait_for_attaches(&attaches, 2).await;
+        let second = attaches.lock().await[1].clone();
+        assert_eq!(second.len(), 1);
+        assert_eq!(
+            second[0].backed_by,
+            arcbox_fleet_proto::v1::Backend::Vm as i32
+        );
+
+        shutdown.cancel();
+        tokio::time::timeout(Duration::from_secs(5), run_task)
+            .await
+            .expect("attach loop exits on shutdown")
+            .expect("attach task must not panic")
+            .expect("clean exit");
     }
 
     /// The verdict-resend loop is attachment-scoped: cancelling the shutdown
@@ -916,6 +1107,8 @@ mod tests {
     async fn connect_and_serve_bails_out_immediately_when_already_cancelled() {
         let state = AgentState::new(&seed());
         let supervisor = supervisor();
+        let backends = Backends::fixed(Vec::new(), AgentState::new(&seed()));
+        let mut backends_rx = backends.subscribe();
         let (_egress_tx, mut egress_rx) = mpsc::channel::<AttachRequest>(1);
         let mut pending = None;
         let mut backoff = INITIAL_BACKOFF;
@@ -935,7 +1128,8 @@ mod tests {
                 &mut egress_rx,
                 &mut pending,
                 &mut backoff,
-                &[],
+                &backends,
+                &mut backends_rx,
                 &shutdown,
                 &state,
                 &mut drained_for_update,

--- a/fleet/arcbox-fleet-agent/src/backends.rs
+++ b/fleet/arcbox-fleet-agent/src/backends.rs
@@ -1,0 +1,272 @@
+//! Live registry of the job-execution backends behind the agent's
+//! advertised capabilities.
+//!
+//! One shared handle replaces the per-consumer `Option<DockerRunner>` /
+//! `Option<VmRunner>` / `Option<InteropRunner>` copies that used to be
+//! frozen at startup: offer routing (`RunnerSupervisor`), capability
+//! advertisement (`attach`), image preparation (`FleetImageService`), and
+//! `GetAgentInfo` all read the same slots, so what the agent advertises
+//! and what it can actually serve cannot drift apart.
+//!
+//! On the wire, the capability set is per-attachment declarative state:
+//! the gateway rewrites the machine's capability pools from each `Attach`
+//! handshake, and a reconnect refreshes them. This registry is the client
+//! half of that contract — the VM slot can activate after startup (an
+//! arcbox-daemon that was not up yet when the agent started at login),
+//! and the attach loop re-attaches with the fresh set when it does.
+//!
+//! Activation is one-way: a slot never empties once filled, so
+//! "capability advertised ⇒ runner present" holds for the process
+//! lifetime. A backend that dies later surfaces as per-job failures
+//! (reject + platform re-offer), never as a capability retraction.
+
+use std::sync::{Arc, RwLock};
+
+use arcbox_fleet_control_proto::v1 as control_proto;
+use arcbox_fleet_proto::v1::{Backend, Capability};
+
+use crate::docker::DockerRunner;
+use crate::host;
+use crate::interop::InteropRunner;
+use crate::state::AgentState;
+use crate::vm::VmRunner;
+
+/// Convert a gateway-advertised capability into its control-plane
+/// counterpart. A plain function, not `From`: both `Capability` types are
+/// generated in other crates, so Rust's orphan rule blocks implementing a
+/// foreign trait (`From`) for two foreign types here.
+fn capability_to_control(c: &Capability) -> control_proto::Capability {
+    let backed_by = match Backend::try_from(c.backed_by) {
+        Ok(Backend::HostRunner) => control_proto::Backend::HostRunner,
+        Ok(Backend::Docker) => control_proto::Backend::Docker,
+        Ok(Backend::Vm) => control_proto::Backend::Vm,
+        Ok(Backend::Unspecified) | Err(_) => control_proto::Backend::Unspecified,
+    };
+    control_proto::Capability {
+        os: c.os.clone(),
+        arch: c.arch.clone(),
+        backed_by: backed_by as i32,
+    }
+}
+
+/// The agent's job-execution backends, shared by every consumer.
+///
+/// Slot lock discipline: the `RwLock` is held only to clone a handle in or
+/// out (runners are cheap-clone channel wrappers) — never across an await.
+pub struct Backends {
+    /// Whether a host runner script is configured — the native-platform
+    /// fallback capability when no isolating backend serves it.
+    runner_script_present: bool,
+    /// Docker runtime for Linux jobs. Probed at startup only (its `Auto`
+    /// re-probe is a known follow-up); lives here so every consumer reads
+    /// the same slot.
+    docker: Option<DockerRunner>,
+    /// macOS VM backend for darwin jobs. Live: empty while the daemon
+    /// probe has not succeeded, one-way filled once it does.
+    vm: RwLock<Option<VmRunner>>,
+    /// WSL interop backend for windows jobs. Startup-probed only: it
+    /// wraps host binaries, not a daemon that can come up later.
+    interop: Option<InteropRunner>,
+    /// Observable-state handle the advertised capability set is mirrored
+    /// into on every change.
+    state: AgentState,
+    /// Test override for [`Self::capabilities`], so routing/advertisement
+    /// logic can be exercised with synthetic sets independent of the host
+    /// this test runs on.
+    #[cfg(test)]
+    fixed_capabilities: Option<Vec<Capability>>,
+}
+
+impl Backends {
+    /// Build the registry from the startup probes' results and mirror the
+    /// initial capability set into the observable state.
+    pub fn new(
+        runner_script_present: bool,
+        docker: Option<DockerRunner>,
+        vm: Option<VmRunner>,
+        interop: Option<InteropRunner>,
+        state: AgentState,
+    ) -> Arc<Self> {
+        let this = Arc::new(Self {
+            runner_script_present,
+            docker,
+            vm: RwLock::new(vm),
+            interop,
+            state,
+            #[cfg(test)]
+            fixed_capabilities: None,
+        });
+        this.mirror_capabilities();
+        this
+    }
+
+    /// The capability set this agent serves right now — what the `Attach`
+    /// handshake declares and what offer routing agrees with.
+    pub fn capabilities(&self) -> Vec<Capability> {
+        #[cfg(test)]
+        if let Some(capabilities) = &self.fixed_capabilities {
+            return capabilities.clone();
+        }
+        let docker_arches = self
+            .docker
+            .as_ref()
+            .map(DockerRunner::linux_arches)
+            .unwrap_or_default();
+        host::capabilities(
+            self.runner_script_present,
+            &docker_arches,
+            self.vm_active(),
+            self.interop.is_some(),
+        )
+    }
+
+    /// The backend serving `(os, arch)` per the current capability set —
+    /// the offer-routing table, derived live so routing and advertisement
+    /// can never disagree.
+    pub fn backend_for(&self, os: &str, arch: &str) -> Option<Backend> {
+        self.capabilities()
+            .into_iter()
+            .find(|c| c.os == os && c.arch == arch)
+            .and_then(|c| Backend::try_from(c.backed_by).ok())
+    }
+
+    /// A handle to the Docker runtime, if the startup probe passed.
+    pub fn docker(&self) -> Option<DockerRunner> {
+        self.docker.clone()
+    }
+
+    /// A handle to the macOS VM backend, if active.
+    pub fn vm(&self) -> Option<VmRunner> {
+        self.vm.read().expect(LOCK_INVARIANT).clone()
+    }
+
+    /// A handle to the WSL interop backend, if the startup probe passed.
+    pub fn interop(&self) -> Option<InteropRunner> {
+        self.interop.clone()
+    }
+
+    /// Whether the macOS VM backend is active (the daemon probe succeeded
+    /// at startup or a later re-probe activated it).
+    pub fn vm_active(&self) -> bool {
+        self.vm.read().expect(LOCK_INVARIANT).is_some()
+    }
+
+    /// Whether the WSL interop backend is active.
+    pub fn interop_active(&self) -> bool {
+        self.interop.is_some()
+    }
+
+    /// Mirror the current capability set into the observable state.
+    fn mirror_capabilities(&self) {
+        let capabilities = self.capabilities();
+        self.state
+            .set_capabilities(capabilities.iter().map(capability_to_control).collect());
+    }
+}
+
+/// The slot locks are held only for handle clones — no code path can panic
+/// while holding one, so poisoning is unreachable.
+const LOCK_INVARIANT: &str = "backend slot lock poisoned";
+
+#[cfg(test)]
+impl Backends {
+    /// Registry whose [`Self::capabilities`] returns a fixed synthetic set,
+    /// with no live runtimes behind it. For routing/advertisement tests
+    /// that must not depend on the host the test runs on.
+    pub(crate) fn fixed(capabilities: Vec<Capability>, state: AgentState) -> Arc<Self> {
+        Self::fixed_with_interop(capabilities, None, state)
+    }
+
+    /// [`Self::fixed`] with a live interop backend, for windows-dispatch
+    /// tests that exercise the real interop path behind a synthetic
+    /// capability set.
+    pub(crate) fn fixed_with_interop(
+        capabilities: Vec<Capability>,
+        interop: Option<InteropRunner>,
+        state: AgentState,
+    ) -> Arc<Self> {
+        let this = Arc::new(Self {
+            runner_script_present: false,
+            docker: None,
+            vm: RwLock::new(None),
+            interop,
+            state,
+            fixed_capabilities: Some(capabilities),
+        });
+        this.mirror_capabilities();
+        this
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::settings::PersistedSettings;
+
+    fn seed() -> PersistedSettings {
+        PersistedSettings {
+            load_ceiling: 0.9,
+            mem_floor_mib: 2048,
+            linux_runner_image: "img".to_owned(),
+            gateway: "https://fleet.arcbox.dev".to_owned(),
+            docker_mode: crate::config::DockerMode::Disabled,
+            runner_script: None,
+            windows_runner_script: None,
+            participate: true,
+            vm_mode: crate::config::VmMode::Auto,
+            macos_runner_image: "tahoe-base".to_owned(),
+        }
+    }
+
+    fn capability(os: &str, arch: &str, backend: Backend) -> Capability {
+        Capability {
+            os: os.to_owned(),
+            arch: arch.to_owned(),
+            backed_by: backend as i32,
+        }
+    }
+
+    #[test]
+    fn construction_mirrors_capabilities_into_state() {
+        let state = AgentState::new(&seed());
+        let _backends = Backends::fixed(
+            vec![capability("darwin", "arm64", Backend::HostRunner)],
+            state.clone(),
+        );
+        let mirrored = state.current().capabilities;
+        assert_eq!(mirrored.len(), 1);
+        assert_eq!(mirrored[0].os, "darwin");
+        assert_eq!(mirrored[0].arch, "arm64");
+        assert_eq!(
+            mirrored[0].backed_by,
+            control_proto::Backend::HostRunner as i32
+        );
+    }
+
+    #[test]
+    fn backend_for_routes_by_os_arch() {
+        let backends = Backends::fixed(
+            vec![
+                capability("linux", "amd64", Backend::Docker),
+                capability("darwin", "arm64", Backend::Vm),
+            ],
+            AgentState::new(&seed()),
+        );
+        assert_eq!(
+            backends.backend_for("linux", "amd64"),
+            Some(Backend::Docker)
+        );
+        assert_eq!(backends.backend_for("darwin", "arm64"), Some(Backend::Vm));
+        assert_eq!(backends.backend_for("windows", "amd64"), None);
+    }
+
+    #[test]
+    fn empty_registry_serves_nothing() {
+        let backends = Backends::new(false, None, None, None, AgentState::new(&seed()));
+        assert!(!backends.vm_active());
+        assert!(!backends.interop_active());
+        assert!(backends.docker().is_none());
+        assert!(backends.vm().is_none());
+        assert!(backends.capabilities().is_empty());
+    }
+}

--- a/fleet/arcbox-fleet-agent/src/backends.rs
+++ b/fleet/arcbox-fleet-agent/src/backends.rs
@@ -20,16 +20,27 @@
 //! lifetime. A backend that dies later surfaces as per-job failures
 //! (reject + platform re-offer), never as a capability retraction.
 
+use std::path::PathBuf;
 use std::sync::{Arc, RwLock};
+use std::time::Duration;
 
 use arcbox_fleet_control_proto::v1 as control_proto;
 use arcbox_fleet_proto::v1::{Backend, Capability};
+use tokio::sync::watch;
+use tokio_util::sync::CancellationToken;
+use tracing::{debug, info};
 
+use crate::config::VmMode;
 use crate::docker::DockerRunner;
 use crate::host;
 use crate::interop::InteropRunner;
 use crate::state::AgentState;
 use crate::vm::VmRunner;
+
+/// How often to re-run the VM backend probe while it is inactive. The
+/// probe is one unix-socket connect plus one `ImageList` RPC against the
+/// local daemon — cheap enough to poll; the loop exits on activation.
+const VM_REPROBE_INTERVAL: Duration = Duration::from_secs(30);
 
 /// Convert a gateway-advertised capability into its control-plane
 /// counterpart. A plain function, not `From`: both `Capability` types are
@@ -70,6 +81,9 @@ pub struct Backends {
     /// Observable-state handle the advertised capability set is mirrored
     /// into on every change.
     state: AgentState,
+    /// Nudged on every activation. Attach loops subscribe and treat a
+    /// change as "the advertised capability set is stale — re-attach".
+    changed: watch::Sender<()>,
     /// Test override for [`Self::capabilities`], so routing/advertisement
     /// logic can be exercised with synthetic sets independent of the host
     /// this test runs on.
@@ -93,11 +107,35 @@ impl Backends {
             vm: RwLock::new(vm),
             interop,
             state,
+            changed: watch::channel(()).0,
             #[cfg(test)]
             fixed_capabilities: None,
         });
         this.mirror_capabilities();
         this
+    }
+
+    /// Activate the macOS VM backend. One-way: the first activation wins
+    /// and later calls are ignored (the existing handle keeps serving).
+    /// Mirrors the grown capability set into the observable state and
+    /// nudges [`Self::subscribe`]rs so attach loops re-attach and the
+    /// gateway learns the new set.
+    pub fn activate_vm(&self, runner: VmRunner) {
+        {
+            let mut slot = self.vm.write().expect(LOCK_INVARIANT);
+            if slot.is_some() {
+                return;
+            }
+            *slot = Some(runner);
+        }
+        self.mirror_capabilities();
+        self.changed.send_replace(());
+    }
+
+    /// Subscribe to activations. Receivers only learn "something changed"
+    /// and re-derive the capability set from the registry.
+    pub fn subscribe(&self) -> watch::Receiver<()> {
+        self.changed.subscribe()
     }
 
     /// The capability set this agent serves right now — what the `Attach`
@@ -168,6 +206,70 @@ impl Backends {
 /// while holding one, so poisoning is unreachable.
 const LOCK_INVARIANT: &str = "backend slot lock poisoned";
 
+/// Spawn the VM backend re-probe when this host could ever activate it:
+/// macOS, `vm_mode` Auto, and the startup probe having failed. `Enabled`
+/// needs no re-probe (startup fails while the daemon is down, and launchd
+/// respawns the agent until it comes up); `Disabled` means never. This
+/// closes the login race where the LaunchAgent starts before arcbox-daemon
+/// has bound its socket — without it the failed startup probe silently
+/// benched darwin VM jobs for the whole process lifetime.
+///
+/// The task is detached: it exits on activation or when `shutdown` fires.
+pub fn spawn_vm_reprobe(
+    backends: &Arc<Backends>,
+    state: AgentState,
+    mode: VmMode,
+    daemon_socket: PathBuf,
+    shutdown: CancellationToken,
+) {
+    if std::env::consts::OS != "macos" || mode != VmMode::Auto || backends.vm_active() {
+        return;
+    }
+    info!("macOS VM backend unavailable at startup; re-probing in the background");
+    tokio::spawn(vm_reprobe_loop(
+        Arc::clone(backends),
+        state,
+        daemon_socket,
+        VM_REPROBE_INTERVAL,
+        shutdown,
+    ));
+}
+
+/// Re-run the startup probe every `interval` until it succeeds, then
+/// activate the backend and exit. Probes against the *current*
+/// `macos_runner_image` — the same image dispatch would boot — so a probe
+/// can also start succeeding once the image gets installed (e.g. by
+/// `abctl macos image pull`), not only once the daemon comes up.
+async fn vm_reprobe_loop(
+    backends: Arc<Backends>,
+    state: AgentState,
+    daemon_socket: PathBuf,
+    interval: Duration,
+    shutdown: CancellationToken,
+) {
+    loop {
+        tokio::select! {
+            biased;
+            () = shutdown.cancelled() => return,
+            () = tokio::time::sleep(interval) => {}
+        }
+        let image = state.macos_runner_image_current();
+        match VmRunner::new(&daemon_socket, &image).await {
+            Ok(runner) => {
+                info!("macOS VM backend became available; activating");
+                backends.activate_vm(runner);
+                return;
+            }
+            // The startup probe already warned once; steady-state misses
+            // stay at debug so an offline daemon doesn't spam the log.
+            Err(e) => debug!(
+                error = format!("{e:#}"),
+                "macOS VM backend still unavailable"
+            ),
+        }
+    }
+}
+
 #[cfg(test)]
 impl Backends {
     /// Registry whose [`Self::capabilities`] returns a fixed synthetic set,
@@ -191,6 +293,7 @@ impl Backends {
             vm: RwLock::new(None),
             interop,
             state,
+            changed: watch::channel(()).0,
             fixed_capabilities: Some(capabilities),
         });
         this.mirror_capabilities();
@@ -268,5 +371,65 @@ mod tests {
         assert!(backends.docker().is_none());
         assert!(backends.vm().is_none());
         assert!(backends.capabilities().is_empty());
+    }
+
+    /// Activation must grow the derived capability set (native platform,
+    /// VM-backed), refresh the observable-state mirror, and nudge
+    /// subscribers — the re-attach trigger.
+    #[tokio::test]
+    async fn activate_vm_grows_capabilities_and_notifies() {
+        let daemon = crate::mock_daemon::MockDaemon::spawn(&["tahoe-base"]).await;
+        let runner = VmRunner::new(&daemon.socket, "tahoe-base")
+            .await
+            .expect("probe against the mock daemon");
+
+        let state = AgentState::new(&seed());
+        let backends = Backends::new(false, None, None, None, state.clone());
+        let mut rx = backends.subscribe();
+        rx.mark_unchanged();
+
+        backends.activate_vm(runner);
+
+        assert!(backends.vm_active());
+        assert!(backends.vm().is_some());
+        assert!(rx.has_changed().expect("registry alive"));
+        let capabilities = backends.capabilities();
+        assert_eq!(capabilities.len(), 1);
+        assert_eq!(capabilities[0].os, host::host_os());
+        assert_eq!(capabilities[0].backed_by, Backend::Vm as i32);
+        assert_eq!(
+            backends.backend_for(&host::host_os(), &host::host_arch()),
+            Some(Backend::Vm)
+        );
+        assert_eq!(state.current().capabilities.len(), 1);
+    }
+
+    /// While the probe keeps failing (daemon up, image missing) the loop
+    /// stays inactive; once the probe starts succeeding it activates and
+    /// exits. This is the image-appears flavor of the login race — the
+    /// daemon-appears flavor differs only in which probe step fails.
+    #[tokio::test]
+    async fn vm_reprobe_loop_activates_when_the_probe_starts_succeeding() {
+        let daemon = crate::mock_daemon::MockDaemon::spawn(&[]).await;
+        let state = AgentState::new(&seed());
+        let backends = Backends::new(false, None, None, None, state.clone());
+        let loop_task = tokio::spawn(vm_reprobe_loop(
+            Arc::clone(&backends),
+            state,
+            daemon.socket.clone(),
+            Duration::from_millis(10),
+            CancellationToken::new(),
+        ));
+
+        // Give a few ticks their chance to mis-activate on the missing image.
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        assert!(!backends.vm_active());
+
+        daemon.install("tahoe-base");
+        tokio::time::timeout(Duration::from_secs(5), loop_task)
+            .await
+            .expect("loop must exit once the probe succeeds")
+            .expect("reprobe loop must not panic");
+        assert!(backends.vm_active());
     }
 }

--- a/fleet/arcbox-fleet-agent/src/control/image.rs
+++ b/fleet/arcbox-fleet-agent/src/control/image.rs
@@ -13,19 +13,16 @@ use arcbox_fleet_control_proto::v1::{ImageKind, PrepareRequest, PrepareResponse}
 use tokio_stream::Stream;
 use tonic::{Request, Response, Status};
 
-use crate::docker::DockerRunner;
+use crate::backends::Backends;
 use crate::state::AgentState;
-use crate::vm::VmRunner;
 
 pub struct ImageService {
     state: AgentState,
-    /// The process-lifetime Docker handle, if configured. Never stale:
-    /// `docker_mode` changes are restart-scoped (see
-    /// `AgentSupervisor::docker`'s doc).
-    docker: Option<DockerRunner>,
-    /// The process-lifetime macOS VM backend handle, if active. Never
-    /// stale for the same reason (`vm_mode` is restart-scoped).
-    vm: Option<VmRunner>,
+    /// The live backend registry: the Docker handle for
+    /// `linux_runner_image`, the macOS VM backend for `macos_runner_image`
+    /// — read per request, so a backend that activated after startup is
+    /// visible to the next Prepare.
+    backends: Arc<Backends>,
     /// Serializes preparations. Two racing Prepares would pull concurrently
     /// and promote in arbitrary order, so the loser gets `ABORTED` instead
     /// of queueing behind a transfer of unknown length.
@@ -33,11 +30,10 @@ pub struct ImageService {
 }
 
 impl ImageService {
-    pub fn new(state: AgentState, docker: Option<DockerRunner>, vm: Option<VmRunner>) -> Self {
+    pub fn new(state: AgentState, backends: Arc<Backends>) -> Self {
         Self {
             state,
-            docker,
-            vm,
+            backends,
             busy: Arc::new(tokio::sync::Mutex::new(())),
         }
     }
@@ -100,8 +96,7 @@ impl FleetImageServiceTrait for ImageService {
             .try_lock_owned()
             .map_err(|_| Status::aborted("another prepare is already in progress"))?;
         let state = self.state.clone();
-        let docker = self.docker.clone();
-        let vm = self.vm.clone();
+        let backends = Arc::clone(&self.backends);
 
         // The work runs inside the stream itself, not a detached task, so a
         // client disconnect drops it mid-pull: no promotion happens, and a
@@ -112,7 +107,7 @@ impl FleetImageServiceTrait for ImageService {
                 match kind {
                     ImageKind::LinuxRunnerImage => {
                         let target = state.linux_runner_image_target();
-                        match &docker {
+                        match &backends.docker() {
                             Some(docker) => {
                                 // All-or-nothing: every advertised arch must pull
                                 // before promotion, so a partial-arch image can
@@ -143,7 +138,7 @@ impl FleetImageServiceTrait for ImageService {
                     }
                     ImageKind::MacosRunnerImage => {
                         let target = state.macos_runner_image_target();
-                        match &vm {
+                        match &backends.vm() {
                             Some(vm) => {
                                 // The daemon streams pull progress (its terminal
                                 // stage is "done"); relay each event. Any failure
@@ -255,7 +250,8 @@ mod tests {
     async fn prepare_without_docker_promotes_target() {
         let state = AgentState::new(&seed());
         state.set_linux_runner_image_target("ghcr.io/acme/runner:v2");
-        let service = ImageService::new(state.clone(), None, None);
+        let backends = Backends::new(false, None, None, None, state.clone());
+        let service = ImageService::new(state.clone(), backends);
 
         let mut stream = service
             .prepare(Request::new(PrepareRequest {
@@ -286,7 +282,8 @@ mod tests {
     async fn prepare_without_vm_backend_promotes_macos_target() {
         let state = AgentState::new(&seed());
         state.set_macos_runner_image_target("tahoe-base@2026.07.03");
-        let service = ImageService::new(state.clone(), None, None);
+        let backends = Backends::new(false, None, None, None, state.clone());
+        let service = ImageService::new(state.clone(), backends);
 
         let mut stream = service
             .prepare(Request::new(PrepareRequest {
@@ -311,7 +308,9 @@ mod tests {
     /// dropping the live stream (client disconnect) must release the slot.
     #[tokio::test]
     async fn concurrent_prepare_is_refused_until_the_first_stream_drops() {
-        let service = ImageService::new(AgentState::new(&seed()), None, None);
+        let state = AgentState::new(&seed());
+        let service =
+            ImageService::new(state.clone(), Backends::new(false, None, None, None, state));
 
         let held = service
             .prepare(Request::new(PrepareRequest { kinds: Vec::new() }))

--- a/fleet/arcbox-fleet-agent/src/control/image.rs
+++ b/fleet/arcbox-fleet-agent/src/control/image.rs
@@ -5,6 +5,7 @@
 //! Split from `FleetSettingsService` so quick state reads/writes never
 //! share a service with RPCs that stream a multi-gigabyte transfer.
 
+use std::path::{Path, PathBuf};
 use std::pin::Pin;
 use std::sync::Arc;
 
@@ -12,9 +13,12 @@ use arcbox_fleet_control_proto::v1::fleet_image_service_server::FleetImageServic
 use arcbox_fleet_control_proto::v1::{ImageKind, PrepareRequest, PrepareResponse};
 use tokio_stream::Stream;
 use tonic::{Request, Response, Status};
+use tracing::{debug, warn};
 
 use crate::backends::Backends;
+use crate::config::VmMode;
 use crate::state::AgentState;
+use crate::vm::VmRunner;
 
 pub struct ImageService {
     state: AgentState,
@@ -23,6 +27,9 @@ pub struct ImageService {
     /// — read per request, so a backend that activated after startup is
     /// visible to the next Prepare.
     backends: Arc<Backends>,
+    /// The arcbox-daemon socket, for pulling `macos_runner_image` through
+    /// a daemon whose backend is not active yet (see [`macos_pull_handle`]).
+    daemon_socket: PathBuf,
     /// Serializes preparations. Two racing Prepares would pull concurrently
     /// and promote in arbitrary order, so the loser gets `ABORTED` instead
     /// of queueing behind a transfer of unknown length.
@@ -30,11 +37,41 @@ pub struct ImageService {
 }
 
 impl ImageService {
-    pub fn new(state: AgentState, backends: Arc<Backends>) -> Self {
+    pub fn new(state: AgentState, backends: Arc<Backends>, daemon_socket: PathBuf) -> Self {
         Self {
             state,
             backends,
+            daemon_socket,
             busy: Arc::new(tokio::sync::Mutex::new(())),
+        }
+    }
+}
+
+/// The handle to pull `macos_runner_image` through: the active backend
+/// when there is one, else a direct dial of the daemon (`vm_mode`
+/// permitting). The dial deliberately skips the installed-image readiness
+/// check — the image being missing is exactly what the pull is about to
+/// fix, and requiring the full probe first was circular: an inactive
+/// backend skipped the very pull its activation was waiting on.
+async fn macos_pull_handle(
+    backends: &Backends,
+    vm_mode: VmMode,
+    daemon_socket: &Path,
+) -> Option<VmRunner> {
+    if let Some(vm) = backends.vm() {
+        return Some(vm);
+    }
+    if vm_mode == VmMode::Disabled {
+        return None;
+    }
+    match VmRunner::connect(daemon_socket).await {
+        Ok(vm) => Some(vm),
+        Err(e) => {
+            debug!(
+                error = format!("{e:#}"),
+                "daemon not reachable; macos_runner_image prepare will skip"
+            );
+            None
         }
     }
 }
@@ -97,6 +134,7 @@ impl FleetImageServiceTrait for ImageService {
             .map_err(|_| Status::aborted("another prepare is already in progress"))?;
         let state = self.state.clone();
         let backends = Arc::clone(&self.backends);
+        let daemon_socket = self.daemon_socket.clone();
 
         // The work runs inside the stream itself, not a detached task, so a
         // client disconnect drops it mid-pull: no promotion happens, and a
@@ -138,7 +176,8 @@ impl FleetImageServiceTrait for ImageService {
                     }
                     ImageKind::MacosRunnerImage => {
                         let target = state.macos_runner_image_target();
-                        match &backends.vm() {
+                        let vm_mode = state.vm_mode_current();
+                        match macos_pull_handle(&backends, vm_mode, &daemon_socket).await {
                             Some(vm) => {
                                 // The daemon streams pull progress (its terminal
                                 // stage is "done"); relay each event. Any failure
@@ -159,11 +198,28 @@ impl FleetImageServiceTrait for ImageService {
                                     let Some(progress) = progress else { break };
                                     yield event(kind, &progress.stage, "pulling", progress.fraction);
                                 }
+                                // A pull through a direct dial leaves a daemon that
+                                // can now pass the full readiness probe: activate the
+                                // backend so darwin VM jobs start dispatching without
+                                // an agent restart (the registry re-attaches for us).
+                                if !backends.vm_active() {
+                                    match VmRunner::new(&daemon_socket, &target).await {
+                                        Ok(runner) => {
+                                            backends.activate_vm(runner);
+                                            yield event(kind, "macOS VM backend activated", "activated", 1.0);
+                                        }
+                                        Err(e) => warn!(
+                                            error = format!("{e:#}"),
+                                            "macos_runner_image pulled, but the backend activation probe failed"
+                                        ),
+                                    }
+                                }
                             }
                             // Same rationale as the Docker-absent branch: with the
-                            // VM backend inactive no darwin VM job can dispatch, so
-                            // there is nothing to verify against — promote rather
-                            // than leave the setting pending forever.
+                            // VM backend inactive and the daemon unreachable no
+                            // darwin VM job can dispatch, so there is nothing to
+                            // verify against — promote rather than leave the
+                            // setting pending forever.
                             None => yield event(kind, "vm backend not active", "skipped", 1.0),
                         }
                         state.set_macos_runner_image_current(&target);
@@ -251,7 +307,11 @@ mod tests {
         let state = AgentState::new(&seed());
         state.set_linux_runner_image_target("ghcr.io/acme/runner:v2");
         let backends = Backends::new(false, None, None, None, state.clone());
-        let service = ImageService::new(state.clone(), backends);
+        let service = ImageService::new(
+            state.clone(),
+            backends,
+            PathBuf::from("/nonexistent/arcbox.sock"),
+        );
 
         let mut stream = service
             .prepare(Request::new(PrepareRequest {
@@ -283,7 +343,11 @@ mod tests {
         let state = AgentState::new(&seed());
         state.set_macos_runner_image_target("tahoe-base@2026.07.03");
         let backends = Backends::new(false, None, None, None, state.clone());
-        let service = ImageService::new(state.clone(), backends);
+        let service = ImageService::new(
+            state.clone(),
+            backends,
+            PathBuf::from("/nonexistent/arcbox.sock"),
+        );
 
         let mut stream = service
             .prepare(Request::new(PrepareRequest {
@@ -304,13 +368,51 @@ mod tests {
         );
     }
 
+    /// Prepare with an inactive VM backend but a reachable daemon must
+    /// pull through a direct dial and then activate the backend — breaking
+    /// the old circularity where an inactive backend skipped exactly the
+    /// pull its own activation probe was waiting on. macOS-only for the
+    /// same reason as the test above.
+    #[cfg(target_os = "macos")]
+    #[tokio::test]
+    async fn prepare_activates_the_vm_backend_through_a_reachable_daemon() {
+        let daemon = crate::mock_daemon::MockDaemon::spawn(&[]).await;
+        let state = AgentState::new(&seed());
+        state.set_macos_runner_image_target("tahoe-base@2026.07.03");
+        let backends = Backends::new(false, None, None, None, state.clone());
+        let service =
+            ImageService::new(state.clone(), Arc::clone(&backends), daemon.socket.clone());
+
+        let mut stream = service
+            .prepare(Request::new(PrepareRequest {
+                kinds: vec![ImageKind::MacosRunnerImage as i32],
+            }))
+            .await
+            .expect("Prepare")
+            .into_inner();
+        let mut stages = Vec::new();
+        while let Some(item) = stream.next().await {
+            stages.push(item.expect("event").stage);
+        }
+
+        assert_eq!(stages, ["pulling", "activated", "promoted"]);
+        assert!(backends.vm_active(), "prepare must activate the backend");
+        assert_eq!(
+            state.macos_runner_image_current(),
+            state.macos_runner_image_target()
+        );
+    }
+
     /// A second Prepare while one is live must be refused, not queued — and
     /// dropping the live stream (client disconnect) must release the slot.
     #[tokio::test]
     async fn concurrent_prepare_is_refused_until_the_first_stream_drops() {
         let state = AgentState::new(&seed());
-        let service =
-            ImageService::new(state.clone(), Backends::new(false, None, None, None, state));
+        let service = ImageService::new(
+            state.clone(),
+            Backends::new(false, None, None, None, state),
+            PathBuf::from("/nonexistent/arcbox.sock"),
+        );
 
         let held = service
             .prepare(Request::new(PrepareRequest { kinds: Vec::new() }))

--- a/fleet/arcbox-fleet-agent/src/control/image.rs
+++ b/fleet/arcbox-fleet-agent/src/control/image.rs
@@ -177,7 +177,7 @@ impl FleetImageServiceTrait for ImageService {
                     ImageKind::MacosRunnerImage => {
                         let target = state.macos_runner_image_target();
                         let vm_mode = state.vm_mode_current();
-                        match macos_pull_handle(&backends, vm_mode, &daemon_socket).await {
+                        let activation = match macos_pull_handle(&backends, vm_mode, &daemon_socket).await {
                             Some(vm) => {
                                 // The daemon streams pull progress (its terminal
                                 // stage is "done"); relay each event. Any failure
@@ -204,15 +204,17 @@ impl FleetImageServiceTrait for ImageService {
                                 // an agent restart (the registry re-attaches for us).
                                 if !backends.vm_active() {
                                     match VmRunner::new(&daemon_socket, &target).await {
-                                        Ok(runner) => {
-                                            backends.activate_vm(runner);
-                                            yield event(kind, "macOS VM backend activated", "activated", 1.0);
+                                        Ok(runner) => Some(runner),
+                                        Err(e) => {
+                                            warn!(
+                                                error = format!("{e:#}"),
+                                                "macos_runner_image pulled, but the backend activation probe failed"
+                                            );
+                                            None
                                         }
-                                        Err(e) => warn!(
-                                            error = format!("{e:#}"),
-                                            "macos_runner_image pulled, but the backend activation probe failed"
-                                        ),
                                     }
+                                } else {
+                                    None
                                 }
                             }
                             // Same rationale as the Docker-absent branch: with the
@@ -220,9 +222,16 @@ impl FleetImageServiceTrait for ImageService {
                             // darwin VM job can dispatch, so there is nothing to
                             // verify against — promote rather than leave the
                             // setting pending forever.
-                            None => yield event(kind, "vm backend not active", "skipped", 1.0),
-                        }
+                            None => {
+                                yield event(kind, "vm backend not active", "skipped", 1.0);
+                                None
+                            }
+                        };
                         state.set_macos_runner_image_current(&target);
+                        if let Some(runner) = activation {
+                            backends.activate_vm(runner);
+                            yield event(kind, "macOS VM backend activated", "activated", 1.0);
+                        }
                     }
                     // `resolve_kinds` admits no other variant.
                     ImageKind::Unspecified => unreachable!("resolve_kinds admits no other variant"),
@@ -392,7 +401,16 @@ mod tests {
             .into_inner();
         let mut stages = Vec::new();
         while let Some(item) = stream.next().await {
-            stages.push(item.expect("event").stage);
+            let stage = item.expect("event").stage;
+            if stage == "activated" {
+                assert_eq!(
+                    state.macos_runner_image_current(),
+                    state.macos_runner_image_target(),
+                    "the promoted image must be visible before VM capability activation"
+                );
+                assert!(backends.vm_active(), "the VM backend must be active");
+            }
+            stages.push(stage);
         }
 
         assert_eq!(stages, ["pulling", "activated", "promoted"]);

--- a/fleet/arcbox-fleet-agent/src/control/mod.rs
+++ b/fleet/arcbox-fleet-agent/src/control/mod.rs
@@ -90,6 +90,7 @@ pub async fn serve(
     info!(socket = %socket_path.display(), "control-plane server listening");
 
     let backends = supervisor.backends();
+    let daemon_socket = supervisor.config.vm.daemon_socket.clone();
     Server::builder()
         .add_service(FleetLifecycleServiceServer::new(LifecycleService::new(
             supervisor,
@@ -102,7 +103,9 @@ pub async fn serve(
             settings_store,
         )))
         .add_service(FleetImageServiceServer::new(ImageService::new(
-            state, backends,
+            state,
+            backends,
+            daemon_socket,
         )))
         .serve_with_incoming_shutdown(incoming, shutdown.cancelled())
         .await

--- a/fleet/arcbox-fleet-agent/src/control/mod.rs
+++ b/fleet/arcbox-fleet-agent/src/control/mod.rs
@@ -325,7 +325,7 @@ impl AgentSupervisor {
             credential.clone(),
             supervisor.clone(),
             egress_rx,
-            self.backends.capabilities(),
+            self.backends(),
             shutdown.clone(),
             self.agent_state.clone(),
         ));

--- a/fleet/arcbox-fleet-agent/src/control/mod.rs
+++ b/fleet/arcbox-fleet-agent/src/control/mod.rs
@@ -22,7 +22,6 @@ use arcbox_fleet_control_proto::v1::fleet_lifecycle_service_server::FleetLifecyc
 use arcbox_fleet_control_proto::v1::fleet_settings_service_server::FleetSettingsServiceServer;
 use arcbox_fleet_control_proto::v1::fleet_state_service_server::FleetStateServiceServer;
 use arcbox_fleet_control_proto::v1::{ConnectionState, Enrollment};
-use arcbox_fleet_proto::v1::Capability;
 use tokio::net::UnixListener;
 use tokio::sync::Mutex;
 use tokio_stream::wrappers::UnixListenerStream;
@@ -31,9 +30,9 @@ use tonic::Status;
 use tonic::transport::Server;
 use tracing::{info, warn};
 
+use crate::backends::Backends;
 use crate::config::AgentConfig;
 use crate::credentials::Credential;
-use crate::docker::DockerRunner;
 use crate::runner::RunnerSupervisor;
 use crate::settings::SettingsStore;
 use crate::state::AgentState;
@@ -90,8 +89,7 @@ pub async fn serve(
 
     info!(socket = %socket_path.display(), "control-plane server listening");
 
-    let docker = supervisor.docker();
-    let vm = supervisor.vm();
+    let backends = supervisor.backends();
     Server::builder()
         .add_service(FleetLifecycleServiceServer::new(LifecycleService::new(
             supervisor,
@@ -104,7 +102,7 @@ pub async fn serve(
             settings_store,
         )))
         .add_service(FleetImageServiceServer::new(ImageService::new(
-            state, docker, vm,
+            state, backends,
         )))
         .serve_with_incoming_shutdown(incoming, shutdown.cancelled())
         .await
@@ -228,10 +226,9 @@ enum State {
 /// subcommand works entirely offline, before this process even starts.
 pub struct AgentSupervisor {
     config: AgentConfig,
-    docker: Option<DockerRunner>,
-    vm: Option<crate::vm::VmRunner>,
-    interop: Option<crate::interop::InteropRunner>,
-    capabilities: Vec<Capability>,
+    /// The live backend registry: runtimes and the capability set they
+    /// serve, shared with every attachment and with `FleetImageService`.
+    backends: Arc<Backends>,
     /// Cancelled on process shutdown (SIGTERM/Ctrl-C); every attachment's
     /// `shutdown` is a child of this token.
     process_shutdown: CancellationToken,
@@ -248,28 +245,16 @@ pub struct AgentSupervisor {
 impl AgentSupervisor {
     /// Build the supervisor, immediately attaching if a credential is
     /// already persisted — the existing headless/farm behavior.
-    #[expect(
-        clippy::too_many_arguments,
-        reason = "construction genuinely needs the config, all three optional job backends \
-                  (docker/vm/interop), the advertised capabilities, and the three process-wide \
-                  handles; same shape as attach::run"
-    )]
     pub async fn new(
         config: AgentConfig,
-        docker: Option<DockerRunner>,
-        vm: Option<crate::vm::VmRunner>,
-        interop: Option<crate::interop::InteropRunner>,
-        capabilities: Vec<Capability>,
+        backends: Arc<Backends>,
         process_shutdown: CancellationToken,
         agent_state: AgentState,
         settings_store: SettingsStore,
     ) -> Result<Self> {
         let this = Self {
             config,
-            docker,
-            vm,
-            interop,
-            capabilities,
+            backends,
             process_shutdown,
             state: Mutex::new(State::Unenrolled),
             agent_state,
@@ -296,36 +281,27 @@ impl AgentSupervisor {
         Ok(this)
     }
 
-    /// A handle to the process-lifetime Docker runtime, if configured — read
-    /// by [`serve`] and passed to `FleetImageService` to prepare a candidate
-    /// `linux_runner_image` (see `control::image`). Fixed at construction
-    /// and unaffected by the attach/detach cycle: `docker_mode` changes are
-    /// restart-scoped, so this is never stale.
-    fn docker(&self) -> Option<DockerRunner> {
-        self.docker.clone()
+    /// The live backend registry — read by [`serve`] and shared with
+    /// `FleetImageService`, which prepares candidate runner images through
+    /// the runtimes it holds. The registry is live (the VM slot can
+    /// activate after startup); `docker_mode`/`vm_mode` *policy* changes
+    /// remain restart-scoped.
+    fn backends(&self) -> Arc<Backends> {
+        Arc::clone(&self.backends)
     }
 
     /// Whether the macOS VM backend is active — the daemon probe succeeded
-    /// at startup. Reported as a `GetAgentInfo` feature so clients can
-    /// discover it. Fixed at construction like [`Self::docker`]:
-    /// `vm_mode` changes are restart-scoped.
+    /// (at startup or on a later re-probe). Reported as a `GetAgentInfo`
+    /// feature so clients can discover it.
     pub fn vm_active(&self) -> bool {
-        self.vm.is_some()
-    }
-
-    /// A handle to the macOS VM backend, if active — read by [`serve`] and
-    /// passed to `FleetImageService` to prepare a candidate
-    /// `macos_runner_image` through the daemon. Fixed at construction, same
-    /// rationale as [`Self::docker`].
-    fn vm(&self) -> Option<crate::vm::VmRunner> {
-        self.vm.clone()
+        self.backends.vm_active()
     }
 
     /// Whether the WSL interop backend for windows jobs is active — the
     /// startup probe passed. Reported as a `GetAgentInfo` feature, same
-    /// rationale as [`Self::vm_active`]; restart-scoped like every backend.
+    /// rationale as [`Self::vm_active`].
     pub fn interop_active(&self) -> bool {
-        self.interop.is_some()
+        self.backends.interop_active()
     }
 
     /// Spawn the attach task for `credential` and build its [`Attachment`].
@@ -341,21 +317,15 @@ impl AgentSupervisor {
         // process-lifetime state, so clear any stale draining flag rather than
         // letting a re-enroll inherit it.
         self.agent_state.set_draining(false);
-        let (supervisor, egress_rx) = attach::spawn_supervisor(
-            &self.config,
-            self.docker.clone(),
-            self.vm.clone(),
-            self.interop.clone(),
-            self.capabilities.clone(),
-            self.agent_state.clone(),
-        );
+        let (supervisor, egress_rx) =
+            attach::spawn_supervisor(&self.config, self.backends(), self.agent_state.clone());
         let shutdown = self.process_shutdown.child_token();
         let task = tokio::spawn(attach::run(
             self.config.clone(),
             credential.clone(),
             supervisor.clone(),
             egress_rx,
-            self.capabilities.clone(),
+            self.backends.capabilities(),
             shutdown.clone(),
             self.agent_state.clone(),
         ));
@@ -424,9 +394,10 @@ impl AgentSupervisor {
             control_plane.map_or_else(|| self.agent_state.gateway_target(), str::to_owned);
 
         // The gateway round-trip must not hold `state` locked.
-        let credential = enroll::enroll(&self.config, token, self.capabilities.clone(), &gateway)
-            .await
-            .map_err(Internal)?;
+        let credential =
+            enroll::enroll(&self.config, token, self.backends.capabilities(), &gateway)
+                .await
+                .map_err(Internal)?;
 
         let mut state = self.state.lock().await;
         // `check_enrollable` refuses `Enrolling`, so nothing else can
@@ -782,10 +753,7 @@ mod tests {
         Arc::new(
             AgentSupervisor::new(
                 test_config(dir.to_path_buf()),
-                None,
-                None,
-                None,
-                Vec::new(),
+                Backends::new(false, None, None, None, agent_state.clone()),
                 CancellationToken::new(),
                 agent_state,
                 SettingsStore::new(dir.join("settings.json")),
@@ -858,10 +826,7 @@ mod tests {
         let runner = crate::runner::RunnerSupervisor::new(
             events,
             None,
-            None,
-            None,
-            None,
-            Vec::new(),
+            Backends::new(false, None, None, None, agent_state.clone()),
             agent_state.clone(),
         );
         *supervisor.state.lock().await = State::Attached(Attachment {
@@ -953,10 +918,7 @@ mod tests {
         });
         let supervisor = AgentSupervisor::new(
             config,
-            None,
-            None,
-            None,
-            Vec::new(),
+            Backends::new(false, None, None, None, agent_state.clone()),
             CancellationToken::new(),
             agent_state.clone(),
             SettingsStore::new(dir.join("settings.json")),
@@ -988,10 +950,7 @@ mod tests {
         let supervisor = Arc::new(
             AgentSupervisor::new(
                 test_config(dir.clone()),
-                None,
-                None,
-                None,
-                Vec::new(),
+                Backends::new(false, None, None, None, agent_state.clone()),
                 CancellationToken::new(),
                 agent_state.clone(),
                 SettingsStore::new(dir.join("settings.json")),
@@ -1013,10 +972,7 @@ mod tests {
         let runner = crate::runner::RunnerSupervisor::new(
             events,
             None,
-            None,
-            None,
-            None,
-            Vec::new(),
+            Backends::new(false, None, None, None, agent_state.clone()),
             agent_state,
         );
         // A persisted credential, so the completed unenroll can prove the

--- a/fleet/arcbox-fleet-agent/src/main.rs
+++ b/fleet/arcbox-fleet-agent/src/main.rs
@@ -36,6 +36,8 @@ mod enroll;
 mod fsutil;
 mod host;
 mod interop;
+#[cfg(test)]
+mod mock_daemon;
 mod runner;
 #[cfg(target_os = "macos")]
 mod service;
@@ -302,6 +304,13 @@ async fn run(command: Command, config: AgentConfig) -> Result<()> {
             // `attach::run` stops accepting work and tears down in-flight
             // runners once this fires.
             let shutdown = spawn_shutdown_signal("termination signal received; draining runners");
+            backends::spawn_vm_reprobe(
+                &backends,
+                agent_state.clone(),
+                seed.vm_mode,
+                config.vm.daemon_socket.clone(),
+                shutdown.clone(),
+            );
 
             let (supervisor, egress_rx) =
                 attach::spawn_supervisor(&config, Arc::clone(&backends), agent_state.clone());
@@ -310,7 +319,7 @@ async fn run(command: Command, config: AgentConfig) -> Result<()> {
                 credential,
                 supervisor,
                 egress_rx,
-                backends.capabilities(),
+                backends,
                 shutdown,
                 agent_state,
             )
@@ -338,6 +347,13 @@ async fn run(command: Command, config: AgentConfig) -> Result<()> {
             // drain on SIGTERM even though `Unenroll` can also cancel one
             // independently.
             let shutdown = spawn_shutdown_signal("termination signal received; shutting down");
+            backends::spawn_vm_reprobe(
+                &backends,
+                agent_state.clone(),
+                seed.vm_mode,
+                config.vm.daemon_socket.clone(),
+                shutdown.clone(),
+            );
 
             let supervisor = Arc::new(
                 control::AgentSupervisor::new(

--- a/fleet/arcbox-fleet-agent/src/main.rs
+++ b/fleet/arcbox-fleet-agent/src/main.rs
@@ -27,6 +27,7 @@
 compile_error!("arcbox-fleet-agent supports macOS and Linux only");
 
 mod attach;
+mod backends;
 mod config;
 mod control;
 mod credentials;
@@ -51,12 +52,12 @@ use arcbox_fleet_control_proto::v1 as control_proto;
 use arcbox_fleet_control_proto::v1::fleet_image_service_client::FleetImageServiceClient;
 use arcbox_fleet_control_proto::v1::fleet_lifecycle_service_client::FleetLifecycleServiceClient;
 use arcbox_fleet_control_proto::v1::fleet_settings_service_client::FleetSettingsServiceClient;
-use arcbox_fleet_proto::v1::Capability;
 use arcbox_logging::LogConfig;
 use clap::{Args, Parser, Subcommand};
 use tokio_util::sync::CancellationToken;
 use tracing::{info, warn};
 
+use crate::backends::Backends;
 use crate::config::{AgentConfig, DockerMode, VmMode};
 use crate::docker::DockerRunner;
 use crate::interop::InteropRunner;
@@ -257,9 +258,9 @@ async fn run(command: Command, config: AgentConfig) -> Result<()> {
             // Enrollment is pure credential exchange — it never needs Docker or
             // the daemon, so an operator can enroll before either runtime is up.
             // The capabilities sent here are an initial hint, replaced wholesale
-            // by the first heartbeat once the agent attaches, so we advertise
-            // what we know without probing the runtimes.
-            let capabilities = capabilities(seed.runner_script.is_some(), None, None, None);
+            // by the first Attach handshake once the agent attaches, so we
+            // advertise what we know without probing the runtimes.
+            let capabilities = host::capabilities(seed.runner_script.is_some(), &[], false, false);
             let credential = match enroll::enroll(&config, token, capabilities, &seed.gateway).await
             {
                 Ok(credential) => credential,
@@ -288,20 +289,11 @@ async fn run(command: Command, config: AgentConfig) -> Result<()> {
         Command::Quick(QuickCommand::Run) => {
             let settings_store = SettingsStore::new(config.settings_path());
             let seed = load_or_seed_settings(&settings_store, &config)?;
-            let docker = init_docker(seed.docker_mode, &seed.linux_runner_image).await?;
-            let vm = init_vm(
-                seed.vm_mode,
-                &seed.macos_runner_image,
-                &config.vm.daemon_socket,
-            )
-            .await?;
-            let interop = init_interop(seed.windows_runner_script.as_deref()).await;
-            let capabilities = capabilities(
-                seed.runner_script.is_some(),
-                docker.as_ref(),
-                vm.as_ref(),
-                interop.as_ref(),
-            );
+            // `quick run` opens no control socket, so nothing ever subscribes to
+            // this over `Watch` — but `RunnerSupervisor` still reads
+            // admission thresholds live from it, so it's load-bearing.
+            let agent_state = AgentState::new(&seed);
+            let backends = init_backends(&config, &seed, agent_state.clone()).await?;
             let credential = config.credential_store_for(&seed.gateway).load()?.context(
                 "no credential found — run `arcbox-fleet-agent quick enroll --token-file …` first",
             )?;
@@ -311,24 +303,14 @@ async fn run(command: Command, config: AgentConfig) -> Result<()> {
             // runners once this fires.
             let shutdown = spawn_shutdown_signal("termination signal received; draining runners");
 
-            // `quick run` opens no control socket, so nothing ever subscribes to
-            // this over `Watch` — but `RunnerSupervisor` still reads
-            // admission thresholds live from it, so it's load-bearing.
-            let agent_state = AgentState::new(&seed);
-            let (supervisor, egress_rx) = attach::spawn_supervisor(
-                &config,
-                docker,
-                vm,
-                interop,
-                capabilities.clone(),
-                agent_state.clone(),
-            );
+            let (supervisor, egress_rx) =
+                attach::spawn_supervisor(&config, Arc::clone(&backends), agent_state.clone());
             attach::run(
                 config,
                 credential,
                 supervisor,
                 egress_rx,
-                capabilities,
+                backends.capabilities(),
                 shutdown,
                 agent_state,
             )
@@ -348,20 +330,8 @@ async fn run(command: Command, config: AgentConfig) -> Result<()> {
         Command::Serve => {
             let settings_store = SettingsStore::new(config.settings_path());
             let seed = load_or_seed_settings(&settings_store, &config)?;
-            let docker = init_docker(seed.docker_mode, &seed.linux_runner_image).await?;
-            let vm = init_vm(
-                seed.vm_mode,
-                &seed.macos_runner_image,
-                &config.vm.daemon_socket,
-            )
-            .await?;
-            let interop = init_interop(seed.windows_runner_script.as_deref()).await;
-            let capabilities = capabilities(
-                seed.runner_script.is_some(),
-                docker.as_ref(),
-                vm.as_ref(),
-                interop.as_ref(),
-            );
+            let agent_state = AgentState::new(&seed);
+            let backends = init_backends(&config, &seed, agent_state.clone()).await?;
             let socket_path = config.control_socket_path();
 
             // Cascades to every attach task's child token, so runners still
@@ -369,14 +339,10 @@ async fn run(command: Command, config: AgentConfig) -> Result<()> {
             // independently.
             let shutdown = spawn_shutdown_signal("termination signal received; shutting down");
 
-            let agent_state = AgentState::new(&seed);
             let supervisor = Arc::new(
                 control::AgentSupervisor::new(
                     config,
-                    docker,
-                    vm,
-                    interop,
-                    capabilities,
+                    backends,
                     shutdown.clone(),
                     agent_state.clone(),
                     settings_store.clone(),
@@ -667,24 +633,31 @@ fn resolve_enrollment_token(token_file: Option<PathBuf>, token: Option<String>) 
     Ok(token)
 }
 
-/// Build the capabilities this agent advertises: any Docker-served Linux
-/// capabilities, windows via WSL interop when that probe passed, plus the
-/// native pair — VM-served when the daemon backend is active, else the host
-/// runner (if a runner script is configured). Capacity is decided per offer
-/// from live telemetry, not here.
-fn capabilities(
-    runner_script_present: bool,
-    docker: Option<&DockerRunner>,
-    vm: Option<&VmRunner>,
-    interop: Option<&InteropRunner>,
-) -> Vec<Capability> {
-    let docker_arches = docker.map(DockerRunner::linux_arches).unwrap_or_default();
-    host::capabilities(
-        runner_script_present,
-        &docker_arches,
-        vm.is_some(),
-        interop.is_some(),
+/// Run the startup probes and assemble the backend registry: any
+/// Docker-served Linux capabilities, windows via WSL interop when that
+/// probe passed, plus the native pair — VM-served when the daemon backend
+/// is active, else the host runner (if a runner script is configured).
+/// Capacity is decided per offer from live telemetry, not here.
+async fn init_backends(
+    config: &AgentConfig,
+    seed: &PersistedSettings,
+    agent_state: AgentState,
+) -> Result<Arc<Backends>> {
+    let docker = init_docker(seed.docker_mode, &seed.linux_runner_image).await?;
+    let vm = init_vm(
+        seed.vm_mode,
+        &seed.macos_runner_image,
+        &config.vm.daemon_socket,
     )
+    .await?;
+    let interop = init_interop(seed.windows_runner_script.as_deref()).await;
+    Ok(Backends::new(
+        seed.runner_script.is_some(),
+        docker,
+        vm,
+        interop,
+        agent_state,
+    ))
 }
 
 /// Probe Docker availability according to `mode`.

--- a/fleet/arcbox-fleet-agent/src/mock_daemon.rs
+++ b/fleet/arcbox-fleet-agent/src/mock_daemon.rs
@@ -1,0 +1,180 @@
+//! Test-only mock of the arcbox-daemon's `MacosService`, served on a
+//! scratch Unix socket, so `VmRunner` probes, pulls, and activations can be
+//! exercised without a real daemon (or a macOS host). Only the methods the
+//! agent actually calls are implemented; the rest answer `UNIMPLEMENTED`.
+
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
+
+use arcbox_grpc::{MacosService, MacosServiceServer};
+use arcbox_protocol::v1::{
+    CreateMacosMachineRequest, Empty, InspectMacosMachineRequest, MacosImageListResponse,
+    MacosImagePullEvent, MacosImagePullRequest, MacosImageRemoveRequest, MacosImageResolveRequest,
+    MacosImageResolveResponse, MacosImageSummary, MacosMachineInfo, MacosMachineListResponse,
+    RemoveMacosMachineRequest, StartMacosMachineRequest, StopMacosMachineRequest,
+};
+use tokio::sync::mpsc;
+use tokio_stream::wrappers::{ReceiverStream, UnixListenerStream};
+use tonic::{Request, Response, Status};
+
+/// A running mock daemon: the socket path `VmRunner` should dial, plus the
+/// guards that keep it alive (drop the handle to tear it down).
+pub struct MockDaemon {
+    pub socket: PathBuf,
+    /// Stream names the daemon reports installed; `ImagePull` appends.
+    installed: Arc<Mutex<Vec<String>>>,
+    _dir: tempfile::TempDir,
+    server: tokio::task::JoinHandle<()>,
+}
+
+impl MockDaemon {
+    /// Serve a mock daemon whose registry starts with `images` installed.
+    pub async fn spawn(images: &[&str]) -> Self {
+        let dir = tempfile::tempdir().expect("scratch dir for mock daemon");
+        let socket = dir.path().join("arcbox.sock");
+        let installed = Arc::new(Mutex::new(
+            images.iter().map(|&s| s.to_owned()).collect::<Vec<_>>(),
+        ));
+        let listener = tokio::net::UnixListener::bind(&socket).expect("bind mock daemon socket");
+        let service = Service {
+            installed: Arc::clone(&installed),
+        };
+        let server = tokio::spawn(async move {
+            let _ = tonic::transport::Server::builder()
+                .add_service(MacosServiceServer::new(service))
+                .serve_with_incoming(UnixListenerStream::new(listener))
+                .await;
+        });
+        Self {
+            socket,
+            installed,
+            _dir: dir,
+            server,
+        }
+    }
+
+    /// Register `name` as installed, as if pulled out-of-band (e.g. by
+    /// `abctl macos image pull`) — the next `ImageList` reports it.
+    pub fn install(&self, name: &str) {
+        self.installed
+            .lock()
+            .expect("mock registry lock")
+            .push(name.to_owned());
+    }
+}
+
+impl Drop for MockDaemon {
+    fn drop(&mut self) {
+        self.server.abort();
+    }
+}
+
+struct Service {
+    installed: Arc<Mutex<Vec<String>>>,
+}
+
+fn summary(name: &str) -> MacosImageSummary {
+    MacosImageSummary {
+        name: name.to_owned(),
+        minimum_cpu_count: 2,
+        minimum_memory_mib: 4096,
+        ..Default::default()
+    }
+}
+
+#[tonic::async_trait]
+impl MacosService for Service {
+    async fn create(
+        &self,
+        _: Request<CreateMacosMachineRequest>,
+    ) -> Result<Response<Empty>, Status> {
+        Err(Status::unimplemented("mock daemon runs no guests"))
+    }
+
+    async fn start(&self, _: Request<StartMacosMachineRequest>) -> Result<Response<Empty>, Status> {
+        Err(Status::unimplemented("mock daemon runs no guests"))
+    }
+
+    async fn stop(&self, _: Request<StopMacosMachineRequest>) -> Result<Response<Empty>, Status> {
+        Err(Status::unimplemented("mock daemon runs no guests"))
+    }
+
+    async fn remove(
+        &self,
+        _: Request<RemoveMacosMachineRequest>,
+    ) -> Result<Response<Empty>, Status> {
+        Err(Status::unimplemented("mock daemon runs no guests"))
+    }
+
+    /// Always empty: the leftover sweep sees nothing to remove.
+    async fn list(&self, _: Request<Empty>) -> Result<Response<MacosMachineListResponse>, Status> {
+        Ok(Response::new(MacosMachineListResponse {
+            machines: Vec::new(),
+        }))
+    }
+
+    async fn inspect(
+        &self,
+        _: Request<InspectMacosMachineRequest>,
+    ) -> Result<Response<MacosMachineInfo>, Status> {
+        Err(Status::unimplemented("mock daemon runs no guests"))
+    }
+
+    type ImagePullStream = ReceiverStream<Result<MacosImagePullEvent, Status>>;
+
+    /// Registers the reference's stream name as installed and emits the
+    /// terminal "done" event, mirroring the real daemon's contract.
+    async fn image_pull(
+        &self,
+        request: Request<MacosImagePullRequest>,
+    ) -> Result<Response<Self::ImagePullStream>, Status> {
+        let reference = request.into_inner().reference;
+        let stream_name = reference
+            .split_once('@')
+            .map_or(reference.as_str(), |(s, _)| s)
+            .to_owned();
+        {
+            let mut installed = self.installed.lock().expect("mock registry lock");
+            if !installed.contains(&stream_name) {
+                installed.push(stream_name.clone());
+            }
+        }
+        let (tx, rx) = mpsc::channel(2);
+        let _ = tx
+            .send(Ok(MacosImagePullEvent {
+                stage: "done".to_owned(),
+                fraction: 1.0,
+                image: Some(summary(&stream_name)),
+            }))
+            .await;
+        Ok(Response::new(ReceiverStream::new(rx)))
+    }
+
+    async fn image_resolve(
+        &self,
+        _: Request<MacosImageResolveRequest>,
+    ) -> Result<Response<MacosImageResolveResponse>, Status> {
+        Err(Status::unimplemented("mock daemon resolves nothing"))
+    }
+
+    async fn image_list(
+        &self,
+        _: Request<Empty>,
+    ) -> Result<Response<MacosImageListResponse>, Status> {
+        let images = self
+            .installed
+            .lock()
+            .expect("mock registry lock")
+            .iter()
+            .map(|name| summary(name))
+            .collect();
+        Ok(Response::new(MacosImageListResponse { images }))
+    }
+
+    async fn image_remove(
+        &self,
+        _: Request<MacosImageRemoveRequest>,
+    ) -> Result<Response<Empty>, Status> {
+        Err(Status::unimplemented("mock daemon removes nothing"))
+    }
+}

--- a/fleet/arcbox-fleet-agent/src/runner.rs
+++ b/fleet/arcbox-fleet-agent/src/runner.rs
@@ -13,15 +13,14 @@
 //! Capacity is never a number — admission gates on live load and free memory,
 //! so a busy host simply rejects and the platform re-offers elsewhere.
 
-use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Duration;
 
 use arcbox_fleet_control_proto::v1 as control_proto;
 use arcbox_fleet_proto::v1::{
-    AttachRequest, Backend, Capability, HostTelemetry, ProvisionRunner, RunnerAccepted,
-    RunnerRejected, attach_request,
+    AttachRequest, Backend, HostTelemetry, ProvisionRunner, RunnerAccepted, RunnerRejected,
+    attach_request,
 };
 use command_group::AsyncCommandGroup;
 use dashmap::DashMap;
@@ -29,34 +28,15 @@ use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
 use tracing::{info, warn};
 
-use crate::docker::{DockerRunner, RunSpec};
+use crate::backends::Backends;
+use crate::docker::RunSpec;
 use crate::host;
-use crate::interop::InteropRunner;
 use crate::state::AgentState;
-use crate::vm::VmRunner;
 
 /// Watchdog on a VM job's runtime: GitHub concludes jobs at 6 h, so a
 /// session still open past that (plus slack) means the guest wedged — treat
 /// it as a cancellation and destroy the guest.
 const MAX_VM_JOB_RUNTIME: Duration = Duration::from_secs(6 * 3600 + 1800);
-
-/// Convert a gateway-advertised capability into its control-plane
-/// counterpart. A plain function, not `From`: both `Capability` types are
-/// generated in other crates, so Rust's orphan rule blocks implementing a
-/// foreign trait (`From`) for two foreign types here.
-fn capability_to_control(c: &Capability) -> control_proto::Capability {
-    let backed_by = match Backend::try_from(c.backed_by) {
-        Ok(Backend::HostRunner) => control_proto::Backend::HostRunner,
-        Ok(Backend::Docker) => control_proto::Backend::Docker,
-        Ok(Backend::Vm) => control_proto::Backend::Vm,
-        Ok(Backend::Unspecified) | Err(_) => control_proto::Backend::Unspecified,
-    };
-    control_proto::Capability {
-        os: c.os.clone(),
-        arch: c.arch.clone(),
-        backed_by: backed_by as i32,
-    }
-}
 
 /// Outcome of the admission decision for an incoming offer.
 #[derive(Debug, PartialEq, Eq)]
@@ -99,14 +79,10 @@ struct Inner {
     /// Path to the installed runner's entry point (`run.sh`). `None` when
     /// only Docker-based execution is configured.
     runner_script: Option<PathBuf>,
-    /// Docker runtime for Linux jobs, if available.
-    docker: Option<DockerRunner>,
-    /// macOS VM backend for darwin jobs, if the local daemon serves it.
-    vm: Option<VmRunner>,
-    /// WSL interop backend for windows jobs, if the startup probe passed.
-    interop: Option<InteropRunner>,
-    /// The backend serving each advertised `(os, arch)` — the routing table.
-    backends: HashMap<(String, String), Backend>,
+    /// The live backend registry: the runtimes behind each advertised
+    /// capability and the `(os, arch)` → backend routing, read per offer so
+    /// routing always agrees with what is currently advertised.
+    backends: Arc<Backends>,
     /// Set once `Drain` is received; no new jobs are accepted.
     draining: std::sync::atomic::AtomicBool,
     /// Set while a self-update is pending; no new jobs are accepted. Kept
@@ -138,40 +114,24 @@ impl Drop for ReleaseGuard {
 }
 
 impl RunnerSupervisor {
-    /// Create a supervisor that emits verdicts on `events`. `capabilities` is the
-    /// same set advertised to the gateway, so routing and advertisement agree.
+    /// Create a supervisor that emits verdicts on `events`. Routing comes
+    /// live from `backends` — the same registry the advertised capability
+    /// set derives from, so routing and advertisement agree by construction.
     /// `load_ceiling`/`mem_floor_mib` are not parameters: `admit()` reads
     /// them live from `state`, which is the single source of truth settings
     /// write through.
     pub fn new(
         events: mpsc::Sender<AttachRequest>,
         runner_script: Option<PathBuf>,
-        docker: Option<DockerRunner>,
-        vm: Option<VmRunner>,
-        interop: Option<InteropRunner>,
-        capabilities: Vec<Capability>,
+        backends: Arc<Backends>,
         state: AgentState,
     ) -> Self {
-        // Static for the attachment's lifetime, so this is set once rather
-        // than tracked incrementally alongside `backends` below.
-        state.set_capabilities(capabilities.iter().map(capability_to_control).collect());
-        let backends = capabilities
-            .into_iter()
-            .filter_map(|c| {
-                Backend::try_from(c.backed_by)
-                    .ok()
-                    .map(|b| ((c.os, c.arch), b))
-            })
-            .collect();
         Self {
             inner: Arc::new(Inner {
                 events,
                 outstanding: DashMap::new(),
                 in_flight: DashMap::new(),
                 runner_script,
-                docker,
-                vm,
-                interop,
                 backends,
                 draining: std::sync::atomic::AtomicBool::new(false),
                 draining_for_update: std::sync::atomic::AtomicBool::new(false),
@@ -255,7 +215,7 @@ impl RunnerSupervisor {
         {
             return Admission::Reject("host is draining".to_owned());
         }
-        let Some(&backend) = self.inner.backends.get(&(os.to_owned(), arch.to_owned())) else {
+        let Some(backend) = self.inner.backends.backend_for(os, arch) else {
             return Admission::Reject(format!("no capability for {os}/{arch}"));
         };
         let load_per_core = if telemetry.cpu_count > 0 {
@@ -464,13 +424,13 @@ impl RunnerSupervisor {
         token: &str,
         cancel: CancellationToken,
     ) {
-        // Invariant: the vm capability is only advertised when the daemon
-        // probe succeeded, so admit() routes here only with `vm` set.
-        let vm = self
-            .inner
-            .vm
-            .as_ref()
-            .expect("vm backend implies a vm runner");
+        // A vm capability is only advertised while the registry's VM slot
+        // is filled, and activation is one-way, so this cannot be empty;
+        // reject defensively rather than panic if that ever breaks.
+        let Some(vm) = self.inner.backends.vm() else {
+            self.reject(job_id, token, "macOS VM backend is not available");
+            return;
+        };
 
         // Startup (clone, boot, DHCP wait, ssh) takes minutes and must not
         // make the agent deaf to CancelRunner.
@@ -553,7 +513,7 @@ impl RunnerSupervisor {
         // Invariant: a windows capability is only advertised when the
         // interop probe passed, so admit() routes here only with `interop`
         // set; reject defensively rather than panic if that ever breaks.
-        let Some(interop) = &self.inner.interop else {
+        let Some(interop) = self.inner.backends.interop() else {
             self.reject(job_id, token, "windows jobs are not served by this agent");
             return;
         };
@@ -675,13 +635,13 @@ impl RunnerSupervisor {
         token: &str,
         cancel: CancellationToken,
     ) {
-        // Invariant: a Docker-backed capability is only advertised when Docker
-        // is present, so admit() routes here only with `docker` set.
-        let docker = self
-            .inner
-            .docker
-            .as_ref()
-            .expect("docker backend implies a docker runtime");
+        // A Docker-backed capability is only advertised while the registry's
+        // Docker slot is filled, so this cannot be empty; reject defensively
+        // rather than panic if that ever breaks.
+        let Some(docker) = self.inner.backends.docker() else {
+            self.reject(job_id, token, "docker runtime is not available");
+            return;
+        };
 
         // Startup is cancellation-aware: a slow image pull must not make the
         // agent deaf to CancelRunner and then accept a job the platform has
@@ -820,7 +780,10 @@ fn runner_command(script: &Path, encoded_jit_config: &str) -> tokio::process::Co
 
 #[cfg(test)]
 mod tests {
+    use arcbox_fleet_proto::v1::Capability;
+
     use super::*;
+    use crate::interop::InteropRunner;
 
     fn capability(os: &str, arch: &str, backend: Backend) -> Capability {
         Capability {
@@ -858,30 +821,18 @@ mod tests {
 
     fn supervisor(capabilities: Vec<Capability>) -> RunnerSupervisor {
         let (events, _rx) = mpsc::channel(1);
+        let state = AgentState::new(&seed());
         RunnerSupervisor::new(
             events,
             Some(PathBuf::from("/nonexistent")),
-            None,
-            None,
-            None,
-            capabilities,
-            AgentState::new(&seed()),
+            Backends::fixed(capabilities, state.clone()),
+            state,
         )
     }
 
     // Idle host: plenty of headroom.
     fn idle() -> HostTelemetry {
         telemetry(0.5, 8192)
-    }
-
-    #[test]
-    fn constructor_mirrors_capabilities_into_state() {
-        let sup = supervisor(vec![capability("darwin", "arm64", Backend::HostRunner)]);
-        let caps = sup.inner.state.current().capabilities;
-        assert_eq!(caps.len(), 1);
-        assert_eq!(caps[0].os, "darwin");
-        assert_eq!(caps[0].arch, "arm64");
-        assert_eq!(caps[0].backed_by, control_proto::Backend::HostRunner as i32);
     }
 
     #[test]
@@ -909,19 +860,17 @@ mod tests {
         interop: Option<InteropRunner>,
     ) -> (RunnerSupervisor, mpsc::Receiver<AttachRequest>) {
         let (events, rx) = mpsc::channel(8);
-        let sup = RunnerSupervisor::new(
-            events,
-            None,
-            None,
-            None,
-            interop,
+        let state = AgentState::new(&crate::settings::PersistedSettings {
+            load_ceiling: f64::MAX,
+            mem_floor_mib: 0,
+            ..seed()
+        });
+        let backends = Backends::fixed_with_interop(
             vec![capability("windows", "amd64", Backend::HostRunner)],
-            AgentState::new(&crate::settings::PersistedSettings {
-                load_ceiling: f64::MAX,
-                mem_floor_mib: 0,
-                ..seed()
-            }),
+            interop,
+            state.clone(),
         );
+        let sup = RunnerSupervisor::new(events, None, backends, state);
         (sup, rx)
     }
 
@@ -1134,14 +1083,15 @@ mod tests {
 
     fn supervisor_with_rx(capacity: usize) -> (RunnerSupervisor, mpsc::Receiver<AttachRequest>) {
         let (events, rx) = mpsc::channel(capacity);
+        let state = AgentState::new(&seed());
         let sup = RunnerSupervisor::new(
             events,
             Some(PathBuf::from("/nonexistent")),
-            None,
-            None,
-            None,
-            vec![capability("darwin", "arm64", Backend::HostRunner)],
-            AgentState::new(&seed()),
+            Backends::fixed(
+                vec![capability("darwin", "arm64", Backend::HostRunner)],
+                state.clone(),
+            ),
+            state,
         );
         (sup, rx)
     }
@@ -1154,18 +1104,19 @@ mod tests {
         capacity: usize,
     ) -> (RunnerSupervisor, mpsc::Receiver<AttachRequest>) {
         let (events, rx) = mpsc::channel(capacity);
+        let state = AgentState::new(&crate::settings::PersistedSettings {
+            load_ceiling: f64::MAX,
+            mem_floor_mib: 0,
+            ..seed()
+        });
         let sup = RunnerSupervisor::new(
             events,
             Some(PathBuf::from("/nonexistent")),
-            None,
-            None,
-            None,
-            vec![capability("darwin", "arm64", Backend::HostRunner)],
-            AgentState::new(&crate::settings::PersistedSettings {
-                load_ceiling: f64::MAX,
-                mem_floor_mib: 0,
-                ..seed()
-            }),
+            Backends::fixed(
+                vec![capability("darwin", "arm64", Backend::HostRunner)],
+                state.clone(),
+            ),
+            state,
         );
         (sup, rx)
     }
@@ -1378,8 +1329,13 @@ mod tests {
     async fn shutdown_does_not_flip_observable_draining_but_drain_does() {
         let drained = AgentState::new(&seed());
         let (events, _rx) = mpsc::channel(1);
-        RunnerSupervisor::new(events, None, None, None, None, Vec::new(), drained.clone())
-            .handle_drain();
+        RunnerSupervisor::new(
+            events,
+            None,
+            Backends::fixed(Vec::new(), drained.clone()),
+            drained.clone(),
+        )
+        .handle_drain();
         assert!(
             drained.current().draining,
             "Drain flips the observable flag"
@@ -1390,10 +1346,7 @@ mod tests {
         RunnerSupervisor::new(
             events,
             None,
-            None,
-            None,
-            None,
-            Vec::new(),
+            Backends::fixed(Vec::new(), torn_down.clone()),
             torn_down.clone(),
         )
         .shutdown(Duration::from_secs(1))

--- a/fleet/arcbox-fleet-agent/src/state.rs
+++ b/fleet/arcbox-fleet-agent/src/state.rs
@@ -262,8 +262,9 @@ impl AgentState {
         self.tx.send_modify(|s| s.draining = draining);
     }
 
-    /// Advertised capabilities are static for an attachment's lifetime, so
-    /// this is set once rather than tracked incrementally.
+    /// Mirror the advertised capability set. Written only by the backend
+    /// registry (`crate::backends`): once at construction and again on
+    /// every backend activation.
     pub fn set_capabilities(&self, capabilities: Vec<Capability>) {
         self.tx.send_modify(|s| s.capabilities = capabilities);
     }

--- a/fleet/arcbox-fleet-agent/src/state.rs
+++ b/fleet/arcbox-fleet-agent/src/state.rs
@@ -341,6 +341,20 @@ impl AgentState {
             .clone()
     }
 
+    /// The `vm_mode` this process runs with (`current` is restart-scoped —
+    /// seeded at startup, never moved by `UpdateSettings`). Gates whether
+    /// `FleetImageService.Prepare` may dial the daemon for an inactive VM
+    /// backend.
+    pub fn vm_mode_current(&self) -> VmMode {
+        vm_mode_from_wire(
+            settings_of(&self.tx.borrow())
+                .vm_mode
+                .as_ref()
+                .expect(SETTINGS_INVARIANT)
+                .current,
+        )
+    }
+
     /// The desired macOS image — what `FleetImageService.Prepare` pulls
     /// through the daemon and then promotes to `current`.
     pub fn macos_runner_image_target(&self) -> String {

--- a/fleet/arcbox-fleet-agent/src/vm.rs
+++ b/fleet/arcbox-fleet-agent/src/vm.rs
@@ -90,30 +90,37 @@ impl VmRunner {
     /// whatever `macos_runner_image` is current at dispatch time
     /// ([`RunSpec::runner_image`]).
     pub async fn new(daemon_socket: &Path, default_image: &str) -> Result<Self> {
-        let channel = crate::control::client::connect(daemon_socket).await?;
-        let mut client = MacosServiceClient::new(channel);
-
-        // One call proves the daemon is up *and* speaks MacosService (an
-        // older daemon without it answers Unimplemented), and provides the
-        // installed-image check.
-        let images = client
-            .image_list(Empty {})
+        let runner = Self::connect(daemon_socket).await?;
+        runner
+            .installed_image(default_image)
             .await
-            .context("daemon does not serve macOS guests (MacosService.ImageList failed)")?
-            .into_inner()
-            .images;
-        if !images.iter().any(|i| i.name == stream_name(default_image)) {
-            bail!(
-                "macOS runner image '{default_image}' is not installed in the daemon — \
-                 run `arcbox-fleet-agent prepare macos-runner-image` (or `abctl macos \
-                 image pull {default_image}`) first"
-            );
-        }
-
-        let runner = Self { client };
+            .with_context(|| {
+                format!(
+                    "macOS runner image '{default_image}' is not available — run \
+                     `arcbox-fleet-agent prepare macos-runner-image` (or `abctl macos \
+                     image pull {default_image}`) first"
+                )
+            })?;
         runner.sweep_leftovers().await;
         info!(image = default_image, "macOS VM backend available");
         Ok(runner)
+    }
+
+    /// Connect to the daemon socket and prove it speaks `MacosService` (an
+    /// older daemon without it answers Unimplemented) — the first half of
+    /// [`Self::new`], with no installed-image requirement.
+    /// `FleetImageService.Prepare` uses this to pull an image through a
+    /// daemon whose backend is not yet active: the missing image is exactly
+    /// what that pull is about to fix, so demanding the full readiness
+    /// probe first would be circular.
+    pub async fn connect(daemon_socket: &Path) -> Result<Self> {
+        let channel = crate::control::client::connect(daemon_socket).await?;
+        let mut client = MacosServiceClient::new(channel);
+        client
+            .image_list(Empty {})
+            .await
+            .context("daemon does not serve macOS guests (MacosService.ImageList failed)")?;
+        Ok(Self { client })
     }
 
     /// Force-remove every `fleet-*` guest. Only this agent creates such


### PR DESCRIPTION
## Problem

If the fleet agent's LaunchAgent starts at login before arcbox-daemon has bound its socket (the default `vm_mode=auto` path), the VM backend probe fails once and the result is frozen for the whole process lifetime: no re-probe, capabilities fixed at construction, and launchd never respawns a healthy process. The host silently serves no darwin VM jobs until someone restarts the agent.

A second, related dead-end: `Prepare(macos-runner-image)` with an inactive backend skipped the pull entirely — circular, because the activation probe demands the very image that Prepare would have installed (the probe's own error message recommends running Prepare).

## Approach

Capabilities are per-attachment declarative state on the wire: the gateway rewrites the machine's capability pools from every `Attach` handshake (`apply_attach` → `replace_runtimes`, and gateway.rs documents "a reconnect refreshes them"). This PR makes the client honor that contract — capability changes propagate by deliberately re-attaching. **No gateway/platform change is needed.**

1. **`refactor(fleet)`: backend registry.** One shared `Backends` registry replaces the per-consumer frozen `Option<DockerRunner>`/`Option<VmRunner>`/`Option<InteropRunner>` copies. Offer routing, capability advertisement, image preparation, and `GetAgentInfo` read the same slots, so routing and advertisement derive from a single source.

2. **`feat(fleet)`: activation + re-attach + re-probe.**
   - `Backends::activate_vm` — one-way slot fill (never emptied, preserving "capability advertised ⇒ runner present"); refreshes the observable-state mirror and nudges a `watch` channel.
   - The attach loop snapshots capabilities per connection; a registry change cleanly ends the stream (`StreamEnd::Reattach`) and reconnects immediately, no backoff. In-flight jobs survive reconnects by design.
   - `spawn_vm_reprobe`: macOS + `vm_mode=auto` + failed startup probe → retry every 30s (one local unix connect + `ImageList`) until the daemon answers, then activate and exit. `enabled` keeps fail-fast (launchd respawn already self-heals it); `disabled` never probes.

3. **`feat(fleet)`: Prepare bootstraps an inactive backend.** With the backend inactive but the daemon reachable, Prepare dials directly via the new `VmRunner::connect` (the probe minus the installed-image requirement), relays the pull, then runs the full activation probe and fills the slot — firing the re-attach. Unreachable daemon keeps the existing skip-and-promote behavior.

## Testing

- New mock `MacosService` daemon on a scratch unix socket (`mock_daemon.rs`, test-only).
- End-to-end re-attach test: a recording mock gateway observes the second `Attach` handshake carrying the VM capability after mid-stream activation.
- Re-probe loop test (daemon up, image appears later) and Prepare-activation test (pull through direct dial → backend active, stages `pulling/activated/promoted`).
- `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, 107 unit + 1 integration tests green.

## Follow-ups (out of scope)

- Docker has the identical login race (`init_docker` Auto); the registry is shaped for it, but its probe pulls images, so the retry loop needs backoff design first.
- Platform cosmetic: stale comment at `gateway.rs:444` still claims heartbeats refresh capabilities.