### PR TITLE
fix(net): abort an inbound ActiveOpen handshake when the host peer disconnects

### DIFF
--- a/common/splicetcp/src/tcp_bridge/handshake.rs
+++ b/common/splicetcp/src/tcp_bridge/handshake.rs
@@ -305,6 +305,23 @@ impl TcpBridge {
                     }
                 }
                 HandshakeRole::ActiveOpen => {
+                    // Stop driving the guest-side handshake if the host client
+                    // that opened this inbound connection already disconnected
+                    // (peek on the non-blocking stream: EOF or a hard error) —
+                    // otherwise we retransmit the SYN toward the guest for the
+                    // full TTL for a connection the peer has abandoned.
+                    let host_dead = conn.host_stream.as_ref().is_some_and(|s| {
+                        let mut probe = [0u8; 1];
+                        match s.peek(&mut probe) {
+                            Ok(0) => true, // clean EOF from the host peer
+                            Ok(_) => false,
+                            Err(e) => e.kind() != std::io::ErrorKind::WouldBlock,
+                        }
+                    });
+                    if host_dead {
+                        to_abort.push(*key);
+                        continue;
+                    }
                     if conn.saved_frame.is_none() {
                         let frame =
                             crate::ethernet::build_tcp_syn_frame(&crate::ethernet::SynParams {

--- a/common/splicetcp/src/tcp_bridge/handshake.rs
+++ b/common/splicetcp/src/tcp_bridge/handshake.rs
@@ -305,20 +305,44 @@ impl TcpBridge {
                     }
                 }
                 HandshakeRole::ActiveOpen => {
-                    // Stop driving the guest-side handshake if the host client
-                    // that opened this inbound connection already disconnected
-                    // (peek on the non-blocking stream: EOF or a hard error) —
-                    // otherwise we retransmit the SYN toward the guest for the
-                    // full TTL for a connection the peer has abandoned.
-                    let host_dead = conn.host_stream.as_ref().is_some_and(|s| {
+                    // Stop driving the guest-side handshake only if the host
+                    // client that opened this inbound connection reset it — a
+                    // hard socket error on the non-blocking peek. A clean EOF
+                    // (peek Ok(0)) is NOT abandonment: the client half-closed
+                    // its write side but can still receive our response, so we
+                    // let the handshake complete and the established fast path
+                    // propagate the EOF as a FIN, exactly as it does after
+                    // promotion. Treating EOF as dead here broke protocols that
+                    // write-half-close to signal end-of-input.
+                    let host_reset = conn.host_stream.as_ref().is_some_and(|s| {
                         let mut probe = [0u8; 1];
                         match s.peek(&mut probe) {
-                            Ok(0) => true, // clean EOF from the host peer
-                            Ok(_) => false,
+                            Ok(_) => false, // data or a clean EOF — peer is not gone
                             Err(e) => e.kind() != std::io::ErrorKind::WouldBlock,
                         }
                     });
-                    if host_dead {
+                    if host_reset {
+                        // If we already sent our SYN the guest may sit in
+                        // SYN-RECEIVED; clear it with an RST at seq = our_isn+1
+                        // (its RCV.NXT), which a RFC 5961 guest accepts —
+                        // `handshake_abort_rst`'s seq=0 is for the passive-open
+                        // (SYN-SENT) guest and would be dropped as out-of-window
+                        // here. With no SYN sent the guest has no state to clear.
+                        if conn.saved_frame.is_some() {
+                            out.push(crate::ethernet::build_tcp_rst_frame(
+                                &crate::ethernet::TcpFrameParams {
+                                    src_ip: key.dst_ip,
+                                    dst_ip: key.src_ip,
+                                    src_port: key.dst_port,
+                                    dst_port: key.src_port,
+                                    seq: conn.our_isn.wrapping_add(1),
+                                    ack: 0,
+                                    window: 0,
+                                    src_mac: conn.gw_mac,
+                                    dst_mac: conn.guest_mac,
+                                },
+                            ));
+                        }
                         to_abort.push(*key);
                         continue;
                     }

--- a/common/splicetcp/src/tcp_bridge/tests.rs
+++ b/common/splicetcp/src/tcp_bridge/tests.rs
@@ -244,6 +244,108 @@ async fn handshake_active_open_emits_syn_and_completes() {
     assert_eq!(bridge.fast_path_count(), 1);
 }
 
+/// A host client that half-closes (graceful FIN → peek EOF) before the guest
+/// SYN-ACK must NOT abort the handshake: the client can still receive our
+/// response, and the EOF should propagate as a FIN after promotion. Aborting
+/// here broke write-half-close request/response protocols.
+#[tokio::test]
+async fn active_open_host_eof_does_not_abort() {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let client = tokio::net::TcpStream::connect(addr).await.unwrap();
+    let (server, _) = listener.accept().await.unwrap();
+    let host_stream = client.into_std().unwrap();
+
+    let mut bridge = TcpBridge::new(GW_IP);
+    bridge.set_fast_path_macs(GW_MAC, GUEST_MAC);
+    let flow_key = SynFlowKey {
+        src_ip: GUEST_IP,
+        src_port: 8080,
+        dst_ip: GW_IP,
+        dst_port: 61501,
+    };
+    bridge.initiate_active_handshake(flow_key, host_stream, GW_MAC, GUEST_MAC);
+    let syn = bridge.poll_handshakes();
+    assert_eq!(syn[0][34 + 13], 0x02, "SYN emitted");
+
+    // Graceful close from the host peer: sends a FIN, so the shim's peek sees
+    // EOF (Ok(0)) — which must be treated as alive-but-half-closed, not dead.
+    drop(server);
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+    let out = bridge.poll_handshakes();
+    assert_eq!(
+        bridge.handshake_count(),
+        1,
+        "a clean EOF must not evict the handshake"
+    );
+    assert!(
+        out.iter().all(|f| f[34 + 13] & 0x04 == 0),
+        "no RST on a graceful half-close"
+    );
+}
+
+/// A host client that RESETS (hard socket error on peek) before the guest
+/// SYN-ACK aborts the handshake AND sends the guest an RST at seq=our_isn+1
+/// so a SYN-RECEIVED guest (which received our SYN) clears its half-open
+/// state immediately instead of lingering to its own timeout.
+#[tokio::test]
+async fn active_open_host_reset_aborts_with_guest_rst() {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let client = tokio::net::TcpStream::connect(addr).await.unwrap();
+    let (server, _) = listener.accept().await.unwrap();
+    let host_stream = client.into_std().unwrap();
+
+    let mut bridge = TcpBridge::new(GW_IP);
+    bridge.set_fast_path_macs(GW_MAC, GUEST_MAC);
+    let flow_key = SynFlowKey {
+        src_ip: GUEST_IP,
+        src_port: 8080,
+        dst_ip: GW_IP,
+        dst_port: 61502,
+    };
+    bridge.initiate_active_handshake(flow_key, host_stream, GW_MAC, GUEST_MAC);
+    let syn = bridge.poll_handshakes();
+    let tcp = 34;
+    assert_eq!(syn[0][tcp + 13], 0x02, "SYN emitted");
+    let our_isn = u32::from_be_bytes([
+        syn[0][tcp + 4],
+        syn[0][tcp + 5],
+        syn[0][tcp + 6],
+        syn[0][tcp + 7],
+    ]);
+
+    // Force a RST from the host peer: SO_LINGER=0 makes close send RST.
+    socket2::SockRef::from(&server)
+        .set_linger(Some(std::time::Duration::ZERO))
+        .unwrap();
+    drop(server);
+
+    // The RST may take a moment to land; poll until the handshake is evicted.
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(2);
+    let mut frames = Vec::new();
+    while bridge.handshake_count() > 0 && std::time::Instant::now() < deadline {
+        frames.extend(bridge.poll_handshakes());
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+    }
+    assert_eq!(
+        bridge.handshake_count(),
+        0,
+        "host reset must evict the handshake"
+    );
+    let rst = frames
+        .iter()
+        .find(|f| f[tcp + 13] & 0x04 != 0)
+        .expect("an RST must be sent to the guest");
+    let rst_seq = u32::from_be_bytes([rst[tcp + 4], rst[tcp + 5], rst[tcp + 6], rst[tcp + 7]]);
+    assert_eq!(
+        rst_seq,
+        our_isn.wrapping_add(1),
+        "RST seq must be our_isn+1 so a SYN-RECEIVED guest accepts it"
+    );
+}
+
 #[tokio::test]
 async fn handshake_rejects_mismatched_ack() {
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();


### PR DESCRIPTION
`poll_handshakes`'s ActiveOpen branch retransmitted the synthetic SYN toward the guest and checked only the global 7 s TTL — it never noticed when the host client that opened the inbound connection had **already disconnected**. ArcBox kept driving the guest SYN/retransmit sequence for up to the full TTL for an abandoned connection (and would hand the guest a stale half-open connection if it completed).

Peek the non-blocking `host_stream` at the top of the ActiveOpen branch; on a clean EOF or a hard error, abort (RST + evict). 60 splicetcp tests pass; clippy (all-features) + fmt clean.

This completes the **inbound multi-connection** robustness set alongside #473 (FIN half-close, the marquee abortive-RST cause) and #479 (retransmitted-SYN re-ACK). Found by the cross-repo audit.