### PR TITLE
fix(net): validate IPv4 IHL and TCP data offset before parsing headers

### DIFF
--- a/common/splicetcp/src/classifier.rs
+++ b/common/splicetcp/src/classifier.rs
@@ -315,6 +315,13 @@ impl FrameClassifier {
         let ihl = ((frame[ip_start] & 0x0F) as usize) * 4;
         let l4_start = ip_start + ihl;
 
+        // Reject a malformed IPv4 header: version must be 4 and IHL ≥ 20. A
+        // smaller IHL collapses l4_start into the IP header, so the 'TCP'
+        // fields below would be read from attacker-controlled header bytes.
+        if ihl < 20 || (frame[ip_start] >> 4) != 4 {
+            return;
+        }
+
         // A fragment (MF set or nonzero offset) carries at most a partial L4
         // datagram, and downstream consumers parse one datagram per frame —
         // reassemble first (ABX-429). A completed datagram re-enters here

--- a/common/splicetcp/src/tcp_bridge/fast_path.rs
+++ b/common/splicetcp/src/tcp_bridge/fast_path.rs
@@ -87,7 +87,9 @@ impl TcpBridge {
 
         let ihl = ((frame[ip_start] & 0x0F) as usize) * 4;
         let l4_start = ip_start + ihl;
-        if frame.len() < l4_start + 20 {
+        // IHL < 20 would collapse l4_start into the IP header, so every TCP
+        // field below (ports, seq/ack, flags) would be read from IP bytes.
+        if ihl < 20 || frame.len() < l4_start + 20 {
             return None;
         }
 
@@ -137,6 +139,11 @@ impl TcpBridge {
         let ip_total_len = u16::from_be_bytes([frame[ip_start + 2], frame[ip_start + 3]]) as usize;
         let ip_end = ip_start + ip_total_len;
         let tcp_data_offset = ((frame[l4_start + 12] >> 4) as usize) * 4;
+        // The data offset must cover the 20-byte TCP header; a smaller value
+        // would splice TCP header bytes into the payload written to the host.
+        if tcp_data_offset < 20 || l4_start + tcp_data_offset > frame.len() {
+            return None;
+        }
         let payload_start = l4_start + tcp_data_offset;
         let payload_end = ip_end.min(frame.len());
         let payload_len = payload_end.saturating_sub(payload_start);

--- a/common/splicetcp/src/tcp_bridge/handshake.rs
+++ b/common/splicetcp/src/tcp_bridge/handshake.rs
@@ -33,7 +33,7 @@ impl TcpBridge {
         }
         let ihl = ((syn_frame[ip_start] & 0x0F) as usize) * 4;
         let l4_start = ip_start + ihl;
-        if l4_start + 20 > syn_frame.len() {
+        if ihl < 20 || l4_start + 20 > syn_frame.len() {
             return None;
         }
 
@@ -362,7 +362,7 @@ impl TcpBridge {
         }
         let ihl = ((frame[ip_start] & 0x0F) as usize) * 4;
         let l4_start = ip_start + ihl;
-        if l4_start + 20 > frame.len() {
+        if ihl < 20 || l4_start + 20 > frame.len() {
             return None;
         }
 

--- a/common/splicetcp/src/tcp_bridge/mod.rs
+++ b/common/splicetcp/src/tcp_bridge/mod.rs
@@ -594,7 +594,7 @@ pub(super) fn build_rst_from_syn(syn_frame: &[u8], gateway_mac: [u8; 6]) -> Opti
 
     let ihl = ((syn_frame[ip_start] & 0x0F) as usize) * 4;
     let l4_start = ip_start + ihl;
-    if l4_start + 20 > syn_frame.len() {
+    if ihl < 20 || l4_start + 20 > syn_frame.len() {
         return None;
     }
 

--- a/common/splicetcp/src/tcp_bridge/tests.rs
+++ b/common/splicetcp/src/tcp_bridge/tests.rs
@@ -1865,3 +1865,49 @@ async fn half_closed_flow_reaped_after_idle_timeout() {
         "idle half-open reaped after HALF_CLOSE_TIMEOUT"
     );
 }
+
+/// A segment matching an active flow but with a malformed TCP data offset
+/// (< 20) must be rejected outright and never written to the host socket —
+/// otherwise raw TCP header bytes get spliced into the upstream byte stream.
+#[tokio::test]
+async fn malformed_data_offset_is_not_spliced_to_host() {
+    use tokio::io::AsyncReadExt;
+
+    let mut bridge = TcpBridge::new(GW_IP);
+    bridge.set_fast_path_macs(GW_MAC, GUEST_MAC);
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let connect = tokio::net::TcpStream::connect(addr);
+    let (client, accepted) = tokio::join!(connect, listener.accept());
+    let client = client.unwrap();
+    let (mut server, _) = accepted.unwrap();
+
+    let dst_ip = Ipv4Addr::new(198, 18, 30, 99);
+    let key = SynFlowKey {
+        src_ip: GUEST_IP,
+        src_port: 40077,
+        dst_ip,
+        dst_port: 443,
+    };
+    bridge.promote_to_fast_path(key, client.into_std().unwrap(), 1000, 2000, 1460, None);
+
+    // A PSH|ACK segment carrying 8 payload bytes, but with the TCP data-offset
+    // nibble cleared (data offset = 0, < the 20-byte minimum).
+    let mut bad = make_guest_segment((40077, dst_ip, 443), 2000, 1000, 65535, 0x18, &[0xAA; 8]);
+    let data_offset_byte = ETH_HEADER_LEN + 20 + 12; // IP header is 20 bytes (IHL=5)
+    bad[data_offset_byte] &= 0x0F; // clear the high (data-offset) nibble → 0
+
+    assert!(
+        bridge.try_fast_path_intercept(&bad).is_none(),
+        "a TCP data offset < 20 must be rejected"
+    );
+
+    let mut buf = [0u8; 8];
+    let got =
+        tokio::time::timeout(std::time::Duration::from_millis(100), server.read(&mut buf)).await;
+    assert!(
+        got.is_err(),
+        "a rejected segment must not splice bytes to the host socket"
+    );
+}


### PR DESCRIPTION
## Problem (audit findings, MEDIUM)

The TCP-parsing entry points computed `l4_start = ip_start + ihl` and `payload_start = l4_start + tcp_data_offset` but only checked buffer length — never that `ihl >= 20` or `tcp_data_offset >= 20`.

A guest with raw-socket access (a root container in the VM) crafts a frame matching an active fast-path 4-tuple with the IHL or data-offset nibble set small, so those fields collapse into the IP/TCP header. On the fast path `payload_start` then falls *inside* the TCP header, so `conn.stream.write(fresh)` splices raw TCP header bytes (ports/seq/flags/checksum) into the **upstream** byte stream and advances `last_ack` by the inflated length — corrupting the peer's data and permanently desyncing the flow (later legitimate segments read as a gap and are dropped, wedging the connection). The IHL variant reaches the same corruption independently, so both must be checked.

## Fix

Reject `ihl < 20` (and `version != 4` in the classifier) at every TCP-parse site — `classifier::classify_ipv4`, `try_fast_path_intercept`, both handshake parsers, and the SYN-rebuild helper — and reject `tcp_data_offset < 20` on the fast path. `fragment.rs` already validated `ihl >= 20`.

## Test

`malformed_data_offset_is_not_spliced_to_host`: a segment matching a promoted flow but with a zeroed data-offset nibble is rejected, and nothing is written to the host socket. 61 splicetcp tests pass; clippy (all-features) + fmt clean.

Found by the cross-repo audit (gVisor header parsing as oracle).