### PR TITLE
fix(net): retry EINTR on the NIC datapaths instead of dropping / killing them

### DIFF
--- a/virt/arcbox-net/src/darwin/datapath_loop/fd.rs
+++ b/virt/arcbox-net/src/darwin/datapath_loop/fd.rs
@@ -12,13 +12,22 @@ impl AsRawFd for FdWrapper {
 
 /// Writes data to a raw file descriptor, returning bytes written or an error.
 pub(super) fn fd_write(fd: RawFd, data: &[u8]) -> io::Result<usize> {
-    // SAFETY: writing from our buffer to a valid socketpair fd.
-    let n = unsafe { libc::write(fd, data.as_ptr().cast(), data.len()) };
-    if n < 0 {
-        Err(io::Error::last_os_error())
-    } else {
+    loop {
+        // SAFETY: writing from our buffer to a valid socketpair fd.
+        let n = unsafe { libc::write(fd, data.as_ptr().cast(), data.len()) };
+        if n < 0 {
+            let err = io::Error::last_os_error();
+            // A signal interrupted the write before any bytes were sent
+            // (EINTR). Retry so a Reliable TCP-shim frame is never dropped —
+            // the same permanent-stall failure the ENOBUFS/EAGAIN requeue
+            // path was built to avoid.
+            if err.kind() == io::ErrorKind::Interrupted {
+                continue;
+            }
+            return Err(err);
+        }
         #[allow(clippy::cast_sign_loss)]
-        Ok(n as usize)
+        return Ok(n as usize);
     }
 }
 

--- a/virt/arcbox-vmnet/src/relay.rs
+++ b/virt/arcbox-vmnet/src/relay.rs
@@ -90,18 +90,33 @@ impl VmnetRelay {
                     }
                     Ok(n) => {
                         let fd = reader_fd.as_raw_fd();
-                        // SAFETY: write to a valid socketpair fd with valid buffer.
-                        let written =
-                            unsafe { libc::write(fd, buf.as_ptr().cast::<libc::c_void>(), n) };
-                        if written < 0 {
+                        // Retry EINTR (a signal interrupted the write before any
+                        // bytes were sent); surface any other error to classify.
+                        let write_err = loop {
+                            // SAFETY: write to a valid socketpair fd with valid buffer.
+                            let written =
+                                unsafe { libc::write(fd, buf.as_ptr().cast::<libc::c_void>(), n) };
+                            if written >= 0 {
+                                break None;
+                            }
                             let err = std::io::Error::last_os_error();
-                            match err.kind() {
-                                std::io::ErrorKind::BrokenPipe => break,
-                                // Non-blocking fd: backpressure from guest.
-                                // Drop the packet and continue — the guest
-                                // will retransmit at the transport layer.
-                                std::io::ErrorKind::WouldBlock => {}
-                                _ => tracing::debug!("vmnet→guest write error: {err}"),
+                            if err.kind() == std::io::ErrorKind::Interrupted {
+                                continue;
+                            }
+                            break Some(err);
+                        };
+                        if let Some(err) = write_err {
+                            if err.kind() == std::io::ErrorKind::BrokenPipe {
+                                break;
+                            }
+                            // WouldBlock (EAGAIN) or ENOBUFS: the guest RX ring
+                            // is momentarily full — drop this frame; the
+                            // transport layer retransmits. Anything else is
+                            // unexpected but non-fatal.
+                            if err.kind() != std::io::ErrorKind::WouldBlock
+                                && err.raw_os_error() != Some(libc::ENOBUFS)
+                            {
+                                tracing::debug!("vmnet→guest write error: {err}");
                             }
                         }
                     }
@@ -153,11 +168,17 @@ impl VmnetRelay {
                             std::cmp::Ordering::Equal => break, // Peer closed
                             std::cmp::Ordering::Less => {
                                 let err = std::io::Error::last_os_error();
-                                if err.kind() == std::io::ErrorKind::WouldBlock {
-                                    guard.clear_ready();
-                                } else {
-                                    tracing::debug!("guest→vmnet read error: {err}");
-                                    break;
+                                match err.kind() {
+                                    std::io::ErrorKind::WouldBlock => guard.clear_ready(),
+                                    // A signal interrupted the read before a
+                                    // frame arrived (EINTR): retry on the next
+                                    // iteration instead of tearing down the
+                                    // whole bridge-NIC relay.
+                                    std::io::ErrorKind::Interrupted => {}
+                                    _ => {
+                                        tracing::debug!("guest→vmnet read error: {err}");
+                                        break;
+                                    }
                                 }
                             }
                         }


### PR DESCRIPTION
## Problem (audit findings)

A signal delivered to a worker thread mid-syscall (SIGTERM racing an in-flight request, or any handled signal) returns EINTR, which three raw read/write paths mishandled:

1. **Primary NIC GuestTx (`fd_write`)** — LOW: EINTR fell through to the catch-all that counts `io_errors` and **drops** the frame, including a *Reliable* TCP-shim ACK/data/handshake frame. The guest dup-ACKs forever and the fast-path flow stalls — the exact permanent-stall the ENOBUFS/EAGAIN requeue machinery was built to avoid.
2. **vmnet bridge NIC guest→vmnet read** — HIGH: any non-WouldBlock read error, EINTR included, hit `break`, which resolved the relay's `select!` and **permanently tore down both directions of the bridge NIC** (debug log only). All host→container traffic on that NIC is lost until VM restart.
3. **vmnet bridge NIC vmnet→guest write** — MEDIUM: ENOBUFS (guest RX ring momentarily full) was logged as a generic error and dropped; EINTR the same.

## Fix

Uniform principle — **retry EINTR, never drop/kill**:
- `fd_write` retries EINTR internally, so it is transparent to the reliable-frame requeue logic.
- vmnet guest→vmnet read: EINTR retries on the next loop iteration instead of tearing down the relay.
- vmnet vmnet→guest write: retry EINTR; treat ENOBUFS like WouldBlock (backpressure — drop, TCP retransmits) rather than a generic error.

## Notes

EINTR retry is a standard POSIX idiom not deterministically unit-testable (needs signal injection during the syscall). arcbox-net + arcbox-vmnet test suites pass; clippy + fmt clean.

A proper ENOBUFS **counter** for the bridge NIC (the primary NIC counts it) would need a stats struct on the relay — noted as a follow-up.

Found by the cross-repo audit.