### PR TITLE
fix(dns): harden the forwarder — validate replies + stop blocking local lookups

### DIFF
--- a/virt/arcbox-net/src/dns.rs
+++ b/virt/arcbox-net/src/dns.rs
@@ -255,8 +255,11 @@ pub struct DnsForwarder {
     config: DnsConfig,
     /// Shared local hostname mappings (hostname -> IP).
     local_hosts: Arc<LocalHostsTable>,
-    /// DNS cache (query -> response).
-    cache: HashMap<cache::DnsCacheKey, cache::CacheEntry>,
+    /// Response cache. Behind a `Mutex` (interior mutability) so `handle_query`
+    /// takes only `&self`; callers then hold a *read* lock on the surrounding
+    /// `RwLock<DnsForwarder>`, so a slow upstream forward never blocks the fast
+    /// local-resolution / cache-hit path.
+    cache: std::sync::Mutex<HashMap<cache::DnsCacheKey, cache::CacheEntry>>,
 }
 
 impl DnsForwarder {
@@ -266,7 +269,7 @@ impl DnsForwarder {
         Self {
             config,
             local_hosts: Arc::new(LocalHostsTable::new(HashMap::new())),
-            cache: HashMap::new(),
+            cache: std::sync::Mutex::new(HashMap::new()),
         }
     }
 
@@ -280,7 +283,7 @@ impl DnsForwarder {
         Self {
             config,
             local_hosts,
-            cache: HashMap::new(),
+            cache: std::sync::Mutex::new(HashMap::new()),
         }
     }
 
@@ -405,7 +408,7 @@ impl DnsForwarder {
     /// # Errors
     ///
     /// Returns an error if the query cannot be processed.
-    pub fn handle_query(&mut self, data: &[u8]) -> Result<Vec<u8>> {
+    pub fn handle_query(&self, data: &[u8]) -> Result<Vec<u8>> {
         // Parse the query
         let query = DnsQuery::parse(data)?;
 
@@ -481,7 +484,7 @@ impl DnsForwarder {
     /// datagram not from that upstream, and the reply's transaction ID must
     /// echo the query's — together closing the off-path cache-poisoning window
     /// an unconnected `recv_from` (which accepted any sender's bytes) left open.
-    fn forward_query(&mut self, data: &[u8]) -> Result<Vec<u8>> {
+    fn forward_query(&self, data: &[u8]) -> Result<Vec<u8>> {
         use std::net::UdpSocket;
 
         // The query's transaction ID; a valid reply must echo it.
@@ -520,8 +523,8 @@ impl DnsForwarder {
     }
 
     /// Clears the DNS cache.
-    pub fn clear_cache(&mut self) {
-        self.cache.clear();
+    pub fn clear_cache(&self) {
+        self.cache.lock().expect("dns cache lock poisoned").clear();
     }
 }
 
@@ -871,11 +874,11 @@ mod tests {
 
         let key =
             cache::DnsCacheKey::new(&parsed_query.name, parsed_query.qtype, parsed_query.qclass);
-        let entry = forwarder
-            .cache
-            .get_mut(&key)
-            .expect("response should be cached");
-        entry.cached_at -= Duration::from_secs(10);
+        {
+            let mut cache = forwarder.cache.lock().unwrap();
+            let entry = cache.get_mut(&key).expect("response should be cached");
+            entry.cached_at -= Duration::from_secs(10);
+        }
 
         let cached = forwarder
             .check_cache(&parsed_query)
@@ -902,10 +905,8 @@ mod tests {
 
         let key =
             cache::DnsCacheKey::new(&parsed_query.name, parsed_query.qtype, parsed_query.qclass);
-        let entry = forwarder
-            .cache
-            .get(&key)
-            .expect("response should be cached");
+        let cache = forwarder.cache.lock().unwrap();
+        let entry = cache.get(&key).expect("response should be cached");
         assert_eq!(entry.ttl, Duration::from_secs(30));
     }
 

--- a/virt/arcbox-net/src/dns.rs
+++ b/virt/arcbox-net/src/dns.rs
@@ -721,21 +721,26 @@ mod tests {
         packet
     }
 
-    /// A one-shot fake upstream that answers a single query with a 12-byte
-    /// response header, echoing the query's transaction id or corrupting it.
+    /// A one-shot fake upstream that answers a single query with a valid
+    /// response header (QDCOUNT=1) followed by the echoed question, so the
+    /// reply is protocol-valid rather than a bare truncated header. Echoes
+    /// the query's transaction id or corrupts it per `echo_txid`.
     fn spawn_fake_upstream(echo_txid: bool) -> (SocketAddr, std::thread::JoinHandle<()>) {
         use std::net::UdpSocket;
         let sock = UdpSocket::bind("127.0.0.1:0").unwrap();
         let addr = sock.local_addr().unwrap();
         let handle = std::thread::spawn(move || {
             let mut buf = [0u8; 512];
-            let (_, peer) = sock.recv_from(&mut buf).unwrap();
+            let (len, peer) = sock.recv_from(&mut buf).unwrap();
             let mut reply = if echo_txid {
                 vec![buf[0], buf[1]]
             } else {
                 vec![buf[0] ^ 0xFF, buf[1] ^ 0xFF]
             };
             reply.extend_from_slice(&[0x81, 0x80, 0, 1, 0, 0, 0, 0, 0, 0]);
+            // Echo the question section so QDCOUNT=1 is honest and the reply
+            // is a protocol-valid message, not a truncated header.
+            reply.extend_from_slice(&buf[12..len]);
             sock.send_to(&reply, peer).unwrap();
         });
         (addr, handle)

--- a/virt/arcbox-net/src/dns.rs
+++ b/virt/arcbox-net/src/dns.rs
@@ -476,28 +476,38 @@ impl DnsForwarder {
     }
 
     /// Forwards a query to upstream servers.
+    ///
+    /// Each upstream gets a freshly `connect`ed socket so the kernel drops any
+    /// datagram not from that upstream, and the reply's transaction ID must
+    /// echo the query's — together closing the off-path cache-poisoning window
+    /// an unconnected `recv_from` (which accepted any sender's bytes) left open.
     fn forward_query(&mut self, data: &[u8]) -> Result<Vec<u8>> {
         use std::net::UdpSocket;
 
-        let socket = UdpSocket::bind("0.0.0.0:0")
-            .map_err(|e| NetError::Dns(format!("failed to bind socket: {}", e)))?;
-
-        socket
-            .set_read_timeout(Some(Duration::from_secs(2)))
-            .map_err(|e| NetError::Dns(format!("failed to set timeout: {}", e)))?;
+        // The query's transaction ID; a valid reply must echo it.
+        let query_id = data.get(0..2);
 
         for upstream in &self.config.upstream {
-            // Send query
-            if socket.send_to(data, upstream).is_err() {
+            let socket = UdpSocket::bind("0.0.0.0:0")
+                .map_err(|e| NetError::Dns(format!("failed to bind socket: {}", e)))?;
+            socket
+                .set_read_timeout(Some(Duration::from_secs(2)))
+                .map_err(|e| NetError::Dns(format!("failed to set timeout: {}", e)))?;
+
+            // connect() filters incoming datagrams to this upstream only.
+            if socket.connect(upstream).is_err() || socket.send(data).is_err() {
                 continue;
             }
 
-            // Receive response
-            let mut buf = [0u8; 512];
-            if let Ok((len, _)) = socket.recv_from(&mut buf) {
+            // Sized for EDNS0 replies (a 512-byte buffer silently truncated
+            // them). Reject anything without a full header echoing our txid.
+            let mut buf = vec![0u8; 65535];
+            if let Ok(len) = socket.recv(&mut buf) {
+                if len < 12 || Some(&buf[0..2]) != query_id {
+                    continue;
+                }
                 let response = buf[..len].to_vec();
 
-                // Cache the response (simplified)
                 if let Ok(query) = DnsQuery::parse(data) {
                     self.cache_response(&query, &response);
                 }
@@ -706,6 +716,63 @@ mod tests {
         packet.extend_from_slice(&[0x00, 0x01]); // QTYPE = A
         packet.extend_from_slice(&[0x00, 0x01]); // QCLASS = IN
         packet
+    }
+
+    /// A one-shot fake upstream that answers a single query with a 12-byte
+    /// response header, echoing the query's transaction id or corrupting it.
+    fn spawn_fake_upstream(echo_txid: bool) -> (SocketAddr, std::thread::JoinHandle<()>) {
+        use std::net::UdpSocket;
+        let sock = UdpSocket::bind("127.0.0.1:0").unwrap();
+        let addr = sock.local_addr().unwrap();
+        let handle = std::thread::spawn(move || {
+            let mut buf = [0u8; 512];
+            let (_, peer) = sock.recv_from(&mut buf).unwrap();
+            let mut reply = if echo_txid {
+                vec![buf[0], buf[1]]
+            } else {
+                vec![buf[0] ^ 0xFF, buf[1] ^ 0xFF]
+            };
+            reply.extend_from_slice(&[0x81, 0x80, 0, 1, 0, 0, 0, 0, 0, 0]);
+            sock.send_to(&reply, peer).unwrap();
+        });
+        (addr, handle)
+    }
+
+    #[test]
+    fn forward_query_accepts_matching_transaction_id() {
+        let (upstream, handle) = spawn_fake_upstream(true);
+        let config = DnsConfig {
+            upstream: vec![upstream],
+            ..DnsConfig::default()
+        };
+        let mut forwarder = DnsForwarder::new(config);
+
+        let query = build_test_query("example.com");
+        let reply = forwarder
+            .forward_query(&query)
+            .expect("a reply echoing the txid must be accepted");
+        handle.join().unwrap();
+        assert_eq!(&reply[0..2], &query[0..2], "reply carries the query's txid");
+    }
+
+    /// Regression (cache-poisoning): a reply whose transaction id does not
+    /// match the query must be rejected, never returned or cached.
+    #[test]
+    fn forward_query_rejects_mismatched_transaction_id() {
+        let (upstream, handle) = spawn_fake_upstream(false);
+        let config = DnsConfig {
+            upstream: vec![upstream],
+            ..DnsConfig::default()
+        };
+        let mut forwarder = DnsForwarder::new(config);
+
+        let query = build_test_query("example.com");
+        let result = forwarder.forward_query(&query);
+        handle.join().unwrap();
+        assert!(
+            result.is_err(),
+            "a reply with the wrong transaction id must be rejected"
+        );
     }
 
     fn build_test_response(query: &[u8], ip: Ipv4Addr, ttl: u32) -> Vec<u8> {

--- a/virt/arcbox-net/src/dns/cache.rs
+++ b/virt/arcbox-net/src/dns/cache.rs
@@ -44,13 +44,14 @@ impl CacheEntry {
 
 impl DnsForwarder {
     /// Checks the cache for a query.
-    pub(super) fn check_cache(&mut self, query: &DnsQuery) -> Option<Vec<u8>> {
+    pub(super) fn check_cache(&self, query: &DnsQuery) -> Option<Vec<u8>> {
         let key = DnsCacheKey::new(&query.name, query.qtype, query.qclass);
 
+        let mut cache = self.cache.lock().expect("dns cache lock poisoned");
         // Clean up expired entries.
-        self.cache.retain(|_, v| !v.is_expired());
+        cache.retain(|_, v| !v.is_expired());
 
-        self.cache.get(&key).and_then(|entry| {
+        cache.get(&key).and_then(|entry| {
             let mut response = entry.response.clone();
             response[0..2].copy_from_slice(&query.raw_header[0..2]);
             rewrite_question(&mut response, &query.raw_question)?;
@@ -72,7 +73,7 @@ impl DnsForwarder {
     /// authority/additional sections, EDNS, DNSSEC, and record-type-specific
     /// RDATA without maintaining a fragile local packet re-builder. Hickory
     /// parses the response only to validate it and derive a safe expiry TTL.
-    pub(super) fn cache_response(&mut self, query: &DnsQuery, response: &[u8]) {
+    pub(super) fn cache_response(&self, query: &DnsQuery, response: &[u8]) {
         let Some(ttl) = self.cache_ttl_for_response(response) else {
             return;
         };
@@ -83,7 +84,10 @@ impl DnsForwarder {
             cached_at: Instant::now(),
             ttl,
         };
-        self.cache.insert(key, entry);
+        self.cache
+            .lock()
+            .expect("dns cache lock poisoned")
+            .insert(key, entry);
     }
 
     fn cache_ttl_for_response(&self, response: &[u8]) -> Option<Duration> {

--- a/virt/arcbox-net/src/lib.rs
+++ b/virt/arcbox-net/src/lib.rs
@@ -391,10 +391,12 @@ impl NetworkManager {
     /// Handles a full DNS query: local resolution first, then upstream forwarding.
     /// This blocks on network I/O for upstream queries.
     pub fn handle_dns_query(&self, query: &[u8]) -> Result<Vec<u8>> {
-        // handle_query needs &mut self for cache updates, so take a write lock.
-        let mut forwarder = self
+        // Only a read lock: `handle_query` takes `&self` (its cache is behind
+        // an inner `Mutex`), so a slow upstream forward held here no longer
+        // blocks the `.read()`-taking local-resolution path.
+        let forwarder = self
             .dns_forwarder
-            .write()
+            .read()
             .map_err(|_| NetError::config("dns forwarder lock poisoned".to_string()))?;
         forwarder.handle_query(query)
     }


### PR DESCRIPTION
Two DNS-forwarder fixes from the cross-repo audit (one commit each).

## 1. Validate upstream replies (CRITICAL — cache poisoning)

`forward_query` bound one **unconnected** UDP socket and accepted the first datagram via `recv_from` — discarding the sender and never checking the reply's transaction id — then returned it **and cached it** under the query's key for up to the cache TTL. Any local process hitting the ephemeral source port within the ~2 s window could inject a forged, cached answer.

Fix: per-upstream `connect()`ed socket (kernel drops datagrams from anyone but that upstream) + reject replies without a full 12-byte header echoing the query's txid + grow the reply buffer 512 → 65535 (EDNS0 was being truncated).

## 2. Don't hold the write lock across blocking upstream I/O (HIGH — DoS)

`handle_dns_query` took a **write** lock on `RwLock<DnsForwarder>` and held it across `handle_query` → `forward_query` (up to 2 s × upstreams). Every fast local lookup (`try_resolve_dns_or_nxdomain`, a **read** lock on the same `RwLock`) serialized behind an in-flight slow query, so a dead/black-holed upstream stalled **all** host DNS — including `*.arcbox.local` lookups needing no I/O — for seconds.

Fix: move the response cache behind an inner `Mutex` (interior mutability, mirroring how `local_hosts` is already shared under a read lock). `handle_query`/`forward_query`/`check_cache`/`cache_response` now take `&self`, so `handle_dns_query` holds only a **read** lock — a slow forward no longer blocks concurrent local resolution.

## Tests

`forward_query_{accepts_matching,rejects_mismatched}_transaction_id` (fake upstream). `cargo test -p arcbox-net dns` → 43 pass; clippy + fmt clean.

## Provenance

Cross-repo audit, `gvisor-tap-vsock` DNS forwarder as oracle. Sibling findings not in this PR: the guest-side async forwarder also skips the source check; local-hostname replies ignore QTYPE.