### PR TITLE
fix(virtio): return zero-capacity RX chains to the used ring instead of leaking

### DIFF
--- a/virt/arcbox-virtio-net/src/device/hot_path.rs
+++ b/virt/arcbox-virtio-net/src/device/hot_path.rs
@@ -230,8 +230,12 @@ impl VirtioNet {
             }
 
             if written == 0 {
-                // No writable space in this chain; drop the frame and leave the
-                // avail entry unconsumed (matches the legacy behavior).
+                // A chain with no writable capacity can't carry the frame, but
+                // it was already popped off the avail ring — return it to the
+                // used ring (zero length) so the guest reclaims the descriptor
+                // instead of leaking it forever (which drains the RX ring dry).
+                // The frame is dropped; TCP retransmits.
+                queue.push_used(chain.head_idx, 0);
                 continue;
             }
 

--- a/virt/arcbox-virtio-net/src/device/hot_path.rs
+++ b/virt/arcbox-virtio-net/src/device/hot_path.rs
@@ -171,7 +171,12 @@ impl VirtioNet {
         let used0 = queue.mem().read_u16(rx_qcfg.used_addr as usize + 2);
         queue.set_last_avail_idx(used0);
 
-        let mut injected = false;
+        // "Published" = we advanced the used ring and the guest must be
+        // interrupted so it reclaims the descriptors — true both for a real
+        // frame injection and for a zero-length completion of an unusable
+        // chain. Returning only on injection would leak the interrupt for a
+        // chain we consumed but couldn't fill, stalling RX.
+        let mut published = false;
         let hdr_len = VirtioNetHeader::SIZE;
         for _ in 0..64 {
             // Stop when the guest has no RX buffer posted.
@@ -234,25 +239,27 @@ impl VirtioNet {
                 // it was already popped off the avail ring — return it to the
                 // used ring (zero length) so the guest reclaims the descriptor
                 // instead of leaking it forever (which drains the RX ring dry).
-                // The frame is dropped; TCP retransmits.
+                // This advances the used ring, so the guest still needs the
+                // interrupt below. The frame is dropped; TCP retransmits.
                 queue.push_used(chain.head_idx, 0);
+                published = true;
                 continue;
             }
 
             queue.push_used(chain.head_idx, written as u32);
-            injected = true;
+            published = true;
         }
 
         // Publish avail_event for an EVENT_IDX guest (gated: the field sits past
         // the used ring when EVENT_IDX is not negotiated). RX publishes the
         // current avail.idx (not the consumed cursor): the host polls for frames
         // so it only wants a kick for RX buffers posted beyond what it has seen.
-        if injected && event_idx {
+        if published && event_idx {
             let avail_idx_now = queue.mem().read_u16(rx_qcfg.avail_addr as usize + 2);
             let avail_event_off = rx_qcfg.used_addr as usize + 4 + rx_qcfg.size as usize * 8;
             queue.mem().write_u16(avail_event_off, avail_idx_now);
         }
 
-        injected
+        published
     }
 }

--- a/virt/arcbox-virtio-vsock/src/device/rx_injection.rs
+++ b/virt/arcbox-virtio-vsock/src/device/rx_injection.rs
@@ -495,7 +495,11 @@ impl VirtioVsock {
         }
 
         if written == 0 {
-            return 0; // Nothing written — leave the avail entry unconsumed.
+            // The chain had no writable capacity, but it was already popped off
+            // the avail ring — return it to the used ring so the guest reclaims
+            // the descriptor instead of leaking it (which drains the RX ring).
+            queue.push_used(chain.head_idx, 0);
+            return 0;
         }
 
         queue.push_used(chain.head_idx, written as u32);

--- a/virt/arcbox-virtio-vsock/src/device/rx_injection.rs
+++ b/virt/arcbox-virtio-vsock/src/device/rx_injection.rs
@@ -358,15 +358,22 @@ impl VirtioVsock {
                 &packet,
             );
 
-            if written > 0 {
+            if let Some(n) = written {
+                // Consuming a chain advances the used ring — even a zero-length
+                // completion of an unusable chain — so the guest must be
+                // interrupted to reclaim the descriptor.
                 injected = true;
 
-                // Fire injected_notify for REQUEST ops — unblocks any
-                // daemon-side connect waiting in `connect_vsock_hv`.
-                if let Ok(mut mgr) = conns.lock() {
-                    if let Some(conn) = mgr.get_mut(&conn_id) {
-                        if let Some(tx) = conn.injected_notify.take() {
-                            let _ = tx.send(());
+                // Fire injected_notify only when the packet actually landed:
+                // a REQUEST op unblocks a daemon-side connect waiting in
+                // `connect_vsock_hv`. A zero-length completion delivered
+                // nothing, so it must not signal delivery.
+                if n > 0 {
+                    if let Ok(mut mgr) = conns.lock() {
+                        if let Some(conn) = mgr.get_mut(&conn_id) {
+                            if let Some(tx) = conn.injected_notify.take() {
+                                let _ = tx.send(());
+                            }
                         }
                     }
                 }
@@ -430,9 +437,11 @@ impl VirtioVsock {
     /// Writes `packet` into the next available RX descriptor chain.
     ///
     /// `desc_addr`, `avail_addr`, `used_addr` are slice offsets (already
-    /// translated from GPA by subtracting `gpa_base`). Returns the number
-    /// of bytes written, or 0 if no RX descriptor was available or the
-    /// descriptor chain ran out of writable buffer space.
+    /// translated from GPA by subtracting `gpa_base`). Returns `None` when no
+    /// RX descriptor was available (nothing consumed), `Some(0)` when a chain
+    /// was consumed but had no writable capacity (a zero-length used completion
+    /// — the guest still needs an interrupt to reclaim it), or `Some(n)` for
+    /// the number of bytes written.
     #[allow(clippy::too_many_arguments)]
     fn write_to_rx_descriptor(
         guest_mem: &mut [u8],
@@ -442,7 +451,7 @@ impl VirtioVsock {
         q_size: usize,
         gpa_base: usize,
         packet: &[u8],
-    ) -> usize {
+    ) -> Option<usize> {
         // Reconstruct a GPA-based QueueConfig from the offset arguments so the
         // queue resolves every address through GuestMemWriter exactly once.
         let cfg = QueueConfig {
@@ -470,7 +479,7 @@ impl VirtioVsock {
         queue.set_last_avail_idx(used0);
 
         let Some(chain) = queue.pop_avail() else {
-            return 0; // No available descriptors.
+            return None; // No available descriptors — nothing consumed.
         };
 
         // Walk the chain, scattering the packet into the write-only buffers.
@@ -498,11 +507,13 @@ impl VirtioVsock {
             // The chain had no writable capacity, but it was already popped off
             // the avail ring — return it to the used ring so the guest reclaims
             // the descriptor instead of leaking it (which drains the RX ring).
+            // Some(0), not None: the used ring advanced, so the caller must
+            // still interrupt the guest.
             queue.push_used(chain.head_idx, 0);
-            return 0;
+            return Some(0);
         }
 
         queue.push_used(chain.head_idx, written as u32);
-        written
+        Some(written)
     }
 }


### PR DESCRIPTION
## Problem (audit finding, HIGH — descriptor leak)

Both the virtio-net bridge RX path (`hot_path.rs` `poll_rx`) and the vsock RX injection (`rx_injection.rs`) popped an avail-ring chain and, when the chain had **no writable capacity** (`written == 0`), returned/continued **without pushing it to the used ring**. The descriptor was already consumed off the avail ring, so the guest never reclaimed it — a per-occurrence leak that eventually **drains the guest RX ring dry and stalls all RX** on that queue.

## Fix

Push the chain back to the used ring with zero length so the guest reclaims the descriptor; the frame is dropped (TCP retransmits).

The sibling **truncation** case (a chain with some but insufficient capacity) is deliberately left as-is: dropping those would risk legitimate large frames if MRG_RXBUF spans chains — that needs the mergeable-buffer semantics confirmed first (follow-up).

arcbox-virtio-net (59) + arcbox-virtio-vsock (74) tests pass; clippy + fmt clean. HV-only. Found by the cross-repo audit.