### PR TITLE
fix(net): re-ACK a retransmitted guest SYN on an established fast-path flow

### DIFF
--- a/common/splicetcp/src/tcp_bridge/fast_path.rs
+++ b/common/splicetcp/src/tcp_bridge/fast_path.rs
@@ -133,6 +133,27 @@ impl TcpBridge {
             return Some(Vec::new()); // Intercepted, no reply frame.
         }
 
+        // A SYN on an already-promoted flow means the guest retransmitted its
+        // SYN / SYN-ACK because it never saw our completing ACK (common on the
+        // inbound ActiveOpen path). Re-send the ACK rather than swallowing it
+        // (the pure-ACK fall-through below returns nothing for such a frame),
+        // which would leave the guest retransmitting until it times out.
+        if flags & 0x02 != 0 {
+            let guest_mac = self.fast_path_guest_mac.unwrap_or([0xFF; 6]);
+            let ack = crate::ethernet::build_tcp_ack_frame(&crate::ethernet::TcpFrameParams {
+                src_ip: conn.remote_ip,
+                dst_ip: conn.guest_ip,
+                src_port: conn.remote_port,
+                dst_port: conn.guest_port,
+                seq: conn.our_seq.load(std::sync::atomic::Ordering::Relaxed),
+                ack: conn.last_ack,
+                window: 65535,
+                src_mac: self.fast_path_gateway_mac,
+                dst_mac: guest_mac,
+            });
+            return Some(ack);
+        }
+
         // Extract payload using IPv4 total_length to exclude Ethernet padding.
         // NOTE: FIN check is deferred until after payload write — RFC 793
         // allows FIN segments to carry data.

--- a/common/splicetcp/src/tcp_bridge/fast_path.rs
+++ b/common/splicetcp/src/tcp_bridge/fast_path.rs
@@ -133,27 +133,6 @@ impl TcpBridge {
             return Some(Vec::new()); // Intercepted, no reply frame.
         }
 
-        // A SYN on an already-promoted flow means the guest retransmitted its
-        // SYN / SYN-ACK because it never saw our completing ACK (common on the
-        // inbound ActiveOpen path). Re-send the ACK rather than swallowing it
-        // (the pure-ACK fall-through below returns nothing for such a frame),
-        // which would leave the guest retransmitting until it times out.
-        if flags & 0x02 != 0 {
-            let guest_mac = self.fast_path_guest_mac.unwrap_or([0xFF; 6]);
-            let ack = crate::ethernet::build_tcp_ack_frame(&crate::ethernet::TcpFrameParams {
-                src_ip: conn.remote_ip,
-                dst_ip: conn.guest_ip,
-                src_port: conn.remote_port,
-                dst_port: conn.guest_port,
-                seq: conn.our_seq.load(std::sync::atomic::Ordering::Relaxed),
-                ack: conn.last_ack,
-                window: 65535,
-                src_mac: self.fast_path_gateway_mac,
-                dst_mac: guest_mac,
-            });
-            return Some(ack);
-        }
-
         // Extract payload using IPv4 total_length to exclude Ethernet padding.
         // NOTE: FIN check is deferred until after payload write — RFC 793
         // allows FIN segments to carry data.
@@ -405,10 +384,15 @@ impl TcpBridge {
             );
         }
 
-        // Only ACK frames that carried payload or a deferred FIN — replying
-        // to a pure ACK would create a dup-ACK loop that triggers fast
-        // retransmits on the peer and tanks host→VM throughput.
-        if payload_len == 0 && flags & 0x01 == 0 {
+        // Only ACK frames that carried payload, a deferred FIN, or a SYN.
+        // Replying to a pure ACK would create a dup-ACK loop that triggers
+        // fast retransmits on the peer and tanks host→VM throughput. A
+        // retransmitted SYN-ACK (the guest never saw our completing ACK, common
+        // on the inbound ActiveOpen path) is the one no-payload-no-FIN frame we
+        // must still ACK, or the guest retransmits until it times out — any
+        // data or FIN it carried was already handled by the paths above, so it
+        // is never dropped.
+        if payload_len == 0 && flags & (0x01 | 0x02) == 0 {
             return Some(Vec::new());
         }
 

--- a/common/splicetcp/src/tcp_bridge/tests.rs
+++ b/common/splicetcp/src/tcp_bridge/tests.rs
@@ -1911,3 +1911,84 @@ async fn malformed_data_offset_is_not_spliced_to_host() {
         "a rejected segment must not splice bytes to the host socket"
     );
 }
+
+/// A retransmitted SYN-ACK on an established flow (the guest never saw our
+/// completing ACK) must be re-ACKed, not swallowed, or the guest keeps
+/// retransmitting until it times out.
+#[tokio::test]
+async fn retransmitted_syn_ack_gets_reack() {
+    let mut bridge = TcpBridge::new(GW_IP);
+    bridge.set_fast_path_macs(GW_MAC, GUEST_MAC);
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let connect = tokio::net::TcpStream::connect(addr);
+    let (client, accepted) = tokio::join!(connect, listener.accept());
+    let (_accepted, _) = accepted.unwrap();
+
+    let dst_ip = Ipv4Addr::new(198, 18, 30, 110);
+    let key = SynFlowKey {
+        src_ip: GUEST_IP,
+        src_port: 40040,
+        dst_ip,
+        dst_port: 443,
+    };
+    // last_ack = 2000 ⇒ the guest's ISN was 1999 (SYN consumed one seq).
+    bridge.promote_to_fast_path(
+        key,
+        client.unwrap().into_std().unwrap(),
+        1000,
+        2000,
+        1460,
+        None,
+    );
+
+    // Retransmitted SYN-ACK at the ISN, no payload.
+    let syn_ack = make_guest_segment((40040, dst_ip, 443), 1999, 1000, 65535, 0x12, &[]);
+    let reply = bridge
+        .try_fast_path_intercept(&syn_ack)
+        .expect("intercepted");
+    assert!(
+        !reply.is_empty(),
+        "a retransmitted SYN-ACK must be re-ACKed"
+    );
+    assert_eq!(tcp_flags_of(&reply) & 0x10, 0x10, "reply carries ACK");
+    assert_eq!(tcp_ack_of(&reply), 2000, "re-ACK acknowledges the SYN");
+}
+
+/// A plain pure ACK (no SYN, no payload, no FIN) must still return nothing —
+/// re-ACKing it would start a dup-ACK loop. Guards the SYN carve-out above
+/// from swallowing the ordinary pure-ACK suppression.
+#[tokio::test]
+async fn pure_ack_returns_no_frame() {
+    let mut bridge = TcpBridge::new(GW_IP);
+    bridge.set_fast_path_macs(GW_MAC, GUEST_MAC);
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let connect = tokio::net::TcpStream::connect(addr);
+    let (client, accepted) = tokio::join!(connect, listener.accept());
+    let (_accepted, _) = accepted.unwrap();
+
+    let dst_ip = Ipv4Addr::new(198, 18, 30, 111);
+    let key = SynFlowKey {
+        src_ip: GUEST_IP,
+        src_port: 40041,
+        dst_ip,
+        dst_port: 443,
+    };
+    bridge.promote_to_fast_path(
+        key,
+        client.unwrap().into_std().unwrap(),
+        1000,
+        2000,
+        1460,
+        None,
+    );
+
+    let pure_ack = make_guest_segment((40041, dst_ip, 443), 2000, 1000, 65535, 0x10, &[]);
+    let reply = bridge
+        .try_fast_path_intercept(&pure_ack)
+        .expect("intercepted");
+    assert!(reply.is_empty(), "a pure ACK must not be answered");
+}


### PR DESCRIPTION
`try_fast_path_intercept` inspected RST and FIN but never the SYN bit. When the guest retransmitted its SYN / SYN-ACK on an already-promoted flow (it never saw our completing ACK — common on the inbound ActiveOpen port-forward path), the frame carried no payload and no FIN, so it hit the `payload_len == 0 && no FIN` early return and got **no reply at all** — the guest kept retransmitting until timeout, contributing to the flaky inbound multi-connection behavior the iperf3 e2e observed.

Detect the SYN bit on an established flow and re-send our ACK (as a real TCP stack does for a duplicate SYN-ACK in ESTABLISHED). 60 splicetcp tests pass; clippy (all-features) + fmt clean.

Note: the marquee inbound FIN-abortive-RST cause was already fixed in #473; the sibling ActiveOpen host-stream-liveness check is a remaining follow-up. Found by the cross-repo audit.