### PR TITLE
fix(network): restore direct container routing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -365,6 +365,7 @@ dependencies = [
  "arcbox-migration",
  "arcbox-net",
  "arcbox-protocol",
+ "arcbox-route",
  "arcbox-transport",
  "arcbox-virtio",
  "arcbox-vmm",
@@ -409,6 +410,7 @@ dependencies = [
  "arcbox-helper",
  "arcbox-logging",
  "arcbox-net",
+ "arcbox-route",
  "arcbox-transport",
  "async-trait",
  "axum",
@@ -646,7 +648,7 @@ dependencies = [
 
 [[package]]
 name = "arcbox-helper"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "arcbox-constants",
  "arcbox-logging",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -259,7 +259,7 @@ arcbox-fleet-control-proto = { version = "0.5.1", path = "fleet/arcbox-fleet-con
 arcbox-docker = { version = "0.5.1", path = "app/arcbox-docker" } # x-release-please-version
 # Pinned to app/arcbox-helper's own version (not workspace.package). Do not
 # attach x-release-please-version — helper releases are manual.
-arcbox-helper = { version = "1.0.1", path = "app/arcbox-helper" }
+arcbox-helper = { version = "1.0.2", path = "app/arcbox-helper" }
 arcbox-core = { version = "0.5.1", path = "app/arcbox-core" } # x-release-please-version
 arcbox-api = { version = "0.5.1", path = "app/arcbox-api" } # x-release-please-version
 arcbox-migration = { version = "0.5.1", path = "app/arcbox-migration" } # x-release-please-version

--- a/app/arcbox-cli/src/commands/doctor.rs
+++ b/app/arcbox-cli/src/commands/doctor.rs
@@ -5,7 +5,6 @@
 //! (on macOS) L3 container routing.
 
 use anyhow::Result;
-use std::process::Command;
 
 /// Runs all diagnostic checks and prints a report.
 pub async fn execute() -> Result<()> {
@@ -44,7 +43,7 @@ pub async fn execute() -> Result<()> {
     #[cfg(target_os = "macos")]
     {
         check!("Bridge NIC", check_bridge_nic());
-        check!("Container route", check_container_route());
+        check!("Container route", check_container_route().await);
         check!("ArcBoxHelper", check_helper().await);
     }
 
@@ -181,39 +180,21 @@ fn check_bridge_nic() -> CheckResult {
 
 /// Check if the container subnet route is installed correctly.
 #[cfg(target_os = "macos")]
-fn check_container_route() -> CheckResult {
-    let Ok(output) = Command::new("route")
-        .args(["-n", "get", "-net", "172.16.0.0/12"])
-        .output()
-    else {
-        return CheckResult::Fail("route command failed".into());
+async fn check_container_route() -> CheckResult {
+    let Some((bridge, _)) = arcbox_core::bridge_discovery::find_bridge_with_vmenet() else {
+        return CheckResult::Fail("cannot identify ArcBox bridge".into());
     };
-    let text = String::from_utf8_lossy(&output.stdout);
-
-    let mut iface = None;
-    let mut gateway = None;
-    let mut is_gateway_route = false;
-    for line in text.lines() {
-        let trimmed = line.trim();
-        if let Some(val) = trimmed.strip_prefix("interface:") {
-            iface = Some(val.trim().to_string());
-        } else if let Some(val) = trimmed.strip_prefix("gateway:") {
-            gateway = Some(val.trim().to_string());
-        } else if let Some(val) = trimmed.strip_prefix("flags:") {
-            is_gateway_route = val.split([',', '<', '>']).any(|flag| flag == "GATEWAY");
+    match arcbox_core::route_reconciler::container_route_mode(&bridge).await {
+        Ok(Some(arcbox_core::route_reconciler::RouteMode::Preferred)) => {
+            CheckResult::Pass(format!("172.16.0.0/12 → {bridge}"))
         }
-    }
-
-    match iface.as_deref() {
-        Some(i) if is_gateway_route => CheckResult::Fail(format!(
-            "172.16.0.0/12 → {i} is a gateway route; container traffic will fail"
+        Ok(Some(arcbox_core::route_reconciler::RouteMode::SplitFallback)) => CheckResult::Pass(
+            format!("172.16.0.0/13 + 172.24.0.0/13 → {bridge} (VPN-compatible fallback)"),
+        ),
+        Ok(None) => CheckResult::Fail(format!(
+            "neither 172.16.0.0/12 nor both split /13 routes point to {bridge}"
         )),
-        Some(i) if i.starts_with("bridge") => CheckResult::Pass(format!("172.16.0.0/12 → {i}")),
-        Some(i) => CheckResult::Fail(format!(
-            "172.16.0.0/12 → {i} (expected bridge*, got wrong interface; gateway={:?})",
-            gateway
-        )),
-        None => CheckResult::Fail("no route for 172.16.0.0/12".into()),
+        Err(error) => CheckResult::Fail(format!("route query failed: {error}")),
     }
 }
 

--- a/app/arcbox-cli/src/commands/doctor.rs
+++ b/app/arcbox-cli/src/commands/doctor.rs
@@ -192,16 +192,22 @@ fn check_container_route() -> CheckResult {
 
     let mut iface = None;
     let mut gateway = None;
+    let mut is_gateway_route = false;
     for line in text.lines() {
         let trimmed = line.trim();
         if let Some(val) = trimmed.strip_prefix("interface:") {
             iface = Some(val.trim().to_string());
         } else if let Some(val) = trimmed.strip_prefix("gateway:") {
             gateway = Some(val.trim().to_string());
+        } else if let Some(val) = trimmed.strip_prefix("flags:") {
+            is_gateway_route = val.split([',', '<', '>']).any(|flag| flag == "GATEWAY");
         }
     }
 
     match iface.as_deref() {
+        Some(i) if is_gateway_route => CheckResult::Fail(format!(
+            "172.16.0.0/12 → {i} is a gateway route; container traffic will fail"
+        )),
         Some(i) if i.starts_with("bridge") => CheckResult::Pass(format!("172.16.0.0/12 → {i}")),
         Some(i) => CheckResult::Fail(format!(
             "172.16.0.0/12 → {i} (expected bridge*, got wrong interface; gateway={:?})",

--- a/app/arcbox-cli/src/commands/doctor.rs
+++ b/app/arcbox-cli/src/commands/doctor.rs
@@ -183,7 +183,7 @@ fn check_bridge_nic() -> CheckResult {
 #[cfg(target_os = "macos")]
 fn check_container_route() -> CheckResult {
     let Ok(output) = Command::new("route")
-        .args(["-n", "get", "172.16.0.0"])
+        .args(["-n", "get", "-net", "172.16.0.0/12"])
         .output()
     else {
         return CheckResult::Fail("route command failed".into());

--- a/app/arcbox-core/Cargo.toml
+++ b/app/arcbox-core/Cargo.toml
@@ -46,6 +46,7 @@ zstd = "0.13.3"
 base64 = "0.22.1"
 
 [target.'cfg(target_os = "macos")'.dependencies]
+arcbox-route.workspace = true
 arcbox-vz.workspace = true
 ifbridge = { workspace = true }
 

--- a/app/arcbox-core/src/route_reconciler.rs
+++ b/app/arcbox-core/src/route_reconciler.rs
@@ -10,11 +10,16 @@
 use std::time::Duration;
 
 use arcbox_helper::client::{Client, ClientError};
+use arcbox_helper::error::HelperError;
+use arcbox_route::{Ipv4Net, RouteInfo};
 
 use crate::bridge_discovery;
 
-/// Container subnet to route.
-const CONTAINER_SUBNET: &str = "172.16.0.0/12";
+/// Preferred route covering the complete container address range.
+pub const CONTAINER_SUBNET: &str = "172.16.0.0/12";
+
+/// More-specific routes used when another network service owns the exact `/12`.
+pub const CONTAINER_SPLIT_SUBNETS: [&str; 2] = ["172.16.0.0/13", "172.24.0.0/13"];
 
 /// Maximum retry attempts for transient route installation failures.
 const MAX_ROUTE_ATTEMPTS: u32 = 5;
@@ -35,9 +40,15 @@ pub enum RouteError {
     /// Helper daemon not reachable. Retryable.
     #[error("helper unavailable: {0}")]
     HelperUnavailable(String),
-    /// `/sbin/route` returned an unexpected error. Retryable.
-    #[error("route command failed: {0}")]
+    /// The routing API returned an unexpected error. Retryable.
+    #[error("route operation failed: {0}")]
     RouteFailed(String),
+    /// A more-specific fallback route is already owned by another service.
+    #[error("route {subnet} is owned by another network service")]
+    RouteConflict {
+        /// Exact subnet ArcBox left untouched.
+        subnet: String,
+    },
 }
 
 impl From<ClientError> for RouteError {
@@ -50,6 +61,269 @@ impl From<ClientError> for RouteError {
             ClientError::Helper(err) => Self::RouteFailed(err.to_string()),
         }
     }
+}
+
+fn route_matches_bridge(route: Option<&RouteInfo>, bridge_ifindex: u16) -> bool {
+    matches!(
+        route,
+        Some(route)
+            if route.ifindex == bridge_ifindex && route.flags & libc::RTF_GATEWAY == 0
+    )
+}
+
+/// Container route shape maintained for the current VM lifecycle.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RouteMode {
+    /// One exact `/12` interface route through the ArcBox bridge.
+    Preferred,
+    /// Two more-specific `/13` routes, leaving an external `/12` untouched.
+    SplitFallback,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ExactRouteState {
+    Missing,
+    Owned,
+    External,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct RouteSnapshot {
+    preferred: ExactRouteState,
+    split: [ExactRouteState; 2],
+}
+
+impl RouteSnapshot {
+    fn is_healthy(self) -> bool {
+        (self.preferred == ExactRouteState::Owned
+            && !self.split.contains(&ExactRouteState::External))
+            || self
+                .split
+                .iter()
+                .all(|state| *state == ExactRouteState::Owned)
+    }
+
+    fn initial_mode(self) -> RouteMode {
+        if self
+            .split
+            .iter()
+            .all(|state| *state == ExactRouteState::Owned)
+        {
+            RouteMode::SplitFallback
+        } else if self.preferred == ExactRouteState::Owned {
+            RouteMode::Preferred
+        } else if self.preferred == ExactRouteState::External
+            || self.split.contains(&ExactRouteState::Owned)
+        {
+            RouteMode::SplitFallback
+        } else {
+            RouteMode::Preferred
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ReconcileAction {
+    Healthy(RouteMode),
+    AddPreferred,
+    EnsureSplit,
+    Conflict(&'static str),
+}
+
+fn plan_reconciliation(mode: RouteMode, snapshot: RouteSnapshot) -> ReconcileAction {
+    if let Some(index) = snapshot
+        .split
+        .iter()
+        .position(|state| *state == ExactRouteState::External)
+    {
+        return ReconcileAction::Conflict(CONTAINER_SPLIT_SUBNETS[index]);
+    }
+    if mode == RouteMode::SplitFallback {
+        return if snapshot
+            .split
+            .iter()
+            .all(|state| *state == ExactRouteState::Owned)
+        {
+            ReconcileAction::Healthy(RouteMode::SplitFallback)
+        } else {
+            ReconcileAction::EnsureSplit
+        };
+    }
+    match snapshot.preferred {
+        ExactRouteState::Owned => ReconcileAction::Healthy(RouteMode::Preferred),
+        ExactRouteState::External => ReconcileAction::EnsureSplit,
+        ExactRouteState::Missing => ReconcileAction::AddPreferred,
+    }
+}
+
+fn parse_network(value: &str) -> Result<Ipv4Net, RouteError> {
+    value.parse().map_err(|error| {
+        RouteError::RouteFailed(format!("invalid container network {value}: {error}"))
+    })
+}
+
+fn classify_route(route: Option<&RouteInfo>, bridge_ifindex: u16) -> ExactRouteState {
+    match route {
+        None => ExactRouteState::Missing,
+        Some(route) if route_matches_bridge(Some(route), bridge_ifindex) => ExactRouteState::Owned,
+        Some(_) => ExactRouteState::External,
+    }
+}
+
+fn inspect_routes_sync(bridge_name: &str) -> Result<RouteSnapshot, RouteError> {
+    let bridge_ifindex =
+        arcbox_route::interface_index(bridge_name).map_err(|_| RouteError::BridgeNotReady)?;
+    let preferred = parse_network(CONTAINER_SUBNET)?;
+    let split = [
+        parse_network(CONTAINER_SPLIT_SUBNETS[0])?,
+        parse_network(CONTAINER_SPLIT_SUBNETS[1])?,
+    ];
+    let query = |network| {
+        arcbox_route::get(network)
+            .map(|route| classify_route(route.as_ref(), bridge_ifindex))
+            .map_err(RouteError::RouteFailed)
+    };
+    Ok(RouteSnapshot {
+        preferred: query(preferred)?,
+        split: [query(split[0])?, query(split[1])?],
+    })
+}
+
+async fn inspect_routes(bridge_name: &str) -> Result<RouteSnapshot, RouteError> {
+    let bridge_name = bridge_name.to_string();
+    tokio::task::spawn_blocking(move || inspect_routes_sync(&bridge_name))
+        .await
+        .map_err(|error| RouteError::RouteFailed(format!("route check task failed: {error}")))?
+}
+
+async fn add_route(client: &Client, subnet: &str, bridge_name: &str) -> Result<bool, RouteError> {
+    match client.route_add(subnet, bridge_name).await {
+        Ok(()) => Ok(true),
+        Err(ClientError::Helper(HelperError::RouteConflict { .. })) => Ok(false),
+        Err(error) => Err(error.into()),
+    }
+}
+
+async fn ensure_split_routes(
+    bridge_name: &str,
+    mut snapshot: RouteSnapshot,
+) -> Result<(), RouteError> {
+    if let Some(index) = snapshot
+        .split
+        .iter()
+        .position(|state| *state == ExactRouteState::External)
+    {
+        return Err(RouteError::RouteConflict {
+            subnet: CONTAINER_SPLIT_SUBNETS[index].to_string(),
+        });
+    }
+    if snapshot
+        .split
+        .iter()
+        .all(|state| *state == ExactRouteState::Owned)
+    {
+        return Ok(());
+    }
+
+    let client = Client::connect().await?;
+    for (index, subnet) in CONTAINER_SPLIT_SUBNETS.iter().enumerate() {
+        if snapshot.split[index] == ExactRouteState::Owned {
+            continue;
+        }
+        if add_route(&client, subnet, bridge_name).await? {
+            snapshot.split[index] = ExactRouteState::Owned;
+            continue;
+        }
+
+        snapshot = inspect_routes(bridge_name).await?;
+        if snapshot.split[index] != ExactRouteState::Owned {
+            return Err(RouteError::RouteConflict {
+                subnet: (*subnet).to_string(),
+            });
+        }
+    }
+    Ok(())
+}
+
+async fn reconcile_with_snapshot(
+    bridge_name: &str,
+    mode: RouteMode,
+    mut snapshot: RouteSnapshot,
+) -> Result<RouteMode, RouteError> {
+    match plan_reconciliation(mode, snapshot) {
+        ReconcileAction::Healthy(mode) => return Ok(mode),
+        ReconcileAction::Conflict(subnet) => {
+            return Err(RouteError::RouteConflict {
+                subnet: subnet.to_string(),
+            });
+        }
+        ReconcileAction::EnsureSplit => {}
+        ReconcileAction::AddPreferred => {
+            let client = Client::connect().await?;
+            if add_route(&client, CONTAINER_SUBNET, bridge_name).await? {
+                return Ok(RouteMode::Preferred);
+            }
+            // Another service won the add race. Re-query before deciding: an
+            // ArcBox route added by a concurrent reconciler is already good.
+            snapshot = inspect_routes(bridge_name).await?;
+            if snapshot.preferred == ExactRouteState::Owned {
+                return Ok(RouteMode::Preferred);
+            }
+        }
+    }
+
+    ensure_split_routes(bridge_name, snapshot).await?;
+    tracing::info!(
+        preferred = CONTAINER_SUBNET,
+        lower = CONTAINER_SPLIT_SUBNETS[0],
+        upper = CONTAINER_SPLIT_SUBNETS[1],
+        bridge = bridge_name,
+        "external container route detected; switched to sticky split fallback"
+    );
+    Ok(RouteMode::SplitFallback)
+}
+
+/// Reconciles the container routes while preserving a sticky lifecycle mode.
+pub async fn reconcile_route_for_bridge(
+    bridge_name: &str,
+    mode: RouteMode,
+) -> Result<RouteMode, RouteError> {
+    let snapshot = inspect_routes(bridge_name).await?;
+    reconcile_with_snapshot(bridge_name, mode, snapshot).await
+}
+
+/// Detects the route shape left by this VM lifecycle and reconciles it.
+pub async fn initialize_route_for_bridge(bridge_name: &str) -> Result<RouteMode, RouteError> {
+    let snapshot = inspect_routes(bridge_name).await?;
+    reconcile_with_snapshot(bridge_name, snapshot.initial_mode(), snapshot).await
+}
+
+/// Checks whether the container subnet is an interface route through `bridge_name`.
+///
+/// The routing query is unprivileged but blocking, so it runs outside the async
+/// executor. A route through the expected interface still fails the check when
+/// `RTF_GATEWAY` remains set, which is the invalid state produced when a VPN's
+/// gateway route is changed in place.
+pub async fn container_route_matches_bridge(bridge_name: &str) -> Result<bool, RouteError> {
+    Ok(container_route_mode(bridge_name).await?.is_some())
+}
+
+/// Returns the healthy route shape currently installed through `bridge_name`.
+pub async fn container_route_mode(bridge_name: &str) -> Result<Option<RouteMode>, RouteError> {
+    let snapshot = inspect_routes(bridge_name).await?;
+    if !snapshot.is_healthy() {
+        return Ok(None);
+    }
+    Ok(Some(snapshot.initial_mode()))
+}
+
+/// Performs one route installation attempt through a known bridge interface.
+///
+/// Callers that need retries own the retry cadence. Keeping this operation
+/// single-shot prevents a continuous route guard from blocking inside a nested
+/// retry loop when another network service replaces the route.
+pub async fn repair_route_for_bridge(bridge_name: &str) -> Result<(), RouteError> {
+    initialize_route_for_bridge(bridge_name).await.map(|_| ())
 }
 
 /// Ensures the container subnet route points to the correct bridge.
@@ -67,14 +341,12 @@ async fn ensure_route(bridge_mac: &str) -> Result<(), RouteError> {
         .ok_or(RouteError::BridgeNotReady)?;
 
     // Step 2: Tell helper to add the route.
-    let client = Client::connect().await?;
-    client.route_add(CONTAINER_SUBNET, &bridge.name).await?;
+    repair_route_for_bridge(&bridge.name).await?;
 
     tracing::info!(
-        subnet = CONTAINER_SUBNET,
         bridge = %bridge.name,
         %bridge_mac,
-        "route ensured"
+        "container route ensured"
     );
     Ok(())
 }
@@ -118,18 +390,11 @@ pub async fn ensure_route_with_retry(bridge_mac: &str) -> Result<(), RouteError>
 #[cfg(all(feature = "vmnet", target_os = "macos"))]
 pub async fn ensure_route_for_bridge(bridge_name: &str) -> Result<(), RouteError> {
     for attempt in 1..=2 {
-        match async {
-            let client = Client::connect().await?;
-            client.route_add(CONTAINER_SUBNET, bridge_name).await?;
-            Ok::<(), RouteError>(())
-        }
-        .await
-        {
+        match repair_route_for_bridge(bridge_name).await {
             Ok(()) => {
                 tracing::info!(
-                    subnet = CONTAINER_SUBNET,
                     bridge = bridge_name,
-                    "route ensured (vmnet direct)"
+                    "container route ensured (vmnet direct)"
                 );
                 return Ok(());
             }
@@ -143,31 +408,133 @@ pub async fn ensure_route_for_bridge(bridge_name: &str) -> Result<(), RouteError
     unreachable!()
 }
 
-/// Removes the container subnet route.
-///
-/// Called on: VM stop, daemon shutdown.
-pub async fn remove_route() {
-    let client = match Client::connect().await {
-        Ok(c) => c,
-        Err(e) => {
-            tracing::debug!(error = %e, "arcbox-helper not reachable for route cleanup");
-            return;
-        }
-    };
+#[cfg(test)]
+mod tests {
+    use super::*;
 
-    match client.route_remove(CONTAINER_SUBNET).await {
-        Ok(()) => {
-            tracing::info!(subnet = CONTAINER_SUBNET, "route removed");
-        }
-        Err(ClientError::Helper(err)) if err.to_string().contains("not in table") => {
-            tracing::debug!(subnet = CONTAINER_SUBNET, "route already absent");
-        }
-        Err(e) => {
-            tracing::debug!(
-                subnet = CONTAINER_SUBNET,
-                error = %e,
-                "route remove failed"
-            );
-        }
+    #[test]
+    fn correct_interface_route_matches() {
+        let route = RouteInfo {
+            ifindex: 26,
+            flags: libc::RTF_UP | libc::RTF_STATIC,
+        };
+
+        assert!(route_matches_bridge(Some(&route), 26));
+    }
+
+    #[test]
+    fn gateway_route_on_expected_interface_does_not_match() {
+        let route = RouteInfo {
+            ifindex: 26,
+            flags: libc::RTF_UP | libc::RTF_STATIC | libc::RTF_GATEWAY,
+        };
+
+        assert!(!route_matches_bridge(Some(&route), 26));
+    }
+
+    #[test]
+    fn absent_or_wrong_interface_route_does_not_match() {
+        let route = RouteInfo {
+            ifindex: 7,
+            flags: libc::RTF_UP | libc::RTF_STATIC,
+        };
+
+        assert!(!route_matches_bridge(None, 26));
+        assert!(!route_matches_bridge(Some(&route), 26));
+    }
+
+    #[test]
+    fn external_preferred_route_selects_split_fallback() {
+        let snapshot = RouteSnapshot {
+            preferred: ExactRouteState::External,
+            split: [ExactRouteState::Missing; 2],
+        };
+
+        assert_eq!(snapshot.initial_mode(), RouteMode::SplitFallback);
+        assert!(!snapshot.is_healthy());
+    }
+
+    #[test]
+    fn complete_split_routes_restore_sticky_mode_after_restart() {
+        let snapshot = RouteSnapshot {
+            preferred: ExactRouteState::Missing,
+            split: [ExactRouteState::Owned; 2],
+        };
+
+        assert_eq!(snapshot.initial_mode(), RouteMode::SplitFallback);
+        assert!(snapshot.is_healthy());
+    }
+
+    #[test]
+    fn owned_preferred_route_is_selected_without_split_evidence() {
+        let snapshot = RouteSnapshot {
+            preferred: ExactRouteState::Owned,
+            split: [ExactRouteState::Missing; 2],
+        };
+
+        assert_eq!(snapshot.initial_mode(), RouteMode::Preferred);
+        assert!(snapshot.is_healthy());
+    }
+
+    #[test]
+    fn external_more_specific_route_makes_preferred_shape_unhealthy() {
+        let snapshot = RouteSnapshot {
+            preferred: ExactRouteState::Owned,
+            split: [ExactRouteState::External, ExactRouteState::Missing],
+        };
+
+        assert!(!snapshot.is_healthy());
+    }
+
+    #[test]
+    fn healthy_preferred_mode_is_a_noop() {
+        let snapshot = RouteSnapshot {
+            preferred: ExactRouteState::Owned,
+            split: [ExactRouteState::Missing; 2],
+        };
+
+        assert_eq!(
+            plan_reconciliation(RouteMode::Preferred, snapshot),
+            ReconcileAction::Healthy(RouteMode::Preferred)
+        );
+    }
+
+    #[test]
+    fn external_preferred_route_plans_split_fallback() {
+        let snapshot = RouteSnapshot {
+            preferred: ExactRouteState::External,
+            split: [ExactRouteState::Missing; 2],
+        };
+
+        assert_eq!(
+            plan_reconciliation(RouteMode::Preferred, snapshot),
+            ReconcileAction::EnsureSplit
+        );
+    }
+
+    #[test]
+    fn split_mode_never_reverts_to_preferred() {
+        let snapshot = RouteSnapshot {
+            preferred: ExactRouteState::Missing,
+            split: [ExactRouteState::Owned; 2],
+        };
+
+        assert_eq!(
+            plan_reconciliation(RouteMode::SplitFallback, snapshot),
+            ReconcileAction::Healthy(RouteMode::SplitFallback)
+        );
+    }
+
+    #[test]
+    fn external_split_route_is_never_replaced() {
+        let snapshot = RouteSnapshot {
+            preferred: ExactRouteState::External,
+            split: [ExactRouteState::Owned, ExactRouteState::External],
+        };
+
+        assert_eq!(
+            plan_reconciliation(RouteMode::SplitFallback, snapshot),
+            ReconcileAction::Conflict("172.24.0.0/13")
+        );
     }
 }

--- a/app/arcbox-daemon/Cargo.toml
+++ b/app/arcbox-daemon/Cargo.toml
@@ -43,6 +43,7 @@ tonic-reflection = "0.14"
 arcbox-transport.workspace = true
 
 [target.'cfg(target_os = "macos")'.dependencies]
+arcbox-route.workspace = true
 macos-resolver = { workspace = true }
 libproc = { workspace = true }
 

--- a/app/arcbox-daemon/src/context.rs
+++ b/app/arcbox-daemon/src/context.rs
@@ -129,4 +129,6 @@ pub struct ServiceHandles {
     pub docker: Option<tokio::task::JoinHandle<()>>,
     pub grpc: tokio::task::JoinHandle<()>,
     pub kubernetes_proxy: Option<tokio::task::JoinHandle<()>>,
+    /// Host container-route guard; present only on macOS with the Linux VM enabled.
+    pub route_guard: Option<tokio::task::JoinHandle<()>>,
 }

--- a/app/arcbox-daemon/src/services.rs
+++ b/app/arcbox-daemon/src/services.rs
@@ -27,6 +27,11 @@ use tracing::{info, warn};
 use crate::context::{DaemonContext, ServiceHandles};
 use crate::dns_service::DnsService;
 
+#[cfg(target_os = "macos")]
+const ROUTE_POLL_INTERVAL: std::time::Duration = std::time::Duration::from_secs(30);
+#[cfg(target_os = "macos")]
+const ROUTE_EVENT_DEBOUNCE: std::time::Duration = std::time::Duration::from_millis(250);
+
 /// Starts the gRPC server with all services.
 ///
 /// Called before `init_runtime()` — Machine/Sandbox/Snapshot services will
@@ -188,11 +193,24 @@ pub async fn start_services(
         route_status_loop(route_events, route_state, route_shutdown).await;
     }));
 
+    #[cfg(target_os = "macos")]
+    let route_guard = linux_vm.then(|| {
+        let runtime = Arc::clone(runtime);
+        let setup_state = Arc::clone(&ctx.setup_state);
+        let shutdown = ctx.shutdown.clone();
+        tokio::spawn(async move {
+            container_route_guard(runtime, setup_state, shutdown).await;
+        })
+    });
+    #[cfg(not(target_os = "macos"))]
+    let route_guard = None;
+
     Ok(ServiceHandles {
         dns,
         docker,
         grpc,
         kubernetes_proxy,
+        route_guard,
     })
 }
 
@@ -230,6 +248,205 @@ async fn route_status_loop(
             },
         }
     }
+}
+
+#[cfg(target_os = "macos")]
+async fn container_route_guard(
+    runtime: Arc<Runtime>,
+    setup_state: Arc<arcbox_api::SetupState>,
+    shutdown: tokio_util::sync::CancellationToken,
+) {
+    use arcbox_core::route_reconciler::RouteMode;
+
+    let mut ticker = tokio::time::interval(ROUTE_POLL_INTERVAL);
+    ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+    let mut watcher = open_route_watcher();
+    let mut active: Option<(String, RouteMode)> = None;
+    let mut consecutive_failures = 0u32;
+
+    loop {
+        let route_event = tokio::select! {
+            () = shutdown.cancelled() => break,
+            _ = ticker.tick() => false,
+            event = next_managed_route_event(watcher.as_ref()) => {
+                match event {
+                    Ok(()) => true,
+                    Err(error) if error.raw_os_error() == Some(libc::ENOBUFS) => {
+                        tracing::debug!(
+                            "route event queue overflowed; reconciling current state"
+                        );
+                        true
+                    }
+                    Err(error) => {
+                        tracing::warn!(%error, "route event watcher failed; polling remains active");
+                        watcher = None;
+                        false
+                    }
+                }
+            }
+        };
+
+        if route_event {
+            tokio::select! {
+                () = shutdown.cancelled() => break,
+                () = tokio::time::sleep(ROUTE_EVENT_DEBOUNCE) => {}
+            }
+            if let Some(watcher) = watcher.as_ref() {
+                drain_route_events(watcher);
+            }
+        } else if watcher.is_none() {
+            watcher = open_route_watcher();
+        }
+
+        let runtime_for_bridge = Arc::clone(&runtime);
+        let bridge = match tokio::task::spawn_blocking(move || {
+            resolve_container_bridge(&runtime_for_bridge)
+        })
+        .await
+        {
+            Ok(bridge) => bridge,
+            Err(error) => {
+                tracing::warn!(%error, "container bridge resolution task failed");
+                None
+            }
+        };
+        let Some(bridge) = bridge else {
+            active = None;
+            setup_state.set_route_installed(false);
+            consecutive_failures = 0;
+            continue;
+        };
+
+        let current_mode = active
+            .as_ref()
+            .filter(|(active_bridge, _)| active_bridge == &bridge)
+            .map(|(_, mode)| *mode);
+        let result = match current_mode {
+            Some(mode) => {
+                arcbox_core::route_reconciler::reconcile_route_for_bridge(&bridge, mode).await
+            }
+            None => arcbox_core::route_reconciler::initialize_route_for_bridge(&bridge).await,
+        };
+
+        match result {
+            Ok(mode) => {
+                let was_installed = setup_state.current().route_installed;
+                active = Some((bridge, mode));
+                setup_state.set_route_installed(true);
+                consecutive_failures = 0;
+                if !was_installed {
+                    runtime.event_bus().publish(
+                        arcbox_core::event::Event::ContainerRouteInstalled {
+                            name: arcbox_core::DEFAULT_MACHINE_NAME.to_string(),
+                        },
+                    );
+                }
+            }
+            Err(error) => {
+                setup_state.set_route_installed(false);
+                consecutive_failures = consecutive_failures.saturating_add(1);
+                if should_log_route_failure(consecutive_failures) {
+                    tracing::warn!(
+                        %error,
+                        %bridge,
+                        consecutive_failures,
+                        "container route reconciliation failed"
+                    );
+                }
+            }
+        }
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn open_route_watcher() -> Option<tokio::io::unix::AsyncFd<arcbox_route::RouteWatcher>> {
+    match arcbox_route::RouteWatcher::open().and_then(tokio::io::unix::AsyncFd::new) {
+        Ok(watcher) => Some(watcher),
+        Err(error) => {
+            tracing::warn!(%error, "route event watcher unavailable; using polling");
+            None
+        }
+    }
+}
+
+#[cfg(target_os = "macos")]
+async fn next_managed_route_event(
+    watcher: Option<&tokio::io::unix::AsyncFd<arcbox_route::RouteWatcher>>,
+) -> std::io::Result<()> {
+    let Some(watcher) = watcher else {
+        return std::future::pending().await;
+    };
+
+    loop {
+        let mut ready = watcher.readable().await?;
+        match ready.try_io(|inner| inner.get_ref().read_event()) {
+            Ok(Ok(Some(event))) if event.network.is_some_and(is_managed_route) => return Ok(()),
+            Ok(Ok(_)) => {}
+            Ok(Err(error)) if error.kind() == std::io::ErrorKind::InvalidData => {
+                tracing::debug!(%error, "ignored malformed route event");
+            }
+            Ok(Err(error)) => return Err(error),
+            Err(_would_block) => {}
+        }
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn drain_route_events(watcher: &tokio::io::unix::AsyncFd<arcbox_route::RouteWatcher>) {
+    for _ in 0..256 {
+        match watcher.get_ref().read_event() {
+            Ok(_) => {}
+            Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => break,
+            Err(_) => break,
+        }
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn is_managed_route(network: arcbox_route::Ipv4Net) -> bool {
+    let network = network.to_string();
+    network == arcbox_core::route_reconciler::CONTAINER_SUBNET
+        || arcbox_core::route_reconciler::CONTAINER_SPLIT_SUBNETS
+            .iter()
+            .any(|candidate| network == *candidate)
+}
+
+#[cfg(all(target_os = "macos", feature = "vmnet"))]
+fn resolve_container_bridge(runtime: &Runtime) -> Option<String> {
+    let machine = runtime
+        .machine_manager()
+        .get(arcbox_core::DEFAULT_MACHINE_NAME)?;
+    if !matches!(
+        machine.state,
+        arcbox_core::machine::MachineState::Starting | arcbox_core::machine::MachineState::Running
+    ) {
+        return None;
+    }
+    runtime
+        .machine_manager()
+        .vmnet_bridge_name(arcbox_core::DEFAULT_MACHINE_NAME)
+}
+
+#[cfg(all(target_os = "macos", not(feature = "vmnet")))]
+fn resolve_container_bridge(runtime: &Runtime) -> Option<String> {
+    let machine = runtime
+        .machine_manager()
+        .get(arcbox_core::DEFAULT_MACHINE_NAME)?;
+    if !matches!(
+        machine.state,
+        arcbox_core::machine::MachineState::Starting | arcbox_core::machine::MachineState::Running
+    ) {
+        return None;
+    }
+    let mac = runtime
+        .machine_manager()
+        .bridge_mac(arcbox_core::DEFAULT_MACHINE_NAME)?;
+    arcbox_core::bridge_discovery::resolve_bridge_by_mac(&mac).map(|bridge| bridge.name)
+}
+
+#[cfg(target_os = "macos")]
+fn should_log_route_failure(consecutive_failures: u32) -> bool {
+    consecutive_failures == 1 || consecutive_failures.is_multiple_of(30)
 }
 
 fn register_host_dns(runtime: &Arc<Runtime>) {

--- a/app/arcbox-daemon/src/shutdown.rs
+++ b/app/arcbox-daemon/src/shutdown.rs
@@ -117,11 +117,6 @@ async fn stop_runtime(runtime: Arc<Runtime>, grace: Option<Duration>) -> bool {
 }
 
 async fn cleanup(ctx: &DaemonContext) {
-    #[cfg(target_os = "macos")]
-    {
-        arcbox_core::route_reconciler::remove_route().await;
-    }
-
     if ctx.docker_integration {
         if let Ok(ctx_manager) = DockerContextManager::new(ctx.layout.docker_socket.clone()) {
             let _ = ctx_manager.disable();
@@ -223,6 +218,9 @@ async fn drain(handles: &mut ServiceHandles) {
         if let Some(h) = handles.kubernetes_proxy.as_mut() {
             let _ = h.await;
         }
+        if let Some(h) = handles.route_guard.as_mut() {
+            let _ = h.await;
+        }
     })
     .await
     .is_err()
@@ -237,6 +235,9 @@ async fn drain(handles: &mut ServiceHandles) {
             h.abort();
         }
         if let Some(h) = handles.kubernetes_proxy.as_mut() {
+            h.abort();
+        }
+        if let Some(h) = handles.route_guard.as_mut() {
             h.abort();
         }
     }

--- a/app/arcbox-helper/Cargo.toml
+++ b/app/arcbox-helper/Cargo.toml
@@ -6,7 +6,7 @@ description = "Privileged helper daemon for host mutations (routes, DNS, sockets
 # root helper, or behavior the current daemon hard-requires). Ordinary runtime
 # bumps must NOT change this, or every Desktop user gets an admin-password
 # reinstall prompt.
-version = "1.0.1"
+version = "1.0.2"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/app/arcbox-helper/src/error.rs
+++ b/app/arcbox-helper/src/error.rs
@@ -65,6 +65,10 @@ pub enum HelperError {
     /// UX copy is not stuffed into structured fields.
     #[error("{path} exists but is not a symlink (is Docker Desktop running? stop it first)")]
     DockerSocketOccupied { path: String },
+
+    /// An exact route already exists and was left untouched.
+    #[error("route conflict for {subnet}")]
+    RouteConflict { subnet: String },
 }
 
 impl HelperError {
@@ -133,6 +137,7 @@ impl HelperError {
             Self::Io { .. } => "io",
             Self::Other(_) => "other",
             Self::DockerSocketOccupied { .. } => "docker_socket_occupied",
+            Self::RouteConflict { .. } => "route_conflict",
         }
     }
 }

--- a/app/arcbox-helper/src/lib.rs
+++ b/app/arcbox-helper/src/lib.rs
@@ -55,7 +55,7 @@ pub fn hosts_alias_installed(hosts_content: &str) -> bool {
 #[tarpc::service]
 pub trait HelperService {
     /// Adds a host route for `subnet` via `iface`.
-    /// Idempotent: returns Ok if the route already exists.
+    /// Returns `RouteConflict` without modifying an exact existing route.
     async fn route_add(subnet: String, iface: String) -> Result<(), HelperError>;
 
     /// Removes the host route for `subnet`.

--- a/app/arcbox-helper/src/server/mutations/route.rs
+++ b/app/arcbox-helper/src/server/mutations/route.rs
@@ -7,7 +7,12 @@ use arcbox_route::Ipv4Net;
 /// Adds a route for `subnet` via `iface`.
 pub fn add(subnet: &Subnet, iface: &BridgeIface) -> Result<(), HelperError> {
     let net = to_ipv4net(subnet)?;
-    arcbox_route::add(net, iface.as_str()).map_err(HelperError::other)
+    match arcbox_route::add(net, iface.as_str()).map_err(HelperError::other)? {
+        arcbox_route::AddOutcome::Added => Ok(()),
+        arcbox_route::AddOutcome::Conflict => Err(HelperError::RouteConflict {
+            subnet: subnet.to_string(),
+        }),
+    }
 }
 
 /// Removes the route for `subnet`.

--- a/app/arcbox-helper/tests/connection_test.rs
+++ b/app/arcbox-helper/tests/connection_test.rs
@@ -81,7 +81,7 @@ fn helper_version_pins_are_aligned() {
     );
 
     // Independent of the workspace package version.
-    assert_eq!(pkg, "1.0.1");
+    assert_eq!(pkg, "1.0.2");
 }
 
 #[tokio::test]

--- a/app/arcbox-helper/tests/e2e_fs_test.rs
+++ b/app/arcbox-helper/tests/e2e_fs_test.rs
@@ -44,14 +44,15 @@ impl HelperFixture {
         fs::write(etc.join("hosts"), "##\n127.0.0.1\tlocalhost\n").unwrap();
 
         let home = std::env::var("HOME").expect("HOME required for CliTarget-shaped paths");
-        // Unique per fixture so parallel tokio tests do not collide.
+        // Unique per fixture so parallel tokio tests do not collide. All tests
+        // share one process, so the PID is not distinguishing; a monotonic
+        // counter guarantees a distinct root even when two fixtures start
+        // within the same nanosecond.
+        static FIXTURE_SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
         let home_root = PathBuf::from(&home).join(format!(
             ".arcbox-helper-e2e-{}-{}",
             std::process::id(),
-            std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap()
-                .as_nanos()
+            FIXTURE_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
         ));
         let _ = fs::remove_dir_all(&home_root);
         fs::create_dir_all(&home_root).unwrap();

--- a/common/arcbox-constants/src/helper.rs
+++ b/common/arcbox-constants/src/helper.rs
@@ -2,7 +2,7 @@
 //! string format) the Desktop app.
 //!
 //! The helper crate (`arcbox-helper`) owns an **independent** Cargo version
-//! (currently `1.0.1`), not `workspace.package.version`. Compare that version
+//! (currently `1.0.2`), not `workspace.package.version`. Compare that version
 //! — never the daemon/workspace crate version — when deciding whether to
 //! reinstall the root binary.
 //!
@@ -19,7 +19,7 @@
 ///
 /// Must stay in sync with `app/arcbox-helper/Cargo.toml` `version` (and the
 /// workspace path-dep pin) whenever the floor moves.
-pub const MIN_HELPER_VERSION: &str = "1.0.1";
+pub const MIN_HELPER_VERSION: &str = "1.0.2";
 
 /// Strips the optional `arcbox-helper ` prefix and whitespace from a version line.
 #[must_use]

--- a/common/arcbox-route/AGENTS.md
+++ b/common/arcbox-route/AGENTS.md
@@ -18,6 +18,6 @@
 - `Ipv4Net` is `Copy` (5 bytes) — always pass by value, never `&Ipv4Net`
 - `unsafe` blocks require `// Safety:` comments explaining the invariant
 - `sockaddr` module is `pub(crate)` — public API uses `Ipv4Net`, not raw libc types
-- EEXIST → RTM_CHANGE retry logic lives in `send_change()` (single source of truth)
+- EEXIST replacement must delete then add; XNU's `RTM_CHANGE` cannot clear a conflicting route's `RTF_GATEWAY` flag
 - Error type: `Result<(), String>` to match helper's tarpc interface; `Ipv4NetError` for construction
 - Follow root `CLAUDE.md` for all general conventions (clippy, fmt, English comments, no section dividers)

--- a/common/arcbox-route/src/lib.rs
+++ b/common/arcbox-route/src/lib.rs
@@ -13,8 +13,8 @@
 //!
 //! # Operations
 //!
-//! - [`add`] — Add a subnet route via an interface. Falls back to
-//!   `RTM_CHANGE` if the route already exists (atomic replace).
+//! - [`add`] — Add a subnet route via an interface. Replaces an existing
+//!   route when necessary.
 //! - [`remove`] — Delete a subnet route. Idempotent (missing route = Ok).
 //! - [`get`] — Query the current route for a subnet.
 //!
@@ -182,9 +182,9 @@ pub struct RouteInfo {
 ///
 /// Equivalent to: `route -n add -net <net> -interface <iface>`
 ///
-/// If the route already exists (`EEXIST`), atomically replaces it via
-/// `RTM_CHANGE`. This fixes the bug where a pre-existing route pointing
-/// to a different gateway/interface was silently left in place.
+/// If the route already exists (`EEXIST`), deletes it before adding the
+/// interface route. XNU's `RTM_CHANGE` cannot clear `RTF_GATEWAY`, so it
+/// cannot safely convert a conflicting VPN gateway route.
 ///
 /// # Errors
 ///
@@ -204,8 +204,12 @@ pub fn add(net: Ipv4Net, iface: &str) -> Result<(), String> {
             Ok(())
         }
         Err(e) if e.raw_os_error() == Some(libc::EEXIST) => {
-            tracing::debug!(iface, net = %net, "route exists, replacing via RTM_CHANGE");
-            send_change(net, iface, &dst, &gw, &mask)
+            tracing::debug!(iface, net = %net, "route exists, replacing via delete and add");
+            remove(net)?;
+            msg::route_write(&add_msg)
+                .map_err(|e| format!("RTM_ADD {net} via {iface} after delete: {e}"))?;
+            tracing::debug!(iface, net = %net, "route replaced");
+            Ok(())
         }
         Err(e) => Err(format!("RTM_ADD {net} via {iface}: {e}")),
     }
@@ -268,28 +272,19 @@ pub fn get(net: Ipv4Net) -> Result<Option<RouteInfo>, String> {
     }
 }
 
-// ── Internal helpers ───────────────────────────────────────────────────
-
-/// Sends an RTM_CHANGE message — extracted to eliminate duplication in [`add`].
-fn send_change(
-    net: Ipv4Net,
-    iface: &str,
-    dst: &libc::sockaddr_in,
-    gw: &libc::sockaddr_dl,
-    mask: &libc::sockaddr_in,
-) -> Result<(), String> {
-    let change_msg = msg::build_msg(msg::MsgType::Change, dst, Some(gw), mask)
-        .map_err(|e| format!("RTM_CHANGE {net} via {iface}: failed to build message: {e}"))?;
-    msg::route_write(&change_msg).map_err(|e| format!("RTM_CHANGE {net} via {iface}: {e}"))?;
-    tracing::debug!(net = %net, "route replaced");
-    Ok(())
-}
-
 // ── Tests ──────────────────────────────────────────────────────────────
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    struct RouteCleanup(Ipv4Net);
+
+    impl Drop for RouteCleanup {
+        fn drop(&mut self) {
+            let _ = remove(self.0);
+        }
+    }
 
     #[test]
     fn ipv4net_valid() {
@@ -365,5 +360,35 @@ mod tests {
             "0.0.0.0/0".parse::<Ipv4Net>().unwrap().mask(),
             Ipv4Addr::UNSPECIFIED
         );
+    }
+
+    #[test]
+    #[ignore = "requires root to mutate the macOS routing table"]
+    fn gateway_route_is_replaced_with_interface_route() {
+        use std::process::Command;
+
+        let net: Ipv4Net = "198.51.100.0/24".parse().unwrap();
+        remove(net).unwrap();
+        let _cleanup = RouteCleanup(net);
+
+        let output = Command::new("/sbin/route")
+            .args(["-n", "add", "-net", &net.to_string(), "127.0.0.1"])
+            .output()
+            .unwrap();
+        assert!(
+            output.status.success(),
+            "failed to install gateway-route fixture: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+
+        add(net, "lo0").unwrap();
+        let route = get(net).unwrap().expect("replacement route should exist");
+
+        assert_eq!(route.flags & libc::RTF_GATEWAY, 0);
+        let lo0 = std::ffi::CString::new("lo0").unwrap();
+        // Safety: `lo0` is a valid NUL-terminated interface name.
+        let lo0_index = unsafe { libc::if_nametoindex(lo0.as_ptr()) };
+        assert_ne!(lo0_index, 0);
+        assert_eq!(u32::from(route.ifindex), lo0_index);
     }
 }

--- a/common/arcbox-route/src/lib.rs
+++ b/common/arcbox-route/src/lib.rs
@@ -13,8 +13,7 @@
 //!
 //! # Operations
 //!
-//! - [`add`] — Add a subnet route via an interface. Replaces an existing
-//!   route when necessary.
+//! - [`add`] — Add a subnet route via an interface without replacing conflicts.
 //! - [`remove`] — Delete a subnet route. Idempotent (missing route = Ok).
 //! - [`get`] — Query the current route for a subnet.
 //!
@@ -33,8 +32,11 @@
 pub mod msg;
 pub(crate) mod sockaddr;
 
+use std::ffi::{CStr, CString};
 use std::fmt;
+use std::io;
 use std::net::Ipv4Addr;
+use std::os::fd::{AsRawFd, OwnedFd};
 use std::str::FromStr;
 
 // ── Ipv4Net: validated network type ────────────────────────────────────
@@ -168,12 +170,78 @@ impl fmt::Display for Ipv4Net {
 // ── RouteInfo ──────────────────────────────────────────────────────────
 
 /// Information about an existing route, returned by [`get`].
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct RouteInfo {
     /// Kernel interface index the route points to.
     pub ifindex: u16,
     /// Route flags (`RTF_*`).
     pub flags: i32,
+}
+
+/// Result of a non-destructive route-add attempt.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AddOutcome {
+    /// The route was added.
+    Added,
+    /// An exact route already exists and was left untouched.
+    Conflict,
+}
+
+/// A routing-table mutation observed through [`RouteWatcher`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RouteEvent {
+    /// Exact IPv4 network changed by the event, when the message carries one.
+    pub network: Option<Ipv4Net>,
+}
+
+/// Nonblocking listener for macOS routing-table mutations.
+pub struct RouteWatcher {
+    fd: OwnedFd,
+}
+
+impl RouteWatcher {
+    /// Opens an unprivileged PF_ROUTE listener.
+    pub fn open() -> io::Result<Self> {
+        let fd = msg::open_route_socket()?;
+        // Safety: `fd` is a valid open file descriptor.
+        let flags = unsafe { libc::fcntl(fd.as_raw_fd(), libc::F_GETFL) };
+        if flags < 0 {
+            return Err(io::Error::last_os_error());
+        }
+        // Safety: `fd` remains valid and `flags | O_NONBLOCK` is a valid flag set.
+        let result =
+            unsafe { libc::fcntl(fd.as_raw_fd(), libc::F_SETFL, flags | libc::O_NONBLOCK) };
+        if result < 0 {
+            return Err(io::Error::last_os_error());
+        }
+        Ok(Self { fd })
+    }
+
+    /// Reads one pending route message.
+    ///
+    /// Returns `Ok(None)` for non-mutation messages. Returns `WouldBlock` when
+    /// all pending messages have been consumed.
+    pub fn read_event(&self) -> io::Result<Option<RouteEvent>> {
+        let mut buffer = [0u8; 512];
+        // Safety: `fd` is valid and `buffer` is writable for its full length.
+        let count = unsafe {
+            libc::read(
+                self.fd.as_raw_fd(),
+                buffer.as_mut_ptr().cast(),
+                buffer.len(),
+            )
+        };
+        if count < 0 {
+            return Err(io::Error::last_os_error());
+        }
+        decode_route_event(&buffer[..count as usize])
+    }
+}
+
+impl AsRawFd for RouteWatcher {
+    fn as_raw_fd(&self) -> std::os::fd::RawFd {
+        self.fd.as_raw_fd()
+    }
 }
 
 // ── Public API ─────────────────────────────────────────────────────────
@@ -182,14 +250,10 @@ pub struct RouteInfo {
 ///
 /// Equivalent to: `route -n add -net <net> -interface <iface>`
 ///
-/// If the route already exists (`EEXIST`), deletes it before adding the
-/// interface route. XNU's `RTM_CHANGE` cannot clear `RTF_GATEWAY`, so it
-/// cannot safely convert a conflicting VPN gateway route.
-///
 /// # Errors
 ///
 /// Returns an error string if the kernel rejects the route operation.
-pub fn add(net: Ipv4Net, iface: &str) -> Result<(), String> {
+pub fn add(net: Ipv4Net, iface: &str) -> Result<AddOutcome, String> {
     let dst = sockaddr::make_dst(net);
     let mask = sockaddr::make_netmask(net);
     let gw = sockaddr::make_gateway_dl(iface)
@@ -201,15 +265,11 @@ pub fn add(net: Ipv4Net, iface: &str) -> Result<(), String> {
     match msg::route_write(&add_msg) {
         Ok(()) => {
             tracing::debug!(iface, net = %net, "route added");
-            Ok(())
+            Ok(AddOutcome::Added)
         }
         Err(e) if e.raw_os_error() == Some(libc::EEXIST) => {
-            tracing::debug!(iface, net = %net, "route exists, replacing via delete and add");
-            remove(net)?;
-            msg::route_write(&add_msg)
-                .map_err(|e| format!("RTM_ADD {net} via {iface} after delete: {e}"))?;
-            tracing::debug!(iface, net = %net, "route replaced");
-            Ok(())
+            tracing::debug!(iface, net = %net, "exact route already exists");
+            Ok(AddOutcome::Conflict)
         }
         Err(e) => Err(format!("RTM_ADD {net} via {iface}: {e}")),
     }
@@ -263,13 +323,99 @@ pub fn get(net: Ipv4Net) -> Result<Option<RouteInfo>, String> {
         .map_err(|e| format!("RTM_GET {net}: failed to build message: {e}"))?;
 
     match msg::route_query(&get_msg) {
-        Ok(reply) => Ok(Some(RouteInfo {
-            ifindex: reply.ifindex,
-            flags: reply.flags,
-        })),
+        Ok(reply) => {
+            let prefix = prefix_from_mask(reply.netmask)
+                .ok_or_else(|| format!("RTM_GET {net}: kernel returned non-contiguous netmask"))?;
+            let matched_address =
+                Ipv4Addr::from(u32::from(reply.destination) & u32::from(reply.netmask));
+            let matched = Ipv4Net::new(matched_address, prefix)
+                .map_err(|e| format!("RTM_GET {net}: invalid matched route: {e}"))?;
+            if matched != net {
+                return Ok(None);
+            }
+            Ok(Some(RouteInfo {
+                ifindex: reply.ifindex,
+                flags: reply.flags,
+            }))
+        }
         Err(e) if e.raw_os_error() == Some(libc::ESRCH) => Ok(None),
         Err(e) => Err(format!("RTM_GET {net}: {e}")),
     }
+}
+
+/// Resolves an interface name to its kernel index.
+pub fn interface_index(interface: &str) -> Result<u16, String> {
+    let interface = CString::new(interface).map_err(|e| format!("invalid interface name: {e}"))?;
+    // Safety: `interface` is a valid NUL-terminated string.
+    let raw_index = unsafe { libc::if_nametoindex(interface.as_ptr()) };
+    if raw_index == 0 {
+        return Err(io::Error::last_os_error().to_string());
+    }
+    u16::try_from(raw_index).map_err(|_| format!("interface index {raw_index} exceeds u16"))
+}
+
+/// Resolves a kernel interface index to its name.
+pub fn interface_name(index: u16) -> Result<String, String> {
+    let mut name = [0i8; libc::IF_NAMESIZE];
+    // Safety: `name` has IF_NAMESIZE writable bytes and `index` is promoted losslessly.
+    let result = unsafe { libc::if_indextoname(u32::from(index), name.as_mut_ptr()) };
+    if result.is_null() {
+        return Err(io::Error::last_os_error().to_string());
+    }
+    // Safety: `if_indextoname` wrote a NUL-terminated interface name into `name`.
+    let name = unsafe { CStr::from_ptr(name.as_ptr()) };
+    name.to_str()
+        .map(str::to_owned)
+        .map_err(|e| format!("interface name is not UTF-8: {e}"))
+}
+
+fn prefix_from_mask(mask: Ipv4Addr) -> Option<u8> {
+    let mask = u32::from(mask);
+    let prefix = mask.leading_ones() as u8;
+    let expected = if prefix == 0 {
+        0
+    } else {
+        u32::MAX << (32 - prefix)
+    };
+    (mask == expected).then_some(prefix)
+}
+
+fn decode_route_event(message: &[u8]) -> io::Result<Option<RouteEvent>> {
+    if message.len() < 4 {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "routing event is shorter than its common header",
+        ));
+    }
+    if message[2] != libc::RTM_VERSION as u8
+        || !matches!(
+            i32::from(message[3]),
+            libc::RTM_ADD | libc::RTM_CHANGE | libc::RTM_DELETE
+        )
+    {
+        return Ok(None);
+    }
+
+    let header_size = std::mem::size_of::<libc::rt_msghdr>();
+    if message.len() < header_size {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "route mutation event is shorter than rt_msghdr",
+        ));
+    }
+    // Safety: the length check above guarantees a full header; routing socket
+    // buffers have no alignment guarantee, so use an unaligned read.
+    let header = unsafe { std::ptr::read_unaligned(message.as_ptr().cast::<libc::rt_msghdr>()) };
+
+    let network =
+        msg::parse_ipv4_route(message, &header)
+            .ok()
+            .and_then(|(destination, netmask)| {
+                let prefix = prefix_from_mask(netmask)?;
+                let address = Ipv4Addr::from(u32::from(destination) & u32::from(netmask));
+                Ipv4Net::new(address, prefix).ok()
+            });
+    Ok(Some(RouteEvent { network }))
 }
 
 // ── Tests ──────────────────────────────────────────────────────────────
@@ -277,14 +423,6 @@ pub fn get(net: Ipv4Net) -> Result<Option<RouteInfo>, String> {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    struct RouteCleanup(Ipv4Net);
-
-    impl Drop for RouteCleanup {
-        fn drop(&mut self) {
-            let _ = remove(self.0);
-        }
-    }
 
     #[test]
     fn ipv4net_valid() {
@@ -363,13 +501,35 @@ mod tests {
     }
 
     #[test]
+    fn route_event_decoder_ignores_queries() {
+        let net: Ipv4Net = "172.16.0.0/12".parse().unwrap();
+        let destination = sockaddr::make_dst(net);
+        let netmask = sockaddr::make_netmask(net);
+        let message = msg::build_msg(msg::MsgType::Get, &destination, None, &netmask).unwrap();
+
+        assert_eq!(decode_route_event(&message).unwrap(), None);
+    }
+
+    #[test]
+    fn route_event_decoder_reports_changed_network() {
+        let net: Ipv4Net = "172.24.0.0/13".parse().unwrap();
+        let destination = sockaddr::make_dst(net);
+        let netmask = sockaddr::make_netmask(net);
+        let message = msg::build_msg(msg::MsgType::Delete, &destination, None, &netmask).unwrap();
+
+        assert_eq!(
+            decode_route_event(&message).unwrap(),
+            Some(RouteEvent { network: Some(net) })
+        );
+    }
+
+    #[test]
     #[ignore = "requires root to mutate the macOS routing table"]
-    fn gateway_route_is_replaced_with_interface_route() {
+    fn existing_gateway_route_is_not_replaced() {
         use std::process::Command;
 
         let net: Ipv4Net = "198.51.100.0/24".parse().unwrap();
         remove(net).unwrap();
-        let _cleanup = RouteCleanup(net);
 
         let output = Command::new("/sbin/route")
             .args(["-n", "add", "-net", &net.to_string(), "127.0.0.1"])
@@ -381,14 +541,11 @@ mod tests {
             String::from_utf8_lossy(&output.stderr)
         );
 
-        add(net, "lo0").unwrap();
-        let route = get(net).unwrap().expect("replacement route should exist");
+        let outcome = add(net, "lo0").unwrap();
+        let route = get(net).unwrap().expect("gateway route should remain");
+        remove(net).unwrap();
 
-        assert_eq!(route.flags & libc::RTF_GATEWAY, 0);
-        let lo0 = std::ffi::CString::new("lo0").unwrap();
-        // Safety: `lo0` is a valid NUL-terminated interface name.
-        let lo0_index = unsafe { libc::if_nametoindex(lo0.as_ptr()) };
-        assert_ne!(lo0_index, 0);
-        assert_eq!(u32::from(route.ifindex), lo0_index);
+        assert_eq!(outcome, AddOutcome::Conflict);
+        assert_ne!(route.flags & libc::RTF_GATEWAY, 0);
     }
 }

--- a/common/arcbox-route/src/msg.rs
+++ b/common/arcbox-route/src/msg.rs
@@ -14,6 +14,7 @@
 //!   matching, since the kernel fills interface/flags info in the reply.
 
 use std::io;
+use std::net::Ipv4Addr;
 use std::os::fd::{AsRawFd, FromRawFd, OwnedFd};
 use std::sync::atomic::{AtomicI32, Ordering};
 
@@ -172,6 +173,10 @@ pub struct GetReply {
     pub ifindex: u16,
     /// The flags from the reply (`rtm_flags`).
     pub flags: i32,
+    /// Destination network address selected by the kernel.
+    pub destination: Ipv4Addr,
+    /// Netmask of the route selected by the kernel.
+    pub netmask: Ipv4Addr,
 }
 
 /// Opens a PF_ROUTE socket, writes an RTM_GET message, and reads back the
@@ -223,9 +228,12 @@ pub fn route_query(msg: &[u8]) -> io::Result<GetReply> {
             if reply_hdr.rtm_errno != 0 {
                 return Err(io::Error::from_raw_os_error(reply_hdr.rtm_errno));
             }
+            let (destination, netmask) = parse_ipv4_route(&buf[..n as usize], &reply_hdr)?;
             return Ok(GetReply {
                 ifindex: reply_hdr.rtm_index,
                 flags: reply_hdr.rtm_flags,
+                destination,
+                netmask,
             });
         }
     }
@@ -236,8 +244,93 @@ pub fn route_query(msg: &[u8]) -> io::Result<GetReply> {
     ))
 }
 
+pub(crate) fn parse_ipv4_route(
+    message: &[u8],
+    header: &libc::rt_msghdr,
+) -> io::Result<(Ipv4Addr, Ipv4Addr)> {
+    let message_len = usize::from(header.rtm_msglen).min(message.len());
+    let mut offset = std::mem::size_of::<libc::rt_msghdr>();
+    let mut destination = None;
+    let mut netmask = None;
+
+    for index in 0..libc::RTAX_MAX {
+        if header.rtm_addrs & (1 << index) == 0 {
+            continue;
+        }
+        if offset + 2 > message_len {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "routing message sockaddr header is truncated",
+            ));
+        }
+
+        let sockaddr_len = usize::from(message[offset]);
+        let padded_len = sa_rlen(sockaddr_len);
+        if offset + padded_len > message_len {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "routing message sockaddr is truncated",
+            ));
+        }
+
+        if index == libc::RTAX_DST {
+            destination = Some(parse_sockaddr_ipv4(
+                &message[offset..offset + sockaddr_len],
+            )?);
+        } else if index == libc::RTAX_NETMASK {
+            netmask = Some(parse_sockaddr_netmask(
+                &message[offset..offset + sockaddr_len],
+            ));
+        }
+        offset += padded_len;
+    }
+
+    match destination {
+        Some(destination) => Ok((destination, netmask.unwrap_or(Ipv4Addr::BROADCAST))),
+        None => Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "routing reply omitted destination",
+        )),
+    }
+}
+
+fn parse_sockaddr_ipv4(sockaddr: &[u8]) -> io::Result<Ipv4Addr> {
+    if sockaddr.len() < 4 {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "IPv4 sockaddr is too short",
+        ));
+    }
+    let family = i32::from(sockaddr[1]);
+    if family != libc::AF_INET {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "routing message sockaddr is not IPv4",
+        ));
+    }
+    let mut octets = [0u8; 4];
+    let available = sockaddr.len().saturating_sub(4).min(octets.len());
+    octets[..available].copy_from_slice(&sockaddr[4..4 + available]);
+    Ok(Ipv4Addr::from(octets))
+}
+
+/// Parses XNU's radix-tree netmask representation.
+///
+/// Kernel replies do not contain a regular `sockaddr_in`: the family byte can
+/// hold mask data, trailing zero octets are omitted, and the default route is
+/// represented by `sa_len == 0`. IPv4 mask bytes still begin at the
+/// `sockaddr_in.sin_addr` offset.
+fn parse_sockaddr_netmask(sockaddr: &[u8]) -> Ipv4Addr {
+    let mut octets = [0u8; 4];
+    let available = sockaddr.len().saturating_sub(4).min(octets.len());
+    if available > 0 {
+        octets[..available].copy_from_slice(&sockaddr[4..4 + available]);
+    }
+    Ipv4Addr::from(octets)
+}
+
 /// Opens a fresh `PF_ROUTE` socket.
-fn open_route_socket() -> io::Result<OwnedFd> {
+pub(crate) fn open_route_socket() -> io::Result<OwnedFd> {
     // Safety: socket(PF_ROUTE, SOCK_RAW, AF_UNSPEC) is always safe.
     let fd = unsafe { libc::socket(libc::PF_ROUTE, libc::SOCK_RAW, 0) };
     if fd < 0 {
@@ -269,6 +362,17 @@ mod tests {
         assert!(buf.len() >= std::mem::size_of::<libc::rt_msghdr>());
         // Safety: buf is large enough; read_unaligned handles alignment.
         unsafe { std::ptr::read_unaligned(buf.as_ptr().cast::<libc::rt_msghdr>()) }
+    }
+
+    fn write_hdr(buf: &mut [u8], header: libc::rt_msghdr) {
+        assert!(buf.len() >= std::mem::size_of::<libc::rt_msghdr>());
+        // Safety: buf is large enough; write_unaligned handles alignment.
+        unsafe { std::ptr::write_unaligned(buf.as_mut_ptr().cast(), header) };
+    }
+
+    fn netmask_offset(message: &[u8]) -> usize {
+        let destination_offset = std::mem::size_of::<libc::rt_msghdr>();
+        destination_offset + sa_rlen(usize::from(message[destination_offset]))
     }
 
     #[test]
@@ -343,5 +447,91 @@ mod tests {
         let hdr2 = read_hdr(&buf2);
 
         assert_ne!(hdr1.rtm_seq, hdr2.rtm_seq);
+    }
+
+    #[test]
+    fn parses_compact_ipv4_netmask_from_route_reply() {
+        let net: Ipv4Net = "172.16.0.0/12".parse().unwrap();
+        let dst = sockaddr::make_dst(net);
+        let mask = sockaddr::make_netmask(net);
+        let message = build_msg(MsgType::Get, &dst, None, &mask).unwrap();
+        let header = read_hdr(&message);
+
+        let (destination, netmask) = parse_ipv4_route(&message, &header).unwrap();
+
+        assert_eq!(destination, Ipv4Addr::new(172, 16, 0, 0));
+        assert_eq!(netmask, Ipv4Addr::new(255, 240, 0, 0));
+    }
+
+    #[test]
+    fn parses_kernel_shaped_trimmed_netmask() {
+        let net: Ipv4Net = "172.16.0.0/12".parse().unwrap();
+        let dst = sockaddr::make_dst(net);
+        let mask = sockaddr::make_netmask(net);
+        let mut message = build_msg(MsgType::Get, &dst, None, &mask).unwrap();
+        let offset = netmask_offset(&message);
+        message[offset..offset + 6].copy_from_slice(&[6, 0xff, 0xff, 0xff, 0xff, 0xf0]);
+        let header = read_hdr(&message);
+
+        let (_, netmask) = parse_ipv4_route(&message, &header).unwrap();
+
+        assert_eq!(netmask, Ipv4Addr::new(255, 240, 0, 0));
+    }
+
+    #[test]
+    fn zero_length_netmask_represents_default_route() {
+        let net: Ipv4Net = "172.16.0.0/12".parse().unwrap();
+        let dst = sockaddr::make_dst(net);
+        let mask = sockaddr::make_netmask(net);
+        let mut message = build_msg(MsgType::Get, &dst, None, &mask).unwrap();
+        let offset = netmask_offset(&message);
+        message[offset] = 0;
+        let header = read_hdr(&message);
+
+        let (_, netmask) = parse_ipv4_route(&message, &header).unwrap();
+
+        assert_eq!(netmask, Ipv4Addr::UNSPECIFIED);
+    }
+
+    #[test]
+    fn omitted_netmask_represents_host_route() {
+        let net: Ipv4Net = "172.16.0.0/12".parse().unwrap();
+        let dst = sockaddr::make_dst(net);
+        let mask = sockaddr::make_netmask(net);
+        let mut message = build_msg(MsgType::Get, &dst, None, &mask).unwrap();
+        let mut header = read_hdr(&message);
+        header.rtm_addrs &= !libc::RTA_NETMASK;
+        write_hdr(&mut message, header);
+
+        let (_, netmask) = parse_ipv4_route(&message, &header).unwrap();
+
+        assert_eq!(netmask, Ipv4Addr::BROADCAST);
+    }
+
+    #[test]
+    fn rejects_truncated_route_sockaddr() {
+        let net: Ipv4Net = "172.16.0.0/12".parse().unwrap();
+        let dst = sockaddr::make_dst(net);
+        let mask = sockaddr::make_netmask(net);
+        let message = build_msg(MsgType::Get, &dst, None, &mask).unwrap();
+        let header = read_hdr(&message);
+
+        let error = parse_ipv4_route(&message[..message.len() - 1], &header).unwrap_err();
+
+        assert_eq!(error.kind(), io::ErrorKind::InvalidData);
+    }
+
+    #[test]
+    fn rejects_non_ipv4_route_destination() {
+        let net: Ipv4Net = "172.16.0.0/12".parse().unwrap();
+        let dst = sockaddr::make_dst(net);
+        let mask = sockaddr::make_netmask(net);
+        let mut message = build_msg(MsgType::Get, &dst, None, &mask).unwrap();
+        let header = read_hdr(&message);
+        message[std::mem::size_of::<libc::rt_msghdr>() + 1] = libc::AF_INET6 as u8;
+
+        let error = parse_ipv4_route(&message, &header).unwrap_err();
+
+        assert_eq!(error.kind(), io::ErrorKind::InvalidData);
     }
 }

--- a/common/arcbox-route/src/msg.rs
+++ b/common/arcbox-route/src/msg.rs
@@ -1,11 +1,11 @@
 //! Routing socket message construction and I/O.
 //!
 //! Builds `rt_msghdr` + variable-length sockaddr payloads for PF_ROUTE
-//! operations (RTM_ADD, RTM_DELETE, RTM_CHANGE, RTM_GET).
+//! operations (RTM_ADD, RTM_DELETE, RTM_GET).
 //!
 //! # I/O model
 //!
-//! - **Mutations** (add/delete/change): `write()` only. Success/failure is
+//! - **Mutations** (add/delete): `write()` only. Success/failure is
 //!   determined entirely by the `write()` return value and `errno`. No reply
 //!   is read — this avoids alignment UB on reply buffers, seq/pid matching
 //!   complexity, and `SO_USELOOPBACK` contradictions.
@@ -39,7 +39,6 @@ const MAX_READ_ATTEMPTS: usize = 50;
 pub enum MsgType {
     Add,
     Delete,
-    Change,
     Get,
 }
 
@@ -48,7 +47,6 @@ impl MsgType {
         match self {
             Self::Add => libc::RTM_ADD,
             Self::Delete => libc::RTM_DELETE,
-            Self::Change => libc::RTM_CHANGE,
             Self::Get => libc::RTM_GET,
         }
     }
@@ -311,19 +309,6 @@ mod tests {
             + sa_rlen(std::mem::size_of::<libc::sockaddr_in>())
             + sa_rlen(std::mem::size_of::<libc::sockaddr_in>());
         assert_eq!(buf.len(), expected);
-    }
-
-    #[test]
-    fn build_msg_change_type() {
-        let net: Ipv4Net = "10.0.0.0/8".parse().unwrap();
-        let dst = sockaddr::make_dst(net);
-        let gw = sockaddr::make_gateway_dl_with_index("bridge100", 1);
-        let mask = sockaddr::make_netmask(net);
-
-        let buf = build_msg(MsgType::Change, &dst, Some(&gw), &mask).unwrap();
-        let hdr = read_hdr(&buf);
-
-        assert_eq!(hdr.rtm_type, libc::RTM_CHANGE as u8);
     }
 
     #[test]

--- a/docs/daemon-lifecycle.md
+++ b/docs/daemon-lifecycle.md
@@ -102,10 +102,9 @@ write current PID
 signal received
   ├─ cancel CancellationToken         → all services begin draining
   ├─ drain(DNS, Docker, gRPC)         → 5 s timeout, then abort
-  ├─ remove_route()                   → clean up container subnet route (macOS)
   ├─ runtime.shutdown()
   │   ├─ stop port forwarders
-  │   ├─ vm_lifecycle.shutdown()       → graceful VM stop, flush disk
+  │   ├─ vm_lifecycle.shutdown()       → graceful VM stop; bridge routes expire
   │   ├─ stop remaining machines
   │   └─ network_manager.stop()
   ├─ DockerContextManager.disable()   → remove Docker CLI integration

--- a/docs/helper.md
+++ b/docs/helper.md
@@ -7,19 +7,19 @@ perform: `/usr/local/bin` CLI symlinks, `/var/run/docker.sock`, `/etc/resolver`,
 ## Independent version
 
 `arcbox-helper` owns its **own** Cargo package version
-(`app/arcbox-helper/Cargo.toml`), currently `1.0.1`. It is **not** tied to
+(`app/arcbox-helper/Cargo.toml`), currently `1.0.2`. It is **not** tied to
 `workspace.package.version`.
 
 | Pin | Location |
 |-----|----------|
-| Helper package version | `app/arcbox-helper/Cargo.toml` → `version = "1.0.1"` |
-| Workspace path-dep | root `Cargo.toml` → `arcbox-helper = { version = "1.0.1", path = ... }` (**no** `x-release-please-version`) |
+| Helper package version | `app/arcbox-helper/Cargo.toml` → `version = "1.0.2"` |
+| Workspace path-dep | root `Cargo.toml` → `arcbox-helper = { version = "1.0.2", path = ... }` (**no** `x-release-please-version`) |
 | Daemon/CLI floor | `arcbox_constants::helper::MIN_HELPER_VERSION` |
 
 `arcbox-helper --version` and the tarpc `version` RPC both print:
 
 ```text
-arcbox-helper 1.0.1
+arcbox-helper 1.0.2
 ```
 
 Desktop and daemon parse that line with

--- a/guest/arcbox-agent/src/agent/linux/agent.rs
+++ b/guest/arcbox-agent/src/agent/linux/agent.rs
@@ -8,6 +8,7 @@ use arcbox_constants::ports::AGENT_PORT;
 use super::disk::fstrim_loop;
 use super::proxy::{run_docker_api_proxy, run_kubernetes_api_proxy};
 use super::rpc::handle_connection;
+use super::runtime::direct_container_routing_loop;
 use super::sandbox::sandbox_service;
 use super::vsock::{bind_vsock_listener_with_retry, is_peer_closed_error};
 
@@ -56,6 +57,10 @@ impl Agent {
 
         // Periodic fstrim to reclaim sparse file space on the host.
         tokio::spawn(fstrim_loop());
+
+        // Docker recreates its firewall chains on restart. Keep the direct
+        // host-to-container rule present after the initial readiness gate.
+        tokio::spawn(direct_container_routing_loop());
 
         let mut listener = bind_vsock_listener_with_retry(AGENT_PORT, "agent rpc listener").await?;
 

--- a/guest/arcbox-agent/src/agent/linux/rpc.rs
+++ b/guest/arcbox-agent/src/agent/linux/rpc.rs
@@ -222,7 +222,10 @@ where
             }
         };
 
-        if response.ready || status.docker_ready {
+        // EnsureRuntime settles only after Docker and its post-start routing
+        // setup are ready; RuntimeStatus independently confirms Docker is
+        // still reachable at the point we publish the terminal event.
+        if response.ready && status.docker_ready {
             return write_readiness_event(
                 stream,
                 trace_id,

--- a/guest/arcbox-agent/src/agent/linux/runtime.rs
+++ b/guest/arcbox-agent/src/agent/linux/runtime.rs
@@ -52,6 +52,9 @@ const MIN_SANE_EPOCH: u64 = 1_577_836_800;
 /// All Docker bridge subnets routed from macOS through the bridge NIC.
 const CONTAINER_SUBNET: &str = "172.16.0.0/12";
 
+/// Polling fallback for firewall managers that recreate `DOCKER-USER`.
+const DIRECT_ROUTING_RECONCILE_INTERVAL: Duration = Duration::from_secs(30);
+
 /// Idempotent, non-blocking EnsureRuntime handler.
 ///
 /// The first driver spawns [`do_ensure_runtime_start`] as a background
@@ -152,6 +155,7 @@ pub(super) async fn handle_runtime_status(_req: RuntimeStatusRequest) -> RpcResp
 /// daemon option `allow-direct-routing` removes Docker's earlier raw-table
 /// per-container drops; this rule then bypasses its unpublished-port drop.
 async fn ensure_direct_container_routing() -> Result<()> {
+    let _guard = direct_routing_lock().lock().await;
     let Some(bridge_iface) = crate::init::detect_bridge_interface() else {
         tracing::debug!("no bridge NIC found; skipping direct container routing rule");
         return Ok(());
@@ -175,6 +179,12 @@ async fn ensure_direct_container_routing() -> Result<()> {
     if check.status.success() {
         return Ok(());
     }
+    if check.status.code() != Some(1) {
+        bail!(
+            "iptables check failed: {}",
+            String::from_utf8_lossy(&check.stderr).trim()
+        );
+    }
 
     let install = Command::new("/sbin/iptables")
         .args(["-w", "2", "-I"])
@@ -195,6 +205,30 @@ async fn ensure_direct_container_routing() -> Result<()> {
         "direct container routing rule installed"
     );
     Ok(())
+}
+
+fn direct_routing_lock() -> &'static Mutex<()> {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(()))
+}
+
+/// Restores the direct-routing firewall rule if Docker recreates its chains.
+pub(super) async fn direct_container_routing_loop() {
+    let mut ticker = tokio::time::interval(DIRECT_ROUTING_RECONCILE_INTERVAL);
+    ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+    // Initial runtime setup owns the readiness gate and first installation.
+    // Delay this fallback's first check to avoid duplicating startup probes.
+    ticker.tick().await;
+
+    loop {
+        ticker.tick().await;
+        if !probe_docker_api_ready(DOCKER_API_UNIX_SOCKET).await {
+            continue;
+        }
+        if let Err(error) = ensure_direct_container_routing().await {
+            tracing::warn!(%error, "failed to reconcile direct container routing rule");
+        }
+    }
 }
 
 pub(super) fn runtime_path_env(runtime_bin_dir: &Path) -> String {

--- a/guest/arcbox-agent/src/agent/linux/runtime.rs
+++ b/guest/arcbox-agent/src/agent/linux/runtime.rs
@@ -10,6 +10,7 @@ use std::process::Stdio;
 use std::sync::OnceLock;
 use std::time::Duration;
 
+use anyhow::{Context, Result, bail};
 use tokio::process::Command;
 use tokio::sync::Mutex;
 
@@ -47,6 +48,9 @@ const REQUIRED_RUNTIME_BINARIES: &[&str] = &[
 /// enough that TLS certificates issued after 2020 pass validation.
 /// 2020-01-01T00:00:00Z
 const MIN_SANE_EPOCH: u64 = 1_577_836_800;
+
+/// All Docker bridge subnets routed from macOS through the bridge NIC.
+const CONTAINER_SUBNET: &str = "172.16.0.0/12";
 
 /// Idempotent, non-blocking EnsureRuntime handler.
 ///
@@ -90,19 +94,30 @@ async fn do_ensure_runtime_start() -> RuntimeEnsureResponse {
         status = collect_runtime_status().await;
     }
 
-    let mut message = status.detail.clone();
-    if !notes.is_empty() {
-        message = format!("{}; {}", notes.join("; "), status.detail);
+    let routing_error = if status.docker_ready {
+        ensure_direct_container_routing().await.err()
+    } else {
+        None
+    };
+
+    let mut message = if notes.is_empty() {
+        status.detail.clone()
+    } else {
+        format!("{}; {}", notes.join("; "), status.detail)
+    };
+    if let Some(error) = &routing_error {
+        message = format!("{message}; direct container routing setup failed: {error:#}");
     }
 
-    let result_status = if status.docker_ready {
+    let ready = status.docker_ready && routing_error.is_none();
+    let result_status = if ready {
         ensure_runtime::STATUS_STARTED.to_string()
     } else {
         ensure_runtime::STATUS_FAILED.to_string()
     };
 
     RuntimeEnsureResponse {
-        ready: status.docker_ready,
+        ready,
         endpoint: status.endpoint,
         message,
         status: result_status,
@@ -126,6 +141,60 @@ async fn do_ensure_runtime_probe() -> RuntimeEnsureResponse {
 
 pub(super) async fn handle_runtime_status(_req: RuntimeStatusRequest) -> RpcResponse {
     RpcResponse::RuntimeStatus(collect_runtime_status().await)
+}
+
+/// Allows traffic arriving on the vmnet bridge NIC to reach Docker bridge
+/// subnets routed from macOS.
+///
+/// Docker creates `DOCKER-USER` only after it starts. Installing this rule
+/// before dockerd is ineffective, and inserting directly into `FORWARD` is
+/// unstable because Docker prepends its own chains on startup. The matching
+/// daemon option `allow-direct-routing` removes Docker's earlier raw-table
+/// per-container drops; this rule then bypasses its unpublished-port drop.
+async fn ensure_direct_container_routing() -> Result<()> {
+    let Some(bridge_iface) = crate::init::detect_bridge_interface() else {
+        tracing::debug!("no bridge NIC found; skipping direct container routing rule");
+        return Ok(());
+    };
+
+    let rule = [
+        "DOCKER-USER",
+        "-i",
+        bridge_iface.as_str(),
+        "-d",
+        CONTAINER_SUBNET,
+        "-j",
+        "ACCEPT",
+    ];
+    let check = Command::new("/sbin/iptables")
+        .args(["-w", "2", "-C"])
+        .args(rule)
+        .output()
+        .await
+        .context("checking DOCKER-USER rule")?;
+    if check.status.success() {
+        return Ok(());
+    }
+
+    let install = Command::new("/sbin/iptables")
+        .args(["-w", "2", "-I"])
+        .args(rule)
+        .output()
+        .await
+        .context("installing DOCKER-USER rule")?;
+    if !install.status.success() {
+        bail!(
+            "iptables failed: {}",
+            String::from_utf8_lossy(&install.stderr).trim()
+        );
+    }
+
+    tracing::info!(
+        interface = bridge_iface,
+        subnet = CONTAINER_SUBNET,
+        "direct container routing rule installed"
+    );
+    Ok(())
 }
 
 pub(super) fn runtime_path_env(runtime_bin_dir: &Path) -> String {

--- a/guest/arcbox-agent/src/init.rs
+++ b/guest/arcbox-agent/src/init.rs
@@ -586,39 +586,11 @@ exit 0
     /// (socketpair datapath), while the bridge NIC is reachable from the host
     /// for inbound container traffic.
     fn configure_bridge_nic() {
-        // Find the bridge NIC: it's the non-loopback interface that is NOT
-        // the primary interface. The primary interface was already configured
-        // by configure_primary_interface_dhcp() and has an IP in 10.0.2.0/24.
-        let primary = detect_primary_interface();
-        let entries = match fs::read_dir("/sys/class/net") {
-            Ok(e) => e,
-            Err(_) => return,
-        };
-        let mut bridge_iface: Option<String> = None;
-        for entry in entries.flatten() {
-            let Ok(name) = entry.file_name().into_string() else {
-                continue;
-            };
-            // Skip loopback, virtual, and the primary interface.
-            if name == "lo"
-                || name.starts_with("dummy")
-                || name.starts_with("veth")
-                || name.starts_with("br-")
-                || name.starts_with("docker")
-                || name.starts_with("vmtap")
-                || name.starts_with("sit")
-                || primary.as_deref() == Some(&name)
-            {
-                continue;
-            }
-            bridge_iface = Some(name);
-            break;
-        }
-
-        let Some(bridge_iface) = bridge_iface.as_deref() else {
+        let Some(bridge_iface) = detect_bridge_interface() else {
             tracing::debug!("no bridge NIC found");
             return;
         };
+        let bridge_iface = bridge_iface.as_str();
 
         // Bring up the interface.
         run_init_cmd(
@@ -681,28 +653,25 @@ exit 0
         } else {
             tracing::info!(interface = bridge_iface, "proxy ARP enabled");
         }
+    }
 
-        // Add iptables FORWARD rules for the bridge NIC so container
-        // traffic can flow through.
-        run_iptables(
-            &["-I", "FORWARD", "-i", bridge_iface, "-j", "ACCEPT"],
-            "FORWARD accept from bridge NIC",
-        );
-        run_iptables(
-            &[
-                "-I",
-                "FORWARD",
-                "-o",
-                bridge_iface,
-                "-m",
-                "conntrack",
-                "--ctstate",
-                "RELATED,ESTABLISHED",
-                "-j",
-                "ACCEPT",
-            ],
-            "FORWARD accept established to bridge NIC",
-        );
+    /// Finds the bridge NIC: the non-loopback physical interface that is not
+    /// the primary 10.0.2.0/24 interface.
+    pub fn detect_bridge_interface() -> Option<String> {
+        let primary = detect_primary_interface();
+        let entries = fs::read_dir("/sys/class/net").ok()?;
+        let mut candidates = Vec::new();
+        for entry in entries.flatten() {
+            let Ok(name) = entry.file_name().into_string() else {
+                continue;
+            };
+            if !is_uplink_interface(&name) || primary.as_deref() == Some(&name) {
+                continue;
+            }
+            candidates.push(name);
+        }
+        candidates.sort();
+        candidates.into_iter().next()
     }
 
     /// Install iptables FORWARD rules for sandbox networking.
@@ -807,19 +776,19 @@ exit 0
             let Ok(name) = entry.file_name().into_string() else {
                 continue;
             };
-            // Skip loopback and virtual interfaces that are not real NICs.
-            if name == "lo"
-                || name.starts_with("dummy")
-                || name.starts_with("veth")
-                || name.starts_with("br-")
-                || name.starts_with("docker")
-            {
+            if !is_uplink_interface(&name) {
                 continue;
             }
             candidates.push(name);
         }
         candidates.sort();
         candidates.into_iter().next()
+    }
+
+    /// Physical NICs use the kernel's predictable Ethernet prefixes; virtual
+    /// interfaces such as docker0, cni0, flannel.1, and veth* do not.
+    fn is_uplink_interface(name: &str) -> bool {
+        name.starts_with("eth") || name.starts_with("en")
     }
 
     fn write_etc_resolv_conf() {
@@ -833,7 +802,7 @@ exit 0
         }
     }
 
-    /// Writes Docker daemon configuration (DNS + default ulimits).
+    /// Writes Docker daemon configuration (DNS, direct routing, and ulimits).
     ///
     /// Containers get their DNS from the Docker daemon config, NOT from the
     /// guest's /etc/resolv.conf. We point them to 10.0.2.1 (the gateway)
@@ -906,9 +875,9 @@ const NOFILE_LIMIT: u64 = 1_048_576;
 
 /// Returns the Docker daemon.json content as a string.
 ///
-/// Extracted as a pure function so the output contract (DNS + default
-/// ulimits + containerd image store) is testable independently of the
-/// filesystem and platform.
+/// Extracted as a pure function so the output contract (DNS, direct routing,
+/// default ulimits, and containerd image store) is testable independently of
+/// the filesystem and platform.
 ///
 /// `containerd-snapshotter` stays explicitly `true` even though dockerd ≥ 29
 /// defaults to the containerd image store: without the explicit flag, dockerd
@@ -920,6 +889,7 @@ const NOFILE_LIMIT: u64 = 1_048_576;
 fn docker_daemon_json() -> String {
     serde_json::json!({
         "dns": ["10.0.2.1"],
+        "allow-direct-routing": true,
         "default-ulimits": {
             "nofile": { "Name": "nofile", "Soft": NOFILE_LIMIT, "Hard": NOFILE_LIMIT }
         },
@@ -930,6 +900,8 @@ fn docker_daemon_json() -> String {
     .to_string()
 }
 
+#[cfg(target_os = "linux")]
+pub use platform::detect_bridge_interface;
 #[cfg(target_os = "linux")]
 pub use platform::{init_system, machine_init};
 
@@ -1007,6 +979,13 @@ mod tests {
         let json = docker_daemon_json();
         let v: serde_json::Value = serde_json::from_str(&json).expect("valid JSON");
         assert_eq!(v["dns"][0], "10.0.2.1");
+    }
+
+    #[test]
+    fn daemon_json_allows_direct_container_routing() {
+        let json = docker_daemon_json();
+        let v: serde_json::Value = serde_json::from_str(&json).expect("valid JSON");
+        assert_eq!(v["allow-direct-routing"], true);
     }
 
     #[test]

--- a/virt/arcbox-net/examples/tun_proxy.rs
+++ b/virt/arcbox-net/examples/tun_proxy.rs
@@ -351,8 +351,12 @@ mod macos {
     impl RouteGuard {
         fn install(cidr: &str, iface: &str) -> Result<Self> {
             let net = parse_cidr(cidr).with_context(|| format!("invalid --route CIDR: {cidr}"))?;
-            arcbox_route::add(net, iface)
+            let outcome = arcbox_route::add(net, iface)
                 .map_err(|e| anyhow::anyhow!("add route {cidr} via {iface}: {e}"))?;
+            anyhow::ensure!(
+                outcome == arcbox_route::AddOutcome::Added,
+                "route {cidr} already exists and was left untouched"
+            );
             tracing::info!(%cidr, iface, "installed scoped route");
             Ok(Self { net })
         }


### PR DESCRIPTION
## Summary

- prefer ArcBox's exact `172.16.0.0/12` interface route when that network is available
- preserve an exact `/12` owned by Surge or another VPN and install the more-specific `172.16.0.0/13` + `172.24.0.0/13` ArcBox routes instead
- keep split mode sticky for the current VM lifetime, with PF_ROUTE event reconciliation (250 ms debounce) and a 30-second typed-query fallback
- make helper route conflicts non-destructive, surface them as typed `RouteConflict` errors, and require `arcbox-helper` 1.0.2
- make `abctl doctor` accept either ArcBox's exact `/12` or both ArcBox `/13` routes using typed route queries
- restore the guest `DOCKER-USER` direct-routing rule if dockerd or another firewall manager recreates the chain

## Root cause and design

A VPN can install an exact `172.16.0.0/12` gateway route. Replacing that route is both unsafe and prone to an ownership fight: Surge can recreate its `/12`, while a delete-and-add transition can temporarily remove networking if the add fails.

ArcBox now treats an exact route through another gateway/interface as externally owned. It never deletes or rewrites that route. If the preferred `/12` is externally owned, ArcBox installs two more-specific interface routes:

```text
172.16.0.0/13 -> ArcBox bridge
172.16.0.0/12 -> external VPN gateway (preserved)
172.24.0.0/13 -> ArcBox bridge
```

Longest-prefix matching sends ArcBox's container range through the bridge while leaving the VPN route intact. Once selected, split mode remains active until the VM stops so transient VPN changes cannot cause `/12` ownership oscillation. The routes disappear naturally when the vmnet bridge is destroyed; shutdown does not issue a potentially racy route delete.

The daemon watches PF_ROUTE changes and normally reconciles 250 ms after a relevant event. A 30-second typed query is retained as a fallback for watcher interruption or event loss. Route replies are validated against their actual destination and netmask, including compact macOS netmasks, so default/wider routes cannot be mistaken for the exact target.

For the guest data plane, Docker's documented `allow-direct-routing` option removes its raw-table direct-access drops. ArcBox gates initial runtime readiness on a scoped, idempotent `DOCKER-USER` accept rule, then rechecks the rule every 30 seconds so a Docker/firewall chain rebuild self-heals.

## Validation

### Automated

- `cargo fmt --all -- --check`
- `cargo test -p arcbox-route -p arcbox-helper`
- `cargo test -p arcbox-core`
- `cargo test -p arcbox-daemon`
- `cargo test -p arcbox-cli`
- `cargo test -p arcbox-agent` — 111 tests passed
- production-target Clippy for route/helper/core/daemon/CLI
- `cargo check -p arcbox-daemon --no-default-features`
- `devenv shell -- cargo check -p arcbox-agent --target aarch64-unknown-linux-musl`
- `devenv shell -- cargo build -p arcbox-agent --target aarch64-unknown-linux-musl --release`
- privileged route regression: an existing gateway route is not replaced

Rust 1.96 strict all-target Clippy also reports pre-existing lints in unchanged files (`arcbox-pty`, agent shutdown/supervisor/Btrfs/RPC code, and helper E2E fixtures); no reported lint points at this change.

### Live Surge/VZ verification

Surge 6.7.0 (build 11600) owned `172.16.0.0/12` through `10.66.10.1` on `en10`.

- startup with Surge active preserved its `/12` and installed both ArcBox `/13` routes
- starting Surge after ArcBox switched preferred `/12` -> split mode 247 ms after the external route appeared
- three consecutive Surge reloads left the same stable route set, with no repeated split transition
- stopping Surge for more than 30 seconds did not revert sticky split mode
- direct container ICMP succeeded (3/3) before and after the transition
- direct HTTP reached the unpublished container service
- `abctl doctor` passed all 7 checks
- deleting the guest `DOCKER-USER` rule restored it within 29 seconds; ICMP (2/2), HTTP, and Doctor (7/7) then passed
- stopping the VM removed `bridge100` and both ArcBox `/13` routes while preserving Surge's `/12`

Temporary VM, helper, container, socket, route, and firewall test resources were removed afterward.
