### PR TITLE
fix(net): park out-of-order upload segments instead of dropping them

### DIFF
--- a/common/splicetcp/src/tcp_bridge/fast_path.rs
+++ b/common/splicetcp/src/tcp_bridge/fast_path.rs
@@ -753,7 +753,7 @@ impl TcpBridge {
                 up_would_block: 0,
                 up_short_writes: 0,
                 up_out_of_order: 0,
-                ooo_segs: Vec::new(),
+                ooo_segs: std::collections::VecDeque::new(),
                 ooo_bytes: 0,
                 up_ooo_dropped: 0,
                 window_stalled: false,

--- a/common/splicetcp/src/tcp_bridge/fast_path.rs
+++ b/common/splicetcp/src/tcp_bridge/fast_path.rs
@@ -197,13 +197,17 @@ impl TcpBridge {
         }
 
         // Write payload to host stream (if any). The invariant that keeps
-        // uploads lossless with no shim-side buffering: `last_ack` advances
-        // ONLY over bytes actually written, in order, to the host socket.
-        // Everything else (out-of-order arrival, WouldBlock, the unwritten
-        // tail of a short write) stays un-ACKed, so the guest's own
-        // fast-retransmit/RTO machinery repairs the stream — dup-ACKs from
-        // the fall-through below are the recovery signal. ACKing past
-        // unwritten bytes is how uploads silently lost data (2026-07-19).
+        // uploads lossless: `last_ack` advances ONLY over bytes actually
+        // written, in order, to the host socket. Everything else
+        // (WouldBlock, the unwritten tail of a short write) stays un-ACKed,
+        // so the guest's own fast-retransmit/RTO machinery repairs the
+        // stream — dup-ACKs from the fall-through below are the recovery
+        // signal. ACKing past unwritten bytes is how uploads silently lost
+        // data (2026-07-19). Out-of-order segments are parked un-ACKed in
+        // `ooo_segs` and written once the hole before them fills — parking
+        // (vs the old drop) is what keeps one lost frame from forcing the
+        // guest to retransmit the entire in-flight window.
+        let mut in_order_advanced = false;
         if payload_len > 0 {
             use std::io::Write;
             let seq_end = guest_seq.wrapping_add(payload_len as u32);
@@ -221,17 +225,20 @@ impl TcpBridge {
                 let overlap = conn.last_ack.wrapping_sub(guest_seq);
                 if overlap >= 0x8000_0000 {
                     // guest_seq is ahead of the cursor: a hole precedes this
-                    // segment. Writing it would corrupt the byte stream and
-                    // ACKing it would bury the hole forever. Leave last_ack
-                    // alone — the ACK below is a dup-ACK, which is exactly
-                    // what makes the guest fast-retransmit the gap.
+                    // segment. Writing it now would corrupt the byte stream
+                    // and ACKing it would bury the hole forever. Park it
+                    // (bounded) for delivery once the hole fills; leave
+                    // last_ack alone — the ACK below is a dup-ACK, which is
+                    // exactly what makes the guest fast-retransmit the gap.
                     conn.up_out_of_order += 1;
+                    conn.buffer_ooo_segment(guest_seq, &frame[payload_start..payload_end]);
                 } else {
                     let fresh = &frame[payload_start + overlap as usize..payload_end];
                     match conn.stream.write(fresh) {
                         Ok(n) => {
                             conn.up_bytes += n as u64;
                             conn.set_last_ack(conn.last_ack.wrapping_add(n as u32));
+                            in_order_advanced = true;
                             if n < fresh.len() {
                                 // Host socket buffer filled mid-segment: ACK
                                 // covers only what was written; the guest
@@ -249,6 +256,7 @@ impl TcpBridge {
                             // Peer closed; inject already relayed FIN. ACK at
                             // TCP layer so the guest stops retransmitting.
                             conn.set_last_ack(seq_end);
+                            in_order_advanced = true;
                             tracing::debug!(
                                 "Fast path TX: {src_ip}:{src_port}→{dst_ip}:{dst_port} Broken pipe, draining {payload_len} bytes"
                             );
@@ -277,6 +285,30 @@ impl TcpBridge {
                     }
                 }
             }
+        }
+
+        // A cursor advance may have landed right behind parked out-of-order
+        // segments — flush them now so the ACK below leaps over everything
+        // contiguous instead of forcing the guest to retransmit data that
+        // already arrived.
+        if in_order_advanced
+            && !conn.ooo_segs.is_empty()
+            && let Err(e) = conn.drain_parked_segments()
+        {
+            tracing::warn!("Fast path TX drain error, RST to guest: {e}");
+            let rst = crate::ethernet::build_tcp_rst_frame(&crate::ethernet::TcpFrameParams {
+                src_ip: conn.remote_ip,
+                dst_ip: conn.guest_ip,
+                src_port: conn.remote_port,
+                dst_port: conn.guest_port,
+                seq: conn.our_seq.load(std::sync::atomic::Ordering::Relaxed),
+                ack: conn.last_ack,
+                window: 0,
+                src_mac: self.fast_path_gateway_mac,
+                dst_mac: self.fast_path_guest_mac.unwrap_or([0xFF; 6]),
+            });
+            self.close_fast_path(&key);
+            return Some(rst);
         }
 
         // FIN handling — only once every byte before it has been written and
@@ -574,7 +606,7 @@ impl TcpBridge {
         if conn.up_would_block + conn.up_short_writes + conn.up_out_of_order + conn.retransmits > 0
         {
             tracing::debug!(
-                "Fast path close {}:{} → {}:{}: loss recovery (up: would_block={}, short_writes={}, out_of_order={}; down: retransmits={})",
+                "Fast path close {}:{} → {}:{}: loss recovery (up: would_block={}, short_writes={}, out_of_order={}, ooo_dropped={}; down: retransmits={})",
                 key.src_ip,
                 key.src_port,
                 key.dst_ip,
@@ -582,6 +614,7 @@ impl TcpBridge {
                 conn.up_would_block,
                 conn.up_short_writes,
                 conn.up_out_of_order,
+                conn.up_ooo_dropped,
                 conn.retransmits,
             );
         }
@@ -720,6 +753,9 @@ impl TcpBridge {
                 up_would_block: 0,
                 up_short_writes: 0,
                 up_out_of_order: 0,
+                ooo_segs: Vec::new(),
+                ooo_bytes: 0,
+                up_ooo_dropped: 0,
                 window_stalled: false,
                 retransmit_buf: std::collections::VecDeque::new(),
                 retransmit_seq: our_seq,

--- a/common/splicetcp/src/tcp_bridge/mod.rs
+++ b/common/splicetcp/src/tcp_bridge/mod.rs
@@ -91,6 +91,17 @@ const SHIM_WSCALE: u8 = 7;
 /// drop-and-dup-ACK, which the guest repairs by retransmitting.
 const OOO_REASSEMBLY_CAP: usize = 4 * 1024 * 1024;
 
+/// Upper bound on the *number* of parked out-of-order segments per flow.
+/// [`OOO_REASSEMBLY_CAP`] alone bounds only payload bytes, so a guest could
+/// otherwise park millions of 1-byte segments — exhausting memory in
+/// per-segment `Vec`/allocator overhead and driving quadratic insert/scan
+/// work on the datapath thread. A real out-of-order burst is at most one
+/// window's worth of MSS-sized segments accumulated over a sub-millisecond
+/// local RTT (a few hundred); 4096 clears that by a wide margin while
+/// capping the adversarial case. Segments past this fall back to
+/// drop-and-dup-ACK like the byte cap.
+const OOO_MAX_SEGMENTS: usize = 4096;
+
 /// MSS we advertise in handshake frames to the guest. 1460 is the standard
 /// Ethernet MSS (1500 MTU − 40 bytes IP+TCP). Host→guest large frames with
 /// GSO are unaffected — MSS only bounds the *guest's* segment size.
@@ -294,12 +305,15 @@ pub(super) struct FastPathConn {
     up_short_writes: u64,
     up_out_of_order: u64,
     /// Upload segments that arrived beyond the contiguous cursor, parked
-    /// until the hole before them fills: `(guest_seq, payload)`, sorted by
+    /// until the hole before them fills: `(guest_seq, payload)`, ordered by
     /// wrapping distance from `last_ack`. Parking turns one lost frame into
     /// one guest retransmission; dropping (the pre-2026-07 behavior) made
     /// recovery go-back-N across the whole 8 MiB advertised window, which
-    /// collapsed docker-bridge uploads to tens of Mbit/s.
-    ooo_segs: Vec<(u32, Vec<u8>)>,
+    /// collapsed docker-bridge uploads to tens of Mbit/s. A deque so the
+    /// drain pops contiguous segments off the front in O(1); a real burst
+    /// arrives in ascending order (append to back), so keeping it ordered is
+    /// cheap. Bounded by [`OOO_REASSEMBLY_CAP`] and [`OOO_MAX_SEGMENTS`].
+    ooo_segs: std::collections::VecDeque<(u32, Vec<u8>)>,
     /// Total payload bytes parked in `ooo_segs`; bounded by
     /// [`OOO_REASSEMBLY_CAP`].
     ooo_bytes: usize,
@@ -373,23 +387,28 @@ impl FastPathConn {
     pub(super) fn buffer_ooo_segment(&mut self, seq: u32, payload: &[u8]) {
         let base = self.last_ack;
         let rel = seq.wrapping_sub(base) as usize;
+        let idx = self
+            .ooo_segs
+            .partition_point(|(s, _)| (s.wrapping_sub(base) as usize) < rel);
+        let replaces_existing = matches!(self.ooo_segs.get(idx), Some((s, _)) if *s == seq);
         if rel.saturating_add(payload.len()) > OOO_REASSEMBLY_CAP
             || self.ooo_bytes.saturating_add(payload.len()) > OOO_REASSEMBLY_CAP
+            // A new distinct segment past the count cap is dropped; an
+            // in-place replacement of a parked seq does not grow the count.
+            || (!replaces_existing && self.ooo_segs.len() >= OOO_MAX_SEGMENTS)
         {
             self.up_ooo_dropped += 1;
             return;
         }
-        let idx = self
-            .ooo_segs
-            .partition_point(|(s, _)| (s.wrapping_sub(base) as usize) < rel);
-        if let Some((s, existing)) = self.ooo_segs.get(idx)
-            && *s == seq
-        {
-            if existing.len() >= payload.len() {
-                return; // duplicate of an already-parked segment
+        if replaces_existing {
+            // Same start seq already parked: keep whichever is longer (a
+            // retransmit may carry more data), never write the shorter twice.
+            if self.ooo_segs[idx].1.len() >= payload.len() {
+                return;
             }
-            let (_, old) = self.ooo_segs.remove(idx);
-            self.ooo_bytes -= old.len();
+            if let Some((_, old)) = self.ooo_segs.remove(idx) {
+                self.ooo_bytes -= old.len();
+            }
         }
         self.ooo_bytes += payload.len();
         self.ooo_segs.insert(idx, (seq, payload.to_vec()));
@@ -404,15 +423,16 @@ impl FastPathConn {
     /// drain). A hard write error propagates for the caller's RST teardown.
     pub(super) fn drain_parked_segments(&mut self) -> std::io::Result<()> {
         use std::io::Write;
-        while let Some(&(seq, ref data)) = self.ooo_segs.first() {
+        while let Some(&(seq, ref data)) = self.ooo_segs.front() {
             let len = data.len();
             let seg_end = seq.wrapping_add(len as u32);
             let extends = seg_end.wrapping_sub(self.last_ack);
             if extends == 0 || extends >= 0x8000_0000 {
                 // Fully at/behind the cursor: a retransmit landed in-order
                 // first and already covered these bytes.
-                let (_, old) = self.ooo_segs.remove(0);
-                self.ooo_bytes -= old.len();
+                if let Some((_, old)) = self.ooo_segs.pop_front() {
+                    self.ooo_bytes -= old.len();
+                }
                 continue;
             }
             let overlap = self.last_ack.wrapping_sub(seq);
@@ -430,8 +450,9 @@ impl FastPathConn {
                     // Peer closed — drain at the TCP layer like the in-order
                     // path so the guest stops retransmitting.
                     self.set_last_ack(seg_end);
-                    let (_, old) = self.ooo_segs.remove(0);
-                    self.ooo_bytes -= old.len();
+                    if let Some((_, old)) = self.ooo_segs.pop_front() {
+                        self.ooo_bytes -= old.len();
+                    }
                     continue;
                 }
                 Err(e) => return Err(e),
@@ -443,8 +464,9 @@ impl FastPathConn {
                 self.up_short_writes += 1;
                 break; // remainder stays parked; overlap math resumes here
             }
-            let (_, old) = self.ooo_segs.remove(0);
-            self.ooo_bytes -= old.len();
+            if let Some((_, old)) = self.ooo_segs.pop_front() {
+                self.ooo_bytes -= old.len();
+            }
         }
         Ok(())
     }

--- a/common/splicetcp/src/tcp_bridge/mod.rs
+++ b/common/splicetcp/src/tcp_bridge/mod.rs
@@ -83,6 +83,14 @@ const HANDSHAKE_TOTAL_TTL: std::time::Duration = std::time::Duration::from_secs(
 /// for any VM→Host BDP on a local loopback link.
 const SHIM_WSCALE: u8 = 7;
 
+/// Upper bound on parked out-of-order upload bytes per flow, and on how far
+/// past `last_ack` a parked segment may start. The [`SHIM_WSCALE`] window
+/// invites the guest to keep up to 8 MiB in flight, so a single lost frame
+/// can put megabytes of valid data behind a hole; parking is capped below
+/// the full window to bound memory. Segments past either cap fall back to
+/// drop-and-dup-ACK, which the guest repairs by retransmitting.
+const OOO_REASSEMBLY_CAP: usize = 4 * 1024 * 1024;
+
 /// MSS we advertise in handshake frames to the guest. 1460 is the standard
 /// Ethernet MSS (1500 MTU − 40 bytes IP+TCP). Host→guest large frames with
 /// GSO are unaffected — MSS only bounds the *guest's* segment size.
@@ -285,6 +293,19 @@ pub(super) struct FastPathConn {
     up_would_block: u64,
     up_short_writes: u64,
     up_out_of_order: u64,
+    /// Upload segments that arrived beyond the contiguous cursor, parked
+    /// until the hole before them fills: `(guest_seq, payload)`, sorted by
+    /// wrapping distance from `last_ack`. Parking turns one lost frame into
+    /// one guest retransmission; dropping (the pre-2026-07 behavior) made
+    /// recovery go-back-N across the whole 8 MiB advertised window, which
+    /// collapsed docker-bridge uploads to tens of Mbit/s.
+    ooo_segs: Vec<(u32, Vec<u8>)>,
+    /// Total payload bytes parked in `ooo_segs`; bounded by
+    /// [`OOO_REASSEMBLY_CAP`].
+    ooo_bytes: usize,
+    /// OOO segments discarded because a reassembly cap was exceeded
+    /// (recovered by guest retransmission, exactly as before parking existed).
+    up_ooo_dropped: u64,
     /// True while the flow sits at a zero send budget — transition
     /// logging only, so a stuck window is visible in the daemon log
     /// without per-poll noise.
@@ -340,6 +361,92 @@ impl FastPathConn {
         if let Some(ref shared) = self.last_ack_shared {
             shared.store(ack, std::sync::atomic::Ordering::Relaxed);
         }
+    }
+
+    /// Parks an upload segment that arrived beyond the contiguous cursor
+    /// (caller guarantees `seq` is strictly ahead of `last_ack`).
+    /// Deduplicates same-seq arrivals and enforces [`OOO_REASSEMBLY_CAP`]
+    /// on both total parked bytes and how far past the cursor a segment
+    /// may start. Parking never ACKs: `last_ack` still advances only over
+    /// bytes actually written to the host socket, in
+    /// [`Self::drain_parked_segments`].
+    pub(super) fn buffer_ooo_segment(&mut self, seq: u32, payload: &[u8]) {
+        let base = self.last_ack;
+        let rel = seq.wrapping_sub(base) as usize;
+        if rel.saturating_add(payload.len()) > OOO_REASSEMBLY_CAP
+            || self.ooo_bytes.saturating_add(payload.len()) > OOO_REASSEMBLY_CAP
+        {
+            self.up_ooo_dropped += 1;
+            return;
+        }
+        let idx = self
+            .ooo_segs
+            .partition_point(|(s, _)| (s.wrapping_sub(base) as usize) < rel);
+        if let Some((s, existing)) = self.ooo_segs.get(idx)
+            && *s == seq
+        {
+            if existing.len() >= payload.len() {
+                return; // duplicate of an already-parked segment
+            }
+            let (_, old) = self.ooo_segs.remove(idx);
+            self.ooo_bytes -= old.len();
+        }
+        self.ooo_bytes += payload.len();
+        self.ooo_segs.insert(idx, (seq, payload.to_vec()));
+    }
+
+    /// Writes parked out-of-order segments that the advanced `last_ack` now
+    /// reaches, in sequence order, with the same partial-take semantics as
+    /// the in-order path: the cursor advances only over bytes the host
+    /// socket accepted. Stops at the first remaining hole, `WouldBlock`, or
+    /// short take — whatever stays parked is re-driven by the guest's
+    /// retransmission machinery (an arriving retransmit re-enters this
+    /// drain). A hard write error propagates for the caller's RST teardown.
+    pub(super) fn drain_parked_segments(&mut self) -> std::io::Result<()> {
+        use std::io::Write;
+        while let Some(&(seq, ref data)) = self.ooo_segs.first() {
+            let len = data.len();
+            let seg_end = seq.wrapping_add(len as u32);
+            let extends = seg_end.wrapping_sub(self.last_ack);
+            if extends == 0 || extends >= 0x8000_0000 {
+                // Fully at/behind the cursor: a retransmit landed in-order
+                // first and already covered these bytes.
+                let (_, old) = self.ooo_segs.remove(0);
+                self.ooo_bytes -= old.len();
+                continue;
+            }
+            let overlap = self.last_ack.wrapping_sub(seq);
+            if overlap >= 0x8000_0000 {
+                break; // a hole still precedes the first parked segment
+            }
+            let start = overlap as usize;
+            let take = match self.stream.write(&self.ooo_segs[0].1[start..]) {
+                Ok(n) => n,
+                Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => {
+                    self.up_would_block += 1;
+                    break;
+                }
+                Err(e) if e.kind() == std::io::ErrorKind::BrokenPipe => {
+                    // Peer closed — drain at the TCP layer like the in-order
+                    // path so the guest stops retransmitting.
+                    self.set_last_ack(seg_end);
+                    let (_, old) = self.ooo_segs.remove(0);
+                    self.ooo_bytes -= old.len();
+                    continue;
+                }
+                Err(e) => return Err(e),
+            };
+            self.up_bytes += take as u64;
+            let new_ack = self.last_ack.wrapping_add(take as u32);
+            self.set_last_ack(new_ack);
+            if take < len - start {
+                self.up_short_writes += 1;
+                break; // remainder stays parked; overlap math resumes here
+            }
+            let (_, old) = self.ooo_segs.remove(0);
+            self.ooo_bytes -= old.len();
+        }
+        Ok(())
     }
 }
 

--- a/common/splicetcp/src/tcp_bridge/tests.rs
+++ b/common/splicetcp/src/tcp_bridge/tests.rs
@@ -982,6 +982,109 @@ async fn upload_ooo_beyond_cap_is_dropped() {
     assert_eq!(conn.up_ooo_dropped, 1);
 }
 
+/// Overlapping parked segments (different start seqs, e.g. from guest
+/// re-segmentation) must not double-write their overlap into the host
+/// stream: the drain's `overlap` offset skips bytes the advancing cursor
+/// already covered. `[2100,2200)` + `[2150,2250)` ⇒ 2000..2250 exactly once.
+#[tokio::test]
+async fn upload_ooo_overlapping_segments_write_each_byte_once() {
+    use std::io::Read;
+
+    let mut bridge = TcpBridge::new(GW_IP);
+    bridge.set_fast_path_macs(GW_MAC, GUEST_MAC);
+    let dst_ip = Ipv4Addr::new(198, 18, 30, 104);
+    let key = SynFlowKey {
+        src_ip: GUEST_IP,
+        src_port: 40036,
+        dst_ip,
+        dst_port: 443,
+    };
+    let mut server = fast_path_pair(&mut bridge, key, 2000).await;
+
+    // Two overlapping segments park behind the 2000..2100 hole. Their
+    // payloads agree on the overlap (2150..2200 = 0xBB), as a real TCP
+    // retransmit would.
+    let s_a = make_guest_segment((40036, dst_ip, 443), 2100, 1000, 65535, 0x18, &[0xBB; 100]);
+    assert_eq!(
+        tcp_ack_of(&bridge.try_fast_path_intercept(&s_a).unwrap()),
+        2000
+    );
+    let s_b = make_guest_segment((40036, dst_ip, 443), 2150, 1000, 65535, 0x18, &[0xBB; 100]);
+    assert_eq!(
+        tcp_ack_of(&bridge.try_fast_path_intercept(&s_b).unwrap()),
+        2000
+    );
+
+    // Fill the hole → both drain, overlap written once, ACK at 2250.
+    let fill = make_guest_segment((40036, dst_ip, 443), 2000, 1000, 65535, 0x18, &[0xAA; 100]);
+    let reply = bridge.try_fast_path_intercept(&fill).expect("intercepted");
+    assert_eq!(
+        tcp_ack_of(&reply),
+        2250,
+        "ACK must cover the union of overlapping segments, not their summed lengths"
+    );
+
+    let mut got = [0u8; 250];
+    server.read_exact(&mut got).unwrap();
+    assert!(got[..100].iter().all(|&b| b == 0xAA));
+    assert!(
+        got[100..].iter().all(|&b| b == 0xBB),
+        "overlap region intact, no shift"
+    );
+    // Exactly 250 bytes reached the server — no duplicated overlap tail.
+    server
+        .set_read_timeout(Some(std::time::Duration::from_millis(100)))
+        .unwrap();
+    let mut extra = [0u8; 1];
+    assert!(
+        matches!(server.read(&mut extra), Err(_) | Ok(0)),
+        "no bytes beyond the 250-byte union — overlap was not written twice"
+    );
+}
+
+/// A guest flooding tiny distinct out-of-order segments cannot exhaust the
+/// daemon: the parked-segment count is capped independently of the byte
+/// cap, and excess segments fall back to drop-and-dup-ACK.
+#[tokio::test]
+async fn upload_ooo_segment_count_is_bounded() {
+    let mut bridge = TcpBridge::new(GW_IP);
+    bridge.set_fast_path_macs(GW_MAC, GUEST_MAC);
+    let dst_ip = Ipv4Addr::new(198, 18, 30, 105);
+    let key = SynFlowKey {
+        src_ip: GUEST_IP,
+        src_port: 40037,
+        dst_ip,
+        dst_port: 443,
+    };
+    let _server = fast_path_pair(&mut bridge, key, 2000).await;
+
+    // 1-byte segments at 2002, 2004, … each sit past the 2000..2001 hole and
+    // never fill it, so every one parks. Total bytes stay far under the byte
+    // cap, so only the count cap can bound them.
+    let overshoot = 500u32;
+    for i in 0..(OOO_MAX_SEGMENTS as u32 + overshoot) {
+        let seq = 2002u32.wrapping_add(i * 2);
+        let seg = make_guest_segment((40037, dst_ip, 443), seq, 1000, 65535, 0x18, &[0x5A]);
+        assert_eq!(
+            tcp_ack_of(&bridge.try_fast_path_intercept(&seg).unwrap()),
+            2000
+        );
+    }
+
+    let conn = bridge.fast_path_conns.get(&key).unwrap();
+    assert_eq!(
+        conn.ooo_segs.len(),
+        OOO_MAX_SEGMENTS,
+        "parked segment count must be capped"
+    );
+    assert!(
+        conn.up_ooo_dropped >= overshoot as u64,
+        "segments past the cap must be dropped (got {})",
+        conn.up_ooo_dropped
+    );
+    assert!(conn.ooo_bytes <= OOO_REASSEMBLY_CAP);
+}
+
 /// Parking and draining must survive a sequence-number wraparound mid-gap.
 #[tokio::test]
 async fn upload_ooo_reassembly_across_seq_wraparound() {

--- a/common/splicetcp/src/tcp_bridge/tests.rs
+++ b/common/splicetcp/src/tcp_bridge/tests.rs
@@ -778,8 +778,9 @@ fn tcp_ack_of(frame: &[u8]) -> u32 {
 
 /// A segment arriving beyond the contiguous cursor (a hole precedes it)
 /// must not be written to the host socket and must not advance the ACK —
-/// the reply is a dup-ACK at the cursor. Filling the hole in order then
-/// delivers everything, bytes in the right order.
+/// the reply is a dup-ACK at the cursor. It is parked instead: filling the
+/// hole delivers everything, bytes in the right order, and the fill's ACK
+/// leaps over the parked data.
 #[tokio::test]
 async fn upload_hole_is_never_acked_or_written() {
     use std::io::Read;
@@ -812,10 +813,12 @@ async fn upload_hole_is_never_acked_or_written() {
         "hole ahead of the segment: reply must be a dup-ACK at the cursor"
     );
 
-    // Fill the hole in order, then retransmit the tail.
+    // Filling the hole delivers the parked tail too: the ACK leaps to the
+    // end of everything contiguous.
     let fill = make_guest_segment((40021, dst_ip, 443), 2000, 1000, 65535, 0x18, &[0xAA; 100]);
     let reply = bridge.try_fast_path_intercept(&fill).expect("intercepted");
-    assert_eq!(tcp_ack_of(&reply), 2100);
+    assert_eq!(tcp_ack_of(&reply), 2150);
+    // A late retransmit of the parked range is a duplicate — same ACK.
     let tail = make_guest_segment((40021, dst_ip, 443), 2100, 1000, 65535, 0x18, &[0xBB; 50]);
     let reply = bridge.try_fast_path_intercept(&tail).expect("intercepted");
     assert_eq!(tcp_ack_of(&reply), 2150);
@@ -831,6 +834,318 @@ async fn upload_hole_is_never_acked_or_written() {
     server.read_exact(&mut got).unwrap();
     assert!(got[..100].iter().all(|&b| b == 0xAA));
     assert!(got[100..].iter().all(|&b| b == 0xBB));
+}
+
+async fn fast_path_pair(
+    bridge: &mut TcpBridge,
+    key: SynFlowKey,
+    last_ack: u32,
+) -> std::net::TcpStream {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let connect = tokio::net::TcpStream::connect(addr);
+    let (client, accepted) = tokio::join!(connect, listener.accept());
+    let (accepted, _) = accepted.unwrap();
+    bridge.promote_to_fast_path(
+        key,
+        client.unwrap().into_std().unwrap(),
+        1000,
+        last_ack,
+        1460,
+        None,
+    );
+    let server = accepted.into_std().unwrap();
+    server.set_nonblocking(false).unwrap();
+    server
+        .set_read_timeout(Some(std::time::Duration::from_secs(2)))
+        .unwrap();
+    server
+}
+
+/// Multiple segments parked behind one hole are all delivered, in order,
+/// the moment the hole fills — the fill's ACK leaps over every parked
+/// byte, so one lost frame costs exactly one retransmission.
+#[tokio::test]
+async fn upload_ooo_reassembly_flushes_on_gap_fill() {
+    use std::io::Read;
+
+    let mut bridge = TcpBridge::new(GW_IP);
+    bridge.set_fast_path_macs(GW_MAC, GUEST_MAC);
+    let dst_ip = Ipv4Addr::new(198, 18, 30, 99);
+    let key = SynFlowKey {
+        src_ip: GUEST_IP,
+        src_port: 40031,
+        dst_ip,
+        dst_port: 443,
+    };
+    let mut server = fast_path_pair(&mut bridge, key, 2000).await;
+
+    // 2000..2100 is missing; the two segments behind it park as dup-ACKs.
+    let s2 = make_guest_segment((40031, dst_ip, 443), 2100, 1000, 65535, 0x18, &[0xBB; 50]);
+    let reply = bridge.try_fast_path_intercept(&s2).expect("intercepted");
+    assert_eq!(tcp_ack_of(&reply), 2000);
+    let s3 = make_guest_segment((40031, dst_ip, 443), 2150, 1000, 65535, 0x18, &[0xCC; 50]);
+    let reply = bridge.try_fast_path_intercept(&s3).expect("intercepted");
+    assert_eq!(tcp_ack_of(&reply), 2000);
+
+    let fill = make_guest_segment((40031, dst_ip, 443), 2000, 1000, 65535, 0x18, &[0xAA; 100]);
+    let reply = bridge.try_fast_path_intercept(&fill).expect("intercepted");
+    assert_eq!(
+        tcp_ack_of(&reply),
+        2200,
+        "fill must flush both parked segments and ACK past them"
+    );
+
+    let mut got = [0u8; 200];
+    server.read_exact(&mut got).unwrap();
+    assert!(got[..100].iter().all(|&b| b == 0xAA));
+    assert!(got[100..150].iter().all(|&b| b == 0xBB));
+    assert!(got[150..].iter().all(|&b| b == 0xCC));
+}
+
+/// A retransmitted copy of an already-parked segment must not be written
+/// twice: the byte stream stays exact.
+#[tokio::test]
+async fn upload_ooo_duplicate_parked_segment_writes_once() {
+    use std::io::Read;
+
+    let mut bridge = TcpBridge::new(GW_IP);
+    bridge.set_fast_path_macs(GW_MAC, GUEST_MAC);
+    let dst_ip = Ipv4Addr::new(198, 18, 30, 100);
+    let key = SynFlowKey {
+        src_ip: GUEST_IP,
+        src_port: 40032,
+        dst_ip,
+        dst_port: 443,
+    };
+    let mut server = fast_path_pair(&mut bridge, key, 2000).await;
+
+    let s2 = make_guest_segment((40032, dst_ip, 443), 2100, 1000, 65535, 0x18, &[0xBB; 50]);
+    bridge.try_fast_path_intercept(&s2).expect("intercepted");
+    bridge.try_fast_path_intercept(&s2).expect("intercepted");
+
+    let fill = make_guest_segment((40032, dst_ip, 443), 2000, 1000, 65535, 0x18, &[0xAA; 100]);
+    let reply = bridge.try_fast_path_intercept(&fill).expect("intercepted");
+    assert_eq!(tcp_ack_of(&reply), 2150);
+
+    // An in-order sentinel lands directly after — if the duplicate had been
+    // written, the stream would misalign and the content checks would fail.
+    let sentinel = make_guest_segment((40032, dst_ip, 443), 2150, 1000, 65535, 0x18, &[0xDD; 10]);
+    let reply = bridge
+        .try_fast_path_intercept(&sentinel)
+        .expect("intercepted");
+    assert_eq!(tcp_ack_of(&reply), 2160);
+
+    let mut got = [0u8; 160];
+    server.read_exact(&mut got).unwrap();
+    assert!(got[..100].iter().all(|&b| b == 0xAA));
+    assert!(got[100..150].iter().all(|&b| b == 0xBB));
+    assert!(got[150..].iter().all(|&b| b == 0xDD));
+}
+
+/// Segments beyond the reassembly cap are dropped, not parked — the
+/// pre-parking dup-ACK behavior, so memory stays bounded and the guest
+/// recovers by retransmitting.
+#[tokio::test]
+async fn upload_ooo_beyond_cap_is_dropped() {
+    let mut bridge = TcpBridge::new(GW_IP);
+    bridge.set_fast_path_macs(GW_MAC, GUEST_MAC);
+    let dst_ip = Ipv4Addr::new(198, 18, 30, 101);
+    let key = SynFlowKey {
+        src_ip: GUEST_IP,
+        src_port: 40033,
+        dst_ip,
+        dst_port: 443,
+    };
+    let _server = fast_path_pair(&mut bridge, key, 2000).await;
+
+    // Control: a near segment parks.
+    let near = make_guest_segment((40033, dst_ip, 443), 2100, 1000, 65535, 0x18, &[0xBB; 50]);
+    let reply = bridge.try_fast_path_intercept(&near).expect("intercepted");
+    assert_eq!(tcp_ack_of(&reply), 2000);
+    assert_eq!(bridge.fast_path_conns.get(&key).unwrap().ooo_bytes, 50);
+
+    // A segment starting past the cap horizon is dropped.
+    let far_seq = 2000u32.wrapping_add(OOO_REASSEMBLY_CAP as u32 + 1000);
+    let far = make_guest_segment(
+        (40033, dst_ip, 443),
+        far_seq,
+        1000,
+        65535,
+        0x18,
+        &[0xEE; 50],
+    );
+    let reply = bridge.try_fast_path_intercept(&far).expect("intercepted");
+    assert_eq!(tcp_ack_of(&reply), 2000);
+    let conn = bridge.fast_path_conns.get(&key).unwrap();
+    assert_eq!(conn.ooo_bytes, 50, "far-future segment must not be parked");
+    assert_eq!(conn.up_ooo_dropped, 1);
+}
+
+/// Parking and draining must survive a sequence-number wraparound mid-gap.
+#[tokio::test]
+async fn upload_ooo_reassembly_across_seq_wraparound() {
+    use std::io::Read;
+
+    let mut bridge = TcpBridge::new(GW_IP);
+    bridge.set_fast_path_macs(GW_MAC, GUEST_MAC);
+    let dst_ip = Ipv4Addr::new(198, 18, 30, 102);
+    let key = SynFlowKey {
+        src_ip: GUEST_IP,
+        src_port: 40034,
+        dst_ip,
+        dst_port: 443,
+    };
+    let base: u32 = u32::MAX - 60;
+    let mut server = fast_path_pair(&mut bridge, key, base).await;
+
+    // Parked segment sits entirely past the wrap point.
+    let tail_seq = base.wrapping_add(100);
+    let tail = make_guest_segment(
+        (40034, dst_ip, 443),
+        tail_seq,
+        1000,
+        65535,
+        0x18,
+        &[0xBB; 50],
+    );
+    let reply = bridge.try_fast_path_intercept(&tail).expect("intercepted");
+    assert_eq!(tcp_ack_of(&reply), base);
+
+    // The fill itself straddles the wrap.
+    let fill = make_guest_segment((40034, dst_ip, 443), base, 1000, 65535, 0x18, &[0xAA; 100]);
+    let reply = bridge.try_fast_path_intercept(&fill).expect("intercepted");
+    assert_eq!(tcp_ack_of(&reply), base.wrapping_add(150));
+
+    let mut got = [0u8; 150];
+    server.read_exact(&mut got).unwrap();
+    assert!(got[..100].iter().all(|&b| b == 0xAA));
+    assert!(got[100..].iter().all(|&b| b == 0xBB));
+}
+
+/// Property: draining parked segments obeys the same contract as in-order
+/// writes — the ACK never covers bytes the host socket did not take, and
+/// retransmitting from the cursor eventually delivers every byte exactly
+/// once even when the drain hits a full socket mid-segment.
+#[tokio::test]
+async fn upload_ooo_drain_respects_host_writable() {
+    use std::io::Read;
+
+    let mut bridge = TcpBridge::new(GW_IP);
+    bridge.set_fast_path_macs(GW_MAC, GUEST_MAC);
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let connect = tokio::net::TcpStream::connect(addr);
+    let (client, accepted) = tokio::join!(connect, listener.accept());
+    let std_client = client.unwrap().into_std().unwrap();
+    socket2::SockRef::from(&std_client)
+        .set_send_buffer_size(4096)
+        .unwrap();
+    let (accepted, _) = accepted.unwrap();
+    socket2::SockRef::from(&accepted)
+        .set_recv_buffer_size(4096)
+        .unwrap();
+
+    let dst_ip = Ipv4Addr::new(198, 18, 30, 103);
+    let key = SynFlowKey {
+        src_ip: GUEST_IP,
+        src_port: 40035,
+        dst_ip,
+        dst_port: 443,
+    };
+    bridge.promote_to_fast_path(key, std_client, 1000, 2000, 1460, None);
+
+    let mut server = accepted.into_std().unwrap();
+    server.set_nonblocking(false).unwrap();
+    server
+        .set_read_timeout(Some(std::time::Duration::from_millis(500)))
+        .unwrap();
+
+    // Position-dependent pattern (251 is prime, so no aliasing if a chunk
+    // were duplicated or skipped).
+    const HOLE: usize = 100;
+    const PARKED: usize = 16 * 1024;
+    const TOTAL: usize = HOLE + PARKED;
+    let payload: Vec<u8> = (0..TOTAL).map(|i| (i % 251) as u8).collect();
+    let base: u32 = 2000;
+
+    // Park far more than the shrunken socket can take, then fill the hole:
+    // the drain must stop at the socket's capacity, ACKing only taken bytes.
+    let parked = make_guest_segment(
+        (40035, dst_ip, 443),
+        base.wrapping_add(HOLE as u32),
+        1000,
+        65535,
+        0x18,
+        &payload[HOLE..],
+    );
+    let reply = bridge
+        .try_fast_path_intercept(&parked)
+        .expect("intercepted");
+    assert_eq!(tcp_ack_of(&reply), base);
+
+    let fill = make_guest_segment(
+        (40035, dst_ip, 443),
+        base,
+        1000,
+        65535,
+        0x18,
+        &payload[..HOLE],
+    );
+    let reply = bridge.try_fast_path_intercept(&fill).expect("intercepted");
+    let mut cursor = tcp_ack_of(&reply);
+    let first_advance = cursor.wrapping_sub(base) as usize;
+    assert!(
+        first_advance >= HOLE,
+        "the in-order fill itself must be ACKed"
+    );
+    assert!(
+        first_advance < TOTAL,
+        "4 KiB socket buffers cannot take all {TOTAL} bytes at once — \
+         the test must exercise the drain's partial-take stop"
+    );
+
+    // Retransmit from the cursor (the guest's recovery) until everything
+    // lands; drain the server as we go and verify every byte positionally.
+    let mut server_received = 0usize;
+    let mut read_buf = vec![0u8; 64 * 1024];
+    for _ in 0..2000 {
+        while server_received < cursor.wrapping_sub(base) as usize {
+            match server.read(&mut read_buf) {
+                Ok(0) => panic!("server EOF mid-transfer"),
+                Ok(n) => {
+                    for (j, &b) in read_buf[..n].iter().enumerate() {
+                        assert_eq!(
+                            b,
+                            payload[server_received + j],
+                            "byte at stream offset {} corrupted",
+                            server_received + j
+                        );
+                    }
+                    server_received += n;
+                }
+                Err(e) => panic!("ACKed bytes never reached the server: {e}"),
+            }
+        }
+        let offset = cursor.wrapping_sub(base) as usize;
+        if offset >= TOTAL {
+            break;
+        }
+        let chunk = &payload[offset..(offset + 8 * 1024).min(TOTAL)];
+        let seg = make_guest_segment((40035, dst_ip, 443), cursor, 1000, 65535, 0x18, chunk);
+        let reply = bridge.try_fast_path_intercept(&seg).expect("intercepted");
+        let acked = tcp_ack_of(&reply);
+        // The ACK may leap past this chunk (the drain flushes parked bytes
+        // behind it) but never past bytes that were never offered.
+        assert!(
+            acked.wrapping_sub(base) as usize <= TOTAL,
+            "ACK beyond the offered bytes"
+        );
+        cursor = acked;
+    }
+    assert_eq!(cursor.wrapping_sub(base) as usize, TOTAL);
+    assert_eq!(server_received, TOTAL);
 }
 
 /// A FIN whose sequence position lies beyond the cursor (its stream still


### PR DESCRIPTION
# Park out-of-order upload segments instead of dropping them

Root-cause fix for the **container upload 126x collapse** (docker-bridge
container → host upload at 22–75 Mbps vs 3.69 Gbps from `--net=host`,
found by the iperf3 matrix e2e, #461).

## Mechanism (why bridge collapsed and host-net didn't)

- The fast-path upload receiver **discarded every segment that arrived
  beyond the contiguous cursor** (`up_out_of_order += 1` + dup-ACK), with
  no reassembly buffer.
- The handshake advertises `SHIM_WSCALE = 7`, i.e. a **65535 × 128 = 8 MiB
  effective receive window** — the guest is invited to keep megabytes in
  flight.
- One seed loss (the docker-bridge veth/NAT forward path has no TSQ
  backpressure, so its bursts occasionally overrun a queue; `--net=host`
  traffic is TSQ-paced and never takes the seed loss — 0 retransmits)
  therefore made the shim throw away the **entire in-flight window** behind
  the hole. The shim sends no SACK, so the guest falls back to
  NewReno-style recovery: ~1 segment per RTT on partial ACKs, or a 200 ms
  RTO when the loss lands near a burst tail. Recovery-dominated throughput
  ≈ tens of Mbit/s, retransmit counts in the thousands — exactly the
  observed collapse (guest-side counters stay clean: eth0 `tx_drop=0`, the
  "loss" is manufactured by the discard).

## Fix

Park out-of-order segments in a bounded per-flow reassembly buffer
(`OOO_REASSEMBLY_CAP` = 4 MiB) instead of dropping them:

- `buffer_ooo_segment`: insert sorted by wrapping distance from
  `last_ack`, dedup same-seq retransmits, drop beyond-cap segments (the
  old behavior, so degradation is graceful and memory is bounded).
- `drain_parked_segments`: when an in-order write advances the cursor,
  flush contiguous parked segments into the host socket with the **same
  partial-take semantics as the in-order path** (short take / WouldBlock
  stop the drain; BrokenPipe drains at the TCP layer; hard errors RST the
  guest via the existing teardown).
- The ACK emitted after a gap-fill now leaps over everything parked →
  **one lost frame costs one retransmission** instead of a full-window
  go-back-N.

The lossless-upload invariant is unchanged: `last_ack` still advances
*only* over bytes actually written to the host socket. Parked data is
never ACKed until written, so a mid-recovery crash/close loses nothing the
guest wasn't already responsible for retransmitting.

## Not changed here

- No SACK emission (unnecessary once the ACK leaps over parked data).
- No shrink of the advertised window.
- The VZ NIC's missing TSO/GSO (`ethtool -k eth0`: `scatter-gather: off
  [fixed]`) is Apple's device feature set and stays as-is; it explains the
  MSS-sized frame flood, but the collapse amplifier was ours.

## Verification

- 6 unit tests (reassembly flush + ACK leap, duplicate parked segment
  writes once, beyond-cap fallback, seq wraparound mid-gap, drain vs full
  host socket property test, updated hole test).
- iperf3 matrix e2e (#461 reproducer) against a daemon with this fix
  (2026-07-21, full matrix green in 106 s):

| cell | before (#461 / audit runs) | after |
|---|---|---|
| bridge/upload/single | **0.022–0.075 Gbps**, 1300–3000 retrans | **3.09 Gbps** |
| bridge/upload/p4 | collapsed | 2.80 Gbps |
| hostnet/upload/single | 2.8–3.7 Gbps, 0 retrans | 2.82 Gbps |
| bridge÷hostnet upload ratio | up to 126x gap | **1.10 (parity)** |
| bridge/download/single | ~3.6 Gbps (was fine) | 3.64 Gbps (no regression) |
| hostnet/download/p4 | — | 5.40 Gbps (no regression) |

The e2e's own gap detector now reports "bridge upload is 0.9x slower
than bare-guest" — i.e. the gap is gone (its "(known gap)" labels are the
test's stale expectation and can flip to hard assertions once this and
#461 land).

Part of the 2026-07-21 cross-repo audit fix series (#472–#482). Touches
the same file as #473/#477/#479 — expect trivial merge conflicts with
whichever lands first.
