### PR TITLE
fix(fs): harden the passthrough FUSE server against hostile guests

### DIFF
--- a/virt/arcbox-fs/src/dispatcher/file_ops.rs
+++ b/virt/arcbox-fs/src/dispatcher/file_ops.rs
@@ -61,7 +61,16 @@ impl FuseDispatcher {
 
         // SAFETY: FuseWriteIn may sit at an unaligned offset in the VirtIO buffer.
         let write_in = unsafe { std::ptr::read_unaligned(body.as_ptr() as *const FuseWriteIn) };
-        let data = &body[size_of::<FuseWriteIn>()..];
+        // Honor the request's declared length rather than writing whatever
+        // bytes trail the header: a padded/oversized descriptor chain must not
+        // expand the write beyond `write_in.size`.
+        let Some(data) = body
+            .get(size_of::<FuseWriteIn>()..)
+            .and_then(|d| d.get(..write_in.size as usize))
+        else {
+            response.write_error(ctx.unique, libc::EINVAL);
+            return;
+        };
 
         match self
             .fs

--- a/virt/arcbox-fs/src/dispatcher/mapping_xattr.rs
+++ b/virt/arcbox-fs/src/dispatcher/mapping_xattr.rs
@@ -160,9 +160,15 @@ impl FuseDispatcher {
             unsafe { std::ptr::read_unaligned(body.as_ptr() as *const FuseGetxattrIn) };
         let name = self.parse_name(&body[size_of::<FuseGetxattrIn>()..]);
 
-        match self.fs.getxattr(ctx.nodeid, name, getxattr_in.size) {
+        // Bound the guest-controlled `size`: no xattr exceeds XATTR_SIZE_MAX
+        // (64 KiB), so a larger value can only be an attempt to force a huge
+        // per-request allocation. Clamping keeps the get correct (a real value
+        // fits; an over-large request that wouldn't fit still gets ERANGE).
+        const MAX_XATTR_SIZE: u32 = 64 * 1024;
+        let size = getxattr_in.size.min(MAX_XATTR_SIZE);
+        match self.fs.getxattr(ctx.nodeid, name, size) {
             Ok(value) => {
-                if getxattr_in.size == 0 {
+                if size == 0 {
                     // Return size only
                     let out = FuseGetxattrOut {
                         size: value.len() as u32,
@@ -196,7 +202,16 @@ impl FuseDispatcher {
         // Parse name\0value
         if let Some(null_pos) = rest.iter().position(|&b| b == 0) {
             let name = OsStr::from_bytes(&rest[..null_pos]);
-            let value = &rest[null_pos + 1..][..setxattr_in.size as usize];
+            // The declared value length must fit the bytes actually present
+            // after `name\0`; an oversized `size` used to index-panic here, and
+            // with panic=abort that killed the whole host process.
+            let Some(value) = rest
+                .get(null_pos + 1..)
+                .and_then(|v| v.get(..setxattr_in.size as usize))
+            else {
+                response.write_error(ctx.unique, libc::EINVAL);
+                return;
+            };
 
             match self.fs.setxattr(ctx.nodeid, name, value, setxattr_in.flags) {
                 Ok(()) => response.write_empty(ctx.unique),

--- a/virt/arcbox-fs/src/passthrough.rs
+++ b/virt/arcbox-fs/src/passthrough.rs
@@ -185,6 +185,20 @@ impl PassthroughFs {
     /// Constructs the full host path for a given parent inode and name.
     #[allow(clippy::significant_drop_tightening)]
     fn get_path(&self, parent: u64, name: &OsStr) -> Result<PathBuf> {
+        // A FUSE name must be a single safe path component. The guest must
+        // never escape the shared root via `/`, `..`, `.`, an empty name, or an
+        // absolute path — `Path::join` replaces the base on an absolute arg and
+        // never lexically resolves `..`, so an unchecked name is a full
+        // host-filesystem escape (reachable read/write, incl. via DAX
+        // SETUPMAPPING). This is the single choke point for every name-taking
+        // opcode (lookup/create/mkdir/mknod/link/symlink/unlink/rmdir/rename).
+        let bytes = name.as_encoded_bytes();
+        if bytes.is_empty() || bytes == b"." || bytes == b".." || bytes.contains(&b'/') {
+            return Err(FsError::InvalidPath(format!(
+                "unsafe FUSE name: {}",
+                name.display()
+            )));
+        }
         if parent == Self::ROOT_INODE {
             return Ok(self.root.join(name));
         }

--- a/virt/arcbox-fs/src/passthrough/tests.rs
+++ b/virt/arcbox-fs/src/passthrough/tests.rs
@@ -512,3 +512,22 @@ fn test_concurrent_operations() {
         handle.join().expect("Thread panicked");
     }
 }
+
+/// Security regression: a name that is not a single safe path component must be
+/// rejected at lookup, so the guest cannot obtain a nodeid outside the shared
+/// root (which it could then read/write or DAX-map).
+#[test]
+fn lookup_rejects_path_traversal_names() {
+    let (temp, fs) = setup_test_fs();
+    for name in ["..", ".", "", "../etc/passwd", "/etc/passwd", "a/b"] {
+        assert!(
+            fs.lookup(PassthroughFs::ROOT_INODE, OsStr::new(name))
+                .is_err(),
+            "unsafe FUSE name {name:?} must be rejected, not resolved"
+        );
+    }
+    // A normal single component still resolves.
+    std::fs::write(temp.path().join("normal.txt"), b"x").unwrap();
+    fs.lookup(PassthroughFs::ROOT_INODE, OsStr::new("normal.txt"))
+        .expect("a safe name must resolve normally");
+}


### PR DESCRIPTION
Four audit findings on the HV virtio-fs passthrough server — all reachable by a guest that controls the FUSE request bytes. HV-only (non-production until the blk-capacity bug is fixed), but these must be closed before HV ships.

## 1. Shared-directory path traversal → host FS escape (CRITICAL)
FUSE names were joined onto the shared root with **no validation** (`get_path`: `self.root.join(name)`), and `parse_name` only split on the first NUL. `Path::join` replaces the base on an absolute arg and never resolves `..`, so `LOOKUP` of `..` / `/Users/…/.ssh/id_rsa` returned a nodeid **outside** the root — then readable/writable, or DAX-mapped straight into guest memory via `SETUPMAPPING(FUSE_NO_FH)`. **Fix:** reject any name that isn't a single safe component (`/`, `..`, `.`, empty) at `get_path`, the single choke point for every name-taking opcode.

## 2. FUSE_SETXATTR value-length panic → whole host process dies (CRITICAL)
`&rest[null_pos+1..][..setxattr_in.size]` used the guest-declared size unchecked; an oversized value index-**panicked**, and `[profile.release] panic = "abort"` turned that into a full host-process kill. **Fix:** bounds-check → `EINVAL`.

## 3. FUSE_GETXATTR unbounded allocation (MEDIUM, DoS)
The guest-controlled `size` (up to ~4 GiB) drove a per-request zeroed allocation. **Fix:** clamp to `XATTR_SIZE_MAX` (64 KiB) — no real xattr exceeds it, so the get stays correct.

## 4. FUSE_WRITE ignored `write_in.size` (LOW)
It wrote *all* bytes trailing the header, not the declared length. **Fix:** honor `write_in.size`, bounds-checked → `EINVAL`.

## Tests
`lookup_rejects_path_traversal_names` (`..`, `.`, ``, `../etc/passwd`, `/etc/passwd`, `a/b` all rejected; a normal name still resolves). 64 arcbox-fs tests pass; clippy + fmt clean.

Found by the cross-repo audit (crosvm virtio-fs / virtiofsd as oracle).