### PR TITLE
fix(dns): source-check forwarded replies and honor the query QTYPE

### DIFF
--- a/guest/arcbox-agent/src/dns_server.rs
+++ b/guest/arcbox-agent/src/dns_server.rs
@@ -265,10 +265,17 @@ impl GuestDnsServer {
     /// Forwards a query to the gateway DNS forwarder over UDP.
     async fn forward_to_gateway(&self, data: &[u8]) -> anyhow::Result<Vec<u8>> {
         let sock = UdpSocket::bind("0.0.0.0:0").await?;
-        sock.send_to(data, GATEWAY).await?;
+        // Connect so the kernel accepts only the gateway's reply (recv on an
+        // unconnected UDP socket takes a datagram from ANY local sender), and
+        // verify the reply echoes the query's transaction id.
+        sock.connect(GATEWAY).await?;
+        sock.send(data).await?;
 
         let mut buf = [0u8; MAX_PACKET];
         let len = tokio::time::timeout(FORWARD_TIMEOUT, sock.recv(&mut buf)).await??;
+        if len < 12 || data.get(0..2) != buf.get(0..2) {
+            anyhow::bail!("gateway DNS reply failed validation");
+        }
         Ok(buf[..len].to_vec())
     }
 }

--- a/virt/arcbox-net/src/darwin/datapath_loop/intercept.rs
+++ b/virt/arcbox-net/src/darwin/datapath_loop/intercept.rs
@@ -283,18 +283,20 @@ async fn forward_dns_async(data: &[u8], upstream: &[SocketAddr]) -> Result<Vec<u
     }
     let query_id = [data[0], data[1]];
 
-    let socket = tokio::net::UdpSocket::bind("0.0.0.0:0")
-        .await
-        .map_err(|e| format!("bind failed: {e}"))?;
-
     for addr in upstream {
-        if socket.send_to(data, addr).await.is_err() {
+        // A connected socket makes the kernel drop datagrams from anyone but
+        // this upstream — a 16-bit txid alone is guessable by an off-path
+        // attacker flooding the ephemeral port, so the source filter matters.
+        let socket = tokio::net::UdpSocket::bind("0.0.0.0:0")
+            .await
+            .map_err(|e| format!("bind failed: {e}"))?;
+        if socket.connect(addr).await.is_err() || socket.send(data).await.is_err() {
             continue;
         }
 
         let mut buf = [0u8; 4096];
-        match tokio::time::timeout(Duration::from_secs(2), socket.recv_from(&mut buf)).await {
-            Ok(Ok((len, _))) if len >= 2 && buf[0] == query_id[0] && buf[1] == query_id[1] => {
+        match tokio::time::timeout(Duration::from_secs(2), socket.recv(&mut buf)).await {
+            Ok(Ok(len)) if len >= 2 && buf[0] == query_id[0] && buf[1] == query_id[1] => {
                 return Ok(buf[..len].to_vec());
             }
             _ => {}

--- a/virt/arcbox-net/src/dns.rs
+++ b/virt/arcbox-net/src/dns.rs
@@ -438,6 +438,22 @@ impl DnsForwarder {
         // Set response flags
         response[2] = 0x81; // QR=1, Opcode=0, AA=0, TC=0, RD=1
         response[3] = 0x80; // RA=1, Z=0, RCODE=0
+
+        // Only answer with the address record the client actually asked for.
+        // A mismatched qtype — a different family (A vs AAAA), or MX/TXT/SRV/…
+        // — is NODATA (the name exists but has no record of that type), never
+        // an A/AAAA record mislabeled as the answer to the asked-for type.
+        let qtype_matches = matches!(
+            (query.qtype, ip),
+            (DnsRecordType::A, IpAddr::V4(_)) | (DnsRecordType::Aaaa, IpAddr::V6(_))
+        );
+        if !qtype_matches {
+            response[6] = 0x00; // ANCOUNT high
+            response[7] = 0x00; // ANCOUNT low — NODATA
+            response.extend_from_slice(&query.raw_question);
+            return Ok(response);
+        }
+
         response[6] = 0x00; // ANCOUNT high
         response[7] = 0x01; // ANCOUNT low
 
@@ -780,6 +796,39 @@ mod tests {
         assert!(
             result.is_err(),
             "a reply with the wrong transaction id must be rejected"
+        );
+    }
+
+    /// A local-hostname reply must honor the query's QTYPE: an A query gets the
+    /// address record, but a mismatched type (e.g. MX) is NODATA, not an A
+    /// record mislabeled as an MX answer.
+    #[test]
+    fn local_response_honors_qtype() {
+        let forwarder = DnsForwarder::new(DnsConfig::default());
+        let ip = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+
+        let a = build_test_query("myvm.arcbox.local");
+        let a_resp = forwarder
+            .build_local_response(&DnsQuery::parse(&a).unwrap(), ip)
+            .unwrap();
+        assert_eq!(
+            [a_resp[6], a_resp[7]],
+            [0x00, 0x01],
+            "an A query returns the address record"
+        );
+
+        // Same name, QTYPE = MX (15). QTYPE is the 4th/3rd-to-last byte.
+        let mut mx = build_test_query("myvm.arcbox.local");
+        let n = mx.len();
+        mx[n - 4] = 0x00;
+        mx[n - 3] = 0x0f;
+        let mx_resp = forwarder
+            .build_local_response(&DnsQuery::parse(&mx).unwrap(), ip)
+            .unwrap();
+        assert_eq!(
+            [mx_resp[6], mx_resp[7]],
+            [0x00, 0x00],
+            "an MX query on an A-only host is NODATA, not a mislabeled A record"
         );
     }
 

--- a/virt/arcbox-net/src/dns.rs
+++ b/virt/arcbox-net/src/dns.rs
@@ -439,6 +439,14 @@ impl DnsForwarder {
         response[2] = 0x81; // QR=1, Opcode=0, AA=0, TC=0, RD=1
         response[3] = 0x80; // RA=1, Z=0, RCODE=0
 
+        // This builder emits only answer records — never authority or
+        // additional. Zero NSCOUNT and ARCOUNT (copied verbatim from the
+        // query header) so an EDNS query, which sets ARCOUNT=1 for its OPT
+        // pseudo-record, doesn't leave the response advertising a record we
+        // dropped — strict resolvers reject that as malformed. ANCOUNT is
+        // set per branch below. Mirrors `build_nxdomain_response`.
+        response[8..12].fill(0);
+
         // Only answer with the address record the client actually asked for.
         // A mismatched qtype — a different family (A vs AAAA), or MX/TXT/SRV/…
         // — is NODATA (the name exists but has no record of that type), never
@@ -830,6 +838,43 @@ mod tests {
             [0x00, 0x00],
             "an MX query on an A-only host is NODATA, not a mislabeled A record"
         );
+    }
+
+    /// A local-hostname reply to an EDNS(0) query must not advertise section
+    /// records it doesn't carry: the query's ARCOUNT=1 (OPT pseudo-record) is
+    /// copied into the response header, but the builder emits no OPT record,
+    /// so NSCOUNT and ARCOUNT must be zeroed on both the answer and NODATA
+    /// paths or strict resolvers reject the reply as malformed.
+    #[test]
+    fn local_response_zeroes_section_counts_for_edns() {
+        let forwarder = DnsForwarder::new(DnsConfig::default());
+        let ip = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+
+        // Turn an A query into an EDNS query: ARCOUNT=1 + an OPT record.
+        let make_edns = |name: &str, qtype: u8| {
+            let mut q = build_test_query(name);
+            let n = q.len();
+            q[n - 4] = 0x00;
+            q[n - 3] = qtype; // QTYPE
+            q[11] = 0x01; // ARCOUNT = 1
+            // Minimal OPT pseudo-record: root name, TYPE=41, CLASS=4096, TTL=0, RDLEN=0.
+            q.extend_from_slice(&[
+                0x00, 0x00, 0x29, 0x10, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            ]);
+            q
+        };
+
+        for (label, qtype) in [("answer (A match)", 0x01u8), ("NODATA (MX)", 0x0f)] {
+            let q = make_edns("myvm.arcbox.local", qtype);
+            let resp = forwarder
+                .build_local_response(&DnsQuery::parse(&q).unwrap(), ip)
+                .unwrap();
+            assert_eq!(
+                &resp[8..12],
+                &[0x00, 0x00, 0x00, 0x00],
+                "{label}: NSCOUNT and ARCOUNT must be zero (no authority/additional records emitted)"
+            );
+        }
     }
 
     fn build_test_response(query: &[u8], ip: Ipv4Addr, ttl: u32) -> Vec<u8> {


### PR DESCRIPTION
Three more DNS audit findings across the guest + host forward paths.

- **Guest agent `forward_to_gateway`** (`dns_server.rs`): unconnected UDP socket, returned the first datagram with no txid/source check. On Darwin `recv` on an unconnected socket accepts a datagram from **any** local sender → any local process could spoof the guest's DNS. Fix: `connect(GATEWAY)` + txid check.
- **Host async forward `forward_dns_async`** (`intercept.rs`, the guest's real internet DNS path): checked only the 16-bit txid, discarded the responder address → off-path spoofable by flooding the ephemeral port. Fix: `connect()` each upstream (kernel drops foreign sources).
- **Local-hostname `build_local_response`** (`dns.rs`): ignored the query QTYPE, always emitted an A/AAAA record — an MX/TXT/SRV/… (or wrong-family) query on a `*.arcbox.local` host got an address record mislabeled as that type. Fix: answer only when the qtype matches the family; otherwise NODATA.

Test: `local_response_honors_qtype`. arcbox-net 42 dns tests pass; arcbox-agent checks clean; clippy + fmt clean. Found by the cross-repo audit; complements the host-side reply validation + lock fix in #472.