### PR TITLE
fix(net): detect and reap zombie fast-path flows on both legs

### DIFF
--- a/common/splicetcp/Cargo.toml
+++ b/common/splicetcp/Cargo.toml
@@ -16,6 +16,7 @@ arcbox-packet = { workspace = true }
 arcbox-proxy = { workspace = true }
 crossbeam-channel = "0.5"
 libc = { workspace = true }
+socket2 = "0.6"
 tokio = { workspace = true }
 tracing = { workspace = true }
 
@@ -28,6 +29,3 @@ tokio-frame-sink = []
 
 [lints]
 workspace = true
-
-[dev-dependencies]
-socket2 = "0.6"

--- a/common/splicetcp/src/tcp_bridge/fast_path.rs
+++ b/common/splicetcp/src/tcp_bridge/fast_path.rs
@@ -117,6 +117,9 @@ impl TcpBridge {
         };
 
         let conn = self.fast_path_conns.get_mut(&key)?;
+        // Any guest frame for the flow — data, ACK, dup-ACK, even a bare
+        // window probe — is its sign of life for the dead-flow reaper.
+        conn.last_guest_activity = std::time::Instant::now();
 
         let guest_seq = u32::from_be_bytes([
             frame[l4_start + 4],
@@ -428,6 +431,7 @@ impl TcpBridge {
             guest_mac,
         };
         let now = std::time::Instant::now();
+        let dead_flow_timeout = self.dead_flow_timeout;
 
         for (key, conn) in &mut self.fast_path_conns {
             if conn.inline_owned {
@@ -468,6 +472,40 @@ impl TcpBridge {
                     .min(super::HONORED_WINDOW_CAP);
                 let in_flight = sent.wrapping_sub(acked);
                 let nothing_in_flight = in_flight == 0 || in_flight >= 0x8000_0000;
+                // Dead-flow give-up: the inline path has no RTO, so a guest
+                // that vanished with data in flight freezes the send budget
+                // and would hold the entry, host fd, and owner task forever
+                // (the persist probe below never fires while bytes are
+                // outstanding). Soliciting = unACKed data outstanding or a
+                // closed window under persist; either demands a guest reply,
+                // so prolonged silence means the endpoint is gone.
+                if (!nothing_in_flight || conn.window_stalled_at.is_some())
+                    && now.duration_since(conn.last_guest_activity) >= dead_flow_timeout
+                {
+                    tracing::warn!(
+                        "Fast path: guest silent {:?} on soliciting inline flow {}:{} → {}:{}, RST + reap",
+                        dead_flow_timeout,
+                        key.src_ip,
+                        key.src_port,
+                        key.dst_ip,
+                        key.dst_port,
+                    );
+                    frames.push(crate::ethernet::build_tcp_rst_frame(
+                        &crate::ethernet::TcpFrameParams {
+                            src_ip: conn.remote_ip,
+                            dst_ip: conn.guest_ip,
+                            src_port: conn.remote_port,
+                            dst_port: conn.guest_port,
+                            seq: sent,
+                            ack: conn.last_ack,
+                            window: 0,
+                            src_mac: gw_mac,
+                            dst_mac: guest_mac,
+                        },
+                    ));
+                    to_remove.push(*key);
+                    continue;
+                }
                 if super::send_budget(sent, acked, window) == 0 && nothing_in_flight {
                     match conn.window_stalled_at {
                         None => conn.window_stalled_at = Some(now),
@@ -545,6 +583,39 @@ impl TcpBridge {
             }
             let sent = conn.our_seq.load(std::sync::atomic::Ordering::Relaxed);
             let in_flight = sent.wrapping_sub(acked);
+            // Dead-flow give-up: while soliciting (unACKed data or FIN being
+            // RTO-retransmitted, or a closed window under persist probes) a
+            // live guest always answers — with at least a dup-ACK or a
+            // window-bearing ACK. Prolonged total silence means the guest
+            // endpoint is gone; without this the RTO path retransmits forever
+            // and the entry leaks its fd and retransmission buffer.
+            let soliciting =
+                (in_flight > 0 && in_flight < 0x8000_0000) || conn.window_stalled_at.is_some();
+            if soliciting && now.duration_since(conn.last_guest_activity) >= dead_flow_timeout {
+                tracing::warn!(
+                    "Fast path: guest silent {:?} on soliciting flow {}:{} → {}:{}, RST + reap",
+                    dead_flow_timeout,
+                    key.src_ip,
+                    key.src_port,
+                    key.dst_ip,
+                    key.dst_port,
+                );
+                frames.push(crate::ethernet::build_tcp_rst_frame(
+                    &crate::ethernet::TcpFrameParams {
+                        src_ip: conn.remote_ip,
+                        dst_ip: conn.guest_ip,
+                        src_port: conn.remote_port,
+                        dst_port: conn.guest_port,
+                        seq: sent,
+                        ack: conn.last_ack,
+                        window: 0,
+                        src_mac: gw_mac,
+                        dst_mac: guest_mac,
+                    },
+                ));
+                to_remove.push(*key);
+                continue;
+            }
             if in_flight > 0 && in_flight < 0x8000_0000 {
                 let timed_out = now.duration_since(conn.last_progress) >= conn.rto;
                 if conn.fast_retransmit || timed_out {
@@ -812,6 +883,17 @@ impl TcpBridge {
         // Set non-blocking for polling in the event loop.
         stream.set_nonblocking(true).ok();
         stream.set_nodelay(true).ok();
+        // Keepalive on the upstream leg: a silently dead upstream (route
+        // flap, crashed proxy) otherwise never errors, leaving the guest leg
+        // ESTABLISHED forever. Applies to the underlying socket, so inline
+        // owners reading a cloned fd inherit it. See UPSTREAM_KEEPALIVE_*.
+        let keepalive = socket2::TcpKeepalive::new()
+            .with_time(super::UPSTREAM_KEEPALIVE_IDLE)
+            .with_interval(super::UPSTREAM_KEEPALIVE_INTERVAL)
+            .with_retries(super::UPSTREAM_KEEPALIVE_RETRIES);
+        if let Err(e) = socket2::SockRef::from(&stream).set_tcp_keepalive(&keepalive) {
+            tracing::warn!("Fast path: keepalive setup failed for {key:?}: {e}");
+        }
 
         let last_ack_atomic = std::sync::Arc::new(std::sync::atomic::AtomicU32::new(last_ack));
         let our_seq_atomic = std::sync::Arc::new(std::sync::atomic::AtomicU32::new(our_seq));
@@ -936,6 +1018,7 @@ impl TcpBridge {
                 down_bytes: 0,
                 down_shared: if inline_owned { down_shared } else { None },
                 dead,
+                last_guest_activity: std::time::Instant::now(),
             },
         );
     }

--- a/common/splicetcp/src/tcp_bridge/fast_path.rs
+++ b/common/splicetcp/src/tcp_bridge/fast_path.rs
@@ -478,8 +478,19 @@ impl TcpBridge {
                 // (the persist probe below never fires while bytes are
                 // outstanding). Soliciting = unACKed data outstanding or a
                 // closed window under persist; either demands a guest reply,
-                // so prolonged silence means the endpoint is gone.
-                if (!nothing_in_flight || conn.window_stalled_at.is_some())
+                // so prolonged unanswered soliciting means the endpoint is
+                // gone. Both clocks must be stale — the soliciting clock
+                // starts fresh when a long-idle flow's owner resumes sending,
+                // so its guest gets the full deadline to answer.
+                let soliciting = !nothing_in_flight || conn.window_stalled_at.is_some();
+                if !soliciting {
+                    conn.soliciting_since = None;
+                } else if conn.soliciting_since.is_none() {
+                    conn.soliciting_since = Some(now);
+                }
+                if conn
+                    .soliciting_since
+                    .is_some_and(|since| now.duration_since(since) >= dead_flow_timeout)
                     && now.duration_since(conn.last_guest_activity) >= dead_flow_timeout
                 {
                     tracing::warn!(
@@ -586,12 +597,24 @@ impl TcpBridge {
             // Dead-flow give-up: while soliciting (unACKed data or FIN being
             // RTO-retransmitted, or a closed window under persist probes) a
             // live guest always answers — with at least a dup-ACK or a
-            // window-bearing ACK. Prolonged total silence means the guest
-            // endpoint is gone; without this the RTO path retransmits forever
-            // and the entry leaks its fd and retransmission buffer.
+            // window-bearing ACK. Prolonged unanswered soliciting means the
+            // guest endpoint is gone; without this the RTO path retransmits
+            // forever and the entry leaks its fd and retransmission buffer.
+            // Both clocks must be stale: a long-idle flow whose upstream just
+            // woke up starts the soliciting clock here and now, so its guest
+            // gets the full deadline to answer despite an ancient last frame.
             let soliciting =
                 (in_flight > 0 && in_flight < 0x8000_0000) || conn.window_stalled_at.is_some();
-            if soliciting && now.duration_since(conn.last_guest_activity) >= dead_flow_timeout {
+            if !soliciting {
+                conn.soliciting_since = None;
+            } else if conn.soliciting_since.is_none() {
+                conn.soliciting_since = Some(now);
+            }
+            if conn
+                .soliciting_since
+                .is_some_and(|since| now.duration_since(since) >= dead_flow_timeout)
+                && now.duration_since(conn.last_guest_activity) >= dead_flow_timeout
+            {
                 tracing::warn!(
                     "Fast path: guest silent {:?} on soliciting flow {}:{} → {}:{}, RST + reap",
                     dead_flow_timeout,
@@ -1019,6 +1042,7 @@ impl TcpBridge {
                 down_shared: if inline_owned { down_shared } else { None },
                 dead,
                 last_guest_activity: std::time::Instant::now(),
+                soliciting_since: None,
             },
         );
     }

--- a/common/splicetcp/src/tcp_bridge/mod.rs
+++ b/common/splicetcp/src/tcp_bridge/mod.rs
@@ -87,6 +87,33 @@ const HANDSHAKE_TOTAL_TTL: std::time::Duration = std::time::Duration::from_secs(
 /// live response while still bounding a hostile guest's accumulated entries.
 const HALF_CLOSE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(120);
 
+/// Give-up deadline for a flow whose guest has gone silent while the shim is
+/// actively soliciting a response — retransmitting unACKed data or a FIN, or
+/// persist-probing a closed receive window. A live guest answers every
+/// solicit (a retransmit elicits at least a dup-ACK; a persist probe elicits
+/// a window-bearing ACK per RFC 793 §3.9), so five minutes of silence means
+/// the guest endpoint is gone (container netns torn down, VM wedged) and the
+/// entry would otherwise retransmit forever and leak its host fd plus up to
+/// [`HONORED_WINDOW_CAP`] of retransmission buffer. Deliberately generous so
+/// a paused-then-resumed VM (see `arcbox-vz` pause / sandbox checkpoint)
+/// keeps its in-flight flows across any reasonable pause. Purely idle flows
+/// (nothing in flight, window open) are never reaped — matching real TCP,
+/// which keeps quiescent connections indefinitely.
+const DEAD_FLOW_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(300);
+
+/// TCP keepalive for the host-side (upstream) leg of every fast-path flow.
+/// Without it a silently dead upstream — a default-route flap, a crashed
+/// system proxy, a NAT timeout — never surfaces on the socket: reads stay
+/// `WouldBlock` forever and the guest leg sits ESTABLISHED with empty queues
+/// until the guest app gives up (observed in prod: `apk` hung 23+ minutes).
+/// With keepalive the kernel probes an idle upstream and turns its death
+/// into a read error, which `poll_fast_path` / the inline owners already
+/// propagate as a guest RST. Idle 60 s + 4 probes × 15 s ⇒ a dead upstream
+/// is detected within ~2 minutes of its last byte.
+const UPSTREAM_KEEPALIVE_IDLE: std::time::Duration = std::time::Duration::from_secs(60);
+const UPSTREAM_KEEPALIVE_INTERVAL: std::time::Duration = std::time::Duration::from_secs(15);
+const UPSTREAM_KEEPALIVE_RETRIES: u32 = 4;
+
 /// Window scale we advertise to the guest. Shift by 7 = 128× scaling,
 /// giving an effective receive window of 65535 × 128 = 8 MiB. Sufficient
 /// for any VM→Host BDP on a local loopback link.
@@ -270,6 +297,9 @@ pub struct TcpBridge {
     /// waiting for the next guest frame or timer tick (an idle loop
     /// otherwise adds up to a full tick of connect latency).
     handshake_waker: Option<std::sync::Arc<tokio::sync::Notify>>,
+    /// Silence deadline before a soliciting flow is declared dead
+    /// ([`DEAD_FLOW_TIMEOUT`]; overridable in tests).
+    dead_flow_timeout: std::time::Duration,
 }
 
 /// A TCP connection promoted to the fast path — bypasses any TCP state
@@ -394,6 +424,13 @@ pub(super) struct FastPathConn {
     /// unset so the entry survives for the guest's close handshake. `Some`
     /// only when `inline_owned` (ABX-431).
     dead: Option<std::sync::Arc<std::sync::atomic::AtomicBool>>,
+    /// Last time any guest frame for this flow reached
+    /// `try_fast_path_intercept` — the flow's sign of life. While the shim is
+    /// soliciting a response (data/FIN in flight, or a closed window being
+    /// persist-probed) and this goes stale past [`DEAD_FLOW_TIMEOUT`], the
+    /// guest endpoint is gone and the flow is RST-reaped instead of
+    /// retransmitting forever.
+    last_guest_activity: StdInstant,
 }
 
 impl FastPathConn {
@@ -536,7 +573,13 @@ impl TcpBridge {
             observer: None,
             handshake_conns: HashMap::new(),
             handshake_waker: None,
+            dead_flow_timeout: DEAD_FLOW_TIMEOUT,
         }
+    }
+
+    #[cfg(test)]
+    pub(super) fn set_dead_flow_timeout(&mut self, timeout: std::time::Duration) {
+        self.dead_flow_timeout = timeout;
     }
 
     /// Installs a waker notified whenever an async host connect for a

--- a/common/splicetcp/src/tcp_bridge/mod.rs
+++ b/common/splicetcp/src/tcp_bridge/mod.rs
@@ -91,11 +91,15 @@ const HALF_CLOSE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(1
 /// actively soliciting a response — retransmitting unACKed data or a FIN, or
 /// persist-probing a closed receive window. A live guest answers every
 /// solicit (a retransmit elicits at least a dup-ACK; a persist probe elicits
-/// a window-bearing ACK per RFC 793 §3.9), so five minutes of silence means
-/// the guest endpoint is gone (container netns torn down, VM wedged) and the
-/// entry would otherwise retransmit forever and leak its host fd plus up to
-/// [`HONORED_WINDOW_CAP`] of retransmission buffer. Deliberately generous so
-/// a paused-then-resumed VM (see `arcbox-vz` pause / sandbox checkpoint)
+/// a window-bearing ACK per RFC 793 §3.9), so five minutes of unanswered
+/// soliciting means the guest endpoint is gone (container netns torn down,
+/// VM wedged) and the entry would otherwise retransmit forever and leak its
+/// host fd plus up to [`HONORED_WINDOW_CAP`] of retransmission buffer. Both
+/// clocks must be stale: five minutes of *continuous soliciting* AND five
+/// minutes since the last guest frame — a long-idle flow whose upstream
+/// wakes up starts the soliciting clock fresh at the wake-up, so its guest
+/// gets the full deadline to answer. Deliberately generous so a
+/// paused-then-resumed VM (see `arcbox-vz` pause / sandbox checkpoint)
 /// keeps its in-flight flows across any reasonable pause. Purely idle flows
 /// (nothing in flight, window open) are never reaped — matching real TCP,
 /// which keeps quiescent connections indefinitely.
@@ -431,6 +435,11 @@ pub(super) struct FastPathConn {
     /// guest endpoint is gone and the flow is RST-reaped instead of
     /// retransmitting forever.
     last_guest_activity: StdInstant,
+    /// When the current uninterrupted stretch of soliciting began; `None`
+    /// while quiescent. The reap deadline runs against this too, so a
+    /// long-idle flow whose upstream wakes up is measured from the wake-up —
+    /// not from its (legitimately ancient) last guest frame.
+    soliciting_since: Option<StdInstant>,
 }
 
 impl FastPathConn {

--- a/common/splicetcp/src/tcp_bridge/tests.rs
+++ b/common/splicetcp/src/tcp_bridge/tests.rs
@@ -2249,3 +2249,294 @@ async fn zero_window_stall_is_broken_by_a_persist_probe() {
         "sending must resume once the window reopens"
     );
 }
+
+// -------- Zombie-flow guards: upstream keepalive + dead-guest give-up --------
+// Regression net for the 2026-07-19 prod zombie: a silently dead upstream leg
+// left the guest leg ESTABLISHED forever (apk hung 23+ minutes), and a
+// vanished guest endpoint would leave the shim soliciting forever.
+
+/// Backdates a flow's sign-of-life clock so the dead-flow deadline is already
+/// past, without sleeping in the test.
+fn backdate_guest_activity(bridge: &mut TcpBridge, key: &SynFlowKey, by: std::time::Duration) {
+    bridge
+        .fast_path_conns
+        .get_mut(key)
+        .unwrap()
+        .last_guest_activity = std::time::Instant::now()
+        .checked_sub(by)
+        .expect("test clock underflow");
+}
+
+/// Promotion must arm TCP keepalive on the upstream socket: a silently dead
+/// upstream (route flap, crashed proxy) otherwise never errors, and the guest
+/// leg stays ESTABLISHED with empty queues forever.
+#[tokio::test]
+async fn promotion_arms_upstream_keepalive() {
+    let mut bridge = TcpBridge::new(GW_IP);
+    bridge.set_fast_path_macs(GW_MAC, GUEST_MAC);
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let connect = tokio::net::TcpStream::connect(addr);
+    let (client, _accepted) = tokio::join!(connect, listener.accept());
+    let std_client = client.unwrap().into_std().unwrap();
+    // A cloned fd shares the underlying socket, so it observes the option.
+    let probe = std_client.try_clone().unwrap();
+    assert!(
+        !socket2::SockRef::from(&probe).keepalive().unwrap(),
+        "precondition: keepalive off before promotion"
+    );
+
+    let dst_ip = Ipv4Addr::new(198, 18, 30, 140);
+    let key = SynFlowKey {
+        src_ip: GUEST_IP,
+        src_port: 40100,
+        dst_ip,
+        dst_port: 443,
+    };
+    bridge.promote_to_fast_path(key, std_client, 1000, 2000, 1460, None);
+
+    assert!(
+        socket2::SockRef::from(&probe).keepalive().unwrap(),
+        "promotion must enable keepalive on the upstream leg"
+    );
+}
+
+/// A guest that vanishes with unACKed data in flight must be RST-reaped after
+/// the dead-flow deadline instead of being retransmitted to forever (leaking
+/// the entry, host fd, and retransmission buffer).
+#[tokio::test]
+async fn silent_guest_with_data_in_flight_is_rst_reaped() {
+    use std::io::Write;
+
+    let mut bridge = TcpBridge::new(GW_IP);
+    bridge.set_fast_path_macs(GW_MAC, GUEST_MAC);
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let connect = tokio::net::TcpStream::connect(addr);
+    let (client, accepted) = tokio::join!(connect, listener.accept());
+    let (server, _) = accepted.unwrap();
+    let mut server = server.into_std().unwrap();
+
+    let dst_ip = Ipv4Addr::new(198, 18, 30, 141);
+    let key = SynFlowKey {
+        src_ip: GUEST_IP,
+        src_port: 40101,
+        dst_ip,
+        dst_port: 443,
+    };
+    bridge.promote_to_fast_path(
+        key,
+        client.unwrap().into_std().unwrap(),
+        1000,
+        2000,
+        1460,
+        None,
+    );
+
+    // Upstream data goes into flight; the guest never ACKs a byte of it.
+    server.write_all(b"unacked-data").unwrap();
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(2);
+    let mut in_flight = false;
+    while !in_flight && std::time::Instant::now() < deadline {
+        in_flight = !bridge.poll_fast_path().is_empty();
+        tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+    }
+    assert!(in_flight, "data must go into flight toward the guest");
+
+    bridge.set_dead_flow_timeout(std::time::Duration::from_millis(100));
+    backdate_guest_activity(&mut bridge, &key, std::time::Duration::from_millis(200));
+
+    let frames = bridge.poll_fast_path();
+    assert!(
+        frames.iter().any(|f| tcp_flags_of(f) & 0x04 != 0),
+        "a dead soliciting flow must be RST-terminated"
+    );
+    assert_eq!(bridge.fast_path_count(), 0, "the dead flow must be reaped");
+}
+
+/// A guest that closed its receive window and then vanished (persist probes
+/// go unanswered) must be reaped too — the zero-window arm of the give-up.
+#[tokio::test]
+async fn silent_guest_at_zero_window_is_rst_reaped() {
+    use std::io::Write;
+
+    let mut bridge = TcpBridge::new(GW_IP);
+    bridge.set_fast_path_macs(GW_MAC, GUEST_MAC);
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let connect = tokio::net::TcpStream::connect(addr);
+    let (client, accepted) = tokio::join!(connect, listener.accept());
+    let (server, _) = accepted.unwrap();
+    let mut server = server.into_std().unwrap();
+
+    let dst_ip = Ipv4Addr::new(198, 18, 30, 142);
+    let key = SynFlowKey {
+        src_ip: GUEST_IP,
+        src_port: 40102,
+        dst_ip,
+        dst_port: 443,
+    };
+    bridge.promote_to_fast_path(
+        key,
+        client.unwrap().into_std().unwrap(),
+        1000,
+        2000,
+        1460,
+        None,
+    );
+
+    // Guest shuts its window with upstream data pending, then goes silent.
+    let zero_win = make_guest_segment((40102, dst_ip, 443), 2000, 1000, 0, 0x10, &[]);
+    bridge.try_fast_path_intercept(&zero_win);
+    server.write_all(b"pending").unwrap();
+    assert!(
+        bridge.poll_fast_path().is_empty(),
+        "a closed window sends nothing (persist clock armed)"
+    );
+
+    bridge.set_dead_flow_timeout(std::time::Duration::from_millis(100));
+    backdate_guest_activity(&mut bridge, &key, std::time::Duration::from_millis(200));
+
+    let frames = bridge.poll_fast_path();
+    assert!(
+        frames.iter().any(|f| tcp_flags_of(f) & 0x04 != 0),
+        "a dead zero-window flow must be RST-terminated"
+    );
+    assert_eq!(bridge.fast_path_count(), 0, "the dead flow must be reaped");
+}
+
+/// Any guest frame — here a dup-ACK — is a sign of life that must reset the
+/// dead-flow clock: a slow guest is not a dead guest.
+#[tokio::test]
+async fn guest_ack_refreshes_dead_flow_clock() {
+    use std::io::Write;
+
+    let mut bridge = TcpBridge::new(GW_IP);
+    bridge.set_fast_path_macs(GW_MAC, GUEST_MAC);
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let connect = tokio::net::TcpStream::connect(addr);
+    let (client, accepted) = tokio::join!(connect, listener.accept());
+    let (server, _) = accepted.unwrap();
+    let mut server = server.into_std().unwrap();
+
+    let dst_ip = Ipv4Addr::new(198, 18, 30, 143);
+    let key = SynFlowKey {
+        src_ip: GUEST_IP,
+        src_port: 40103,
+        dst_ip,
+        dst_port: 443,
+    };
+    bridge.promote_to_fast_path(
+        key,
+        client.unwrap().into_std().unwrap(),
+        1000,
+        2000,
+        1460,
+        None,
+    );
+
+    server.write_all(b"unacked-data").unwrap();
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(2);
+    let mut in_flight = false;
+    while !in_flight && std::time::Instant::now() < deadline {
+        in_flight = !bridge.poll_fast_path().is_empty();
+        tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+    }
+    assert!(in_flight, "data must go into flight toward the guest");
+
+    bridge.set_dead_flow_timeout(std::time::Duration::from_millis(100));
+    backdate_guest_activity(&mut bridge, &key, std::time::Duration::from_millis(200));
+
+    // The guest answers (dup-ACK at the promoted seq) before the next poll.
+    let dup_ack = make_guest_segment((40103, dst_ip, 443), 2000, 1000, 65535, 0x10, &[]);
+    bridge.try_fast_path_intercept(&dup_ack);
+
+    let frames = bridge.poll_fast_path();
+    assert!(
+        frames.iter().all(|f| tcp_flags_of(f) & 0x04 == 0),
+        "a responding guest must not be RST"
+    );
+    assert_eq!(
+        bridge.fast_path_count(),
+        1,
+        "a responding guest keeps its flow"
+    );
+}
+
+/// The inline path has no RTO, so a vanished guest freezes the send budget
+/// with data in flight and nothing would ever tear the flow down: the give-up
+/// must reap it and fire the owner's cancel flag so the reader task exits.
+#[tokio::test]
+async fn inline_silent_guest_with_data_in_flight_is_rst_reaped() {
+    struct CaptureSink(std::sync::Mutex<Option<crate::direct_rx::PromotedConn>>);
+    impl crate::direct_rx::ConnSink for CaptureSink {
+        fn send_conn(&self, conn: crate::direct_rx::PromotedConn) -> bool {
+            *self.0.lock().unwrap() = Some(conn);
+            true
+        }
+    }
+
+    let sink = std::sync::Arc::new(CaptureSink(std::sync::Mutex::new(None)));
+    let mut bridge = TcpBridge::new(GW_IP);
+    bridge.set_fast_path_macs(GW_MAC, GUEST_MAC);
+    bridge.set_conn_sink(std::sync::Arc::clone(&sink) as _);
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let connect = tokio::net::TcpStream::connect(addr);
+    let (client, accepted) = tokio::join!(connect, listener.accept());
+    let _accepted = accepted.unwrap();
+
+    let dst_ip = Ipv4Addr::new(198, 18, 30, 144);
+    let key = SynFlowKey {
+        src_ip: GUEST_IP,
+        src_port: 40104,
+        dst_ip,
+        dst_port: 443,
+    };
+    // peer_mss ≥ GSO_SEGMENT_MSS → inline-owned.
+    bridge.promote_to_fast_path(
+        key,
+        client.unwrap().into_std().unwrap(),
+        1000,
+        2000,
+        9000,
+        None,
+    );
+    let promoted = sink.0.lock().unwrap().take().expect("inline conn");
+
+    // 1000 bytes in flight, window open — the state a vanished guest leaves
+    // behind (no persist probe fires while bytes are outstanding).
+    promoted
+        .our_seq
+        .store(5000, std::sync::atomic::Ordering::Relaxed);
+    promoted
+        .guest_acked
+        .store(4000, std::sync::atomic::Ordering::Relaxed);
+    promoted
+        .guest_window
+        .store(65535, std::sync::atomic::Ordering::Relaxed);
+
+    bridge.set_dead_flow_timeout(std::time::Duration::from_millis(100));
+    backdate_guest_activity(&mut bridge, &key, std::time::Duration::from_millis(200));
+
+    let frames = bridge.poll_fast_path();
+    assert!(
+        frames.iter().any(|f| tcp_flags_of(f) & 0x04 != 0),
+        "a dead inline flow must be RST-terminated"
+    );
+    assert_eq!(
+        bridge.fast_path_count(),
+        0,
+        "the dead inline flow must be reaped"
+    );
+    assert!(
+        promoted.dead.load(std::sync::atomic::Ordering::Relaxed),
+        "the owner cancel flag must fire so the inline reader exits"
+    );
+}

--- a/common/splicetcp/src/tcp_bridge/tests.rs
+++ b/common/splicetcp/src/tcp_bridge/tests.rs
@@ -2255,16 +2255,16 @@ async fn zero_window_stall_is_broken_by_a_persist_probe() {
 // left the guest leg ESTABLISHED forever (apk hung 23+ minutes), and a
 // vanished guest endpoint would leave the shim soliciting forever.
 
-/// Backdates a flow's sign-of-life clock so the dead-flow deadline is already
-/// past, without sleeping in the test.
-fn backdate_guest_activity(bridge: &mut TcpBridge, key: &SynFlowKey, by: std::time::Duration) {
-    bridge
-        .fast_path_conns
-        .get_mut(key)
-        .unwrap()
-        .last_guest_activity = std::time::Instant::now()
+/// Backdates a flow's sign-of-life AND soliciting clocks so the dead-flow
+/// deadline (which requires both to be stale) is already past, without
+/// sleeping in the test.
+fn backdate_dead_flow_clocks(bridge: &mut TcpBridge, key: &SynFlowKey, by: std::time::Duration) {
+    let past = std::time::Instant::now()
         .checked_sub(by)
         .expect("test clock underflow");
+    let conn = bridge.fast_path_conns.get_mut(key).unwrap();
+    conn.last_guest_activity = past;
+    conn.soliciting_since = Some(past);
 }
 
 /// Promotion must arm TCP keepalive on the upstream socket: a silently dead
@@ -2346,7 +2346,7 @@ async fn silent_guest_with_data_in_flight_is_rst_reaped() {
     assert!(in_flight, "data must go into flight toward the guest");
 
     bridge.set_dead_flow_timeout(std::time::Duration::from_millis(100));
-    backdate_guest_activity(&mut bridge, &key, std::time::Duration::from_millis(200));
+    backdate_dead_flow_clocks(&mut bridge, &key, std::time::Duration::from_millis(200));
 
     let frames = bridge.poll_fast_path();
     assert!(
@@ -2398,7 +2398,7 @@ async fn silent_guest_at_zero_window_is_rst_reaped() {
     );
 
     bridge.set_dead_flow_timeout(std::time::Duration::from_millis(100));
-    backdate_guest_activity(&mut bridge, &key, std::time::Duration::from_millis(200));
+    backdate_dead_flow_clocks(&mut bridge, &key, std::time::Duration::from_millis(200));
 
     let frames = bridge.poll_fast_path();
     assert!(
@@ -2450,7 +2450,7 @@ async fn guest_ack_refreshes_dead_flow_clock() {
     assert!(in_flight, "data must go into flight toward the guest");
 
     bridge.set_dead_flow_timeout(std::time::Duration::from_millis(100));
-    backdate_guest_activity(&mut bridge, &key, std::time::Duration::from_millis(200));
+    backdate_dead_flow_clocks(&mut bridge, &key, std::time::Duration::from_millis(200));
 
     // The guest answers (dup-ACK at the promoted seq) before the next poll.
     let dup_ack = make_guest_segment((40103, dst_ip, 443), 2000, 1000, 65535, 0x10, &[]);
@@ -2523,7 +2523,7 @@ async fn inline_silent_guest_with_data_in_flight_is_rst_reaped() {
         .store(65535, std::sync::atomic::Ordering::Relaxed);
 
     bridge.set_dead_flow_timeout(std::time::Duration::from_millis(100));
-    backdate_guest_activity(&mut bridge, &key, std::time::Duration::from_millis(200));
+    backdate_dead_flow_clocks(&mut bridge, &key, std::time::Duration::from_millis(200));
 
     let frames = bridge.poll_fast_path();
     assert!(
@@ -2538,5 +2538,78 @@ async fn inline_silent_guest_with_data_in_flight_is_rst_reaped() {
     assert!(
         promoted.dead.load(std::sync::atomic::Ordering::Relaxed),
         "the owner cancel flag must fire so the inline reader exits"
+    );
+}
+
+/// A long-idle flow whose upstream wakes up must NOT be insta-reaped: the
+/// last guest frame is legitimately ancient (the flow was quiescent), so the
+/// deadline must run from the moment soliciting began — the wake-up — giving
+/// the guest the full window to answer.
+#[tokio::test]
+async fn long_idle_flow_survives_upstream_wakeup() {
+    use std::io::Write;
+
+    let mut bridge = TcpBridge::new(GW_IP);
+    bridge.set_fast_path_macs(GW_MAC, GUEST_MAC);
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let connect = tokio::net::TcpStream::connect(addr);
+    let (client, accepted) = tokio::join!(connect, listener.accept());
+    let (server, _) = accepted.unwrap();
+    let mut server = server.into_std().unwrap();
+
+    let dst_ip = Ipv4Addr::new(198, 18, 30, 145);
+    let key = SynFlowKey {
+        src_ip: GUEST_IP,
+        src_port: 40105,
+        dst_ip,
+        dst_port: 443,
+    };
+    bridge.promote_to_fast_path(
+        key,
+        client.unwrap().into_std().unwrap(),
+        1000,
+        2000,
+        1460,
+        None,
+    );
+
+    // The flow has been quiescent far beyond the deadline: the guest's last
+    // frame is ancient, but nothing was being solicited.
+    bridge.set_dead_flow_timeout(std::time::Duration::from_millis(100));
+    bridge
+        .fast_path_conns
+        .get_mut(&key)
+        .unwrap()
+        .last_guest_activity = std::time::Instant::now()
+        .checked_sub(std::time::Duration::from_secs(30))
+        .expect("test clock underflow");
+
+    // Upstream wakes up: data goes into flight, soliciting starts NOW.
+    server.write_all(b"wakeup-data").unwrap();
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(2);
+    let mut woke = Vec::new();
+    while woke.is_empty() && std::time::Instant::now() < deadline {
+        woke = bridge.poll_fast_path();
+        tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+    }
+    assert!(!woke.is_empty(), "wakeup data must go into flight");
+    assert!(
+        woke.iter().all(|f| tcp_flags_of(f) & 0x04 == 0),
+        "the wakeup must not be answered with a RST"
+    );
+
+    // Immediately after the wakeup the guest has not answered yet — the flow
+    // must survive: the soliciting clock just started.
+    let frames = bridge.poll_fast_path();
+    assert!(
+        frames.iter().all(|f| tcp_flags_of(f) & 0x04 == 0),
+        "a freshly woken flow must not be RST"
+    );
+    assert_eq!(
+        bridge.fast_path_count(),
+        1,
+        "a freshly woken flow must survive until the guest had its full deadline"
     );
 }


### PR DESCRIPTION
## Problem

A fast-path flow could outlive either of its endpoints **forever**:

**Upstream leg (prod-observed zombie).** The upstream socket is dialed bare — no TCP keepalive. An upstream that dies *silently* (default-route flap, crashed system proxy, NAT timeout) never surfaces on the socket: reads stay `WouldBlock`, and the guest leg sits ESTABLISHED with empty queues until the guest app gives up. Observed 2026-07-19 in prod: `apk` inside a container hung 23+ minutes on a flow whose upstream leg was long dead, with zero proxy-layer logs.

**Guest leg (no give-up).** `retransmits` was only a diagnostic counter — a guest endpoint that vanished (container netns torn down) left the bridge RTO-retransmitting every 2 s or persist-probing forever, leaking the entry, host fd, and up to 256 KiB retransmission buffer per flow. Worse, the **inline** path has no RTO at all: a vanished guest freezes the send budget with bytes outstanding, the persist probe never fires (it is gated on nothing-in-flight), and no teardown path exists at all.

## Fix

- `promote_to_fast_path` arms TCP keepalive on the upstream socket (60 s idle, 4 × 15 s probes → dead upstream detected within ~2 min). The existing error paths (bridge poll `Err` branch, inline owners' ABX-431 machinery) already propagate the resulting read error as a guest RST — keepalive just makes the kernel *produce* that error. Inline owners read a cloned fd of the same underlying socket, so one setup covers every owner.
- New per-flow sign-of-life clock (`last_guest_activity`, refreshed by every guest frame in `try_fast_path_intercept`). `poll_fast_path` RST-reaps a flow that stays silent for **5 minutes while the shim is actively soliciting a response** — data/FIN in flight (a live guest must dup-ACK) or a closed window under persist probes (a live guest must answer per RFC 793 §3.9). Both the non-inline and inline arms are covered.

Purely idle flows are never reaped (matching real TCP), and 5 min is generous enough to survive any reasonable VM pause/resume (vz pause / sandbox checkpoint).

`socket2` moves from dev-dependencies to dependencies (already in the tree via tokio; no resolution change).

## Tests

5 new lib tests: keepalive armed at promotion (observed via cloned fd), silent-guest reap with data in flight, silent-guest reap at zero window, dup-ACK refreshing the clock (no false reap), and inline silent-guest reap incl. the owner cancel flag firing. `cargo test -p splicetcp --lib`: 84 passed. fmt + clippy clean; `arcbox-net` compiles unchanged.

Zombie scenarios (silently-dying upstream) are not stageable in the e2e harness; the keepalive half is kernel behavior verified by socket option assertion.