### PR TITLE
fix(virtio): drop RX frames that don't fit the chain instead of truncating

### DIFF
--- a/virt/arcbox-virtio-net/src/device/hot_path.rs
+++ b/virt/arcbox-virtio-net/src/device/hot_path.rs
@@ -146,8 +146,12 @@ impl VirtioNet {
 
     /// Polls the bound host fd for inbound Ethernet frames and injects up
     /// to 64 of them into the RX virtqueue described by `rx_qcfg`. Prepends
-    /// a zeroed 12-byte virtio-net header to each frame. Returns `true` if
-    /// any frame was injected, so the caller can fire the used-ring IRQ.
+    /// a 12-byte virtio-net header to each frame (`num_buffers` = 1 as
+    /// VERSION_1 requires without MRG_RXBUF; every other field zero — no
+    /// offloads on this path). Frames are delivered whole or not at all: a
+    /// chain that can't hold header + frame completes at zero length and
+    /// the frame is dropped. Returns `true` if the used ring advanced, so
+    /// the caller can fire the used-ring IRQ.
     ///
     /// The caller is responsible for building `rx_qcfg` from the device's
     /// MMIO state and gating on DRIVER_OK.
@@ -213,6 +217,7 @@ impl VirtioNet {
                 break;
             };
             let mut written = 0usize;
+            let mut refused = false;
             for desc in &chain.descriptors {
                 if !desc.is_write() {
                     continue;
@@ -235,22 +240,31 @@ impl VirtioNet {
                         };
                     }
                     written += to_write;
+                } else {
+                    // Descriptor outside guest RAM. Skipping it and filling
+                    // later descriptors could still reach `total` while the
+                    // frame's middle is a hole — poison the chain instead.
+                    refused = true;
+                    break;
                 }
             }
 
             // Deliver whole frames only. A partial fit — an undersized chain,
-            // or a descriptor pointing outside guest RAM (`slice_mut` refused
-            // it) — completes at zero length: the guest reclaims the popped
-            // chain (leaving it off the used ring would drain the RX ring
-            // dry) and the frame is dropped whole; TCP retransmits. Truncated
-            // delivery would hand the guest a corrupt frame it parses as
-            // complete. This device never offers MRG_RXBUF (it serves the
-            // vmnet bridge NIC), so spanning chains is never a legal
-            // alternative and a conformant guest posts full-frame buffers —
-            // the drop fires only for undersized or hostile rings. The used
-            // ring advances either way, so the guest still needs the
-            // interrupt below.
-            let used_len = if written == total { written as u32 } else { 0 };
+            // or a descriptor pointing outside guest RAM (`refused`) —
+            // completes at zero length: the guest reclaims the popped chain
+            // (leaving it off the used ring would drain the RX ring dry) and
+            // the frame is dropped whole; TCP retransmits. Truncated delivery
+            // would hand the guest a corrupt frame it parses as complete.
+            // This device never offers MRG_RXBUF (it serves the vmnet bridge
+            // NIC), so spanning chains is never a legal alternative and a
+            // conformant guest posts full-frame buffers — the drop fires only
+            // for undersized or hostile rings. The used ring advances either
+            // way, so the guest still needs the interrupt below.
+            let used_len = if !refused && written == total {
+                written as u32
+            } else {
+                0
+            };
             queue.push_used(chain.head_idx, used_len);
             published = true;
         }

--- a/virt/arcbox-virtio-net/src/device/hot_path.rs
+++ b/virt/arcbox-virtio-net/src/device/hot_path.rs
@@ -178,6 +178,11 @@ impl VirtioNet {
         // chain we consumed but couldn't fill, stalling RX.
         let mut published = false;
         let hdr_len = VirtioNetHeader::SIZE;
+        // Injected header: num_buffers = 1 (VERSION_1 headers carry the field
+        // even without MRG_RXBUF, and the spec pins it to 1 then); every other
+        // field zero — this path performs no offloads.
+        let mut hdr = [0u8; VirtioNetHeader::SIZE];
+        hdr[10..12].copy_from_slice(&1u16.to_le_bytes());
         for _ in 0..64 {
             // Stop when the guest has no RX buffer posted.
             if !queue.has_avail() {
@@ -200,8 +205,8 @@ impl VirtioNet {
                 break;
             }
             let frame = &buf[..n as usize];
-            // The injected buffer is a zeroed virtio-net header followed by the
-            // frame, scattered across the chain's write-only descriptors.
+            // The injected buffer is the header followed by the frame,
+            // scattered across the chain's write-only descriptors.
             let total = hdr_len + frame.len();
 
             let Some(chain) = queue.pop_avail() else {
@@ -223,9 +228,8 @@ impl VirtioNet {
                 if let Some(out) = unsafe { queue.mem().slice_mut(desc.addr as usize, to_write) } {
                     for (k, slot) in out.iter_mut().enumerate() {
                         let pos = written + k;
-                        // virtio-net header is all zeros; frame follows it.
                         *slot = if pos < hdr_len {
-                            0
+                            hdr[pos]
                         } else {
                             frame[pos - hdr_len]
                         };
@@ -234,19 +238,20 @@ impl VirtioNet {
                 }
             }
 
-            if written == 0 {
-                // A chain with no writable capacity can't carry the frame, but
-                // it was already popped off the avail ring — return it to the
-                // used ring (zero length) so the guest reclaims the descriptor
-                // instead of leaking it forever (which drains the RX ring dry).
-                // This advances the used ring, so the guest still needs the
-                // interrupt below. The frame is dropped; TCP retransmits.
-                queue.push_used(chain.head_idx, 0);
-                published = true;
-                continue;
-            }
-
-            queue.push_used(chain.head_idx, written as u32);
+            // Deliver whole frames only. A partial fit — an undersized chain,
+            // or a descriptor pointing outside guest RAM (`slice_mut` refused
+            // it) — completes at zero length: the guest reclaims the popped
+            // chain (leaving it off the used ring would drain the RX ring
+            // dry) and the frame is dropped whole; TCP retransmits. Truncated
+            // delivery would hand the guest a corrupt frame it parses as
+            // complete. This device never offers MRG_RXBUF (it serves the
+            // vmnet bridge NIC), so spanning chains is never a legal
+            // alternative and a conformant guest posts full-frame buffers —
+            // the drop fires only for undersized or hostile rings. The used
+            // ring advances either way, so the guest still needs the
+            // interrupt below.
+            let used_len = if written == total { written as u32 } else { 0 };
+            queue.push_used(chain.head_idx, used_len);
             published = true;
         }
 

--- a/virt/arcbox-virtio-net/src/device/tests.rs
+++ b/virt/arcbox-virtio-net/src/device/tests.rs
@@ -605,11 +605,11 @@ fn test_handle_tx_normal_packet_uses_send() {
     );
 }
 
-/// Harness for `poll_rx`: scratch guest RAM with one RX chain (single
-/// write-only descriptor of `buf_len` at 0x400), a datagram socketpair as the
-/// host fd, and one queued `frame`. Returns (guest memory, poll result), with
-/// the used ring at 0x300.
-fn poll_rx_one_frame(buf_len: u32, frame: &[u8]) -> (Vec<u8>, bool) {
+/// Harness for `poll_rx`: scratch guest RAM with one RX chain of write-only
+/// descriptors (`descs` = (addr, len) each, linked with NEXT), a datagram
+/// socketpair as the host fd, and one queued `frame`. Returns (guest memory,
+/// poll result), with the used ring at 0x300.
+fn poll_rx_one_frame(descs: &[(u64, u32)], frame: &[u8]) -> (Vec<u8>, bool) {
     use std::os::unix::io::AsRawFd;
     use std::sync::atomic::AtomicU16;
 
@@ -619,13 +619,23 @@ fn poll_rx_one_frame(buf_len: u32, frame: &[u8]) -> (Vec<u8>, bool) {
     use crate::config::NetPort;
 
     let q_size: u16 = 4;
-    let (desc_addr, avail_addr, used_addr, data_addr) = (0x100usize, 0x200, 0x300, 0x400usize);
+    let (desc_addr, avail_addr, used_addr) = (0x100usize, 0x200, 0x300);
     let mut mem = vec![0u8; 0x1000];
 
-    // Descriptor 0: one write-only buffer of `buf_len` at `data_addr`.
-    mem[desc_addr..desc_addr + 8].copy_from_slice(&(data_addr as u64).to_le_bytes());
-    mem[desc_addr + 8..desc_addr + 12].copy_from_slice(&buf_len.to_le_bytes());
-    mem[desc_addr + 12..desc_addr + 14].copy_from_slice(&flags::WRITE.to_le_bytes());
+    // One chain of write-only descriptors, head 0, linked with NEXT.
+    for (i, &(addr, len)) in descs.iter().enumerate() {
+        let d = desc_addr + i * 16;
+        let last = i == descs.len() - 1;
+        let f = if last {
+            flags::WRITE
+        } else {
+            flags::WRITE | flags::NEXT
+        };
+        mem[d..d + 8].copy_from_slice(&addr.to_le_bytes());
+        mem[d + 8..d + 12].copy_from_slice(&len.to_le_bytes());
+        mem[d + 12..d + 14].copy_from_slice(&f.to_le_bytes());
+        mem[d + 14..d + 16].copy_from_slice(&((i as u16) + 1).to_le_bytes());
+    }
     // Avail ring: one posted chain (head 0).
     mem[avail_addr + 2..avail_addr + 4].copy_from_slice(&1u16.to_le_bytes());
     mem[avail_addr + 4..avail_addr + 6].copy_from_slice(&0u16.to_le_bytes());
@@ -667,7 +677,7 @@ fn poll_rx_one_frame(buf_len: u32, frame: &[u8]) -> (Vec<u8>, bool) {
 #[test]
 fn poll_rx_delivers_whole_frame_and_stamps_num_buffers() {
     let frame = [0xABu8; 100];
-    let (mem, published) = poll_rx_one_frame(256, &frame);
+    let (mem, published) = poll_rx_one_frame(&[(0x400, 256)], &frame);
     assert!(published);
 
     let used_addr = 0x300usize;
@@ -696,7 +706,7 @@ fn poll_rx_drops_frame_exceeding_chain_capacity() {
     // guest reclaims), never delivered truncated — the guest would parse a
     // truncated buffer as a complete frame.
     let frame = [0xCDu8; 100];
-    let (mem, published) = poll_rx_one_frame(64, &frame);
+    let (mem, published) = poll_rx_one_frame(&[(0x400, 64)], &frame);
     assert!(published, "the consumed chain still needs its interrupt");
 
     let used_addr = 0x300usize;
@@ -709,4 +719,31 @@ fn poll_rx_drops_frame_exceeding_chain_capacity() {
         mem[used_addr + 11],
     ]);
     assert_eq!(used_len, 0, "no truncated delivery — dropped whole");
+}
+
+#[test]
+fn poll_rx_oob_descriptor_poisons_chain() {
+    // Chain: valid 64B → OOB 64B (outside the 0x1000 scratch RAM) → valid
+    // 64B. Numeric capacity (192) covers the 112-byte frame, and skipping
+    // the OOB descriptor while filling the tail would still reach `total` —
+    // delivering a full-length frame with a hole in the middle. The chain
+    // must be poisoned instead: zero-length completion, nothing delivered.
+    let frame = [0xEFu8; 100];
+    let (mem, published) = poll_rx_one_frame(&[(0x400, 64), (0x10_0000, 64), (0x500, 64)], &frame);
+    assert!(published, "the consumed chain still needs its interrupt");
+
+    let used_addr = 0x300usize;
+    let used_idx = u16::from_le_bytes([mem[used_addr + 2], mem[used_addr + 3]]);
+    assert_eq!(used_idx, 1, "chain returned to the used ring");
+    let used_len = u32::from_le_bytes([
+        mem[used_addr + 8],
+        mem[used_addr + 9],
+        mem[used_addr + 10],
+        mem[used_addr + 11],
+    ]);
+    assert_eq!(used_len, 0, "a holed chain must complete at zero length");
+    assert!(
+        mem[0x500..0x540].iter().all(|&b| b == 0),
+        "nothing may be scattered past the refused descriptor"
+    );
 }

--- a/virt/arcbox-virtio-net/src/device/tests.rs
+++ b/virt/arcbox-virtio-net/src/device/tests.rs
@@ -604,3 +604,109 @@ fn test_handle_tx_normal_packet_uses_send() {
         "send should be called for normal packets"
     );
 }
+
+/// Harness for `poll_rx`: scratch guest RAM with one RX chain (single
+/// write-only descriptor of `buf_len` at 0x400), a datagram socketpair as the
+/// host fd, and one queued `frame`. Returns (guest memory, poll result), with
+/// the used ring at 0x300.
+fn poll_rx_one_frame(buf_len: u32, frame: &[u8]) -> (Vec<u8>, bool) {
+    use std::os::unix::io::AsRawFd;
+    use std::sync::atomic::AtomicU16;
+
+    use arcbox_virtio_core::queue::flags;
+    use arcbox_virtio_core::{DeviceCtx, QueueConfig};
+
+    use crate::config::NetPort;
+
+    let q_size: u16 = 4;
+    let (desc_addr, avail_addr, used_addr, data_addr) = (0x100usize, 0x200, 0x300, 0x400usize);
+    let mut mem = vec![0u8; 0x1000];
+
+    // Descriptor 0: one write-only buffer of `buf_len` at `data_addr`.
+    mem[desc_addr..desc_addr + 8].copy_from_slice(&(data_addr as u64).to_le_bytes());
+    mem[desc_addr + 8..desc_addr + 12].copy_from_slice(&buf_len.to_le_bytes());
+    mem[desc_addr + 12..desc_addr + 14].copy_from_slice(&flags::WRITE.to_le_bytes());
+    // Avail ring: one posted chain (head 0).
+    mem[avail_addr + 2..avail_addr + 4].copy_from_slice(&1u16.to_le_bytes());
+    mem[avail_addr + 4..avail_addr + 6].copy_from_slice(&0u16.to_le_bytes());
+
+    // Host fd: a datagram pair with the frame already queued.
+    let (tx, rx) = std::os::unix::net::UnixDatagram::pair().unwrap();
+    tx.send(frame).unwrap();
+
+    let mut net = VirtioNet::new(NetConfig::default());
+    // SAFETY: `mem` outlives `net` (returned to the caller after `net` is
+    // dropped at the end of this function) and is not moved while the raw
+    // pointer is held by the bound context.
+    let ctx = DeviceCtx {
+        mem: Arc::new(unsafe {
+            arcbox_virtio_core::GuestMemWriter::new(mem.as_mut_ptr(), mem.len(), 0)
+        }),
+        raise_irq: Arc::new(|_| {}),
+    };
+    net.bind_ctx(ctx);
+    net.bind_port(NetPort {
+        host_fd: rx.as_raw_fd(),
+        last_avail_tx: AtomicU16::new(0),
+    })
+    .expect("bind port");
+
+    let qcfg = QueueConfig {
+        desc_addr: desc_addr as u64,
+        avail_addr: avail_addr as u64,
+        used_addr: used_addr as u64,
+        size: q_size,
+        ready: true,
+        gpa_base: 0,
+    };
+    let published = net.poll_rx(&qcfg);
+    drop(net);
+    (mem, published)
+}
+
+#[test]
+fn poll_rx_delivers_whole_frame_and_stamps_num_buffers() {
+    let frame = [0xABu8; 100];
+    let (mem, published) = poll_rx_one_frame(256, &frame);
+    assert!(published);
+
+    let used_addr = 0x300usize;
+    let used_idx = u16::from_le_bytes([mem[used_addr + 2], mem[used_addr + 3]]);
+    assert_eq!(used_idx, 1, "one completion");
+    let used_len = u32::from_le_bytes([
+        mem[used_addr + 8],
+        mem[used_addr + 9],
+        mem[used_addr + 10],
+        mem[used_addr + 11],
+    ]);
+    assert_eq!(used_len, 12 + 100, "header + payload delivered whole");
+
+    // num_buffers (header offset 10..12) = 1 for spec compliance on
+    // VERSION_1 headers without MRG_RXBUF.
+    let num_buffers = u16::from_le_bytes([mem[0x400 + 10], mem[0x400 + 11]]);
+    assert_eq!(num_buffers, 1);
+    assert_eq!(&mem[0x400 + 12..0x400 + 112], &frame[..], "payload intact");
+}
+
+#[test]
+fn poll_rx_drops_frame_exceeding_chain_capacity() {
+    // 100-byte frame + 12-byte header = 112 > the chain's 64 bytes. The
+    // device never offers MRG_RXBUF on this path, so spanning is not an
+    // option: the frame must be dropped whole (zero-length completion the
+    // guest reclaims), never delivered truncated — the guest would parse a
+    // truncated buffer as a complete frame.
+    let frame = [0xCDu8; 100];
+    let (mem, published) = poll_rx_one_frame(64, &frame);
+    assert!(published, "the consumed chain still needs its interrupt");
+
+    let used_addr = 0x300usize;
+    let used_idx = u16::from_le_bytes([mem[used_addr + 2], mem[used_addr + 3]]);
+    assert_eq!(used_idx, 1, "chain returned to the used ring");
+    let used_len = u32::from_le_bytes([
+        mem[used_addr + 8],
+        mem[used_addr + 9],
+        mem[used_addr + 10],
+        mem[used_addr + 11],
+    ]);
+    assert_eq!(used_len, 0, "no truncated delivery — dropped whole");
+}


### PR DESCRIPTION
## Problem

`poll_rx` (the vmnet bridge NIC's RX injection) delivered whatever prefix of a frame fit the popped chain and completed it at the written length — a truncated buffer the guest parses as a complete frame. The same held when a descriptor pointed outside guest RAM: `slice_mut` refused the write but the completion still claimed the partial length. The injected virtio-net header was also all zeros, leaving `num_buffers = 0` where the VERSION_1 spec pins it to 1 without MRG_RXBUF.

This closes the sibling case deliberately deferred in 2ee26450 (#480, "pending MRG_RXBUF confirmation"): confirmed — this device **never offers MRG_RXBUF** (`create_hv_bridge_nic` doesn't call `enable_tso_features`; the primary NIC's RX runs through `inject_rx_batch`, which spans properly), so spanning is never a legal alternative and whole-frame drop is the spec-correct behavior. A conformant guest posts full-frame buffers, so the drop can only fire for undersized or hostile rings — this is latent-bug hardening, not a prod-visible fix.

## Fix

Single enforcement point after the scatter loop: `written == total` delivers, anything else completes at **zero length** (guest reclaims the chain — generalizing #480's zero-capacity rule to every partial case; frame dropped whole, TCP retransmits). Header now stamps `num_buffers = 1`.

## Tests

New `poll_rx` harness (scratch guest RAM + datagram socketpair as host fd): whole-frame delivery asserts used length, payload bytes, and `num_buffers = 1`; the undersized-chain case asserts zero-length completion and no truncated delivery. `cargo test -p arcbox-virtio-net --lib`: 61 passed. fmt + clippy clean.