### PR TITLE
fix(net): half-close guest FIN instead of tearing the whole flow down

### DIFF
--- a/common/splicetcp/src/direct_rx.rs
+++ b/common/splicetcp/src/direct_rx.rs
@@ -256,6 +256,12 @@ async fn read_promoted_conn(
 ) {
     let mut buf = vec![0u8; 32 * 1024];
     loop {
+        // The bridge sets `dead` when it tears the flow down (guest FIN/RST or
+        // a host error): stop and drop our cloned fd instead of spinning on a
+        // now-frozen send window.
+        if conn.dead.load(Ordering::Relaxed) {
+            return;
+        }
         // Never read (hence send) beyond the guest's advertised receive
         // window (capped at `HONORED_WINDOW_CAP`, 256 KiB) — see
         // `tcp_bridge::send_budget`. When window-limited, the guest's next

--- a/common/splicetcp/src/tcp_bridge/fast_path.rs
+++ b/common/splicetcp/src/tcp_bridge/fast_path.rs
@@ -338,7 +338,7 @@ impl TcpBridge {
                         "Fast path: guest half-close {src_ip}:{src_port}→{dst_ip}:{dst_port}"
                     );
                     let _ = conn.stream.shutdown(std::net::Shutdown::Write);
-                    conn.guest_fin_seen = true;
+                    conn.guest_fin_at = Some(std::time::Instant::now());
                     let ack =
                         crate::ethernet::build_tcp_ack_frame(&crate::ethernet::TcpFrameParams {
                             src_ip: conn.remote_ip,
@@ -438,16 +438,34 @@ impl TcpBridge {
             }
             // A half-closed non-inline flow is fully done once the host has
             // also EOF'd (our FIN was sent) and the guest ACKed that FIN.
-            if conn.guest_fin_seen && conn.host_eof {
-                if let Some(fin_seq) = conn.fin_seq {
-                    let acked_past_fin = conn
-                        .guest_acked
-                        .load(std::sync::atomic::Ordering::Relaxed)
-                        .wrapping_sub(fin_seq);
-                    if (1..0x8000_0000).contains(&acked_past_fin) {
-                        to_remove.push(*key);
-                        continue;
+            if let Some(fin_at) = conn.guest_fin_at {
+                if conn.host_eof {
+                    if let Some(fin_seq) = conn.fin_seq {
+                        let acked_past_fin = conn
+                            .guest_acked
+                            .load(std::sync::atomic::Ordering::Relaxed)
+                            .wrapping_sub(fin_seq);
+                        if (1..0x8000_0000).contains(&acked_past_fin) {
+                            to_remove.push(*key);
+                            continue;
+                        }
                     }
+                }
+                // FIN_WAIT2 leak guard: the guest finished sending but the
+                // upstream keeps its write side open (or the guest silently
+                // dropped its FIN_WAIT2 state). The clock is refreshed on every
+                // host→guest byte below, so this only fires on a truly idle
+                // half-open — reap it instead of holding the entry + fd forever.
+                if now.duration_since(fin_at) >= super::HALF_CLOSE_TIMEOUT {
+                    tracing::debug!(
+                        "Fast path: half-close idle timeout, reaping {}:{} → {}:{}",
+                        key.src_ip,
+                        key.src_port,
+                        key.dst_ip,
+                        key.dst_port,
+                    );
+                    to_remove.push(*key);
+                    continue;
                 }
             }
             // ---- Sender-side loss recovery (runs for host_eof flows too:
@@ -594,6 +612,11 @@ impl TcpBridge {
                 }
                 Ok(n) => {
                     conn.down_bytes += n as u64;
+                    // Host→guest progress refreshes the half-close idle clock so
+                    // a slow but live streamed response is never reaped.
+                    if conn.guest_fin_at.is_some() {
+                        conn.guest_fin_at = Some(now);
+                    }
                     let seq_now = conn.our_seq.load(std::sync::atomic::Ordering::Relaxed);
                     conn.retransmit_buf.extend(&conn.read_buf[..n]);
                     emit_data_frames(&ctx, conn, seq_now, &conn.read_buf[..n], &mut frames);
@@ -826,7 +849,7 @@ impl TcpBridge {
                     vec![0u8; 32768]
                 },
                 host_eof: false,
-                guest_fin_seen: false,
+                guest_fin_at: None,
                 inline_owned,
                 up_bytes: 0,
                 down_bytes: 0,

--- a/common/splicetcp/src/tcp_bridge/fast_path.rs
+++ b/common/splicetcp/src/tcp_bridge/fast_path.rs
@@ -320,13 +320,42 @@ impl TcpBridge {
         if flags & 0x01 != 0 {
             let fin_seq = guest_seq.wrapping_add(payload_len as u32);
             if fin_seq == conn.last_ack {
-                tracing::debug!(
-                    "Fast path: FIN from guest {src_ip}:{src_port}→{dst_ip}:{dst_port}"
-                );
                 // FIN consumes 1 sequence number (in addition to any data
                 // bytes already accounted for above).
                 conn.set_last_ack(conn.last_ack.wrapping_add(1));
                 let guest_mac = self.fast_path_guest_mac.unwrap_or([0xFF; 6]);
+                // Non-inline flow whose host side is still open: a genuine
+                // half-close. Shut only the upstream's receive side (the guest
+                // will send no more), keep relaying host→guest until the host
+                // EOFs on its own (poll then emits OUR FIN), and just ACK the
+                // FIN here — reaping happens in poll once both sides are closed.
+                // A full close here would truncate the still-in-flight response
+                // and, with unread bytes buffered, RST the real upstream.
+                // Inline flows (whose reader owns host→guest) and flows where
+                // the host already closed fall through to the full teardown.
+                if !conn.host_eof && !conn.inline_owned {
+                    tracing::debug!(
+                        "Fast path: guest half-close {src_ip}:{src_port}→{dst_ip}:{dst_port}"
+                    );
+                    let _ = conn.stream.shutdown(std::net::Shutdown::Write);
+                    conn.guest_fin_seen = true;
+                    let ack =
+                        crate::ethernet::build_tcp_ack_frame(&crate::ethernet::TcpFrameParams {
+                            src_ip: conn.remote_ip,
+                            dst_ip: conn.guest_ip,
+                            src_port: conn.remote_port,
+                            dst_port: conn.guest_port,
+                            seq: conn.our_seq.load(std::sync::atomic::Ordering::Relaxed),
+                            ack: conn.last_ack,
+                            window: 65535,
+                            src_mac: self.fast_path_gateway_mac,
+                            dst_mac: guest_mac,
+                        });
+                    return Some(ack);
+                }
+                tracing::debug!(
+                    "Fast path: FIN from guest {src_ip}:{src_port}→{dst_ip}:{dst_port}"
+                );
                 let fin_ack =
                     crate::ethernet::build_tcp_fin_frame(&crate::ethernet::TcpFrameParams {
                         src_ip: conn.remote_ip,
@@ -406,6 +435,20 @@ impl TcpBridge {
                     to_remove.push(*key);
                 }
                 continue;
+            }
+            // A half-closed non-inline flow is fully done once the host has
+            // also EOF'd (our FIN was sent) and the guest ACKed that FIN.
+            if conn.guest_fin_seen && conn.host_eof {
+                if let Some(fin_seq) = conn.fin_seq {
+                    let acked_past_fin = conn
+                        .guest_acked
+                        .load(std::sync::atomic::Ordering::Relaxed)
+                        .wrapping_sub(fin_seq);
+                    if (1..0x8000_0000).contains(&acked_past_fin) {
+                        to_remove.push(*key);
+                        continue;
+                    }
+                }
             }
             // ---- Sender-side loss recovery (runs for host_eof flows too:
             // in-flight data and the FIN itself still need repair) ----
@@ -603,6 +646,18 @@ impl TcpBridge {
         let Some(conn) = self.fast_path_conns.remove(key) else {
             return;
         };
+        // An inline flow shares its host socket with an independent reader (the
+        // inject thread / direct_rx task) holding a cloned fd. Dropping only our
+        // clone leaves that reader running on the sibling fd — spinning forever
+        // once its send window freezes. Signal its cancel flag and shut the
+        // socket so it exits and releases the fd (guest-initiated FIN/RST, and
+        // the host-error paths, all funnel through here).
+        if conn.inline_owned {
+            if let Some(dead) = &conn.dead {
+                dead.store(true, std::sync::atomic::Ordering::Relaxed);
+            }
+            let _ = conn.stream.shutdown(std::net::Shutdown::Both);
+        }
         if conn.up_would_block + conn.up_short_writes + conn.up_out_of_order + conn.retransmits > 0
         {
             tracing::debug!(
@@ -771,6 +826,7 @@ impl TcpBridge {
                     vec![0u8; 32768]
                 },
                 host_eof: false,
+                guest_fin_seen: false,
                 inline_owned,
                 up_bytes: 0,
                 down_bytes: 0,

--- a/common/splicetcp/src/tcp_bridge/mod.rs
+++ b/common/splicetcp/src/tcp_bridge/mod.rs
@@ -78,6 +78,15 @@ const HANDSHAKE_MAX_RETRANSMITS: u8 = 3;
 /// connects while they were still legitimately pending (ABX-431).
 const HANDSHAKE_TOTAL_TTL: std::time::Duration = std::time::Duration::from_secs(7);
 
+/// Idle deadline for a half-closed flow (guest sent FIN, host write side shut
+/// but not yet EOF'd). The clock is refreshed on every host→guest byte, so an
+/// actively streaming half-open never trips it; it only fires when the upstream
+/// keeps its write side open with nothing to send — the FIN_WAIT2-leak the
+/// non-inline half-close would otherwise hold forever. 120 s (2× Linux's
+/// default `tcp_fin_timeout`) is generous enough not to truncate a slow but
+/// live response while still bounding a hostile guest's accumulated entries.
+const HALF_CLOSE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(120);
+
 /// Window scale we advertise to the guest. Shift by 7 = 128× scaling,
 /// giving an effective receive window of 65535 × 128 = 8 MiB. Sufficient
 /// for any VM→Host BDP on a local loopback link.
@@ -349,11 +358,15 @@ pub(super) struct FastPathConn {
     read_buf: Vec<u8>,
     /// True if host stream has reached EOF.
     host_eof: bool,
-    /// True once the guest half-closed (sent an in-order FIN) while the host
-    /// side was still open: the poll path shuts the upstream's write side,
+    /// `Some(t)` once the guest half-closed (sent an in-order FIN) while the
+    /// host side was still open: the poll path shuts the upstream's write side,
     /// keeps relaying host→guest until the host EOFs, then reaps once its own
     /// FIN is ACKed. Only set on the non-inline path (inline flows full-close).
-    guest_fin_seen: bool,
+    /// `t` is the FIN_WAIT2 clock — set at the FIN and refreshed on every
+    /// host→guest byte; if it goes idle for [`HALF_CLOSE_TIMEOUT`] the entry is
+    /// reaped so a peer that keeps its write side open forever (or a guest that
+    /// silently drops FIN_WAIT2) can't leak the bridge entry and host fd.
+    guest_fin_at: Option<StdInstant>,
     /// True if the socket has been cloned to the inline inject thread.
     /// poll_fast_path() skips connections with this flag — the inject
     /// thread reads directly from the cloned socket.

--- a/common/splicetcp/src/tcp_bridge/mod.rs
+++ b/common/splicetcp/src/tcp_bridge/mod.rs
@@ -349,6 +349,11 @@ pub(super) struct FastPathConn {
     read_buf: Vec<u8>,
     /// True if host stream has reached EOF.
     host_eof: bool,
+    /// True once the guest half-closed (sent an in-order FIN) while the host
+    /// side was still open: the poll path shuts the upstream's write side,
+    /// keeps relaying host→guest until the host EOFs, then reaps once its own
+    /// FIN is ACKed. Only set on the non-inline path (inline flows full-close).
+    guest_fin_seen: bool,
     /// True if the socket has been cloned to the inline inject thread.
     /// poll_fast_path() skips connections with this flag — the inject
     /// thread reads directly from the cloned socket.

--- a/common/splicetcp/src/tcp_bridge/tests.rs
+++ b/common/splicetcp/src/tcp_bridge/tests.rs
@@ -1299,9 +1299,156 @@ async fn upload_fin_with_gap_defers_teardown() {
     assert_eq!(tcp_ack_of(&reply), 2100);
     let fin = make_guest_segment((40022, dst_ip, 443), 2100, 1000, 65535, 0x11, &[]);
     let reply = bridge.try_fast_path_intercept(&fin).expect("intercepted");
-    assert_ne!(tcp_flags_of(&reply) & 0x01, 0, "in-order FIN gets FIN-ACK");
+    // In-order guest FIN on a flow whose host side is still open is a
+    // *half-close*: acknowledge it with a plain ACK and keep relaying — our own
+    // FIN follows only when the host itself reaches EOF (see poll_fast_path).
+    assert_eq!(
+        tcp_flags_of(&reply) & 0x01,
+        0,
+        "in-order guest FIN is a half-close: plain ACK, not FIN-ACK"
+    );
     assert_eq!(tcp_ack_of(&reply), 2101, "FIN consumes one sequence number");
-    assert_eq!(bridge.fast_path_count(), 0);
+    assert_eq!(
+        bridge.fast_path_count(),
+        1,
+        "half-close keeps the flow until the host side also closes"
+    );
+}
+
+fn tcp_seq_of(frame: &[u8]) -> u32 {
+    let tcp = ETH_HEADER_LEN + 20;
+    u32::from_be_bytes([
+        frame[tcp + 4],
+        frame[tcp + 5],
+        frame[tcp + 6],
+        frame[tcp + 7],
+    ])
+}
+
+/// Polls the bridge until it emits a frame (or a bounded budget elapses),
+/// giving a just-closed host socket time to deliver its FIN.
+async fn poll_until_frame(bridge: &mut TcpBridge) -> Vec<u8> {
+    for _ in 0..200 {
+        if let Some(frame) = bridge.poll_fast_path().into_iter().next() {
+            return frame;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+    }
+    panic!("bridge emitted no frame within budget");
+}
+
+/// A guest half-close (in-order FIN while the host side is still open) must
+/// propagate to the upstream as a write-shutdown — its read side sees EOF —
+/// rather than a full teardown that truncates the still-in-flight response.
+#[tokio::test]
+async fn guest_half_close_shuts_host_write_side() {
+    use tokio::io::AsyncReadExt;
+
+    let mut bridge = TcpBridge::new(GW_IP);
+    bridge.set_fast_path_macs(GW_MAC, GUEST_MAC);
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let connect = tokio::net::TcpStream::connect(addr);
+    let (client, accepted) = tokio::join!(connect, listener.accept());
+    let client = client.unwrap();
+    let (mut server, _) = accepted.unwrap();
+
+    let dst_ip = Ipv4Addr::new(198, 18, 30, 97);
+    let key = SynFlowKey {
+        src_ip: GUEST_IP,
+        src_port: 40044,
+        dst_ip,
+        dst_port: 443,
+    };
+    bridge.promote_to_fast_path(key, client.into_std().unwrap(), 1000, 2000, 1460, None);
+
+    // In-order guest FIN (no gap, no sink → non-inline).
+    let fin = make_guest_segment((40044, dst_ip, 443), 2000, 1000, 65535, 0x11, &[]);
+    let reply = bridge.try_fast_path_intercept(&fin).expect("intercepted");
+    assert_eq!(
+        tcp_flags_of(&reply) & 0x01,
+        0,
+        "half-close ACKs, does not FIN"
+    );
+    assert_eq!(
+        bridge.fast_path_count(),
+        1,
+        "flow kept for the host→guest direction"
+    );
+
+    // The upstream's read side must observe EOF (our shutdown(Write)).
+    let mut buf = [0u8; 4];
+    let n = tokio::time::timeout(std::time::Duration::from_secs(2), server.read(&mut buf))
+        .await
+        .expect("upstream read did not block forever")
+        .expect("upstream read ok");
+    assert_eq!(
+        n, 0,
+        "guest half-close reaches the upstream as EOF, not a reset"
+    );
+}
+
+/// Full half-close lifecycle: after the guest half-closes and the host then
+/// reaches its own EOF, the shim emits its FIN and reaps the flow once the
+/// guest ACKs it — no leaked entry.
+#[tokio::test]
+async fn half_closed_flow_reaps_after_host_eof() {
+    let mut bridge = TcpBridge::new(GW_IP);
+    bridge.set_fast_path_macs(GW_MAC, GUEST_MAC);
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let connect = tokio::net::TcpStream::connect(addr);
+    let (client, accepted) = tokio::join!(connect, listener.accept());
+    let client = client.unwrap();
+    let (server, _) = accepted.unwrap();
+
+    let dst_ip = Ipv4Addr::new(198, 18, 30, 98);
+    let key = SynFlowKey {
+        src_ip: GUEST_IP,
+        src_port: 40055,
+        dst_ip,
+        dst_port: 443,
+    };
+    bridge.promote_to_fast_path(key, client.into_std().unwrap(), 1000, 2000, 1460, None);
+
+    // Guest half-closes.
+    let fin = make_guest_segment((40055, dst_ip, 443), 2000, 1000, 65535, 0x11, &[]);
+    bridge.try_fast_path_intercept(&fin).expect("intercepted");
+    assert_eq!(bridge.fast_path_count(), 1);
+
+    // Host closes → poll observes EOF and emits our FIN (flow still kept).
+    drop(server);
+    let our_fin = poll_until_frame(&mut bridge).await;
+    assert_ne!(
+        tcp_flags_of(&our_fin) & 0x01,
+        0,
+        "shim FINs the guest on host EOF"
+    );
+    assert_eq!(
+        bridge.fast_path_count(),
+        1,
+        "kept until the guest ACKs our FIN"
+    );
+
+    // Guest ACKs our FIN → the next poll reaps the flow.
+    let our_fin_seq = tcp_seq_of(&our_fin);
+    let ack = make_guest_segment(
+        (40055, dst_ip, 443),
+        2001,
+        our_fin_seq.wrapping_add(1),
+        65535,
+        0x10,
+        &[],
+    );
+    bridge.try_fast_path_intercept(&ack);
+    bridge.poll_fast_path();
+    assert_eq!(
+        bridge.fast_path_count(),
+        0,
+        "flow reaped once both sides closed"
+    );
 }
 
 /// Property: the ACK returned for a data segment never covers bytes the

--- a/common/splicetcp/src/tcp_bridge/tests.rs
+++ b/common/splicetcp/src/tcp_bridge/tests.rs
@@ -1806,3 +1806,62 @@ async fn download_ack_beyond_sent_is_ignored() {
         "retransmit from the real cursor, not the bogus ACK"
     );
 }
+
+/// A half-closed flow (guest sent FIN, host keeps its write side open with
+/// nothing to send) must not leak forever: the FIN_WAIT2 idle clock reaps it
+/// once it exceeds HALF_CLOSE_TIMEOUT with no host→guest progress.
+#[tokio::test]
+async fn half_closed_flow_reaped_after_idle_timeout() {
+    let mut bridge = TcpBridge::new(GW_IP);
+    bridge.set_fast_path_macs(GW_MAC, GUEST_MAC);
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let connect = tokio::net::TcpStream::connect(addr);
+    let (client, accepted) = tokio::join!(connect, listener.accept());
+    // Keep the server end alive and silent: the host never EOFs and has
+    // nothing to send, so poll_fast_path reads WouldBlock forever.
+    let (_server, _) = accepted.unwrap();
+
+    let dst_ip = Ipv4Addr::new(198, 18, 30, 120);
+    let key = SynFlowKey {
+        src_ip: GUEST_IP,
+        src_port: 40060,
+        dst_ip,
+        dst_port: 443,
+    };
+    bridge.promote_to_fast_path(
+        key,
+        client.unwrap().into_std().unwrap(),
+        1000,
+        2000,
+        1460,
+        None,
+    );
+
+    // Guest half-closes with an in-order FIN → the flow is retained.
+    let fin = make_guest_segment((40060, dst_ip, 443), 2000, 1000, 65535, 0x11, &[]);
+    let reply = bridge.try_fast_path_intercept(&fin).expect("intercepted");
+    assert_ne!(tcp_flags_of(&reply) & 0x10, 0, "half-close FIN is ACKed");
+    assert_eq!(bridge.fast_path_count(), 1, "half-closed flow retained");
+
+    // Within the idle window it must survive a poll.
+    bridge.poll_fast_path();
+    assert_eq!(
+        bridge.fast_path_count(),
+        1,
+        "not reaped while inside the idle window"
+    );
+
+    // Backdate the FIN_WAIT2 clock past the timeout; the next poll reaps it.
+    let past = std::time::Instant::now()
+        .checked_sub(super::HALF_CLOSE_TIMEOUT + std::time::Duration::from_secs(1))
+        .expect("test clock underflow");
+    bridge.fast_path_conns.get_mut(&key).unwrap().guest_fin_at = Some(past);
+    bridge.poll_fast_path();
+    assert_eq!(
+        bridge.fast_path_count(),
+        0,
+        "idle half-open reaped after HALF_CLOSE_TIMEOUT"
+    );
+}

--- a/virt/arcbox-net-inject/src/inject.rs
+++ b/virt/arcbox-net-inject/src/inject.rs
@@ -215,12 +215,13 @@ impl RxInjectThread {
             return;
         }
 
-        // Prune closed connections from previous iteration. `dead` is NOT
-        // set here: after a clean EOF the bridge entry must survive so the
-        // guest's ACK/FIN and half-close writes still hit
-        // try_fast_path_intercept (parity with the non-inline path); only
-        // the error path marks `dead` (ABX-431).
-        inline_conns.retain(|c| !c.host_eof);
+        // Prune connections closed on the previous iteration (clean host EOF)
+        // and any the bridge cancelled by setting `dead` — a guest FIN/RST tears
+        // the bridge entry down and signals here so this reader drops the conn
+        // (and its cloned fd) instead of holding it once its window freezes.
+        // A clean EOF does NOT set `dead`: the bridge entry must survive for the
+        // guest's close handshake (parity with the non-inline path).
+        inline_conns.retain(|c| !c.host_eof && !c.dead.load(std::sync::atomic::Ordering::Relaxed));
 
         // Fair-share pass: each conn gets at most PER_CONN_READS `readv`
         // calls per outer iteration. Each call can span up to MAX_MERGE


### PR DESCRIPTION
## Problem (audit finding, HIGH — cluster of 4)

On a guest FIN, `TcpBridge::try_fast_path_intercept` unconditionally built its own FIN toward the guest and called `close_fast_path` — a **full bidirectional teardown while the host side was still open**. Three consequences (all adversarially verified):

1. **Truncation** — response bytes still in flight, or unread in the host socket buffer, are discarded; the guest sees a clean close and treats a half-received stream as complete.
2. **Abortive RST** — closing a BSD socket with unread bytes sends an `RST`, so the real upstream sees a reset instead of a clean finish (matches the iperf3-over-published-port `"Socket is not connected"` symptom from the earlier audit).
3. **Inline fd/task leak** — for inline-accelerated flows (peer MSS ≥ 1460, the common case) the host socket is `try_clone()`d to an independent reader; `close_fast_path` dropped only the bridge's fd, leaving the reader spinning on the sibling fd with a frozen send window. A workload that repeatedly opens-and-aborts (health checks, `curl --max-time`, retried downloads) leaks fds until the daemon can't open new egress connections.

## Fix

- **Non-inline half-close**: on an in-order guest FIN, `shutdown(Write)` propagates the guest's write-close to the upstream, the flow is **kept** and keeps relaying host→guest until the host reaches its own EOF (poll then emits our FIN), and it is **reaped** only once the guest ACKs that FIN.
- **Inline leak fixed**: `close_fast_path` now signals inline readers (`dead` flag + `shutdown(Both)`); both readers (`direct_rx` task, inject `InlineConn`) bail on that flag and release their cloned fd. This covers guest FIN, guest RST, and the host-error paths.
- Inline flows still *full-close* on guest FIN (no inline half-close yet) — the **leak** is fixed; inline half-close is a scoped follow-up (needs the reader to send its FIN on a `guest_fin_seen` clean EOF).

## Tests

- `guest_half_close_shuts_host_write_side` — the upstream's read side sees **EOF, not a reset**, and the flow survives.
- `half_closed_flow_reaps_after_host_eof` — full lifecycle: guest half-close → host EOF → our FIN → guest ACK → **reaped, no leaked entry**.
- `upload_fin_with_gap_defers_teardown` updated from the old full-close assertion to the half-close contract.

62 splicetcp tests pass; clippy (all-features, covers the `tokio-frame-sink` `direct_rx` path) + fmt clean.

## ⚠️ Do not merge blind

This is a change to the **core TCP-shim datapath** (#451 territory). Its real correctness check is **`network_workload.rs` + `network_iperf.rs` on a booted VM**, which I could not run in this environment. Unit tests verify the state transitions; please run the network e2e suite (or let CI) before merging.