### PR TITLE
fix(net): add a zero-window persist probe to the download fast path

### DIFF
--- a/common/splicetcp/src/tcp_bridge/fast_path.rs
+++ b/common/splicetcp/src/tcp_bridge/fast_path.rs
@@ -569,9 +569,10 @@ impl TcpBridge {
                 .load(std::sync::atomic::Ordering::Relaxed)
                 .min(super::HONORED_WINDOW_CAP);
             let budget = super::send_budget(sent, acked, window) as usize;
-            if budget == 0 {
+            let cap = if budget == 0 {
                 if !conn.window_stalled {
                     conn.window_stalled = true;
+                    conn.window_stalled_at = Some(now);
                     tracing::debug!(
                         "Fast path window stall {}:{} → {}:{} (sent={sent}, acked={acked}, window={window})",
                         conn.remote_ip,
@@ -580,19 +581,37 @@ impl TcpBridge {
                         conn.guest_port,
                     );
                 }
-                continue;
-            }
-            if conn.window_stalled {
-                conn.window_stalled = false;
-                tracing::debug!(
-                    "Fast path window reopened {}:{} → {}:{} (sent={sent}, acked={acked}, window={window})",
-                    conn.remote_ip,
-                    conn.remote_port,
-                    conn.guest_ip,
-                    conn.guest_port,
-                );
-            }
-            let cap = budget.min(conn.read_buf.len());
+                // Zero-window persist: a window closed with nothing in flight is
+                // reopened only by a guest window-update ACK; if that ACK is
+                // lost the flow deadlocks. Probe with a single byte past the
+                // window on a timer to force the guest to re-advertise it. Once
+                // the probe byte is in flight, the RTO retransmit path above
+                // keeps probing on its own, so this only kicks the first byte.
+                let in_flight = sent.wrapping_sub(acked);
+                let nothing_in_flight = in_flight == 0 || in_flight >= 0x8000_0000;
+                let probe_due = conn.window_stalled_at.is_some_and(|at| {
+                    now.duration_since(at) >= super::ZERO_WINDOW_PERSIST_INTERVAL
+                });
+                if nothing_in_flight && probe_due {
+                    conn.window_stalled_at = Some(now);
+                    1 // one byte beyond the closed window
+                } else {
+                    continue;
+                }
+            } else {
+                if conn.window_stalled {
+                    conn.window_stalled = false;
+                    conn.window_stalled_at = None;
+                    tracing::debug!(
+                        "Fast path window reopened {}:{} → {}:{} (sent={sent}, acked={acked}, window={window})",
+                        conn.remote_ip,
+                        conn.remote_port,
+                        conn.guest_ip,
+                        conn.guest_port,
+                    );
+                }
+                budget.min(conn.read_buf.len())
+            };
 
             use std::io::Read;
             match conn.stream.read(&mut conn.read_buf[..cap]) {
@@ -847,6 +866,7 @@ impl TcpBridge {
                 ooo_bytes: 0,
                 up_ooo_dropped: 0,
                 window_stalled: false,
+                window_stalled_at: None,
                 retransmit_buf: std::collections::VecDeque::new(),
                 retransmit_seq: our_seq,
                 last_progress: std::time::Instant::now(),

--- a/common/splicetcp/src/tcp_bridge/fast_path.rs
+++ b/common/splicetcp/src/tcp_bridge/fast_path.rs
@@ -445,6 +445,55 @@ impl TcpBridge {
                     .is_some_and(|d| d.load(std::sync::atomic::Ordering::Relaxed))
                 {
                     to_remove.push(*key);
+                    continue;
+                }
+
+                // Zero-window persist for the inline path. The inject thread /
+                // direct_rx reader stops reading at a zero send budget and can't
+                // probe on its own, so a lost guest window-update ACK would
+                // deadlock the download forever. Emit a keepalive-style probe —
+                // one byte at `our_seq - 1`, an old duplicate — which a
+                // zero-window guest must answer with a window-bearing ACK
+                // (RFC 793 §3.9). It consumes no sequence space and touches no
+                // shared state, so a lost probe is harmlessly re-sent next
+                // interval with no stream gap (the inline path has no
+                // retransmit). Gated on nothing-in-flight: the guest has ACKed
+                // up to `our_seq`, so `our_seq - 1` is always an old byte, and
+                // any in-flight data would elicit its own window-bearing ACKs.
+                let sent = conn.our_seq.load(std::sync::atomic::Ordering::Relaxed);
+                let acked = conn.guest_acked.load(std::sync::atomic::Ordering::Relaxed);
+                let window = conn
+                    .guest_window
+                    .load(std::sync::atomic::Ordering::Relaxed)
+                    .min(super::HONORED_WINDOW_CAP);
+                let in_flight = sent.wrapping_sub(acked);
+                let nothing_in_flight = in_flight == 0 || in_flight >= 0x8000_0000;
+                if super::send_budget(sent, acked, window) == 0 && nothing_in_flight {
+                    match conn.window_stalled_at {
+                        None => conn.window_stalled_at = Some(now),
+                        Some(at)
+                            if now.duration_since(at) >= super::ZERO_WINDOW_PERSIST_INTERVAL =>
+                        {
+                            conn.window_stalled_at = Some(now);
+                            frames.push(crate::ethernet::build_tcp_data_frame(
+                                &crate::ethernet::TcpFrameParams {
+                                    src_ip: conn.remote_ip,
+                                    dst_ip: conn.guest_ip,
+                                    src_port: conn.remote_port,
+                                    dst_port: conn.guest_port,
+                                    seq: sent.wrapping_sub(1),
+                                    ack: conn.last_ack,
+                                    window: 65535,
+                                    src_mac: gw_mac,
+                                    dst_mac: guest_mac,
+                                },
+                                &[0u8],
+                            ));
+                        }
+                        Some(_) => {}
+                    }
+                } else {
+                    conn.window_stalled_at = None;
                 }
                 continue;
             }

--- a/common/splicetcp/src/tcp_bridge/mod.rs
+++ b/common/splicetcp/src/tcp_bridge/mod.rs
@@ -133,6 +133,12 @@ pub(crate) const HONORED_WINDOW_CAP: u32 = 256 * 1024;
 pub(crate) const INITIAL_RTO: std::time::Duration = std::time::Duration::from_millis(200);
 pub(crate) const MAX_RTO: std::time::Duration = std::time::Duration::from_secs(2);
 
+/// Delay before the first zero-window persist probe once the guest closes its
+/// receive window with nothing in flight. After one probe byte is in flight the
+/// RTO retransmit path (INITIAL_RTO→MAX_RTO backoff) keeps probing on its own.
+pub(crate) const ZERO_WINDOW_PERSIST_INTERVAL: std::time::Duration =
+    std::time::Duration::from_millis(200);
+
 /// Fixed segment size the GSO/inline injection paths let the guest re-segment
 /// at (the `gso_size` stamped by `arcbox-net-inject`'s `write_inline_headers`
 /// and `inject_one_frame` — keep in sync). A flow whose peer advertised a
@@ -333,6 +339,10 @@ pub(super) struct FastPathConn {
     /// logging only, so a stuck window is visible in the daemon log
     /// without per-poll noise.
     window_stalled: bool,
+    /// When the window first closed with nothing in flight, for the
+    /// zero-window persist timer. `None` while the window is open. (The RTO
+    /// `last_progress` clock can't be reused: it is reset every idle poll.)
+    window_stalled_at: Option<StdInstant>,
     /// Sender-side retransmission buffer: every download byte from
     /// `retransmit_seq` (== the last drained `guest_acked`) up to `our_seq`,
     /// bounded by [`HONORED_WINDOW_CAP`]. Non-inline flows only.

--- a/common/splicetcp/src/tcp_bridge/tests.rs
+++ b/common/splicetcp/src/tcp_bridge/tests.rs
@@ -782,6 +782,102 @@ async fn inline_dead_flag_reaps_bridge_entry() {
     );
 }
 
+/// An inline-owned flow whose guest window closes with nothing in flight must
+/// still be probed: the inject/direct_rx reader can't probe on its own, so a
+/// lost window-update ACK would deadlock it. poll_fast_path emits a
+/// keepalive-style probe (1 byte at our_seq-1) on the persist timer, and stops
+/// once the window reopens.
+#[tokio::test]
+async fn inline_zero_window_persist_probes() {
+    struct CaptureSink(std::sync::Mutex<Option<crate::direct_rx::PromotedConn>>);
+    impl crate::direct_rx::ConnSink for CaptureSink {
+        fn send_conn(&self, conn: crate::direct_rx::PromotedConn) -> bool {
+            *self.0.lock().unwrap() = Some(conn);
+            true
+        }
+    }
+
+    let sink = std::sync::Arc::new(CaptureSink(std::sync::Mutex::new(None)));
+    let mut bridge = TcpBridge::new(GW_IP);
+    bridge.set_fast_path_macs(GW_MAC, GUEST_MAC);
+    bridge.set_conn_sink(std::sync::Arc::clone(&sink) as _);
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let connect = tokio::net::TcpStream::connect(addr);
+    let (client, accepted) = tokio::join!(connect, listener.accept());
+    let _accepted = accepted.unwrap();
+
+    let dst_ip = Ipv4Addr::new(198, 18, 30, 130);
+    let key = SynFlowKey {
+        src_ip: GUEST_IP,
+        src_port: 40070,
+        dst_ip,
+        dst_port: 443,
+    };
+    // peer_mss ≥ GSO_SEGMENT_MSS → inline-owned.
+    bridge.promote_to_fast_path(
+        key,
+        client.unwrap().into_std().unwrap(),
+        1000,
+        2000,
+        9000,
+        None,
+    );
+    let promoted = sink.0.lock().unwrap().take().expect("inline conn");
+
+    // Zero window, nothing in flight (guest has ACKed up to our_seq).
+    promoted
+        .our_seq
+        .store(5000, std::sync::atomic::Ordering::Relaxed);
+    promoted
+        .guest_acked
+        .store(5000, std::sync::atomic::Ordering::Relaxed);
+    promoted
+        .guest_window
+        .store(0, std::sync::atomic::Ordering::Relaxed);
+
+    // First poll arms the persist clock but emits nothing yet.
+    assert!(
+        bridge.poll_fast_path().is_empty(),
+        "no probe before the persist interval"
+    );
+
+    // Backdate the persist clock past the interval.
+    let past = std::time::Instant::now()
+        .checked_sub(super::ZERO_WINDOW_PERSIST_INTERVAL + std::time::Duration::from_millis(10))
+        .expect("test clock underflow");
+    bridge
+        .fast_path_conns
+        .get_mut(&key)
+        .unwrap()
+        .window_stalled_at = Some(past);
+
+    // Next poll emits one keepalive-style probe at our_seq-1.
+    let frames = bridge.poll_fast_path();
+    assert_eq!(frames.len(), 1, "one persist probe emitted");
+    let tcp = ETH_HEADER_LEN + 20;
+    let probe_seq = u32::from_be_bytes([
+        frames[0][tcp + 4],
+        frames[0][tcp + 5],
+        frames[0][tcp + 6],
+        frames[0][tcp + 7],
+    ]);
+    assert_eq!(
+        probe_seq, 4999,
+        "probe sits at our_seq-1 (an old duplicate)"
+    );
+
+    // Reopening the window stops the probing.
+    promoted
+        .guest_window
+        .store(65535, std::sync::atomic::Ordering::Relaxed);
+    assert!(
+        bridge.poll_fast_path().is_empty(),
+        "no probe once the window reopens"
+    );
+}
+
 /// A handshake abort (TTL expiry) must RST the guest so its socket dies
 /// immediately instead of retrying SYNs against a flow the bridge already
 /// gave up on (ABX-431).

--- a/common/splicetcp/src/tcp_bridge/tests.rs
+++ b/common/splicetcp/src/tcp_bridge/tests.rs
@@ -2094,3 +2094,62 @@ async fn pure_ack_returns_no_frame() {
         .expect("intercepted");
     assert!(reply.is_empty(), "a pure ACK must not be answered");
 }
+
+/// Zero-window persist: when the guest closes its receive window with nothing
+/// in flight and its window-reopening ACK is lost, the shim must probe with a
+/// single byte to force the guest to re-advertise — otherwise the flow
+/// deadlocks with unread host data forever.
+#[tokio::test]
+async fn zero_window_stall_is_broken_by_a_persist_probe() {
+    use std::io::Write;
+
+    let mut bridge = TcpBridge::new(GW_IP);
+    bridge.set_fast_path_macs(GW_MAC, GUEST_MAC);
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let connect = tokio::net::TcpStream::connect(addr);
+    let (client, accepted) = tokio::join!(connect, listener.accept());
+    let client = client.unwrap();
+    let (server, _) = accepted.unwrap();
+    let mut server = server.into_std().unwrap();
+
+    let dst_ip = Ipv4Addr::new(198, 18, 30, 100);
+    let key = SynFlowKey {
+        src_ip: GUEST_IP,
+        src_port: 40088,
+        dst_ip,
+        dst_port: 443,
+    };
+    bridge.promote_to_fast_path(key, client.into_std().unwrap(), 1000, 2000, 1460, None);
+
+    // Guest advertises a closed window (0), and the upstream has data to send.
+    let zero_win = make_guest_segment((40088, dst_ip, 443), 2000, 1000, 0, 0x10, &[]);
+    bridge.try_fast_path_intercept(&zero_win);
+    server.write_all(b"payload-bytes").unwrap();
+
+    // Arm the stall timer; nothing is sent while the window is shut.
+    assert!(
+        bridge.poll_fast_path().is_empty(),
+        "a closed window must not send before the persist timer fires"
+    );
+
+    // After the persist interval, a single-byte probe is emitted.
+    tokio::time::sleep(std::time::Duration::from_millis(250)).await;
+    let frames = bridge.poll_fast_path();
+    assert_eq!(
+        frames.len(),
+        1,
+        "a persist probe must be emitted after the stall"
+    );
+    let payload_len = frames[0].len() - (ETH_HEADER_LEN + 20 + 20);
+    assert_eq!(payload_len, 1, "the persist probe carries exactly one byte");
+
+    // The guest re-advertises a large window (ACKing the probe): sending resumes.
+    let reopen = make_guest_segment((40088, dst_ip, 443), 2000, 1001, 65535, 0x10, &[]);
+    bridge.try_fast_path_intercept(&reopen);
+    assert!(
+        !bridge.poll_fast_path().is_empty(),
+        "sending must resume once the window reopens"
+    );
+}


### PR DESCRIPTION
## Problem (audit finding, HIGH — deadlock)

When the guest advertised a **zero receive window with nothing in flight**, the download fast path stopped sending and waited for a guest window-update ACK to resume. If that ACK was lost, nothing re-probed the window and the flow **deadlocked forever** with unread host data.

The RTO retransmit path only fires when data is already in flight, and `last_progress` is reset every idle poll — so neither could serve as a persist timer.

## Fix

Track when the window first closed (`window_stalled_at`) and, once `ZERO_WINDOW_PERSIST_INTERVAL` (200 ms) elapses with nothing in flight, send **one byte past the closed window**. That forces the guest to re-advertise its window. Once the probe byte is in flight the existing RTO retransmit path takes over the persisting (INITIAL_RTO→MAX_RTO backoff). No probe is sent when the host has no data to deliver.

## Test

`zero_window_stall_is_broken_by_a_persist_probe`: closed window + host data → no send before the interval, a single-byte probe after it, and sending resumes once the window reopens. 61 splicetcp tests pass; clippy (all-features) + fmt clean.

⚠️ Core TCP-shim datapath change — validate with `network_workload` + `network_iperf` on a booted VM before merge.

Found by the cross-repo audit.